### PR TITLE
ci: develop ブランチでもテストを実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   backend:


### PR DESCRIPTION
## 概要

gitflow 運用で idd-claude が作成する PR は `develop` 宛になるが、現状の `ci.yml` は `main` への push / PR でしかトリガーされず、**develop 向け PR でテストが一切実行されない**。本 PR でトリガーに `develop` を追加し、develop でも `Backend Tests` / `Frontend Tests` が走るようにする。

## 変更内容

```diff
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
```

## なぜ必要か

- develop 宛 PR にチェックが付かないと、`MERGE_QUEUE_*` / `AUTO_REBASE_MODE=claude` がチェック結果を基に merge 可否を判断できず、無検証 merge や待ち続けのリスクがある
- gitflow（develop 統合 → main リリース）で develop の健全性を担保する

## 確認事項

- この PR 自体は head ブランチの更新後トリガー定義で評価されるため、develop 宛でも CI が走る想定
- develop→main 自動昇格（promote pipeline）は別途 System Test 整備が必要で本 PR のスコープ外

🤖 Generated with [Claude Code](https://claude.com/claude-code)