### PR TITLE
fix: web コンテナを非 root ユーザーで実行

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -31,10 +31,12 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-# Next.js のスタンドアロン出力を利用
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
-COPY --from=builder /app/public ./public
+# Next.js のスタンドアロン出力を利用（node ユーザーで所有）
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+COPY --from=builder --chown=node:node /app/public ./public
+
+USER node
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Summary
- web コンテナ（Next.js）が root で実行されていたのを `node` ユーザーに変更
- `COPY --chown=node:node` でファイル所有権を設定し、`USER node` で非特権実行

## Test plan
- [ ] `docker compose build web` でビルドが成功すること
- [ ] `docker compose up web` で正常に起動し `:3000` にアクセスできること
- [ ] `docker compose exec web whoami` が `node` を返すこと

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)