### PR TITLE
feat(#2): DB コネクションプール上限設定を追加（MaxOpenConns/MaxIdleConns/ConnMaxLifetime）

### DIFF
--- a/docs/specs/2-db/impl-notes.md
+++ b/docs/specs/2-db/impl-notes.md
@@ -1,0 +1,55 @@
+# 実装ノート: Issue #2 DB コネクションプール設定を追加
+
+## 採用値と根拠
+
+`internal/database/db.go` にパッケージレベルの名前付き定数として以下を定義し、`Open` 内で適用した。
+
+| 定数 | 値 | 根拠 |
+|---|---|---|
+| `maxOpenConns` | 25 | api 25 + worker 25 = 50 ≤ PostgreSQL `max_connections`（既定 100）。マイグレーション/管理接続の余裕も確保 |
+| `maxIdleConns` | 10 | アイドル接続を際限なく保持しないため `maxOpenConns` 以下に抑制（Requirement 2.2） |
+| `connMaxLifetime` | 5 * time.Minute | 長寿命接続を一定時間で再確立し、NW 機器/DB 側タイムアウトによる断線を顕在化させない（Requirement 3） |
+
+オーケストレーター確定済みの設計判断（Open Questions への回答）に従い:
+
+- **環境変数化はしない**: `internal/database` パッケージ内のパッケージレベル定数として固定。`internal/config` への追加・env 読み込みはしない（Requirement 4.1 「名前付き定数として明示」/ 4.2 シグネチャ後方互換）。
+- **api/worker 共通値**: 共通の `Open` を両プロセスが呼ぶ現状を維持。プロセス別の差別化はしない。
+- `Open` のシグネチャ `func Open(databaseURL string) (*sql.DB, error)` は変更せず、`internal/app/app.go:90`（runServe）/ `:215`（runWorker）の呼び出し側は無変更で動作する（Requirement 4.3 / NFR 2.1）。
+
+## テスト方針
+
+`internal/database/db_test.go` を拡張。既存テスト（`TestOpen_ReturnsDBForAnyURL` / `TestOpen_WithValidURL_ReturnsDB`）は無変更で維持。実 DB 接続は行わず、`sql.Open` が接続を試行しない前提を保持。
+
+### `db.Stats()` の getter 制約
+
+`*sql.DB` には設定値の公開 getter が一部しか存在しない:
+
+- `db.Stats().MaxOpenConnections` は**公開取得可能** → `Open` 後の `*sql.DB` で `MaxOpenConns = 25` が設定されていることを実物に最も近い形で検証（`TestOpen_SetsMaxOpenConns`）。
+- `MaxIdleConns` / `ConnMaxLifetime` には**公開 getter が無い** → パッケージ内テストから**定数の不変条件**として検証する（`maxIdleConns > 0` かつ `maxIdleConns <= maxOpenConns`、`connMaxLifetime > 0`）。
+- 2 プロセス合算 ≤ 100 の AC は定数不変条件（`2 * maxOpenConns <= 100`）として検証する。
+
+Red→Green を確認済み（実装前は定数未定義でコンパイルエラー、実装後に全テスト pass）。
+
+## 受入基準とテストの対応
+
+| Requirement ID | 担保するテスト |
+|---|---|
+| 1.1 / 1.2 | `TestOpen_SetsMaxOpenConns`（実物 `db.Stats().MaxOpenConnections == 25`）/ `TestPoolConstants_AreFinitePositive`（maxOpenConns > 0） |
+| 1.3 / NFR 1.1 | `TestPoolConstants_TwoProcessSumWithinMaxConnections`（`2 * maxOpenConns <= 100`） |
+| 2.1 / 2.2 | `TestPoolConstants_AreFinitePositive`（maxIdleConns > 0 かつ <= maxOpenConns）|
+| 3.1 / 3.2 | `TestPoolConstants_AreFinitePositive`（connMaxLifetime > 0）|
+| 4.1 | パッケージレベル名前付き定数として定義（コード上で担保）|
+| 4.2 / 4.3 / NFR 2.1 | `Open` シグネチャ無変更。`go test ./internal/app/...` を含む全体テストが green（呼び出し側無変更で動作）|
+
+## 検証結果
+
+- `gofmt -l internal/database/`: 差分なし
+- `go vet ./internal/database/...`: 通過
+- `go test ./internal/database/...`: ok
+- `go test ./...`: 全パッケージ ok（既存テストの破壊なし）
+
+## 確認事項
+
+- 同時接続数上限は確定済み設計判断に従い 25 とした。将来のスケール（複数 worker インスタンス等）で 2 プロセスを超える同時稼働が発生する場合、合算上限が 100 を超え得るため、その際は値の再調整または環境変数化（要シグネチャ後方互換の再検討）を別 Issue として検討する余地がある（requirements.md の Open Questions に対応）。
+
+STATUS: complete

--- a/docs/specs/2-db/requirements.md
+++ b/docs/specs/2-db/requirements.md
@@ -1,0 +1,82 @@
+# Requirements Document
+
+## Introduction
+
+`internal/database/db.go` の `Open` 関数は `database/sql` の接続プールパラメータを一切設定して
+おらず、Go のデフォルト（`MaxOpenConns = 0` = 無制限）のまま動作している。Feedman は api / worker
+の 2 プロセスがそれぞれ独立して同一の `Open` を呼び出してプールを保持するため、高負荷時には
+両プロセス合算の同時接続数が PostgreSQL の `max_connections`（デフォルト 100）を超過し、新規接続の
+確立に失敗する恐れがある。本要件では、接続プールに上限・アイドル数・接続寿命の上限を与え、
+2 プロセス合算でも PostgreSQL の上限を超えない範囲に収めることを目的とする。既存の `Open` 呼び出し側
+（api / worker）の後方互換を保つことを前提とする。
+
+## Requirements
+
+### Requirement 1: 接続プールの上限設定
+
+**Objective:** As a Feedman の運用者, I want DB 接続プールに同時接続数の上限が設定されていること, so that 高負荷時でも PostgreSQL への接続が無制限に増加して接続枯渇を引き起こさない
+
+#### Acceptance Criteria
+
+1. When Database Open 関数がデータベース接続を開いたとき, the 接続プール shall 同時接続数（MaxOpenConns）に有限の上限値を設定する
+2. The 接続プール shall 同時接続数の上限を無制限（0）以外の正の有限値とする
+3. When api プロセスと worker プロセスが同時稼働しているとき, the 接続プール shall 両プロセス合算の同時接続数上限が PostgreSQL の `max_connections`（既定 100）を超えない値とする
+
+### Requirement 2: アイドル接続の上限設定
+
+**Objective:** As a Feedman の運用者, I want アイドル接続の保持数に上限があること, so that 利用されていない接続が際限なく保持されてリソースを浪費しない
+
+#### Acceptance Criteria
+
+1. When Database Open 関数がデータベース接続を開いたとき, the 接続プール shall アイドル接続数（MaxIdleConns）に有限の上限値を設定する
+2. The 接続プール shall アイドル接続数の上限を同時接続数の上限以下の値とする
+
+### Requirement 3: 接続寿命の上限設定
+
+**Objective:** As a Feedman の運用者, I want 接続に寿命の上限が設定されていること, so that 長寿命接続が一定時間で再確立され、ネットワーク機器や DB 側のタイムアウトによる断線が顕在化しない
+
+#### Acceptance Criteria
+
+1. When Database Open 関数がデータベース接続を開いたとき, the 接続プール shall 接続の最大寿命（ConnMaxLifetime）に有限の時間上限を設定する
+2. The 接続プール shall 接続の最大寿命を正の有限の時間値とする
+
+### Requirement 4: 設定値の定数化と後方互換
+
+**Objective:** As a Feedman の開発者, I want プール設定値が定数として明示され既存の呼び出し側を壊さないこと, so that 設定値の意図が読み取れ、api / worker の既存コードを変更せずに改善を取り込める
+
+#### Acceptance Criteria
+
+1. The 接続プール設定値 shall 直書きのマジックナンバーではなく名前付き定数として定義される
+2. The Database Open 関数 shall 既存の呼び出し側が依存する関数シグネチャ（引数・返り値の型）を変更しない
+3. When 既存の api / worker から Database Open 関数が呼び出されたとき, the Database Open 関数 shall 呼び出し側のコード変更を要さずに接続プール設定が適用された `*sql.DB` を返す
+
+## Non-Functional Requirements
+
+### NFR 1: 接続枯渇耐性
+
+1. While api と worker の両プロセスが稼働しているとき, the 接続プール shall 両プロセス合算の同時接続数を PostgreSQL `max_connections`（既定 100）以下に保ち、上限超過に起因する接続確立失敗を発生させない
+
+### NFR 2: 後方互換性
+
+1. The 接続プール設定の追加 shall 既存の api / worker 起動フロー（`Open` → `Ping` → 依存ワイヤリング）の観測可能な挙動を維持し、設定追加以前に成功していた起動が引き続き成功する
+
+## Out of Scope
+
+- PostgreSQL 側 `max_connections` のチューニングやインフラ設定変更
+- 接続プールのメトリクス収集・監視基盤の追加（Prometheus 等への露出）
+- `Open` の引数追加によるプール設定の呼び出し側からの注入（シグネチャ変更を伴うため本 Issue では扱わない）
+- 接続リトライ／バックオフ等の接続確立失敗時のリカバリ戦略
+
+## Open Questions
+
+- 同時接続数の上限値の確定: 仮案は api 25 + worker 25 = 50（≤ 100）。本要件では「2 プロセス合算が
+  `max_connections` を超えない有限値」とのみ規定し、具体値（25 など）は設計／実装フェーズで確定する
+  余地を残す。25 で確定してよいか、将来のスケール（複数 worker インスタンス等）を見込んでより低い値に
+  すべきかは Architect / 運用者の判断を仰ぐ。
+- 設定値を環境変数で上書き可能にするか: 既存 `internal/config` は多くの設定値を環境変数 + デフォルト値で
+  管理している（例: `FETCH_MAX_CONCURRENT`）。プール設定値も同様に環境変数化するか、`db.go` 内の定数固定と
+  するかは、シグネチャ後方互換（Requirement 4.2）の制約下での実現方式を含め設計判断とする。本要件では
+  「定数として明示される」までを必須とし、環境変数化は必須要件に含めない。
+- api と worker でプール設定値を変える必要があるか: 現状は共通の `Open` を両者が呼ぶため同一値となる。
+  プロセスごとに負荷特性が異なる場合に値を分けるべきかは Open Question として残す（分ける場合は
+  シグネチャ後方互換との整合を要検討）。

--- a/docs/specs/2-db/review-notes.md
+++ b/docs/specs/2-db/review-notes.md
@@ -1,0 +1,40 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-25T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-2-impl-db
+- HEAD commit: a3c9a0365e4bcda24e3567d2aa46b25a1198a76d
+- Compared to: develop..HEAD
+
+差分は 3 ファイル（`internal/database/db.go` / `internal/database/db_test.go` /
+`docs/specs/2-db/impl-notes.md`）に閉じている。`tasks.md` / `design.md` は本 spec ディレクトリに
+存在しない（Architect 未経由の Issue）ため、`_Boundary:_` アノテーション照合は適用対象外。
+CLAUDE.md の `## Feature Flag Protocol` 採否は **opt-out** のため flag 観点の確認は行わない。
+
+## Verified Requirements
+
+- 1.1 — `db.SetMaxOpenConns(maxOpenConns)`（db.go:41）/ `TestOpen_SetsMaxOpenConns`（実物 `db.Stats().MaxOpenConnections == 25` を検証）
+- 1.2 — `maxOpenConns = 25`（db.go:19、無制限 0 以外の正の有限値）/ `TestPoolConstants_AreFinitePositive`（`maxOpenConns > 0`）
+- 1.3 — `2 * maxOpenConns = 50 <= 100` / `TestPoolConstants_TwoProcessSumWithinMaxConnections`
+- 2.1 — `db.SetMaxIdleConns(maxIdleConns)`（db.go:42）/ `TestPoolConstants_AreFinitePositive`（`maxIdleConns > 0`）
+- 2.2 — `maxIdleConns = 10 <= maxOpenConns(25)` / `TestPoolConstants_AreFinitePositive`（`maxIdleConns <= maxOpenConns`）
+- 3.1 — `db.SetConnMaxLifetime(connMaxLifetime)`（db.go:43）/ `TestPoolConstants_AreFinitePositive`（`connMaxLifetime > 0`）
+- 3.2 — `connMaxLifetime = 5 * time.Minute`（db.go:28、正の有限の時間値）/ `TestPoolConstants_AreFinitePositive`
+- 4.1 — 接続プール設定値はパッケージレベルの名前付き定数として定義（db.go:15-29、マジックナンバー直書きなし）
+- 4.2 — `Open(databaseURL string) (*sql.DB, error)` のシグネチャ無変更（diff 上で引数・返り値型の変更なし）
+- 4.3 — 呼び出し側 `internal/app/app.go:90`（runServe）/ `:215`（runWorker）は無変更で `database.Open(cfg.DatabaseURL)` を呼ぶ（差分は database パッケージに閉じ、呼び出し側コードに変更なし）
+- NFR 1.1 — 2 プロセス合算 ≤ 100 を `TestPoolConstants_TwoProcessSumWithinMaxConnections` で担保
+- NFR 2.1 — 既存テスト（`TestOpen_ReturnsDBForAnyURL` / `TestOpen_WithValidURL_ReturnsDB`）を無変更で維持し、`Open` → `Ping` → ワイヤリングの観測挙動を保持。`go test ./internal/database/...` 通過を確認
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric AC（1.1〜4.3）および NFR 1.1 / 2.1 が実装とテストでカバーされている。`Open` シグネチャ
+無変更で後方互換を保ち、設定値は名前付き定数化済み。`go test ./internal/database/...` も通過。
+
+RESULT: approve

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -3,18 +3,44 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	_ "github.com/lib/pq"
+)
+
+// 接続プール設定の名前付き定数。
+// api / worker の 2 プロセスが同一の Open を呼び出してそれぞれプールを保持するため、
+// 各プロセスの同時接続数上限を合算しても PostgreSQL の max_connections（既定 100）を
+// 超えない値とする。
+const (
+	// maxOpenConns は1プロセスあたりの同時接続数の上限。
+	// api 25 + worker 25 = 50 ≤ max_connections(100) とし、
+	// マイグレーションや管理接続の余裕も確保する。
+	maxOpenConns = 25
+
+	// maxIdleConns はアイドル状態で保持する接続数の上限。
+	// 利用されない接続を際限なく保持しないよう maxOpenConns 以下に抑える。
+	maxIdleConns = 10
+
+	// connMaxLifetime は接続の最大寿命。
+	// 長寿命接続をこの時間で再確立し、ネットワーク機器や DB 側のタイムアウトによる
+	// 断線が顕在化しないようにする。
+	connMaxLifetime = 5 * time.Minute
 )
 
 // Open はPostgreSQLデータベース接続を開く。
 // databaseURLはPostgreSQLの接続URLを指定する（例: "postgres://user:pass@host:5432/dbname?sslmode=disable"）。
 // sql.Openは接続を試行しないため、実際の接続確認にはdb.Ping()を使用すること。
+// 返される*sql.DBには接続プールの上限（MaxOpenConns / MaxIdleConns / ConnMaxLifetime）が設定済み。
 func Open(databaseURL string) (*sql.DB, error) {
 	db, err := sql.Open("postgres", databaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
+
+	db.SetMaxOpenConns(maxOpenConns)
+	db.SetMaxIdleConns(maxIdleConns)
+	db.SetConnMaxLifetime(connMaxLifetime)
 
 	return db, nil
 }

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -4,6 +4,68 @@ import (
 	"testing"
 )
 
+// TestOpen_SetsMaxOpenConns はOpenが返す*sql.DBに同時接続数の上限が設定されていることを検証する。
+// db.Stats().MaxOpenConnectionsは公開取得可能なため、実物に最も近い形で
+// MaxOpenConnsが設定値どおりであることを確認できる。
+// 対応AC: Requirement 1.1 / 1.2（有限の正の上限値を設定する）。
+func TestOpen_SetsMaxOpenConns(t *testing.T) {
+	t.Run("Openが返すDBのMaxOpenConnectionsがmaxOpenConnsと一致するとき設定が適用されている", func(t *testing.T) {
+		// Arrange / Act
+		db, err := Open("postgres://user:pass@localhost:5432/feedman?sslmode=disable")
+		if err != nil {
+			t.Fatalf("Open returned unexpected error: %v", err)
+		}
+		defer db.Close()
+
+		// Assert
+		if got := db.Stats().MaxOpenConnections; got != maxOpenConns {
+			t.Errorf("MaxOpenConnections = %d, want %d", got, maxOpenConns)
+		}
+	})
+}
+
+// TestPoolConstants_AreFinitePositive はプール設定定数の不変条件を検証する。
+// MaxIdleConns / ConnMaxLifetimeには公開getterが無いため、
+// パッケージ内テストから定数の不変条件として検証する。
+func TestPoolConstants_AreFinitePositive(t *testing.T) {
+	// 対応AC: Requirement 1.2（同時接続数の上限は無制限0以外の正の有限値）。
+	t.Run("maxOpenConnsが正の有限値のとき接続枯渇耐性の前提を満たす", func(t *testing.T) {
+		if maxOpenConns <= 0 {
+			t.Errorf("maxOpenConns = %d, want > 0", maxOpenConns)
+		}
+	})
+
+	// 対応AC: Requirement 2.1 / 2.2（アイドル接続数は有限かつ同時接続数の上限以下）。
+	t.Run("maxIdleConnsが正かつmaxOpenConns以下のときアイドル上限の不変条件を満たす", func(t *testing.T) {
+		if maxIdleConns <= 0 {
+			t.Errorf("maxIdleConns = %d, want > 0", maxIdleConns)
+		}
+		if maxIdleConns > maxOpenConns {
+			t.Errorf("maxIdleConns = %d, want <= maxOpenConns(%d)", maxIdleConns, maxOpenConns)
+		}
+	})
+
+	// 対応AC: Requirement 3.1 / 3.2（接続の最大寿命は正の有限の時間値）。
+	t.Run("connMaxLifetimeが正の時間値のとき接続寿命上限の不変条件を満たす", func(t *testing.T) {
+		if connMaxLifetime <= 0 {
+			t.Errorf("connMaxLifetime = %v, want > 0", connMaxLifetime)
+		}
+	})
+}
+
+// TestPoolConstants_TwoProcessSumWithinMaxConnections は
+// api / worker 2プロセス合算の同時接続数上限がPostgreSQL max_connections(既定100)を
+// 超えないことを定数不変条件として検証する。
+// 対応AC: Requirement 1.3 / NFR 1.1。
+func TestPoolConstants_TwoProcessSumWithinMaxConnections(t *testing.T) {
+	t.Run("2プロセス合算のMaxOpenConnsが100以下のとき接続枯渇を引き起こさない", func(t *testing.T) {
+		const postgresMaxConnections = 100
+		if 2*maxOpenConns > postgresMaxConnections {
+			t.Errorf("2 * maxOpenConns = %d, want <= %d", 2*maxOpenConns, postgresMaxConnections)
+		}
+	})
+}
+
 // TestOpen_WithEmptyURL_ReturnsDB はsql.Openは接続を試行しないため、
 // 空URLでもDBオブジェクトが返ることを検証する。
 // 実際の接続確認にはPingが必要。


### PR DESCRIPTION
## 概要

`internal/database/db.go` の `Open` 関数に DB 接続プールの上限設定を追加します。
Go の `database/sql` はデフォルトで `MaxOpenConns = 0`（無制限）のため、api / worker の
2 プロセスが高負荷時に PostgreSQL の `max_connections`（既定 100）を超過する恐れがありました。
本 PR では同時接続数 / アイドル接続数 / 接続寿命の 3 パラメータを名前付き定数として定義し、
`Open` 内で自動適用します。既存の呼び出し側（api / worker）のコード変更は不要です。

## 対応 Issue

Closes #2

## 関連 PR

- 設計 PR: なし（Architect 未経由の Issue のため設計 PR は作成されていません）

## 実装内容

- (Req 1 / Task: db.go) `maxOpenConns = 25` を名前付き定数として定義し、`SetMaxOpenConns` で適用（api 25 + worker 25 = 50 ≤ PostgreSQL `max_connections` 100）
- (Req 2 / Task: db.go) `maxIdleConns = 10` を定義し、`SetMaxIdleConns` で適用（`maxOpenConns` 以下に抑制）
- (Req 3 / Task: db.go) `connMaxLifetime = 5 * time.Minute` を定義し、`SetConnMaxLifetime` で適用
- (Req 4 / Task: db.go) `Open` のシグネチャ `func Open(databaseURL string) (*sql.DB, error)` は変更せず後方互換を維持

## 受入基準チェック

- [x] Req 1.1: When Database Open 関数がデータベース接続を開いたとき, the 接続プール shall MaxOpenConns に有限の上限値を設定する ← `TestOpen_SetsMaxOpenConns`
- [x] Req 1.2: The 接続プール shall 同時接続数の上限を正の有限値とする ← `TestPoolConstants_AreFinitePositive`
- [x] Req 1.3: the 接続プール shall 両プロセス合算の同時接続数上限が 100 を超えない ← `TestPoolConstants_TwoProcessSumWithinMaxConnections`
- [x] Req 2.1: When Database Open 関数がデータベース接続を開いたとき, the 接続プール shall MaxIdleConns に有限の上限値を設定する ← `TestPoolConstants_AreFinitePositive`
- [x] Req 2.2: The 接続プール shall アイドル接続数の上限を同時接続数の上限以下の値とする ← `TestPoolConstants_AreFinitePositive`
- [x] Req 3.1: When Database Open 関数がデータベース接続を開いたとき, the 接続プール shall ConnMaxLifetime に有限の時間上限を設定する ← `TestPoolConstants_AreFinitePositive`
- [x] Req 3.2: The 接続プール shall 接続の最大寿命を正の有限の時間値とする ← `TestPoolConstants_AreFinitePositive`
- [x] Req 4.1: The 接続プール設定値 shall 名前付き定数として定義される ← コード上で担保（db.go:15-29）
- [x] Req 4.2: The Database Open 関数 shall 既存のシグネチャを変更しない ← diff 上でシグネチャ変更なし
- [x] Req 4.3: When 既存の api / worker から Database Open 関数が呼び出されたとき, the Database Open 関数 shall 呼び出し側のコード変更を要さずに設定済み `*sql.DB` を返す ← `internal/app/app.go` は無変更
- [x] NFR 1.1: While api と worker の両プロセスが稼働しているとき, 両プロセス合算 ≤ 100 ← `TestPoolConstants_TwoProcessSumWithinMaxConnections`
- [x] NFR 2.1: The 接続プール設定の追加 shall 既存の起動フローの観測可能な挙動を維持する ← 既存テスト無変更で通過

## テスト結果

```
$ go test ./internal/database/...
ok  	github.com/hitoshiichikawa/feedman/internal/database	(cached)

$ go test ./...
ok  	github.com/hitoshiichikawa/feedman/api	(cached)
ok  	github.com/hitoshiichikawa/feedman/internal/app	(cached)
ok  	github.com/hitoshiichikawa/feedman/internal/config	(cached)
ok  	github.com/hitoshiichikawa/feedman/internal/database	(cached)
ok  	github.com/hitoshiichikawa/feedman/internal/feed	(cached)
... (全パッケージ pass)
```

Reviewer 判定: `RESULT: approve`（`docs/specs/2-db/review-notes.md` 参照）

## 実装上の判断

- 同時接続数上限を 25 に設定（api 25 + worker 25 = 50 ≤ 100）
- 環境変数化はしない（Req 4.1 定数化 / Req 4.2 シグネチャ後方互換の制約から、本 Issue のスコープ外と判断）
- api / worker 共通値を採用（プロセス別設定は Open Questions に残置、別 Issue で検討）
- 設計判断の詳細は `docs/specs/2-db/impl-notes.md` を参照

## 確認事項 / レビュワーへの依頼

- base ブランチ検証: --base develop 指定 / baseRefName: develop / OK（一致）
- 独立 Reviewer の判定: `RESULT: approve`（`docs/specs/2-db/review-notes.md`）
- 同時接続数 `maxOpenConns = 25` の妥当性: 将来 worker インスタンスを複数台に増やす場合、2 プロセス超の合算で 100 超過の恐れがあります。その際は値の再調整または環境変数化（要シグネチャ後方互換の再検討）を別 Issue として起票することを推奨します

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #2 のコメントを参照してください。
