### PR TITLE
fix: DB ポートのホスト公開をデフォルトで無効化

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -66,7 +66,7 @@ CORS_ALLOWED_ORIGIN=http://localhost:3000
 # POSTGRES_USER=feedman              # PostgreSQLユーザー名（デフォルト: feedman）
 # POSTGRES_PASSWORD=feedman          # PostgreSQLパスワード（本番では必ず変更すること）
 # POSTGRES_DB=feedman                # PostgreSQLデータベース名（デフォルト: feedman）
-# DB_PORT=5432                       # ホスト側に公開するDBポート
+# DB_PORT=                            # DBポートのホスト公開（デフォルト: 非公開、開発時のみ設定）
 
 # Cookie設定
 # COOKIE_DOMAIN=                     # Cookieのドメイン（クロスサブドメイン時に設定、例: .example.com）

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ docker compose --env-file .env.production exec api /feedman migrate
 - `BASE_URL` と `GOOGLE_REDIRECT_URL` を実際のドメイン（HTTPS）に変更する
 - PostgreSQL のパスワードをデフォルト（`feedman`）から変更する
 - HTTPS を有効にし、リバースプロキシ（nginx 等）を前段に配置する
-- `docker-compose.yml` の `db` ポートマッピングを削除し、外部からの直接接続を遮断する
+- DB ポートはデフォルトで非公開。開発時に直接接続が必要な場合のみ `DB_PORT=5432` を設定する
 
 ## ネットワークセキュリティ
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,8 +102,6 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-feedman}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-feedman}
       - POSTGRES_DB=${POSTGRES_DB:-feedman}
-    ports:
-      - "${DB_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
## Summary
- `docker-compose.yml` の `db` サービスから `ports` セクションを削除
- DB はデフォルトで `internal` ネットワーク内のみアクセス可能に
- 開発時に直接接続が必要な場合は `docker-compose.override.yml` で対応

## Test plan
- [ ] `docker compose up -d` で全サービスが正常に起動すること
- [ ] api/worker から DB に接続できること（internal ネットワーク経由）
- [ ] ホストから `localhost:5432` に接続できないこと

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)