### PR TITLE
feat(#20): config の環境変数パース失敗時に警告ログを出力する

### DIFF
--- a/docs/specs/20-config/impl-notes.md
+++ b/docs/specs/20-config/impl-notes.md
@@ -1,0 +1,72 @@
+# 実装ノート（Issue #20: config パース失敗時の警告ログ）
+
+## 実装概要
+
+`internal/config/config.go` の数値・期間系ヘルパー `getEnvInt` / `getEnvInt64` /
+`getEnvDuration` について、環境変数のパースに失敗した分岐（`err != nil`）でデフォルト値へ
+フォールバックする直前に `slog.Warn` を 1 件出力するようにした。
+
+- 環境変数が未設定（`v == ""`）の分岐ではログを出さない（正常系の挙動を維持）
+- 正常パース時もログを出さない
+- 各ヘルパーのシグネチャ・フォールバック挙動・デフォルト値は変更していない（NFR 1）
+- パッケージ関数 `slog.Warn(...)`（グローバルデフォルトロガー）を使用。logger 未初期化でも
+  stdlib のデフォルトハンドラが存在するため panic しない（NFR 2）
+
+## 採用したログフィールド名（構造化フィールド / NFR 3）
+
+メッセージ: `環境変数のパースに失敗したためデフォルト値を採用します`（日本語、既存 slog 慣習に準拠）
+
+| フィールド key | 型 | 内容 |
+|---|---|---|
+| `key` | string | 対象の環境変数キー名 |
+| `value` | string | 設定されていた不正値（生の文字列） |
+| `default` | int / int64 / Duration | 採用したデフォルト値（`slog.Int` / `slog.Int64` / `slog.Duration` で型に応じて出力） |
+
+既存コード（`internal/app/app.go` 等）が `slog.String` / `slog.Int` / `slog.Duration` の型付き
+ヘルパーで構造化フィールドを出力している慣習に合わせ、フィールド key は英語とした。
+
+## テスト方針
+
+`internal/config/config_test.go` に近傍配置。`slog.Record` を収集する `captureHandler`
+（独自 `slog.Handler` 実装）を `slog.SetDefault` で差し込み、`t.Cleanup` で元の default logger を
+復元する。各ヘルパーごとに以下のサブテストを `t.Run("<条件>のとき<期待結果>", ...)` 形式で用意:
+
+- 不正値のときデフォルト値を採用し Warn を 1 件出力する（異常系）
+- 不正値のとき Warn ログに `key` / `value` / `default` を構造化フィールドで含める（異常系・構造化検証）
+- 正常値のとき値を採用し Warn を出力しない（正常系）
+- 未設定（空文字）のときデフォルト値を採用し Warn を出力しない（境界値）
+
+## 受入基準とテストの対応
+
+| Requirement ID | 内容 | 担保するテスト |
+|---|---|---|
+| 1.1 | int 不正値でデフォルト採用 | `TestGetEnvInt/不正値のときデフォルト値を採用しWarnを1件出力する` |
+| 1.2 | int 不正値で Warn 1 件 | 同上 |
+| 1.3 | int Warn にキー名・不正値・デフォルト値を構造化フィールドで含む | `TestGetEnvInt/不正値のときWarnログにキー名・不正値・デフォルト値を構造化フィールドで含める` |
+| 2.1 | int64 不正値でデフォルト採用 | `TestGetEnvInt64/不正値のときデフォルト値を採用しWarnを1件出力する` |
+| 2.2 | int64 不正値で Warn 1 件 | 同上 |
+| 2.3 | int64 Warn に構造化フィールド | `TestGetEnvInt64/不正値のときWarnログにキー名・不正値・デフォルト値を構造化フィールドで含める` |
+| 3.1 | duration 不正値でデフォルト採用 | `TestGetEnvDuration/不正値のときデフォルト値を採用しWarnを1件出力する` |
+| 3.2 | duration 不正値で Warn 1 件 | 同上 |
+| 3.3 | duration Warn に構造化フィールド | `TestGetEnvDuration/不正値のときWarnログにキー名・不正値・デフォルト値を構造化フィールドで含める` |
+| 4.1 | 正常値を採用 | 各 `Test*/正常値のとき値を採用しWarnを出力しない` |
+| 4.2 | 正常値で Warn を出さない | 各 `Test*/正常値のとき値を採用しWarnを出力しない` |
+| 4.3 | 未設定でデフォルト採用 | 各 `Test*/未設定（空文字）のときデフォルト値を採用しWarnを出力しない` |
+| 4.4 | 未設定で Warn を出さない | 各 `Test*/未設定（空文字）のときデフォルト値を採用しWarnを出力しない` |
+| NFR 1 | 既存挙動維持（シグネチャ・フォールバック・デフォルト値不変） | 既存 `TestLoad_DefaultValues` / `TestLoad_CustomValues` が引き続き green |
+| NFR 2 | ログ初期化前後で panic しない | グローバル `slog.Warn` を使用（stdlib デフォルトハンドラで panic 回避）。テストは default logger 差し替えで安全に検証 |
+| NFR 3 | 機械検索可能な構造化フィールド | `key` / `value` / `default` を独立フィールドで出力（構造化検証テストで担保） |
+
+## 検証結果
+
+- `gofmt -l internal/config/`: 未整形なし
+- `go vet ./internal/config/...`: pass
+- `go test ./internal/config/...`: pass
+- `go build ./...`: pass
+- `go test ./...`: 全パッケージ pass（既存テストの破壊なし）
+
+## 確認事項
+
+- なし（要件・スコープが Issue 本文で確定しており、設計上の曖昧点は発生しなかった）
+
+STATUS: complete

--- a/docs/specs/20-config/requirements.md
+++ b/docs/specs/20-config/requirements.md
@@ -1,0 +1,80 @@
+# Requirements Document
+
+## Introduction
+
+`internal/config` は環境変数からアプリケーション設定を起動時に 1 回読み込む。数値・期間系の
+オプション設定を読む補助関数（`getEnvInt` / `getEnvInt64` / `getEnvDuration`）は、環境変数に
+不正な値が設定されていてもサイレントにデフォルト値へフォールバックするため、運用者は設定
+ミス（typo・不正フォーマット）に気づけず、「設定したはずの値が反映されない」原因の切り分けが
+困難になっている。本要件は、パース失敗時に構造化された警告ログを出力して運用者が異常を検知
+できるようにする。既存のフォールバック挙動・補助関数のシグネチャは維持し、起動を中断しない。
+
+## Requirements
+
+### Requirement 1: 整数パース失敗時の警告ログ出力
+
+**Objective:** As a 運用者, I want 整数型の設定環境変数が不正値だったときに警告ログを得る, so that 設定ミスに気づいてデフォルト値が採用されたことを検知できる
+
+#### Acceptance Criteria
+
+1. If 整数型の設定環境変数に整数として解釈できない値が設定されている, the Config Loader shall 当該設定でデフォルト値を採用する
+2. If 整数型の設定環境変数に整数として解釈できない値が設定されている, the Config Loader shall 警告レベルのログを 1 件出力する
+3. When 整数パース失敗の警告ログを出力する, the Config Loader shall ログに対象の環境変数キー名・設定されていた不正値・採用したデフォルト値を構造化フィールドとして含める
+
+### Requirement 2: 64bit 整数パース失敗時の警告ログ出力
+
+**Objective:** As a 運用者, I want 64bit 整数型の設定環境変数が不正値だったときに警告ログを得る, so that サイズ系設定の入力ミスを検知できる
+
+#### Acceptance Criteria
+
+1. If 64bit 整数型の設定環境変数に整数として解釈できない値が設定されている, the Config Loader shall 当該設定でデフォルト値を採用する
+2. If 64bit 整数型の設定環境変数に整数として解釈できない値が設定されている, the Config Loader shall 警告レベルのログを 1 件出力する
+3. When 64bit 整数パース失敗の警告ログを出力する, the Config Loader shall ログに対象の環境変数キー名・設定されていた不正値・採用したデフォルト値を構造化フィールドとして含める
+
+### Requirement 3: 期間（Duration）パース失敗時の警告ログ出力
+
+**Objective:** As a 運用者, I want 期間型の設定環境変数が不正値だったときに警告ログを得る, so that タイムアウト・間隔系設定の入力ミスを検知できる
+
+#### Acceptance Criteria
+
+1. If 期間型の設定環境変数を期間値として解釈できない値が設定されている, the Config Loader shall 当該設定でデフォルト値を採用する
+2. If 期間型の設定環境変数を期間値として解釈できない値が設定されている, the Config Loader shall 警告レベルのログを 1 件出力する
+3. When 期間パース失敗の警告ログを出力する, the Config Loader shall ログに対象の環境変数キー名・設定されていた不正値・採用したデフォルト値を構造化フィールドとして含める
+
+### Requirement 4: 正常系・未設定時のログ抑制と既存挙動維持
+
+**Objective:** As a 運用者, I want 正常な設定や未設定の場合に余計な警告ログが出ない, so that 警告ログを設定ミスの信号として信頼できる
+
+#### Acceptance Criteria
+
+1. When 整数・64bit 整数・期間いずれかの設定環境変数に正しく解釈できる値が設定されている, the Config Loader shall 当該の値を採用する
+2. When 設定環境変数に正しく解釈できる値が設定されている, the Config Loader shall パース失敗の警告ログを出力しない
+3. While 設定環境変数が未設定（空文字）の状態, the Config Loader shall デフォルト値を採用する
+4. While 設定環境変数が未設定（空文字）の状態, the Config Loader shall パース失敗の警告ログを出力しない
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The Config Loader shall 各補助関数の入出力（環境変数キー・デフォルト値を受け取り、採用値を返す）と、パース失敗時にデフォルト値へフォールバックする挙動を本機能導入前と同一に保つ
+2. The Config Loader shall 設定項目の追加・削除およびデフォルト値の変更を行わない
+
+### NFR 2: 起動順序への非依存
+
+1. While ログ初期化前後のいずれの状態, the Config Loader shall パース失敗ログ出力処理によって panic せず設定読み込みを完了する
+
+### NFR 3: 可観測性
+
+1. When パース失敗の警告ログを出力する, the Config Loader shall 機械的に検索・集計可能な構造化フィールド形式（キー名・不正値・デフォルト値を独立したフィールドとして）で出力する
+
+## Out of Scope
+
+- パース失敗を fatal error として起動を中断する挙動への変更（現状のデフォルト値フォールバックを維持する）
+- 設定項目の追加・削除、デフォルト値の見直し
+- 必須環境変数（未設定時にエラーを返すフィールド）に関する挙動変更
+- 文字列型・bool 型など、パース失敗の概念を持たない設定の扱いの変更
+- ログ出力先・フォーマット・ログレベル閾値そのものの再設計（既存のログ基盤に準拠する）
+
+## Open Questions
+
+- なし（Issue 本文の受入基準・制約・スコープ除外で要件は確定でき、コメントには人間による追加の決定事項は存在しない）

--- a/docs/specs/20-config/review-notes.md
+++ b/docs/specs/20-config/review-notes.md
@@ -1,0 +1,38 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-25T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-20-impl-config
+- HEAD commit: 8ca386ba894e55497b6e46632e97153078a8825e
+- Compared to: develop..HEAD
+
+## Verified Requirements
+
+- 1.1 — `internal/config/config.go:140`（getEnvInt の err 分岐で defaultVal を返す）／`config_test.go` `TestGetEnvInt/不正値のときデフォルト値を採用しWarnを1件出力する` が `got == defaultVal` を assert
+- 1.2 — `config.go:135-139`（slog.Warn を 1 件）／同テストが `len(warnRecords()) == 1` を assert
+- 1.3 — `config.go:136-138`（slog.String("key") / slog.String("value") / slog.Int("default")）／`TestGetEnvInt/不正値のときWarnログにキー名・不正値・デフォルト値を構造化フィールドで含める` が key/value/default を assert
+- 2.1 — `config.go:157`（getEnvInt64 の err 分岐で defaultVal）／`TestGetEnvInt64/不正値のときデフォルト値を採用しWarnを1件出力する`
+- 2.2 — `config.go:152-156`（slog.Warn 1 件）／同テストが warn 件数 1 を assert
+- 2.3 — `config.go:153-155`（slog.Int64("default")）／`TestGetEnvInt64/...構造化フィールドで含める`
+- 3.1 — `config.go:174`（getEnvDuration の err 分岐で defaultVal）／`TestGetEnvDuration/不正値のときデフォルト値を採用しWarnを1件出力する`
+- 3.2 — `config.go:169-173`（slog.Warn 1 件）／同テストが warn 件数 1 を assert
+- 3.3 — `config.go:170-172`（slog.Duration("default")）／`TestGetEnvDuration/...構造化フィールドで含める`
+- 4.1 — 各ヘルパーの success path（パース値を返す）／各 `Test*/正常値のとき値を採用しWarnを出力しない` が採用値を assert
+- 4.2 — success path で slog.Warn を呼ばない／同テストが `len(warnRecords()) == 0` を assert
+- 4.3 — `config.go:130/147/164`（v == "" で early return defaultVal）／各 `Test*/未設定（空文字）のときデフォルト値を採用しWarnを出力しない`
+- 4.4 — 空文字 early return は err 分岐に到達しないため Warn なし／同テストが warn 件数 0 を assert
+- NFR 1 — 3 ヘルパーのシグネチャ・フォールバック挙動・デフォルト値はいずれも未変更（diff は err 分岐内の Warn 追加のみ）。既存 `TestLoad_DefaultValues` / `TestLoad_CustomValues` は変更なしで green
+- NFR 2 — グローバル `slog.Warn`（stdlib デフォルトハンドラ）を使用し logger 未初期化でも panic しない設計／テストは `slog.SetDefault` 差し替えと `t.Cleanup` 復元で安全に検証
+- NFR 3 — key / value / default を独立した構造化フィールドとして出力（構造化検証テストで担保）
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric AC（1.1〜4.4）および NFR 1〜3 に対し、`internal/config/config.go` の実装と `config_test.go` の正常系・異常系・境界値（空文字）テストが 1:1 で対応している。`go test ./internal/config/...` は green。変更は `internal/config/` に閉じており、tasks.md は存在しないため boundary 制約の対象外。3 カテゴリいずれの reject 理由も検出されなかった。
+
+RESULT: approve

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -131,6 +132,11 @@ func getEnvInt(key string, defaultVal int) int {
 	}
 	i, err := strconv.Atoi(v)
 	if err != nil {
+		slog.Warn("環境変数のパースに失敗したためデフォルト値を採用します",
+			slog.String("key", key),
+			slog.String("value", v),
+			slog.Int("default", defaultVal),
+		)
 		return defaultVal
 	}
 	return i
@@ -143,6 +149,11 @@ func getEnvInt64(key string, defaultVal int64) int64 {
 	}
 	i, err := strconv.ParseInt(v, 10, 64)
 	if err != nil {
+		slog.Warn("環境変数のパースに失敗したためデフォルト値を採用します",
+			slog.String("key", key),
+			slog.String("value", v),
+			slog.Int64("default", defaultVal),
+		)
 		return defaultVal
 	}
 	return i
@@ -155,6 +166,11 @@ func getEnvDuration(key string, defaultVal time.Duration) time.Duration {
 	}
 	d, err := time.ParseDuration(v)
 	if err != nil {
+		slog.Warn("環境変数のパースに失敗したためデフォルト値を採用します",
+			slog.String("key", key),
+			slog.String("value", v),
+			slog.Duration("default", defaultVal),
+		)
 		return defaultVal
 	}
 	return d

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,9 +1,70 @@
 package config
 
 import (
+	"context"
+	"log/slog"
 	"testing"
 	"time"
 )
+
+// captureHandler はテスト中の slog.Record を収集する slog.Handler 実装。
+// パース失敗時の Warn ログ出力（件数・レベル・構造化フィールド）を検証するために使う。
+type captureHandler struct {
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+
+func (h *captureHandler) WithGroup(_ string) slog.Handler { return h }
+
+// warnRecords は Warn レベルのレコードのみを返す。
+func (h *captureHandler) warnRecords() []slog.Record {
+	var out []slog.Record
+	for _, r := range h.records {
+		if r.Level == slog.LevelWarn {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// installCaptureLogger はデフォルトロガーをテスト用の captureHandler に差し替え、
+// t.Cleanup で元のロガーを復元する。返り値のハンドラから収集レコードを参照する。
+func installCaptureLogger(t *testing.T) *captureHandler {
+	t.Helper()
+	prev := slog.Default()
+	h := &captureHandler{}
+	slog.SetDefault(slog.New(h))
+	t.Cleanup(func() {
+		slog.SetDefault(prev)
+	})
+	return h
+}
+
+// attrValue はレコードから指定キーの属性値（文字列表現）を取り出す。
+// キーが存在しない場合は ok=false を返す。
+func attrValue(r slog.Record, key string) (string, bool) {
+	var (
+		val   string
+		found bool
+	)
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == key {
+			val = a.Value.String()
+			found = true
+			return false
+		}
+		return true
+	})
+	return val, found
+}
 
 func setRequiredEnvVars(t *testing.T) {
 	t.Helper()
@@ -219,5 +280,249 @@ func TestLoad_MissingBaseURL_ReturnsError(t *testing.T) {
 	_, err := Load()
 	if err == nil {
 		t.Fatal("expected error for missing BASE_URL, got nil")
+	}
+}
+
+// TestGetEnvInt は getEnvInt のパース失敗時警告ログ・フォールバック・正常系を検証する。
+// Requirement 1 (1.1/1.2/1.3) と Requirement 4 (4.1/4.2/4.3/4.4) に対応。
+func TestGetEnvInt(t *testing.T) {
+	const key = "TEST_GET_ENV_INT"
+	const defaultVal = 42
+
+	t.Run("不正値のときデフォルト値を採用しWarnを1件出力する", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "not-an-int")
+
+		// Act
+		got := getEnvInt(key, defaultVal)
+
+		// Assert
+		if got != defaultVal {
+			t.Errorf("got = %d, want %d (default fallback)", got, defaultVal)
+		}
+		if n := len(h.warnRecords()); n != 1 {
+			t.Fatalf("warn records = %d, want 1", n)
+		}
+	})
+
+	t.Run("不正値のときWarnログにキー名・不正値・デフォルト値を構造化フィールドで含める", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "not-an-int")
+
+		// Act
+		getEnvInt(key, defaultVal)
+
+		// Assert
+		recs := h.warnRecords()
+		if len(recs) != 1 {
+			t.Fatalf("warn records = %d, want 1", len(recs))
+		}
+		r := recs[0]
+		assertAttr(t, r, "key", key)
+		assertAttr(t, r, "value", "not-an-int")
+		assertAttr(t, r, "default", "42")
+	})
+
+	t.Run("正常値のとき値を採用しWarnを出力しない", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "100")
+
+		// Act
+		got := getEnvInt(key, defaultVal)
+
+		// Assert
+		if got != 100 {
+			t.Errorf("got = %d, want %d", got, 100)
+		}
+		if n := len(h.warnRecords()); n != 0 {
+			t.Errorf("warn records = %d, want 0", n)
+		}
+	})
+
+	t.Run("未設定（空文字）のときデフォルト値を採用しWarnを出力しない", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "")
+
+		// Act
+		got := getEnvInt(key, defaultVal)
+
+		// Assert
+		if got != defaultVal {
+			t.Errorf("got = %d, want %d (default fallback)", got, defaultVal)
+		}
+		if n := len(h.warnRecords()); n != 0 {
+			t.Errorf("warn records = %d, want 0", n)
+		}
+	})
+}
+
+// TestGetEnvInt64 は getEnvInt64 のパース失敗時警告ログ・フォールバック・正常系を検証する。
+// Requirement 2 (2.1/2.2/2.3) と Requirement 4 に対応。
+func TestGetEnvInt64(t *testing.T) {
+	const key = "TEST_GET_ENV_INT64"
+	const defaultVal int64 = 5242880
+
+	t.Run("不正値のときデフォルト値を採用しWarnを1件出力する", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "12.5")
+
+		// Act
+		got := getEnvInt64(key, defaultVal)
+
+		// Assert
+		if got != defaultVal {
+			t.Errorf("got = %d, want %d (default fallback)", got, defaultVal)
+		}
+		if n := len(h.warnRecords()); n != 1 {
+			t.Fatalf("warn records = %d, want 1", n)
+		}
+	})
+
+	t.Run("不正値のときWarnログにキー名・不正値・デフォルト値を構造化フィールドで含める", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "12.5")
+
+		// Act
+		getEnvInt64(key, defaultVal)
+
+		// Assert
+		recs := h.warnRecords()
+		if len(recs) != 1 {
+			t.Fatalf("warn records = %d, want 1", len(recs))
+		}
+		r := recs[0]
+		assertAttr(t, r, "key", key)
+		assertAttr(t, r, "value", "12.5")
+		assertAttr(t, r, "default", "5242880")
+	})
+
+	t.Run("正常値のとき値を採用しWarnを出力しない", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "10485760")
+
+		// Act
+		got := getEnvInt64(key, defaultVal)
+
+		// Assert
+		if got != 10485760 {
+			t.Errorf("got = %d, want %d", got, 10485760)
+		}
+		if n := len(h.warnRecords()); n != 0 {
+			t.Errorf("warn records = %d, want 0", n)
+		}
+	})
+
+	t.Run("未設定（空文字）のときデフォルト値を採用しWarnを出力しない", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "")
+
+		// Act
+		got := getEnvInt64(key, defaultVal)
+
+		// Assert
+		if got != defaultVal {
+			t.Errorf("got = %d, want %d (default fallback)", got, defaultVal)
+		}
+		if n := len(h.warnRecords()); n != 0 {
+			t.Errorf("warn records = %d, want 0", n)
+		}
+	})
+}
+
+// TestGetEnvDuration は getEnvDuration のパース失敗時警告ログ・フォールバック・正常系を検証する。
+// Requirement 3 (3.1/3.2/3.3) と Requirement 4 に対応。
+func TestGetEnvDuration(t *testing.T) {
+	const key = "TEST_GET_ENV_DURATION"
+	const defaultVal = 10 * time.Second
+
+	t.Run("不正値のときデフォルト値を採用しWarnを1件出力する", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "10sec")
+
+		// Act
+		got := getEnvDuration(key, defaultVal)
+
+		// Assert
+		if got != defaultVal {
+			t.Errorf("got = %v, want %v (default fallback)", got, defaultVal)
+		}
+		if n := len(h.warnRecords()); n != 1 {
+			t.Fatalf("warn records = %d, want 1", n)
+		}
+	})
+
+	t.Run("不正値のときWarnログにキー名・不正値・デフォルト値を構造化フィールドで含める", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "10sec")
+
+		// Act
+		getEnvDuration(key, defaultVal)
+
+		// Assert
+		recs := h.warnRecords()
+		if len(recs) != 1 {
+			t.Fatalf("warn records = %d, want 1", len(recs))
+		}
+		r := recs[0]
+		assertAttr(t, r, "key", key)
+		assertAttr(t, r, "value", "10sec")
+		assertAttr(t, r, "default", (10 * time.Second).String())
+	})
+
+	t.Run("正常値のとき値を採用しWarnを出力しない", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "30s")
+
+		// Act
+		got := getEnvDuration(key, defaultVal)
+
+		// Assert
+		if got != 30*time.Second {
+			t.Errorf("got = %v, want %v", got, 30*time.Second)
+		}
+		if n := len(h.warnRecords()); n != 0 {
+			t.Errorf("warn records = %d, want 0", n)
+		}
+	})
+
+	t.Run("未設定（空文字）のときデフォルト値を採用しWarnを出力しない", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "")
+
+		// Act
+		got := getEnvDuration(key, defaultVal)
+
+		// Assert
+		if got != defaultVal {
+			t.Errorf("got = %v, want %v (default fallback)", got, defaultVal)
+		}
+		if n := len(h.warnRecords()); n != 0 {
+			t.Errorf("warn records = %d, want 0", n)
+		}
+	})
+}
+
+// assertAttr はレコードに指定キーの属性が存在し、値が期待文字列と一致することを検証する。
+func assertAttr(t *testing.T, r slog.Record, key, want string) {
+	t.Helper()
+	got, ok := attrValue(r, key)
+	if !ok {
+		t.Errorf("attribute %q not found in record", key)
+		return
+	}
+	if got != want {
+		t.Errorf("attribute %q = %q, want %q", key, got, want)
 	}
 }


### PR DESCRIPTION
## 概要

`internal/config` の数値・期間系補助関数（`getEnvInt` / `getEnvInt64` / `getEnvDuration`）は、
環境変数の値が不正なフォーマットだった場合にサイレントにデフォルト値へフォールバックしていた。
この挙動のため、運用者が設定ミス（typo・不正フォーマット）に気づけず、「設定したはずの値が
反映されない」問題の切り分けが困難になっていた。

本 PR では、各補助関数のパース失敗分岐（`err != nil`）において `slog.Warn` を 1 件出力し、
対象の環境変数キー名・不正値・採用したデフォルト値を構造化フィールドで記録する。
既存のフォールバック挙動・補助関数のシグネチャ・デフォルト値は変更しない。
正常値・未設定（空文字）の場合は警告ログを出力しない。

## 対応 Issue

Closes #20

## 関連 PR

なし（Architect 非起動のため設計 PR は作成されていない）

## 実装内容

- (Req 1.1〜1.3 / NFR 1〜3) `getEnvInt` のパース失敗時に `slog.Warn` を 1 件出力（`key` / `value` / `default` を構造化フィールドで記録）
- (Req 2.1〜2.3 / NFR 1〜3) `getEnvInt64` のパース失敗時に `slog.Warn` を 1 件出力（`slog.Int64` でデフォルト値フィールドを出力）
- (Req 3.1〜3.3 / NFR 1〜3) `getEnvDuration` のパース失敗時に `slog.Warn` を 1 件出力（`slog.Duration` でデフォルト値フィールドを出力）
- (Req 4.1〜4.4) 正常値・未設定（空文字）時は Warn を出力しない（既存の early return 分岐はそのまま維持）
- (NFR 2) グローバル `slog.Warn` を使用することで、ログ初期化前後を問わず panic せず動作

## 受入基準チェック

- [x] Req 1.1: If 整数型の設定環境変数に整数として解釈できない値が設定されている, the Config Loader shall 当該設定でデフォルト値を採用する ← `TestGetEnvInt/不正値のときデフォルト値を採用しWarnを1件出力する`
- [x] Req 1.2: If 整数型の設定環境変数に整数として解釈できない値が設定されている, the Config Loader shall 警告レベルのログを 1 件出力する ← 同上（`len(warnRecords()) == 1` を assert）
- [x] Req 1.3: When 整数パース失敗の警告ログを出力する, the Config Loader shall ログに環境変数キー名・不正値・デフォルト値を構造化フィールドとして含める ← `TestGetEnvInt/不正値のときWarnログにキー名・不正値・デフォルト値を構造化フィールドで含める`
- [x] Req 2.1〜2.3: int64 版の対称的な AC ← `TestGetEnvInt64` の各サブテスト
- [x] Req 3.1〜3.3: duration 版の対称的な AC ← `TestGetEnvDuration` の各サブテスト
- [x] Req 4.1: When 正常値が設定されている, the Config Loader shall 当該の値を採用する ← 各 `Test*/正常値のとき値を採用しWarnを出力しない`
- [x] Req 4.2: When 正常値が設定されている, the Config Loader shall パース失敗の警告ログを出力しない ← 同上（`len(warnRecords()) == 0` を assert）
- [x] Req 4.3: While 設定環境変数が未設定（空文字）, the Config Loader shall デフォルト値を採用する ← 各 `Test*/未設定（空文字）のときデフォルト値を採用しWarnを出力しない`
- [x] Req 4.4: While 設定環境変数が未設定（空文字）, the Config Loader shall パース失敗の警告ログを出力しない ← 同上
- [x] NFR 1: The Config Loader shall 各補助関数の入出力・フォールバック挙動を本機能導入前と同一に保つ ← 既存 `TestLoad_DefaultValues` / `TestLoad_CustomValues` が引き続き green

## テスト結果

```
ok  	github.com/hitoshi/feedman/internal/config	(cached)
```

`go test ./internal/config/...` 全件 pass（新規サブテスト 12 件 + 既存テスト維持確認済み）

## 実装上の判断

- ログ出力には `slog.Warn`（パッケージ関数・グローバルデフォルトロガー）を使用。`config.go` は
  ロガーのインスタンスを持たないため、logger 未初期化の起動シーケンスでも panic しない（NFR 2）。
- 既存コード（`internal/app/app.go` 等）が `slog.String` / `slog.Int` / `slog.Duration` の型付き
  ヘルパーを使っている慣習に合わせ、デフォルト値フィールドは型に応じて `slog.Int` / `slog.Int64` /
  `slog.Duration` を使い分けた（NFR 3: 機械的に検索・集計可能な構造化フィールド）。
- フィールドキー名は英語（`key` / `value` / `default`）で統一。既存の構造化フィールド慣習に準拠。

詳細は `docs/specs/20-config/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- Reviewer 独立レビュー（Round 1）は approve 済み。詳細は `docs/specs/20-config/review-notes.md` を参照。
- 確認事項：なし（requirements.md の Open Questions および impl-notes.md の確認事項ともに「なし」）
- base ブランチ: `--base develop` を明示して作成。作成後 `baseRefName` を検証済み。

---

この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #20 のコメントを参照してください。
