### PR TITLE
fix: フィードの認可チェック追加により IDOR を防止 (#34)

### DIFF
--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -128,12 +128,36 @@ func (s *FeedService) RegisterFeed(ctx context.Context, userID string, inputURL 
 }
 
 // GetFeed はフィード情報を取得する。
-func (s *FeedService) GetFeed(ctx context.Context, feedID string) (*model.Feed, error) {
+// 認可: リクエストユーザーが当該フィードを購読している場合のみ取得可能。
+// 購読していない場合は IDOR を避けるため nil, nil を返す（ハンドラーで 404 として扱う）。
+func (s *FeedService) GetFeed(ctx context.Context, userID, feedID string) (*model.Feed, error) {
+	sub, err := s.subRepo.FindByUserAndFeed(ctx, userID, feedID)
+	if err != nil {
+		return nil, fmt.Errorf("購読の確認に失敗しました: %w", err)
+	}
+	if sub == nil {
+		return nil, nil
+	}
 	return s.feedRepo.FindByID(ctx, feedID)
 }
 
 // UpdateFeedURL はフィードURLを更新する。
-func (s *FeedService) UpdateFeedURL(ctx context.Context, feedID string, newURL string) (*model.Feed, error) {
+// 認可: リクエストユーザーが当該フィードを購読している場合のみ更新可能。
+// 購読していない場合は IDOR を避けるため FEED_NOT_FOUND を返す。
+func (s *FeedService) UpdateFeedURL(ctx context.Context, userID, feedID, newURL string) (*model.Feed, error) {
+	sub, err := s.subRepo.FindByUserAndFeed(ctx, userID, feedID)
+	if err != nil {
+		return nil, fmt.Errorf("購読の確認に失敗しました: %w", err)
+	}
+	if sub == nil {
+		return nil, &model.APIError{
+			Code:     "FEED_NOT_FOUND",
+			Message:  "指定されたフィードが見つかりません。",
+			Category: "feed",
+			Action:   "フィードIDを確認してください。",
+		}
+	}
+
 	feed, err := s.feedRepo.FindByID(ctx, feedID)
 	if err != nil {
 		return nil, fmt.Errorf("フィードの取得に失敗しました: %w", err)

--- a/internal/feed/service_test.go
+++ b/internal/feed/service_test.go
@@ -405,9 +405,16 @@ func TestFeedService_GetFeed(t *testing.T) {
 		Title:   "テストフィード",
 	}
 
-	svc := NewFeedService(feedRepo, newMockSubRepo(), &mockDetector{}, &mockFaviconFetcher{})
+	subRepo := newMockSubRepo()
+	subRepo.subs["sub-1"] = &model.Subscription{
+		ID:     "sub-1",
+		UserID: "user-1",
+		FeedID: "feed-1",
+	}
 
-	feed, err := svc.GetFeed(context.Background(), "feed-1")
+	svc := NewFeedService(feedRepo, subRepo, &mockDetector{}, &mockFaviconFetcher{})
+
+	feed, err := svc.GetFeed(context.Background(), "user-1", "feed-1")
 	if err != nil {
 		t.Fatalf("GetFeed returned error: %v", err)
 	}
@@ -424,12 +431,42 @@ func TestFeedService_GetFeed_NotFound(t *testing.T) {
 	feedRepo := newMockFeedRepo()
 	svc := NewFeedService(feedRepo, newMockSubRepo(), &mockDetector{}, &mockFaviconFetcher{})
 
-	feed, err := svc.GetFeed(context.Background(), "nonexistent")
+	feed, err := svc.GetFeed(context.Background(), "user-1", "nonexistent")
 	if err != nil {
 		t.Fatalf("GetFeed returned error: %v", err)
 	}
 	if feed != nil {
 		t.Error("存在しないフィードはnilを返すべき")
+	}
+}
+
+// TestFeedService_GetFeed_NotSubscribed_ReturnsNil は他ユーザー (購読していない) のフィード取得が
+// IDOR を避けるため nil を返すことをテストする (issue #34 リグレッション)。
+func TestFeedService_GetFeed_NotSubscribed_ReturnsNil(t *testing.T) {
+	feedRepo := newMockFeedRepo()
+	feedRepo.feeds["feed-1"] = &model.Feed{
+		ID:      "feed-1",
+		FeedURL: "https://example.com/feed.xml",
+		Title:   "他ユーザーのフィード",
+	}
+
+	subRepo := newMockSubRepo()
+	// user-other のみが購読
+	subRepo.subs["sub-1"] = &model.Subscription{
+		ID:     "sub-1",
+		UserID: "user-other",
+		FeedID: "feed-1",
+	}
+
+	svc := NewFeedService(feedRepo, subRepo, &mockDetector{}, &mockFaviconFetcher{})
+
+	// user-attacker は購読していない
+	feed, err := svc.GetFeed(context.Background(), "user-attacker", "feed-1")
+	if err != nil {
+		t.Fatalf("GetFeed returned error: %v", err)
+	}
+	if feed != nil {
+		t.Error("購読していないフィードは nil を返すべき (IDOR 防止)")
 	}
 }
 
@@ -443,9 +480,16 @@ func TestFeedService_UpdateFeedURL(t *testing.T) {
 		FetchStatus: model.FetchStatusActive,
 	}
 
-	svc := NewFeedService(feedRepo, newMockSubRepo(), &mockDetector{}, &mockFaviconFetcher{})
+	subRepo := newMockSubRepo()
+	subRepo.subs["sub-1"] = &model.Subscription{
+		ID:     "sub-1",
+		UserID: "user-1",
+		FeedID: "feed-1",
+	}
 
-	feed, err := svc.UpdateFeedURL(context.Background(), "feed-1", "https://example.com/new-feed.xml")
+	svc := NewFeedService(feedRepo, subRepo, &mockDetector{}, &mockFaviconFetcher{})
+
+	feed, err := svc.UpdateFeedURL(context.Background(), "user-1", "feed-1", "https://example.com/new-feed.xml")
 	if err != nil {
 		t.Fatalf("UpdateFeedURL returned error: %v", err)
 	}
@@ -462,9 +506,51 @@ func TestFeedService_UpdateFeedURL_NotFound(t *testing.T) {
 	feedRepo := newMockFeedRepo()
 	svc := NewFeedService(feedRepo, newMockSubRepo(), &mockDetector{}, &mockFaviconFetcher{})
 
-	_, err := svc.UpdateFeedURL(context.Background(), "nonexistent", "https://example.com/new-feed.xml")
+	_, err := svc.UpdateFeedURL(context.Background(), "user-1", "nonexistent", "https://example.com/new-feed.xml")
 	if err == nil {
 		t.Fatal("存在しないフィードの更新はエラーを返すべき")
+	}
+}
+
+// TestFeedService_UpdateFeedURL_NotSubscribed_ReturnsNotFound は他ユーザー (購読していない) のフィード更新が
+// IDOR を避けるため FEED_NOT_FOUND を返すことをテストする (issue #34 リグレッション)。
+func TestFeedService_UpdateFeedURL_NotSubscribed_ReturnsNotFound(t *testing.T) {
+	feedRepo := newMockFeedRepo()
+	feedRepo.feeds["feed-1"] = &model.Feed{
+		ID:          "feed-1",
+		FeedURL:     "https://example.com/feed.xml",
+		Title:       "他ユーザーのフィード",
+		FetchStatus: model.FetchStatusActive,
+	}
+
+	subRepo := newMockSubRepo()
+	// user-other のみが購読
+	subRepo.subs["sub-1"] = &model.Subscription{
+		ID:     "sub-1",
+		UserID: "user-other",
+		FeedID: "feed-1",
+	}
+
+	svc := NewFeedService(feedRepo, subRepo, &mockDetector{}, &mockFaviconFetcher{})
+
+	// user-attacker による URL 書き換え試行
+	_, err := svc.UpdateFeedURL(context.Background(), "user-attacker", "feed-1", "https://attacker.example.com/feed.xml")
+	if err == nil {
+		t.Fatal("購読していないフィードの更新はエラーを返すべき (IDOR 防止)")
+	}
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("APIError 型が期待されるが、%T が返された", err)
+	}
+	if apiErr.Code != "FEED_NOT_FOUND" {
+		t.Errorf("エラーコード = %q, want %q", apiErr.Code, "FEED_NOT_FOUND")
+	}
+	// フィードが更新されていないことを確認
+	if feedRepo.updateCalls != 0 {
+		t.Errorf("購読していないフィードへの更新は実行されないべき。updateCalls = %d", feedRepo.updateCalls)
+	}
+	if feedRepo.feeds["feed-1"].FeedURL != "https://example.com/feed.xml" {
+		t.Errorf("フィード URL が書き換えられている: %q", feedRepo.feeds["feed-1"].FeedURL)
 	}
 }
 

--- a/internal/handler/feed_handler.go
+++ b/internal/handler/feed_handler.go
@@ -16,10 +16,10 @@ import (
 type FeedServiceInterface interface {
 	// RegisterFeed はURLからフィードを検出し登録する。
 	RegisterFeed(ctx context.Context, userID, inputURL string) (*model.Feed, *model.Subscription, error)
-	// GetFeed はフィード情報を取得する。
-	GetFeed(ctx context.Context, feedID string) (*model.Feed, error)
-	// UpdateFeedURL はフィードURLを更新する。
-	UpdateFeedURL(ctx context.Context, feedID, newURL string) (*model.Feed, error)
+	// GetFeed はフィード情報を取得する。userID は認可チェック用。
+	GetFeed(ctx context.Context, userID, feedID string) (*model.Feed, error)
+	// UpdateFeedURL はフィードURLを更新する。userID は認可チェック用。
+	UpdateFeedURL(ctx context.Context, userID, feedID, newURL string) (*model.Feed, error)
 }
 
 // SubscriptionDeleter は購読削除のためのインターフェース。
@@ -115,9 +115,20 @@ func (h *FeedHandler) RegisterFeed(w http.ResponseWriter, r *http.Request) {
 // GetFeed はフィード詳細を取得する。
 // GET /api/feeds/:id
 func (h *FeedHandler) GetFeed(w http.ResponseWriter, r *http.Request) {
+	userID, err := middleware.UserIDFromContext(r.Context())
+	if err != nil {
+		writeAPIErrorResponse(w, http.StatusUnauthorized, &model.APIError{
+			Code:     "UNAUTHORIZED",
+			Message:  "認証が必要です。",
+			Category: "auth",
+			Action:   "ログインしてください。",
+		})
+		return
+	}
+
 	feedID := chi.URLParam(r, "id")
 
-	feed, err := h.service.GetFeed(r.Context(), feedID)
+	feed, err := h.service.GetFeed(r.Context(), userID, feedID)
 	if err != nil {
 		handleServiceError(w, err)
 		return
@@ -140,6 +151,17 @@ func (h *FeedHandler) GetFeed(w http.ResponseWriter, r *http.Request) {
 // UpdateFeedURL はフィードURLを更新する。
 // PATCH /api/feeds/:id
 func (h *FeedHandler) UpdateFeedURL(w http.ResponseWriter, r *http.Request) {
+	userID, err := middleware.UserIDFromContext(r.Context())
+	if err != nil {
+		writeAPIErrorResponse(w, http.StatusUnauthorized, &model.APIError{
+			Code:     "UNAUTHORIZED",
+			Message:  "認証が必要です。",
+			Category: "auth",
+			Action:   "ログインしてください。",
+		})
+		return
+	}
+
 	feedID := chi.URLParam(r, "id")
 
 	var req updateFeedURLRequest
@@ -158,7 +180,7 @@ func (h *FeedHandler) UpdateFeedURL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	feed, err := h.service.UpdateFeedURL(r.Context(), feedID, req.FeedURL)
+	feed, err := h.service.UpdateFeedURL(r.Context(), userID, feedID, req.FeedURL)
 	if err != nil {
 		handleServiceError(w, err)
 		return

--- a/internal/handler/feed_handler_test.go
+++ b/internal/handler/feed_handler_test.go
@@ -19,8 +19,8 @@ import (
 // mockFeedService はFeedServiceInterfaceのモック実装。
 type mockFeedService struct {
 	registerFeedFn  func(ctx context.Context, userID, inputURL string) (*model.Feed, *model.Subscription, error)
-	getFeedFn       func(ctx context.Context, feedID string) (*model.Feed, error)
-	updateFeedURLFn func(ctx context.Context, feedID, newURL string) (*model.Feed, error)
+	getFeedFn       func(ctx context.Context, userID, feedID string) (*model.Feed, error)
+	updateFeedURLFn func(ctx context.Context, userID, feedID, newURL string) (*model.Feed, error)
 }
 
 func (m *mockFeedService) RegisterFeed(ctx context.Context, userID, inputURL string) (*model.Feed, *model.Subscription, error) {
@@ -30,16 +30,16 @@ func (m *mockFeedService) RegisterFeed(ctx context.Context, userID, inputURL str
 	return nil, nil, nil
 }
 
-func (m *mockFeedService) GetFeed(ctx context.Context, feedID string) (*model.Feed, error) {
+func (m *mockFeedService) GetFeed(ctx context.Context, userID, feedID string) (*model.Feed, error) {
 	if m.getFeedFn != nil {
-		return m.getFeedFn(ctx, feedID)
+		return m.getFeedFn(ctx, userID, feedID)
 	}
 	return nil, nil
 }
 
-func (m *mockFeedService) UpdateFeedURL(ctx context.Context, feedID, newURL string) (*model.Feed, error) {
+func (m *mockFeedService) UpdateFeedURL(ctx context.Context, userID, feedID, newURL string) (*model.Feed, error) {
 	if m.updateFeedURLFn != nil {
-		return m.updateFeedURLFn(ctx, feedID, newURL)
+		return m.updateFeedURLFn(ctx, userID, feedID, newURL)
 	}
 	return nil, nil
 }
@@ -307,7 +307,10 @@ func TestFeedHandler_RegisterFeed_NoUserID_ReturnsUnauthorized(t *testing.T) {
 
 func TestFeedHandler_GetFeed_Success(t *testing.T) {
 	svc := &mockFeedService{
-		getFeedFn: func(ctx context.Context, feedID string) (*model.Feed, error) {
+		getFeedFn: func(ctx context.Context, userID, feedID string) (*model.Feed, error) {
+			if userID != "user-123" {
+				t.Errorf("userID = %q, want %q", userID, "user-123")
+			}
 			if feedID != "feed-id-1" {
 				t.Errorf("feedID = %q, want %q", feedID, "feed-id-1")
 			}
@@ -351,7 +354,7 @@ func TestFeedHandler_GetFeed_Success(t *testing.T) {
 
 func TestFeedHandler_GetFeed_NotFound(t *testing.T) {
 	svc := &mockFeedService{
-		getFeedFn: func(ctx context.Context, feedID string) (*model.Feed, error) {
+		getFeedFn: func(ctx context.Context, userID, feedID string) (*model.Feed, error) {
 			return nil, nil
 		},
 	}
@@ -378,7 +381,7 @@ func TestFeedHandler_GetFeed_NotFound(t *testing.T) {
 
 func TestFeedHandler_GetFeed_ServiceError_ReturnsInternalServerError(t *testing.T) {
 	svc := &mockFeedService{
-		getFeedFn: func(ctx context.Context, feedID string) (*model.Feed, error) {
+		getFeedFn: func(ctx context.Context, userID, feedID string) (*model.Feed, error) {
 			return nil, errors.New("database error")
 		},
 	}
@@ -398,11 +401,63 @@ func TestFeedHandler_GetFeed_ServiceError_ReturnsInternalServerError(t *testing.
 	}
 }
 
+// TestFeedHandler_GetFeed_NoUserID_ReturnsUnauthorized は未認証アクセスが401を返すことを検証する。
+func TestFeedHandler_GetFeed_NoUserID_ReturnsUnauthorized(t *testing.T) {
+	h := NewFeedHandler(&mockFeedService{}, &mockSubscriptionDeleter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/feeds/feed-id-1", nil)
+	// ユーザーIDを注入しない
+	req = withChiURLParam(req, "id", "feed-id-1")
+	w := httptest.NewRecorder()
+
+	h.GetFeed(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+// TestFeedHandler_GetFeed_OtherUsersFeed_ReturnsNotFound は他ユーザーのフィードに対する
+// GET が IDOR を避けるため 404 を返すことを検証する（リグレッションテスト for issue #34）。
+func TestFeedHandler_GetFeed_OtherUsersFeed_ReturnsNotFound(t *testing.T) {
+	svc := &mockFeedService{
+		// サービス層が認可チェックで購読なしと判定し nil, nil を返す想定。
+		getFeedFn: func(ctx context.Context, userID, feedID string) (*model.Feed, error) {
+			if userID != "user-attacker" {
+				t.Errorf("userID = %q, want %q", userID, "user-attacker")
+			}
+			return nil, nil
+		},
+	}
+
+	h := NewFeedHandler(svc, &mockSubscriptionDeleter{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/feeds/feed-of-other-user", nil)
+	req = withUserID(req, "user-attacker")
+	req = withChiURLParam(req, "id", "feed-of-other-user")
+	w := httptest.NewRecorder()
+
+	h.GetFeed(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+	errResp := parseAPIErrorResponse(t, w)
+	if errResp["code"] != "FEED_NOT_FOUND" {
+		t.Errorf("code = %q, want %q", errResp["code"], "FEED_NOT_FOUND")
+	}
+}
+
 // --- PATCH /api/feeds/:id テスト ---
 
 func TestFeedHandler_UpdateFeedURL_Success(t *testing.T) {
 	svc := &mockFeedService{
-		updateFeedURLFn: func(ctx context.Context, feedID, newURL string) (*model.Feed, error) {
+		updateFeedURLFn: func(ctx context.Context, userID, feedID, newURL string) (*model.Feed, error) {
+			if userID != "user-123" {
+				t.Errorf("userID = %q, want %q", userID, "user-123")
+			}
 			if feedID != "feed-id-1" {
 				t.Errorf("feedID = %q, want %q", feedID, "feed-id-1")
 			}
@@ -482,7 +537,7 @@ func TestFeedHandler_UpdateFeedURL_InvalidJSON_ReturnsBadRequest(t *testing.T) {
 
 func TestFeedHandler_UpdateFeedURL_FeedNotFound_ReturnsNotFound(t *testing.T) {
 	svc := &mockFeedService{
-		updateFeedURLFn: func(ctx context.Context, feedID, newURL string) (*model.Feed, error) {
+		updateFeedURLFn: func(ctx context.Context, userID, feedID, newURL string) (*model.Feed, error) {
 			return nil, &model.APIError{
 				Code:     "FEED_NOT_FOUND",
 				Message:  "Feed not found",
@@ -506,6 +561,64 @@ func TestFeedHandler_UpdateFeedURL_FeedNotFound_ReturnsNotFound(t *testing.T) {
 	resp := w.Result()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+// TestFeedHandler_UpdateFeedURL_NoUserID_ReturnsUnauthorized は未認証アクセスが401を返すことを検証する。
+func TestFeedHandler_UpdateFeedURL_NoUserID_ReturnsUnauthorized(t *testing.T) {
+	h := NewFeedHandler(&mockFeedService{}, &mockSubscriptionDeleter{})
+
+	body := `{"feed_url": "https://example.com/new-feed.xml"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/feeds/feed-id-1", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	// ユーザーIDを注入しない
+	req = withChiURLParam(req, "id", "feed-id-1")
+	w := httptest.NewRecorder()
+
+	h.UpdateFeedURL(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+// TestFeedHandler_UpdateFeedURL_OtherUsersFeed_ReturnsNotFound は他ユーザーのフィードに対する
+// PATCH が IDOR を避けるため 404 を返すことを検証する（リグレッションテスト for issue #34）。
+func TestFeedHandler_UpdateFeedURL_OtherUsersFeed_ReturnsNotFound(t *testing.T) {
+	svc := &mockFeedService{
+		// サービス層が認可チェックで購読なしと判定し FEED_NOT_FOUND を返す想定。
+		updateFeedURLFn: func(ctx context.Context, userID, feedID, newURL string) (*model.Feed, error) {
+			if userID != "user-attacker" {
+				t.Errorf("userID = %q, want %q", userID, "user-attacker")
+			}
+			return nil, &model.APIError{
+				Code:     "FEED_NOT_FOUND",
+				Message:  "指定されたフィードが見つかりません。",
+				Category: "feed",
+				Action:   "フィードIDを確認してください。",
+			}
+		},
+	}
+
+	h := NewFeedHandler(svc, &mockSubscriptionDeleter{})
+
+	body := `{"feed_url": "https://attacker.example.com/feed.xml"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/feeds/feed-of-other-user", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withUserID(req, "user-attacker")
+	req = withChiURLParam(req, "id", "feed-of-other-user")
+	w := httptest.NewRecorder()
+
+	h.UpdateFeedURL(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+	errResp := parseAPIErrorResponse(t, w)
+	if errResp["code"] != "FEED_NOT_FOUND" {
+		t.Errorf("code = %q, want %q", errResp["code"], "FEED_NOT_FOUND")
 	}
 }
 
@@ -675,7 +788,7 @@ func TestSetupFeedRoutes_RegisterEndpoint(t *testing.T) {
 
 func TestSetupFeedRoutes_GetEndpoint(t *testing.T) {
 	svc := &mockFeedService{
-		getFeedFn: func(ctx context.Context, feedID string) (*model.Feed, error) {
+		getFeedFn: func(ctx context.Context, userID, feedID string) (*model.Feed, error) {
 			return &model.Feed{
 				ID:      feedID,
 				FeedURL: "https://example.com/feed.xml",
@@ -700,7 +813,7 @@ func TestSetupFeedRoutes_GetEndpoint(t *testing.T) {
 
 func TestSetupFeedRoutes_PatchEndpoint(t *testing.T) {
 	svc := &mockFeedService{
-		updateFeedURLFn: func(ctx context.Context, feedID, newURL string) (*model.Feed, error) {
+		updateFeedURLFn: func(ctx context.Context, userID, feedID, newURL string) (*model.Feed, error) {
 			return &model.Feed{
 				ID:      feedID,
 				FeedURL: newURL,

--- a/internal/handler/integration_test.go
+++ b/internal/handler/integration_test.go
@@ -104,14 +104,14 @@ func createIntegrationRouter(state *integrationState) http.Handler {
 				state.subsByUser[userID] = append(state.subsByUser[userID], sub.ID)
 				return f, sub, nil
 			},
-			getFeedFn: func(ctx context.Context, feedID string) (*model.Feed, error) {
+			getFeedFn: func(ctx context.Context, userID, feedID string) (*model.Feed, error) {
 				f, ok := state.feeds[feedID]
 				if !ok {
 					return nil, nil
 				}
 				return f, nil
 			},
-			updateFeedURLFn: func(ctx context.Context, feedID, newURL string) (*model.Feed, error) {
+			updateFeedURLFn: func(ctx context.Context, userID, feedID, newURL string) (*model.Feed, error) {
 				f, ok := state.feeds[feedID]
 				if !ok {
 					return nil, &model.APIError{

--- a/internal/handler/router_full_test.go
+++ b/internal/handler/router_full_test.go
@@ -62,7 +62,7 @@ func createTestRouter() (http.Handler, *mockSessionFinderForRouter) {
 					FeedID: "feed-test-1",
 				}, nil
 			},
-			getFeedFn: func(ctx context.Context, feedID string) (*model.Feed, error) {
+			getFeedFn: func(ctx context.Context, userID, feedID string) (*model.Feed, error) {
 				return &model.Feed{
 					ID:      feedID,
 					FeedURL: "https://example.com/feed.xml",
@@ -70,7 +70,7 @@ func createTestRouter() (http.Handler, *mockSessionFinderForRouter) {
 					Title:   "Test Feed",
 				}, nil
 			},
-			updateFeedURLFn: func(ctx context.Context, feedID, newURL string) (*model.Feed, error) {
+			updateFeedURLFn: func(ctx context.Context, userID, feedID, newURL string) (*model.Feed, error) {
 				return &model.Feed{
 					ID:      feedID,
 					FeedURL: newURL,


### PR DESCRIPTION
## Summary
- `GET /api/feeds/{id}` / `PATCH /api/feeds/{id}` にオーナーシップ（購読）チェックを追加し、IDOR/Broken Access Control を修正
- サービス層 `FeedService.GetFeed` / `UpdateFeedURL` のシグネチャに `userID` を追加し、`subscriptions` を参照して購読がない場合は権限の有無を漏らさないよう `FEED_NOT_FOUND` (404) を返す
- ハンドラーで `middleware.UserIDFromContext` により `userID` を取得し、未認証時は 401 を返す (`DeleteFeed` と同じパターンに統一)

## 背景
`feeds` は購読者間で共有されるレコードのため、認可チェックが無いと、認証済みの任意ユーザーが他人が購読しているフィードの URL を書き換え可能で、書き換え先のコンテンツが全購読者に配信されうる（フィッシング/マルウェア配信の踏み台）。Closes #34

## Test plan
- [x] `go build ./...` / `go vet ./...` がクリーン
- [x] `go test ./...` 全パッケージ PASS
- [x] リグレッションテスト追加
  - `TestFeedService_GetFeed_NotSubscribed_ReturnsNil`
  - `TestFeedService_UpdateFeedURL_NotSubscribed_ReturnsNotFound` (URL が書き換えられないことも検証)
  - `TestFeedHandler_GetFeed_OtherUsersFeed_ReturnsNotFound`
  - `TestFeedHandler_UpdateFeedURL_OtherUsersFeed_ReturnsNotFound`
  - `TestFeedHandler_GetFeed_NoUserID_ReturnsUnauthorized`
  - `TestFeedHandler_UpdateFeedURL_NoUserID_ReturnsUnauthorized`

🤖 Generated with [Claude Code](https://claude.com/claude-code)