### PR TITLE
feat(#11): UpsertItems をバルク UPSERT 化して N+1 を解消

### DIFF
--- a/docs/specs/11-upsertitems-n-1-upsert/impl-notes.md
+++ b/docs/specs/11-upsertitems-n-1-upsert/impl-notes.md
@@ -1,0 +1,125 @@
+# 実装ノート: Issue #11 UpsertItems の N+1 をバルク UPSERT に変更
+
+## 採用設計
+
+記事 1 件ごとに最大 3 回の SELECT + 1 回の INSERT/UPDATE を逐次実行していた N+1 構造を、
+以下の 3 フェーズに再構成して DB 往復を定数オーダー化した。
+
+1. **既存記事の一括取得**: バッチに含まれる `guid_or_id` / `link` / `content_hash` の候補集合を
+   収集し、`FindExistingForUpsert` が各キーごとに 1 回ずつ（合計最大 3 回）のバッチ SELECT
+   （`WHERE feed_id = $1 AND <col> IN (...)`）で既存記事を引く。
+2. **Go 側での 3 段階同一性判定**: 取得した既存記事マップに対し、現状と等価な優先順位
+   （`(feed_id, guid_or_id)` > `(feed_id, link)` > `content_hash`）で新規/更新を仕分けする。
+   判定アルゴリズムは Go 側に保持したため、判定結果はバルク化前後で不変（NFR 2）。
+3. **バルク永続化**: 新規は複数行 VALUES の `INSERT`、既存は `UPDATE ... FROM (VALUES ...)` で
+   一括書き込みし、両者を **単一トランザクション**で実行する。
+
+この設計によりスキーマ変更（`link` / `content_hash` へのユニーク制約追加）を回避した。
+items テーブルの `(feed_id, guid_or_id)` は部分ユニークインデックスだが、`(feed_id, link)` /
+`(feed_id, content_hash)` は通常インデックスのみでユニーク制約が無いため、3 段階判定を
+単一 `INSERT ... ON CONFLICT` で表現することは不可能。同一性判定を Go 側に残す方針を採った。
+スキーマ変更は requirements の Out of Scope のため行っていない。
+
+## 追加したインターフェースメソッド（`repository.ItemRepository`）
+
+既存メソッドのシグネチャは一切変更していない（他の呼び出し元があるため）。
+`UpsertItems` の公開シグネチャも NFR 1 のとおり不変。
+
+- `FindExistingForUpsert(ctx, feedID string, guids, links, hashes []string) (*ExistingItems, error)`
+  - 同一性判定に必要な既存記事を guid/link/hash 別に索引した `*ExistingItems` で一括返却。
+  - 各キー集合が空のときは当該 SELECT をスキップ（DB アクセスしない）。
+- `BulkUpsert(ctx, toCreate, toUpdate []*model.Item) error`
+  - 新規一括 INSERT と既存一括 UPDATE を単一トランザクションで実行。途中エラーで全件ロールバック。
+- 新規エクスポート型 `repository.ExistingItems`（`ByGUID` / `ByLink` / `ByContentHash` の 3 マップ）。
+
+## オーケストレーター確定事項の反映
+
+1. **エラー時 = 全件ロールバック**: `BulkUpsert` は単一トランザクションで実行し、INSERT/UPDATE
+   いずれかでエラーが出れば `tx.Rollback()`（`defer`）で全件ロールバック。`UpsertItems` は
+   取得失敗・永続化失敗いずれの場合も `(0, 0, err)` を返し、発生元エラーを `fmt.Errorf("...: %w", ...)`
+   で wrap する。エラーは `slog.Error` で構造化ログに記録する（Requirement 3.1〜3.4）。
+2. **バッチ内重複 = 後勝ち（事前 dedup）**: `dedupByIdentity` がバッチ内で同一性判定上同一と
+   みなされる記事を **最終要素優先（後勝ち）**で 1 件に集約してから書き込む。代表キーは
+   優先順位に沿って「guid_or_id があればそれ、無ければ link、無ければ content_hash」を採用する。
+   代表キーを持たない記事（3 キーすべて空）は dedup 対象外としてそのまま保持する。
+
+## 同一性判定結果の不変性について（NFR 2 / Requirement 1.4）
+
+- 判定の優先順位ロジック・`computeContentHash` のアルゴリズム（対象フィールド・ハッシュ関数）・
+  サニタイズ適用は一切変更していない。`content_hash` は従来どおりサニタイズ後のサマリーを
+  用いて計算する。
+- 既存の優先順位テスト（GUID > Link、Link > Hash、フォールバック）はバルク化後もそのまま通過。
+
+## テスト戦略
+
+`internal/item/upsert_test.go` の `mockItemRepo` を拡張し、新バルクメソッド
+（`FindExistingForUpsert` / `BulkUpsert`）を実装。`findBulkCalls` / `upsertCalls` の呼び出し
+回数カウンタと、`findErr` / `upsertErr` のエラー注入フィールドを追加した。`BulkUpsert` は
+`upsertErr` 設定時に内部マップを一切変更しないことでロールバック相当を表現する。
+
+既存テスト（`createCalls` / `updateCalls` を検証する 20 件以上のテスト）は、モックの
+`BulkUpsert` が `toCreate` / `toUpdate` を走査してこれらのカウンタを更新するため変更なしで通過する。
+
+## 受入基準（AC）とテストの対応
+
+| AC | 担保するテスト |
+|---|---|
+| R1.1 新規/既存件数の分離 | `TestUpsertItems_Mixed50_Counts`, `TestUpsertItems_MultipleItems` |
+| R1.2 混在 50 件で inserted=N/updated=M | `TestUpsertItems_Mixed50_Counts` |
+| R1.3 更新時 id 保持 | `TestUpsertItems_Update_PreservesID`, `TestUpsertItems_Update_OverwritesContent` |
+| R1.4 判定結果不変 | `TestUpsertItems_IdentityPriority_GUIDOverLink`, `..._LinkOverHash`, `TestUpsertItems_GUIDNotFound_FallbackToLink`, `..._FallbackToHash`, `TestUpsertItems_BatchInternalDuplicate_ExistingLastWins` |
+| R1.5 サニタイズ後コンテンツ・再計算 hash 保存 | `TestUpsertItems_Update_SanitizedContentAndHash`, `TestUpsertItems_Update_ContentIsSanitized`, `..._ContentHashUpdated` |
+| R2.1 / R2.2 / NFR3.1 往復定数オーダー | `TestUpsertItems_RoundTripsConstant`（1/10/50 件で findBulkCalls=1, upsertCalls=1） |
+| R3.1 全件ロールバック | `TestUpsertItems_DBError_UpsertRollsBackAndReturnsZero`（永続化記事数 0 を検証） |
+| R3.2 件数 0 + エラー | `TestUpsertItems_DBError_FindReturnsZeroAndWrappedError`, `..._UpsertRollsBackAndReturnsZero` |
+| R3.3 発生元エラーの wrap | 上記 2 テストで `errors.Is(err, sentinel)` を検証 |
+| R3.4 構造化ログ記録 | 実装で `slog.Error` を発行（取得失敗・永続化失敗の両経路）。ログ検証は副作用のため slog 出力のアサートは行わず実装側で担保 |
+| R4.1 0 件で DB 非アクセス | `TestUpsertItems_EmptyItems_NoDBAccess`, `TestUpsertItems_EmptyItems` |
+| R4.2 nil で DB 非アクセス | `TestUpsertItems_NilItems_NoDBAccess`, `TestUpsertItems_NilItems` |
+| R4.3 1 件新規 (1,0,nil) | `TestUpsertItems_SingleNewItem`, `TestUpsertItems_NewItem_Insert` |
+| R4.4 1 件既存 (0,1,nil) | `TestUpsertItems_SingleExistingItem`, `TestUpsertItems_IdentityByGUID` |
+| NFR1.1 公開シグネチャ不変 | `internal/worker/fetch` の `ItemUpserter` インターフェース経由呼び出しが変更なしで通過（コンパイル + 既存テスト green） |
+| NFR1.2 戻り値の意味不変 | 件数系テスト全般 |
+| NFR2.1 / NFR2.2 判定結果不変 | R1.4 のテスト群 |
+| バッチ内重複の後勝ち（確定事項 2） | `TestUpsertItems_BatchInternalDuplicate_LastWins`, `..._ExistingLastWins` |
+
+## ライブ DB 未カバー範囲（手動検証方針）
+
+- `internal/repository/postgres_item_repo_test.go` は既存慣習どおり**インターフェース適合の
+  コンパイル時チェックのみ**で、ライブ DB 結合テストは存在しない。本実装でも同慣習に従い、
+  追加したバルク SQL（`FindExistingForUpsert` の `IN (...)` SELECT、`bulkInsertItems` の
+  複数行 VALUES INSERT、`bulkUpdateItems` の `UPDATE ... FROM (VALUES ...)`）に対する
+  ライブ DB 統合テストは追加していない。
+- バルク UPDATE の SQL は、`VALUES` 由来の派生テーブルでプレースホルダ型推論が NULL 値で
+  失敗するのを避けるため、内側 SELECT で各カラムに明示キャスト（`::uuid` / `::timestamptz` /
+  `::boolean` / `::text`）を付与している。**この SQL の実 DB 動作はローカルの PostgreSQL 16 に
+  対して手動で `docker-compose` 起動 + マイグレーション適用後に検証することを推奨**する
+  （CI には DB 結合テストの仕組みが無いため）。
+- 手動検証観点: (a) guid/link/hash 混在バッチで件数が一致するか、(b) NULL published_at を
+  含む新規/更新が型エラーなく書き込めるか、(c) 途中で意図的にエラー（重複 PK 等）を起こした
+  際にトランザクションが全件ロールバックされるか。
+
+## 確認事項（レビュワー / PM・Architect 判断ポイント）
+
+- **requirements.md の Open Questions（エラー時挙動の変更）**: Requirement 3 は現状の
+  「部分成功カウントを返す」挙動から「全件ロールバック・件数 0」への**意図的な変更**である。
+  オーケストレーター確定事項どおり実装したが、これは呼び出し元（`worker/fetch/fetcher.go`）から
+  見える挙動変更を含む（従来はエラー時も途中までの inserted/updated が返っていた）。運用上
+  部分成功カウントの温存が必要なら PM へ差し戻しが必要。
+- **バッチ内重複の dedup 仕様**: 確定事項どおり「事前 dedup（最終要素優先）」を採用した。
+  これにより同一 guid の新規重複 2 件は `inserted=1, updated=0` となる（逐次処理での
+  `inserted=1, updated=1` とは件数が異なる）。これは requirements R1.2 が前提とする
+  「重複なし混在バッチ」では差異を生まないが、重複ありバッチでの件数定義を確定事項で
+  固定した点を明記する。
+- **ライブ DB テスト不在**: 上記「ライブ DB 未カバー範囲」のとおり、バルク SQL の実 DB 動作は
+  本リポジトリの結合テスト慣習（インターフェース適合のみ）に従い自動テスト化していない。
+  DB 結合テスト基盤の整備は別 Issue として切り出す候補。
+
+## 次の Issue 候補（派生タスク）
+
+- items テーブルのバルク SQL に対するライブ DB 結合テスト基盤の整備（テスト用 PostgreSQL
+  コンテナの導入）。
+- 大量バッチ（PostgreSQL のプレースホルダ上限 65535 に対し 1 記事 16 列 = 約 4000 件で上限）
+  に対する分割書き込み。現状フィードは最大 50 件想定のため未対応だが、将来的な上限到達への備え。
+
+STATUS: complete

--- a/docs/specs/11-upsertitems-n-1-upsert/requirements.md
+++ b/docs/specs/11-upsertitems-n-1-upsert/requirements.md
@@ -1,0 +1,81 @@
+# Requirements Document
+
+## Introduction
+
+`UpsertItems` はフィード取得後に記事をデータベースへ永続化する処理であり、記事 1 件ごとに最大 3 回の同一性判定 SELECT と 1 回の INSERT/UPDATE を逐次実行している。1 フィード 50 記事で最大約 200 回の DB 往復が発生し、フィード数・記事数の増加に対して処理時間が線形に悪化する N+1 構造を抱えている。本要件は、観測可能な永続化結果（`inserted` / `updated` 件数・同一性判定結果）を現状と差異なく保ちつつ、DB 往復回数を記事件数に比例させないバルク化へ改善することを目的とする。同一性判定の優先順位ロジックやサニタイズ / `content_hash` 計算アルゴリズムの変更は含まない。
+
+## Requirements
+
+### Requirement 1: バルク UPSERT による永続化結果の同等性
+
+**Objective:** As a フィード取得処理の運用者, I want 記事をバルク UPSERT で永続化しても挿入・更新の結果が現状と変わらないこと, so that 性能改善後も記事の同一性判定と件数集計が信頼できる
+
+#### Acceptance Criteria
+
+1. When 新規記事と既存記事が混在したバッチを `UpsertItems` に渡したとき, the Item Upsert Service shall 新規記事の件数を `inserted` として、既存記事の件数を `updated` として返す
+2. When 50 件の混在バッチ（新規 N 件・既存 M 件、N+M=50）を渡したとき, the Item Upsert Service shall `inserted` を N、`updated` を M として返す
+3. When 既存記事と一致するバッチを処理したとき, the Item Upsert Service shall 当該記事を上書き更新し、対象記事の `id` を新規採番せず保持する
+4. The Item Upsert Service shall バルク化前後で同一入力に対する同一性判定の結果（どの既存記事に一致するか／新規とみなすか）を変化させない
+5. When 既存記事を更新するとき, the Item Upsert Service shall サニタイズ後のコンテンツ・サマリーと再計算した `content_hash` を保存する
+
+### Requirement 2: DB 往復回数の定数オーダー化
+
+**Objective:** As a システム運用者, I want 記事件数が増えても DB 往復回数が比例して増えないこと, so that フィード・記事のスケールに対して永続化処理がボトルネックにならない
+
+#### Acceptance Criteria
+
+1. When N 件の記事バッチを `UpsertItems` に渡したとき, the Item Upsert Service shall DB 往復回数を記事件数 N に比例させず定数オーダーに収める
+2. While 記事件数が 1 件から 50 件に増加する状況で, the Item Upsert Service shall DB 往復回数を記事件数に比例して線形に増加させない
+
+### Requirement 3: バッチ途中での DB エラー時の挙動
+
+**Objective:** As a フィード取得処理の運用者, I want バッチ処理中に DB エラーが発生したときの挙動が明確に定義されていること, so that エラー時のデータ整合性と件数集計の意味を予測できる
+
+#### Acceptance Criteria
+
+1. If バッチの永続化中に DB エラーが発生したとき, the Item Upsert Service shall 当該バッチによる挿入・更新を全件ロールバックし、当該バッチの記事を 1 件も永続化しない
+2. If バッチの永続化中に DB エラーが発生したとき, the Item Upsert Service shall `inserted` と `updated` をいずれも 0 として返し、エラーを返す
+3. If 永続化中にエラーが発生したとき, the Item Upsert Service shall 発生元の原因エラーを wrap した error を返す
+4. If エラーが発生したとき, the Item Upsert Service shall エラー内容を構造化ログに記録する
+
+### Requirement 4: 境界値（0 件 / 1 件）の取り扱い
+
+**Objective:** As a フィード取得処理の呼び出し元, I want 空バッチや単一記事バッチでも一貫した結果が返ること, so that バルク化によって境界ケースの挙動が変わらない
+
+#### Acceptance Criteria
+
+1. When `items` が 0 件（空スライス）で渡されたとき, the Item Upsert Service shall DB へアクセスせず早期 return し `(0, 0, nil)` を返す
+2. When `items` が nil で渡されたとき, the Item Upsert Service shall DB へアクセスせず早期 return し `(0, 0, nil)` を返す
+3. When `items` が 1 件の新規記事で渡されたとき, the Item Upsert Service shall 当該記事を挿入し `(1, 0, nil)` を返す
+4. When `items` が 1 件の既存記事一致で渡されたとき, the Item Upsert Service shall 当該記事を更新し `(0, 1, nil)` を返す
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性（公開シグネチャの維持）
+
+1. The Item Upsert Service shall `UpsertItems` の公開シグネチャ（引数 `ctx`, `feedID`, `items` と戻り値 `inserted int, updated int, err error`）を変更しない
+2. The Item Upsert Service shall フィード取得処理（呼び出し元）から見える戻り値の意味（`inserted` = 挿入件数、`updated` = 更新件数）を現状から変えない
+
+### NFR 2: 同一性判定結果の不変性
+
+1. The Item Upsert Service shall `content_hash` による同一性判定結果がバルク化前後で差異を生まないことを保証する
+2. The Item Upsert Service shall 同一性判定の優先順位（`(feed_id, guid_or_id)` > `(feed_id, link)` > `content_hash`）の判定結果をバルク化前後で変えない
+
+### NFR 3: 性能（往復回数の上限）
+
+1. When 50 件の記事バッチを処理するとき, the Item Upsert Service shall DB 往復回数を記事件数（50）に比例しない定数オーダー（バッチ数に依存する固定回数）に抑える
+
+## Out of Scope
+
+- 3 段階同一性判定の優先順位ロジック自体の変更（判定順序・判定キーの追加削除）
+- サニタイズアルゴリズムの変更
+- `content_hash` の計算アルゴリズム（対象フィールド・ハッシュ関数）の変更
+- `UpsertItems` の公開シグネチャ・戻り値の意味の変更
+- 記事更新時の履歴保持（現状どおり上書きのみ。履歴テーブル等は対象外）
+- フィード取得処理（worker / fetcher）側のバッチ分割戦略・並列化
+- データベーススキーマ（テーブル定義・既存インデックス）の変更を前提とする要件化（必要なインデックス・制約の判断は design の領分）
+
+## Open Questions
+
+- バッチ途中の DB エラー時の挙動について、本要件では Requirement 3 で「全件ロールバック・件数 0・エラー返却」を方針として定義した。これは現状の「エラー発生時点までの件数を返しつつ即時 error を返す（部分成功カウントが残る）」挙動からの**意図的な変更**であり、永続化のアトミック性を優先したものである。現状挙動（部分成功カウントの温存）を維持すべき運用上の理由がある場合は人間判断を仰ぎたい。
+- 同一バッチ内に「同一性判定上は同一」とみなされる記事が重複して含まれる場合の取り扱い（バッチ内重複の最終勝ち／先勝ち／件数カウント）について、Issue・既存実装ともに明示がない。現状の逐次処理では後続記事が先行記事を上書きし得るが、バルク化時の期待挙動を確定したい。

--- a/docs/specs/11-upsertitems-n-1-upsert/review-notes.md
+++ b/docs/specs/11-upsertitems-n-1-upsert/review-notes.md
@@ -1,0 +1,51 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-25T10:02:14Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-11-impl-upsertitems-n-1-upsert
+- HEAD commit: ab54a55fdf117b762ac19e128797a348c5fc0158
+- Compared to: develop..HEAD
+
+差分対象ファイル: `internal/item/upsert.go`（ItemUpsertService）/ `internal/repository/interfaces.go`
+（ItemRepository インターフェース拡張 + `ExistingItems` 型）/ `internal/repository/postgres_item_repo.go`
+（PostgresItemRepo バルク SQL）/ `internal/item/upsert_test.go`（AC 網羅テスト）。
+`CLAUDE.md` の Feature Flag Protocol は `opt-out` のため flag 観点の確認は行わず、通常の 3 カテゴリ判定を実施。
+`go build ./...` / `go vet` / `go test ./internal/item/... ./internal/repository/... ./internal/worker/...` いずれも green を確認。
+
+## Verified Requirements
+
+- 1.1 — `TestUpsertItems_Mixed50_Counts`, `TestUpsertItems_MultipleItems`（新規=inserted / 既存=updated に分離）
+- 1.2 — `TestUpsertItems_Mixed50_Counts`（新規 30・既存 20 の混在 50 件で inserted=30/updated=20）
+- 1.3 — `TestUpsertItems_Update_PreservesID`（既存 id を保持、`buildUpdatedItem` が `*existing` をコピーし id 不変）
+- 1.4 — `TestUpsertItems_IdentityPriority_GUIDOverLink` / `..._LinkOverHash` / `..._GUIDNotFound_FallbackToLink` / `..._GUIDAndLinkNotFound_FallbackToHash`。`matchExisting`（upsert.go:200-217）の優先順位は旧 `findExistingItem` と等価
+- 1.5 — `TestUpsertItems_Update_SanitizedContentAndHash`, `..._Update_ContentIsSanitized`, `..._Update_ContentHashUpdated`（サニタイズ後コンテンツ・サマリーと再計算 hash を保存）
+- 2.1 — `TestUpsertItems_RoundTripsConstant`（1/10/50 件で findBulkCalls=1, upsertCalls=1）+ postgres_item_repo.go の IN 句バッチ SELECT / 複数行 VALUES
+- 2.2 — `TestUpsertItems_RoundTripsConstant`（件数増加でも往復回数固定）
+- 3.1 — `TestUpsertItems_DBError_UpsertRollsBackAndReturnsZero`（永続化記事数 0 を検証）+ `BulkUpsert` 単一 tx + `defer tx.Rollback()`
+- 3.2 — `TestUpsertItems_DBError_FindReturnsZeroAndWrappedError`, `..._UpsertRollsBackAndReturnsZero`（(0,0,err) 返却）
+- 3.3 — 上記 2 テストで `errors.Is(err, sentinel)`。upsert.go:79/102 が `fmt.Errorf("...: %w", ...)` で wrap
+- 3.4 — upsert.go:75-79 / 96-102 の `slog.Error`（取得失敗・永続化失敗の両経路で構造化ログ発行）。ログ出力は外部副作用のため実装側で担保（テスト規約のモック方針と整合）
+- 4.1 — `TestUpsertItems_EmptyItems_NoDBAccess`, `..._EmptyItems`（空スライスで DB 非アクセス・(0,0,nil)）
+- 4.2 — `TestUpsertItems_NilItems_NoDBAccess`, `..._NilItems`（nil で DB 非アクセス・(0,0,nil)）
+- 4.3 — `TestUpsertItems_SingleNewItem`, `..._NewItem_Insert`（1 件新規で (1,0,nil)）
+- 4.4 — `TestUpsertItems_SingleExistingItem`, `..._IdentityByGUID`（1 件既存で (0,1,nil)）
+- NFR 1.1 — `internal/worker/fetch/fetcher.go` の呼び出し元に diff なし。`UpsertItems` の公開シグネチャ不変・build green
+- NFR 1.2 — 件数系テスト全般で inserted=挿入数 / updated=更新数 の意味を維持
+- NFR 2.1 / 2.2 — 1.4 のテスト群 + `computeContentHash` / サニタイズ / 優先順位ロジックを Go 側に温存（アルゴリズム不変）
+- NFR 3.1 — `TestUpsertItems_RoundTripsConstant`（50 件でも往復定数オーダー）
+
+## Findings
+
+なし
+
+## Summary
+
+requirements.md の全 numeric ID（R1.1〜4.4 / NFR 1〜3）に対応する実装・テストを確認した。バルク化に伴う
+同一性判定・サニタイズ・hash 計算は Go 側に温存され、旧逐次実装と等価。既存の優先順位テストも保持され
+バルク経路で通過する。3 カテゴリ（AC 未カバー / missing test / boundary 逸脱）いずれにも該当なし。テストは
+全 green。impl-notes 記載のエラー時挙動変更・バッチ内 dedup・ライブ DB テスト不在は requirements の Open
+Questions / 確定事項で合意済みであり、AC 観点での reject 事由には当たらない。
+
+RESULT: approve

--- a/docs/specs/11-upsertitems-n-1-upsert/tasks.md
+++ b/docs/specs/11-upsertitems-n-1-upsert/tasks.md
@@ -3,14 +3,14 @@
 本フローに Architect は入っていないため、Developer が `.claude/rules/tasks-generation.md` 準拠で
 作成した簡潔なタスク分割。
 
-- [ ] 1. ItemRepository にバルク用メソッドを追加する
+- [x] 1. ItemRepository にバルク用メソッドを追加する
   - 既存メソッドのシグネチャは変更しない（他の呼び出し元がある）
   - バッチ化 find（guid/link/hash 群を一括取得）とバルク upsert（単一トランザクション内で
     複数行 INSERT + 複数行 UPDATE、エラー時全件ロールバック）のインターフェースを定義
   - `mockItemRepo` にバルクメソッドの呼び出し回数カウンタを追加
   - _Requirements: 2.1, 2.2, 3.1, 3.3, NFR 3.1_
 
-- [ ] 2. UpsertItems をバルク化する
+- [x] 2. UpsertItems をバルク化する
   - サニタイズ・content_hash 計算を全件先行実行（現状アルゴリズム不変）
   - バッチ内 dedup（同一性キー後勝ち）
   - バッチ化 find → Go 側 3 段階優先順位判定 → 新規/更新の仕分け（判定結果不変）
@@ -19,14 +19,14 @@
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4, NFR 1.1, NFR 1.2, NFR 2.1, NFR 2.2, NFR 3.1_
   - _Boundary: ItemUpsertService_
 
-- [ ] 3. Postgres 実装にバルク SQL を実装する
+- [x] 3. Postgres 実装にバルク SQL を実装する
   - バッチ化 SELECT（`WHERE (feed_id, guid_or_id) IN (...)` 等、3 段階ぶん定数回）
   - バルク INSERT（複数行 VALUES）/ バルク UPDATE（`UPDATE ... FROM (VALUES ...)`）を単一トランザクション
   - エラー時はトランザクションロールバック
   - _Requirements: 2.1, 3.1, NFR 3.1_
   - _Boundary: PostgresItemRepo_
 
-- [ ] 4. 全 AC を網羅する単体テストを追加する
+- [x] 4. 全 AC を網羅する単体テストを追加する
   - 混在 50 件、id 保持、判定結果不変、サニタイズ&hash 再計算、往復定数オーダー、
     エラー時 (0,0,err)・ロールバック・wrap・ログ、0件/nil/1件、バッチ内重複後勝ち
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4, NFR 2.1, NFR 2.2, NFR 3.1_

--- a/docs/specs/11-upsertitems-n-1-upsert/tasks.md
+++ b/docs/specs/11-upsertitems-n-1-upsert/tasks.md
@@ -1,0 +1,32 @@
+# Implementation Tasks
+
+本フローに Architect は入っていないため、Developer が `.claude/rules/tasks-generation.md` 準拠で
+作成した簡潔なタスク分割。
+
+- [ ] 1. ItemRepository にバルク用メソッドを追加する
+  - 既存メソッドのシグネチャは変更しない（他の呼び出し元がある）
+  - バッチ化 find（guid/link/hash 群を一括取得）とバルク upsert（単一トランザクション内で
+    複数行 INSERT + 複数行 UPDATE、エラー時全件ロールバック）のインターフェースを定義
+  - `mockItemRepo` にバルクメソッドの呼び出し回数カウンタを追加
+  - _Requirements: 2.1, 2.2, 3.1, 3.3, NFR 3.1_
+
+- [ ] 2. UpsertItems をバルク化する
+  - サニタイズ・content_hash 計算を全件先行実行（現状アルゴリズム不変）
+  - バッチ内 dedup（同一性キー後勝ち）
+  - バッチ化 find → Go 側 3 段階優先順位判定 → 新規/更新の仕分け（判定結果不変）
+  - バルク upsert を単一トランザクションで実行し、エラー時 (0,0,err) wrap + 構造化ログ
+  - 0 件/nil は早期 return で (0,0,nil)
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4, NFR 1.1, NFR 1.2, NFR 2.1, NFR 2.2, NFR 3.1_
+  - _Boundary: ItemUpsertService_
+
+- [ ] 3. Postgres 実装にバルク SQL を実装する
+  - バッチ化 SELECT（`WHERE (feed_id, guid_or_id) IN (...)` 等、3 段階ぶん定数回）
+  - バルク INSERT（複数行 VALUES）/ バルク UPDATE（`UPDATE ... FROM (VALUES ...)`）を単一トランザクション
+  - エラー時はトランザクションロールバック
+  - _Requirements: 2.1, 3.1, NFR 3.1_
+  - _Boundary: PostgresItemRepo_
+
+- [ ] 4. 全 AC を網羅する単体テストを追加する
+  - 混在 50 件、id 保持、判定結果不変、サニタイズ&hash 再計算、往復定数オーダー、
+    エラー時 (0,0,err)・ロールバック・wrap・ログ、0件/nil/1件、バッチ内重複後勝ち
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4, NFR 2.1, NFR 2.2, NFR 3.1_

--- a/internal/item/upsert.go
+++ b/internal/item/upsert.go
@@ -32,11 +32,23 @@ func NewItemUpsertService(
 	}
 }
 
+// preparedItem はサニタイズと content_hash 計算を終えた永続化前の中間表現。
+type preparedItem struct {
+	parsed           model.ParsedItem
+	sanitizedContent string
+	sanitizedSummary string
+	contentHash      string
+}
+
 // UpsertItems はフィードから取得した記事をUPSERTする。
 // 3段階の同一性判定ロジック:
 //  1. (feed_id, guid_or_id) - 最優先
 //  2. (feed_id, link) - 第2優先
 //  3. hash(title + published + summary) - 第3優先
+//
+// 記事件数に比例した DB 往復を避けるため、既存記事の一括取得 → Go 側での同一性判定 →
+// 新規一括 INSERT・既存一括 UPDATE を単一トランザクションで実行する。
+// 永続化中にエラーが発生した場合はバッチ全件をロールバックし、(0, 0, err) を返す。
 //
 // 戻り値は挿入数、更新数、エラー。
 func (s *ItemUpsertService) UpsertItems(
@@ -50,51 +62,48 @@ func (s *ItemUpsertService) UpsertItems(
 
 	now := time.Now()
 
-	for _, parsed := range items {
-		// コンテンツとサマリーにサニタイズ処理を適用
-		sanitizedContent := s.sanitizer.Sanitize(parsed.Content)
-		sanitizedSummary := s.sanitizer.Sanitize(parsed.Summary)
+	// サニタイズと content_hash 計算を全件先行実行する（アルゴリズムは現状不変）。
+	prepared := s.prepareItems(items)
 
-		// content_hashを計算（サニタイズ後のサマリーを使用）
-		contentHash := computeContentHash(parsed.Title, parsed.PublishedAt, sanitizedSummary)
+	// バッチ内重複は最終要素を優先（後勝ち）して dedup する。
+	deduped := dedupByIdentity(prepared)
 
-		// 3段階の同一性判定で既存記事を検索
-		existing, findErr := s.findExistingItem(ctx, feedID, parsed, contentHash)
-		if findErr != nil {
-			slog.Error("記事の同一性判定でエラー",
-				"feed_id", feedID,
-				"guid_or_id", parsed.GuidOrID,
-				"error", findErr,
-			)
-			return inserted, updated, fmt.Errorf("記事の同一性判定に失敗: %w", findErr)
-		}
+	// 同一性判定に必要な候補キー群を収集し、既存記事を一括取得する（DB 往復は定数オーダー）。
+	guids, links, hashes := collectIdentityKeys(deduped)
+	existing, findErr := s.itemRepo.FindExistingForUpsert(ctx, feedID, guids, links, hashes)
+	if findErr != nil {
+		slog.Error("既存記事の一括取得でエラー",
+			"feed_id", feedID,
+			"error", findErr,
+		)
+		return 0, 0, fmt.Errorf("既存記事の一括取得に失敗: %w", findErr)
+	}
 
-		if existing != nil {
-			// 既存記事を上書き更新
-			updateErr := s.updateExistingItem(ctx, existing, parsed, sanitizedContent, sanitizedSummary, contentHash, now)
-			if updateErr != nil {
-				slog.Error("記事の更新でエラー",
-					"feed_id", feedID,
-					"item_id", existing.ID,
-					"error", updateErr,
-				)
-				return inserted, updated, fmt.Errorf("記事の更新に失敗: %w", updateErr)
-			}
-			updated++
+	// Go 側で 3 段階優先順位判定を行い、新規/更新を仕分けする。
+	var toCreate []*model.Item
+	var toUpdate []*model.Item
+	for _, p := range deduped {
+		match := matchExisting(existing, p)
+		if match != nil {
+			toUpdate = append(toUpdate, buildUpdatedItem(match, p, now))
 		} else {
-			// 新規記事を挿入
-			createErr := s.createNewItem(ctx, feedID, parsed, sanitizedContent, sanitizedSummary, contentHash, now)
-			if createErr != nil {
-				slog.Error("記事の挿入でエラー",
-					"feed_id", feedID,
-					"guid_or_id", parsed.GuidOrID,
-					"error", createErr,
-				)
-				return inserted, updated, fmt.Errorf("記事の挿入に失敗: %w", createErr)
-			}
-			inserted++
+			toCreate = append(toCreate, buildNewItem(feedID, p, now))
 		}
 	}
+
+	// 新規一括 INSERT と既存一括 UPDATE を単一トランザクションで永続化する。
+	if upErr := s.itemRepo.BulkUpsert(ctx, toCreate, toUpdate); upErr != nil {
+		slog.Error("記事のバルク UPSERT でエラー",
+			"feed_id", feedID,
+			"to_create", len(toCreate),
+			"to_update", len(toUpdate),
+			"error", upErr,
+		)
+		return 0, 0, fmt.Errorf("記事のバルク UPSERT に失敗: %w", upErr)
+	}
+
+	inserted = len(toCreate)
+	updated = len(toUpdate)
 
 	slog.Info("記事UPSERT完了",
 		"feed_id", feedID,
@@ -105,111 +114,158 @@ func (s *ItemUpsertService) UpsertItems(
 	return inserted, updated, nil
 }
 
-// findExistingItem は3段階の同一性判定で既存記事を検索する。
-// 優先順位: (feed_id, guid_or_id) > (feed_id, link) > hash(title+published+summary)
-func (s *ItemUpsertService) findExistingItem(
-	ctx context.Context,
-	feedID string,
-	parsed model.ParsedItem,
-	contentHash string,
-) (*model.Item, error) {
-	// 第1優先: feed_id + guid_or_id
-	if parsed.GuidOrID != "" {
-		item, err := s.itemRepo.FindByFeedAndGUID(ctx, feedID, parsed.GuidOrID)
-		if err != nil {
-			return nil, err
-		}
-		if item != nil {
-			return item, nil
-		}
+// prepareItems は各記事のコンテンツ・サマリーをサニタイズし content_hash を計算する。
+func (s *ItemUpsertService) prepareItems(items []model.ParsedItem) []preparedItem {
+	prepared := make([]preparedItem, 0, len(items))
+	for _, parsed := range items {
+		sanitizedContent := s.sanitizer.Sanitize(parsed.Content)
+		sanitizedSummary := s.sanitizer.Sanitize(parsed.Summary)
+		// content_hashはサニタイズ後のサマリーを使用する（現状アルゴリズム不変）。
+		contentHash := computeContentHash(parsed.Title, parsed.PublishedAt, sanitizedSummary)
+		prepared = append(prepared, preparedItem{
+			parsed:           parsed,
+			sanitizedContent: sanitizedContent,
+			sanitizedSummary: sanitizedSummary,
+			contentHash:      contentHash,
+		})
 	}
-
-	// 第2優先: feed_id + link
-	if parsed.Link != "" {
-		item, err := s.itemRepo.FindByFeedAndLink(ctx, feedID, parsed.Link)
-		if err != nil {
-			return nil, err
-		}
-		if item != nil {
-			return item, nil
-		}
-	}
-
-	// 第3優先: content_hash
-	if contentHash != "" {
-		item, err := s.itemRepo.FindByContentHash(ctx, feedID, contentHash)
-		if err != nil {
-			return nil, err
-		}
-		if item != nil {
-			return item, nil
-		}
-	}
-
-	return nil, nil
+	return prepared
 }
 
-// updateExistingItem は既存記事を上書き更新する。履歴は保持しない。
-func (s *ItemUpsertService) updateExistingItem(
-	ctx context.Context,
-	existing *model.Item,
-	parsed model.ParsedItem,
-	sanitizedContent, sanitizedSummary, contentHash string,
-	now time.Time,
-) error {
-	existing.GuidOrID = parsed.GuidOrID
-	existing.Title = parsed.Title
-	existing.Link = parsed.Link
-	existing.Content = sanitizedContent
-	existing.Summary = sanitizedSummary
-	existing.Author = parsed.Author
-	existing.ContentHash = contentHash
-	existing.UpdatedAt = now
-
-	// published_atの設定
-	if parsed.PublishedAt != nil {
-		existing.PublishedAt = parsed.PublishedAt
-		existing.IsDateEstimated = false
+// identityKey は 3 段階の優先順位に沿って同一性判定の代表キーを返す。
+// guid_or_id > link > content_hash の順で最初に非空のキーを採用する。
+// いずれも空の場合は空キー（kind="" / value=""）を返し、dedup 対象外として扱う。
+func identityKey(p preparedItem) (kind, value string) {
+	if p.parsed.GuidOrID != "" {
+		return "guid", p.parsed.GuidOrID
 	}
-	// 既存記事の更新時、parsed.PublishedAtがnilの場合は既存の値を維持
-
-	return s.itemRepo.Update(ctx, existing)
+	if p.parsed.Link != "" {
+		return "link", p.parsed.Link
+	}
+	if p.contentHash != "" {
+		return "hash", p.contentHash
+	}
+	return "", ""
 }
 
-// createNewItem は新規記事を作成する。
+// dedupByIdentity はバッチ内で同一性判定上同一とみなされる記事を最終要素優先（後勝ち）で
+// 1 件に集約する。代表キーが空の記事は dedup せずそのまま保持する。
+// 元の出現順は最終出現位置を基準に保たれる。
+func dedupByIdentity(items []preparedItem) []preparedItem {
+	// 各キーの最終出現 index を記録する。
+	lastIndex := make(map[string]int)
+	for i, p := range items {
+		kind, value := identityKey(p)
+		if kind == "" {
+			continue
+		}
+		lastIndex[kind+"|"+value] = i
+	}
+
+	result := make([]preparedItem, 0, len(items))
+	for i, p := range items {
+		kind, value := identityKey(p)
+		if kind == "" {
+			// 代表キーを持たない記事は重複判定の対象外。
+			result = append(result, p)
+			continue
+		}
+		// 最終出現位置のみを採用する（後勝ち）。
+		if lastIndex[kind+"|"+value] == i {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// collectIdentityKeys は既存記事の一括取得に必要な guid_or_id / link / content_hash 群を収集する。
+func collectIdentityKeys(items []preparedItem) (guids, links, hashes []string) {
+	for _, p := range items {
+		if p.parsed.GuidOrID != "" {
+			guids = append(guids, p.parsed.GuidOrID)
+		}
+		if p.parsed.Link != "" {
+			links = append(links, p.parsed.Link)
+		}
+		if p.contentHash != "" {
+			hashes = append(hashes, p.contentHash)
+		}
+	}
+	return guids, links, hashes
+}
+
+// matchExisting は 3 段階の優先順位で既存記事を引き当てる。
+// 優先順位: (feed_id, guid_or_id) > (feed_id, link) > content_hash。
+// 一致しない場合は nil を返す（新規記事とみなす）。
+func matchExisting(existing *repository.ExistingItems, p preparedItem) *model.Item {
+	if p.parsed.GuidOrID != "" {
+		if item, ok := existing.ByGUID[p.parsed.GuidOrID]; ok {
+			return item
+		}
+	}
+	if p.parsed.Link != "" {
+		if item, ok := existing.ByLink[p.parsed.Link]; ok {
+			return item
+		}
+	}
+	if p.contentHash != "" {
+		if item, ok := existing.ByContentHash[p.contentHash]; ok {
+			return item
+		}
+	}
+	return nil
+}
+
+// buildUpdatedItem は既存記事に新しい内容を反映した更新後の記事を構築する。
+// 既存の id を保持し、新規採番は行わない。履歴は保持しない。
+func buildUpdatedItem(existing *model.Item, p preparedItem, now time.Time) *model.Item {
+	updated := *existing
+	updated.GuidOrID = p.parsed.GuidOrID
+	updated.Title = p.parsed.Title
+	updated.Link = p.parsed.Link
+	updated.Content = p.sanitizedContent
+	updated.Summary = p.sanitizedSummary
+	updated.Author = p.parsed.Author
+	updated.ContentHash = p.contentHash
+	updated.UpdatedAt = now
+
+	// published_atの設定。parsed.PublishedAtがnilの場合は既存の値を維持する。
+	if p.parsed.PublishedAt != nil {
+		updated.PublishedAt = p.parsed.PublishedAt
+		updated.IsDateEstimated = false
+	}
+
+	return &updated
+}
+
+// buildNewItem は新規記事を構築する。
 // published_at未設定の場合はfetched_atを代用し、推定フラグを付与する。
-func (s *ItemUpsertService) createNewItem(
-	ctx context.Context,
-	feedID string,
-	parsed model.ParsedItem,
-	sanitizedContent, sanitizedSummary, contentHash string,
-	now time.Time,
-) error {
+func buildNewItem(feedID string, p preparedItem, now time.Time) *model.Item {
 	item := &model.Item{
 		ID:          uuid.New().String(),
 		FeedID:      feedID,
-		GuidOrID:    parsed.GuidOrID,
-		Title:       parsed.Title,
-		Link:        parsed.Link,
-		Content:     sanitizedContent,
-		Summary:     sanitizedSummary,
-		Author:      parsed.Author,
-		ContentHash: contentHash,
+		GuidOrID:    p.parsed.GuidOrID,
+		Title:       p.parsed.Title,
+		Link:        p.parsed.Link,
+		Content:     p.sanitizedContent,
+		Summary:     p.sanitizedSummary,
+		Author:      p.parsed.Author,
+		ContentHash: p.contentHash,
 		FetchedAt:   now,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
 
-	// published_atの設定: 未設定の場合はfetched_atを代用し推定フラグを付与
-	if parsed.PublishedAt != nil {
-		item.PublishedAt = parsed.PublishedAt
+	// published_atの設定: 未設定の場合はfetched_atを代用し推定フラグを付与する。
+	if p.parsed.PublishedAt != nil {
+		item.PublishedAt = p.parsed.PublishedAt
 		item.IsDateEstimated = false
 	} else {
 		item.PublishedAt = &now
 		item.IsDateEstimated = true
 	}
 
-	return s.itemRepo.Create(ctx, item)
+	return item
 }
 
 // computeContentHash はtitle + published + summaryのSHA-256ハッシュを計算する。

--- a/internal/item/upsert_test.go
+++ b/internal/item/upsert_test.go
@@ -2,24 +2,40 @@ package item
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/hitoshi/feedman/internal/model"
+	"github.com/hitoshi/feedman/internal/repository"
 )
 
 // --- テスト用モック ---
 
 // mockItemRepo はテスト用のItemRepositoryモック。
 type mockItemRepo struct {
-	items           map[string]*model.Item // id -> item
-	byFeedGUID      map[string]*model.Item // feedID+guid -> item
-	byFeedLink      map[string]*model.Item // feedID+link -> item
-	byContentHash   map[string]*model.Item // feedID+hash -> item
-	createCalls     int
-	updateCalls     int
+	items         map[string]*model.Item // id -> item
+	byFeedGUID    map[string]*model.Item // feedID+guid -> item
+	byFeedLink    map[string]*model.Item // feedID+link -> item
+	byContentHash map[string]*model.Item // feedID+hash -> item
+	createCalls   int
+	updateCalls   int
+
+	// バルクメソッドの呼び出し回数（DB 往復が記事件数に比例しないことの検証用）。
+	findBulkCalls int
+	upsertCalls   int
+
+	// 直近のバルク永続化内容。
+	lastBulkCreated []*model.Item
+	lastBulkUpdated []*model.Item
+
 	lastCreatedItem *model.Item
 	lastUpdatedItem *model.Item
+
+	// findErr / upsertErr が non-nil の場合、それぞれのバルクメソッドがエラーを返す。
+	findErr   error
+	upsertErr error
 }
 
 func newMockItemRepo() *mockItemRepo {
@@ -90,6 +106,75 @@ func (m *mockItemRepo) Update(_ context.Context, item *model.Item) error {
 	m.updateCalls++
 	m.lastUpdatedItem = item
 	m.items[item.ID] = item
+	return nil
+}
+
+// FindExistingForUpsert はバッチ化した既存記事取得をモックする。
+// 内部の byFeed* マップから guid/link/hash 別の既存記事を一括で索引して返す。
+// 実 DB 実装と同様、呼び出し回数は記事件数に依存せず 1 バッチあたり 1 回に収まる。
+func (m *mockItemRepo) FindExistingForUpsert(
+	_ context.Context,
+	feedID string,
+	guids, links, hashes []string,
+) (*repository.ExistingItems, error) {
+	m.findBulkCalls++
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+
+	result := &repository.ExistingItems{
+		ByGUID:        make(map[string]*model.Item),
+		ByLink:        make(map[string]*model.Item),
+		ByContentHash: make(map[string]*model.Item),
+	}
+	for _, g := range guids {
+		if item, ok := m.byFeedGUID[feedID+"|"+g]; ok {
+			result.ByGUID[g] = item
+		}
+	}
+	for _, l := range links {
+		if item, ok := m.byFeedLink[feedID+"|"+l]; ok {
+			result.ByLink[l] = item
+		}
+	}
+	for _, h := range hashes {
+		if item, ok := m.byContentHash[feedID+"|"+h]; ok {
+			result.ByContentHash[h] = item
+		}
+	}
+	return result, nil
+}
+
+// BulkUpsert はバルク永続化をモックする。
+// upsertErr が設定されている場合はエラーを返し、内部状態を一切変更しない（全件ロールバック相当）。
+func (m *mockItemRepo) BulkUpsert(_ context.Context, toCreate, toUpdate []*model.Item) error {
+	m.upsertCalls++
+	if m.upsertErr != nil {
+		return m.upsertErr
+	}
+
+	m.lastBulkCreated = toCreate
+	m.lastBulkUpdated = toUpdate
+
+	for _, item := range toCreate {
+		m.createCalls++
+		m.lastCreatedItem = item
+		m.items[item.ID] = item
+		if item.GuidOrID != "" {
+			m.byFeedGUID[item.FeedID+"|"+item.GuidOrID] = item
+		}
+		if item.Link != "" {
+			m.byFeedLink[item.FeedID+"|"+item.Link] = item
+		}
+		if item.ContentHash != "" {
+			m.byContentHash[item.FeedID+"|"+item.ContentHash] = item
+		}
+	}
+	for _, item := range toUpdate {
+		m.updateCalls++
+		m.lastUpdatedItem = item
+		m.items[item.ID] = item
+	}
 	return nil
 }
 
@@ -281,7 +366,7 @@ func TestUpsertItems_IdentityPriority_GUIDOverLink(t *testing.T) {
 	parsedItems := []model.ParsedItem{
 		{
 			GuidOrID: "guid-abc",                        // guidで一致
-			Link:     "https://example.com/target-link",  // linkでも別の記事に一致
+			Link:     "https://example.com/target-link", // linkでも別の記事に一致
 			Title:    "更新タイトル",
 			Content:  "<p>更新</p>",
 		},
@@ -880,7 +965,7 @@ func TestUpsertItems_GUIDNotFound_FallbackToLink(t *testing.T) {
 
 	parsedItems := []model.ParsedItem{
 		{
-			GuidOrID: "nonexistent-guid", // GUIDでは見つからない
+			GuidOrID: "nonexistent-guid",             // GUIDでは見つからない
 			Link:     "https://example.com/fallback", // linkで見つかる
 			Title:    "更新タイトル",
 			Content:  "<p>更新</p>",
@@ -985,5 +1070,394 @@ func TestUpsertItems_Update_ContentHashUpdated(t *testing.T) {
 	}
 	if u.ContentHash == "" {
 		t.Error("ContentHashが空であってはならない")
+	}
+}
+
+// --- バルク化に伴う AC 網羅テスト ---
+
+// TestUpsertItems_Mixed50_Counts は50件の混在バッチ（新規N件・既存M件）で
+// inserted=N / updated=M が返ることを検証する（Requirement 1.1, 1.2）。
+func TestUpsertItems_Mixed50_Counts(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+
+	const existingCount = 20 // M
+	const newCount = 30      // N
+	// 既存記事 M 件をリポジトリに用意する。
+	for i := 0; i < existingCount; i++ {
+		repo.addExistingItem(&model.Item{
+			ID:       fmt.Sprintf("existing-%d", i),
+			FeedID:   "feed-1",
+			GuidOrID: fmt.Sprintf("existing-guid-%d", i),
+			Title:    fmt.Sprintf("既存記事-%d", i),
+		})
+	}
+
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	// 既存 M 件と新規 N 件を交互に混在させたバッチ（合計 50 件）。
+	parsedItems := make([]model.ParsedItem, 0, existingCount+newCount)
+	for i := 0; i < existingCount; i++ {
+		parsedItems = append(parsedItems, model.ParsedItem{
+			GuidOrID: fmt.Sprintf("existing-guid-%d", i),
+			Title:    fmt.Sprintf("更新-%d", i),
+			Content:  "<p>更新</p>",
+		})
+	}
+	for i := 0; i < newCount; i++ {
+		parsedItems = append(parsedItems, model.ParsedItem{
+			GuidOrID: fmt.Sprintf("new-guid-%d", i),
+			Title:    fmt.Sprintf("新規-%d", i),
+			Content:  "<p>新規</p>",
+		})
+	}
+
+	inserted, updated, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems)
+	if err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+	if inserted != newCount {
+		t.Errorf("inserted = %d, want %d", inserted, newCount)
+	}
+	if updated != existingCount {
+		t.Errorf("updated = %d, want %d", updated, existingCount)
+	}
+}
+
+// TestUpsertItems_RoundTripsConstant は記事件数を変えても DB 往復が定数オーダーに
+// 収まることを検証する（Requirement 2.1, 2.2, NFR 3.1）。
+func TestUpsertItems_RoundTripsConstant(t *testing.T) {
+	cases := []int{1, 10, 50}
+
+	for _, n := range cases {
+		t.Run(fmt.Sprintf("%d件でも往復回数が定数のとき定数オーダーに収まる", n), func(t *testing.T) {
+			repo := newMockItemRepo()
+			sanitizer := &mockSanitizer{}
+			svc := NewItemUpsertService(repo, sanitizer)
+
+			parsedItems := make([]model.ParsedItem, 0, n)
+			for i := 0; i < n; i++ {
+				parsedItems = append(parsedItems, model.ParsedItem{
+					GuidOrID: fmt.Sprintf("guid-%d", i),
+					Title:    fmt.Sprintf("記事-%d", i),
+				})
+			}
+
+			_, _, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems)
+			if err != nil {
+				t.Fatalf("UpsertItems returned error: %v", err)
+			}
+
+			// バルクメソッドの呼び出しは記事件数に依存せず固定回数（各 1 回）であること。
+			if repo.findBulkCalls != 1 {
+				t.Errorf("findBulkCalls = %d, want 1 (記事件数 %d に依存しない定数)", repo.findBulkCalls, n)
+			}
+			if repo.upsertCalls != 1 {
+				t.Errorf("upsertCalls = %d, want 1 (記事件数 %d に依存しない定数)", repo.upsertCalls, n)
+			}
+		})
+	}
+}
+
+// TestUpsertItems_Update_PreservesID は既存記事更新時に id が新規採番されず保持されることを
+// 検証する（Requirement 1.3）。
+func TestUpsertItems_Update_PreservesID(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+
+	repo.addExistingItem(&model.Item{
+		ID:       "preserve-id-1",
+		FeedID:   "feed-1",
+		GuidOrID: "guid-preserve",
+		Title:    "古い",
+	})
+
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	parsedItems := []model.ParsedItem{
+		{
+			GuidOrID: "guid-preserve",
+			Title:    "新しい",
+			Content:  "<p>新</p>",
+		},
+	}
+
+	_, updated, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems)
+	if err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+	if updated != 1 {
+		t.Errorf("updated = %d, want 1", updated)
+	}
+	if repo.lastUpdatedItem.ID != "preserve-id-1" {
+		t.Errorf("更新後の id = %q, want %q（新規採番してはならない）", repo.lastUpdatedItem.ID, "preserve-id-1")
+	}
+}
+
+// TestUpsertItems_Update_SanitizedContentAndHash は更新時にサニタイズ後コンテンツ・サマリーと
+// 再計算した content_hash が保存されることを検証する（Requirement 1.5）。
+func TestUpsertItems_Update_SanitizedContentAndHash(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+
+	oldPubTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	repo.addExistingItem(&model.Item{
+		ID:          "sanitize-hash-1",
+		FeedID:      "feed-1",
+		GuidOrID:    "guid-sanitize-hash",
+		Title:       "古い",
+		Summary:     "古いサマリー",
+		PublishedAt: &oldPubTime,
+		ContentHash: "old-hash",
+	})
+
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	newPubTime := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	parsedItems := []model.ParsedItem{
+		{
+			GuidOrID:    "guid-sanitize-hash",
+			Title:       "新しい",
+			Content:     "<script>x</script><p>本文</p>",
+			Summary:     "<iframe>y</iframe>要約",
+			PublishedAt: &newPubTime,
+		},
+	}
+
+	_, _, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems)
+	if err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+
+	u := repo.lastUpdatedItem
+	if u == nil {
+		t.Fatal("lastUpdatedItem should not be nil")
+	}
+	if u.Content != "[sanitized]<script>x</script><p>本文</p>" {
+		t.Errorf("更新コンテンツがサニタイズされるべき, got %q", u.Content)
+	}
+	if u.Summary != "[sanitized]<iframe>y</iframe>要約" {
+		t.Errorf("更新サマリーがサニタイズされるべき, got %q", u.Summary)
+	}
+	// content_hash はサニタイズ後サマリーで再計算された値であること。
+	want := computeContentHash("新しい", &newPubTime, "[sanitized]<iframe>y</iframe>要約")
+	if u.ContentHash != want {
+		t.Errorf("content_hash = %q, want %q（サニタイズ後サマリーで再計算）", u.ContentHash, want)
+	}
+}
+
+// TestUpsertItems_DBError_FindReturnsZeroAndWrappedError は既存記事取得時のエラーで
+// (0, 0, err) を返し、発生元エラーが wrap されることを検証する（Requirement 3.1, 3.2, 3.3）。
+func TestUpsertItems_DBError_FindReturnsZeroAndWrappedError(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+
+	sentinel := errors.New("find boom")
+	repo.findErr = sentinel
+
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	parsedItems := []model.ParsedItem{
+		{GuidOrID: "guid-1", Title: "記事"},
+		{GuidOrID: "guid-2", Title: "記事2"},
+	}
+
+	inserted, updated, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems)
+	if err == nil {
+		t.Fatal("エラーが返るべき")
+	}
+	if inserted != 0 || updated != 0 {
+		t.Errorf("(inserted, updated) = (%d, %d), want (0, 0)", inserted, updated)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("発生元エラーが wrap されるべき: %v", err)
+	}
+	// 永続化が呼ばれていない（1 件も書き込んでいない）こと。
+	if repo.upsertCalls != 0 {
+		t.Errorf("upsertCalls = %d, want 0（取得失敗時は永続化しない）", repo.upsertCalls)
+	}
+}
+
+// TestUpsertItems_DBError_UpsertRollsBackAndReturnsZero は永続化時のエラーで全件ロールバックし
+// (0, 0, err) を返し発生元エラーが wrap されることを検証する（Requirement 3.1, 3.2, 3.3）。
+func TestUpsertItems_DBError_UpsertRollsBackAndReturnsZero(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+
+	sentinel := errors.New("upsert boom")
+	repo.upsertErr = sentinel
+
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	parsedItems := []model.ParsedItem{
+		{GuidOrID: "guid-new-1", Title: "新規1"},
+		{GuidOrID: "guid-new-2", Title: "新規2"},
+	}
+
+	inserted, updated, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems)
+	if err == nil {
+		t.Fatal("エラーが返るべき")
+	}
+	if inserted != 0 || updated != 0 {
+		t.Errorf("(inserted, updated) = (%d, %d), want (0, 0)", inserted, updated)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("発生元エラーが wrap されるべき: %v", err)
+	}
+	// ロールバック相当: モックの内部状態に記事が永続化されていないこと。
+	if len(repo.items) != 0 {
+		t.Errorf("永続化された記事数 = %d, want 0（全件ロールバック）", len(repo.items))
+	}
+}
+
+// TestUpsertItems_SingleNewItem は1件の新規記事で (1, 0, nil) を返すことを検証する
+// （Requirement 4.3）。
+func TestUpsertItems_SingleNewItem(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	parsedItems := []model.ParsedItem{
+		{GuidOrID: "single-new", Title: "単一新規"},
+	}
+
+	inserted, updated, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems)
+	if err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+	if inserted != 1 || updated != 0 {
+		t.Errorf("(inserted, updated) = (%d, %d), want (1, 0)", inserted, updated)
+	}
+}
+
+// TestUpsertItems_SingleExistingItem は1件の既存記事一致で (0, 1, nil) を返すことを検証する
+// （Requirement 4.4）。
+func TestUpsertItems_SingleExistingItem(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+
+	repo.addExistingItem(&model.Item{
+		ID:       "single-existing",
+		FeedID:   "feed-1",
+		GuidOrID: "single-existing-guid",
+		Title:    "既存",
+	})
+
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	parsedItems := []model.ParsedItem{
+		{GuidOrID: "single-existing-guid", Title: "更新"},
+	}
+
+	inserted, updated, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems)
+	if err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+	if inserted != 0 || updated != 1 {
+		t.Errorf("(inserted, updated) = (%d, %d), want (0, 1)", inserted, updated)
+	}
+}
+
+// TestUpsertItems_EmptyItems_NoDBAccess は空スライスでDBアクセスせず早期 return することを
+// 検証する（Requirement 4.1）。
+func TestUpsertItems_EmptyItems_NoDBAccess(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	inserted, updated, err := svc.UpsertItems(context.Background(), "feed-1", []model.ParsedItem{})
+	if err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+	if inserted != 0 || updated != 0 {
+		t.Errorf("(inserted, updated) = (%d, %d), want (0, 0)", inserted, updated)
+	}
+	if repo.findBulkCalls != 0 || repo.upsertCalls != 0 {
+		t.Errorf("空入力時は DB へアクセスしてはならない: findBulkCalls=%d upsertCalls=%d", repo.findBulkCalls, repo.upsertCalls)
+	}
+}
+
+// TestUpsertItems_NilItems_NoDBAccess はnilでDBアクセスせず早期 return することを
+// 検証する（Requirement 4.2）。
+func TestUpsertItems_NilItems_NoDBAccess(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	inserted, updated, err := svc.UpsertItems(context.Background(), "feed-1", nil)
+	if err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+	if inserted != 0 || updated != 0 {
+		t.Errorf("(inserted, updated) = (%d, %d), want (0, 0)", inserted, updated)
+	}
+	if repo.findBulkCalls != 0 || repo.upsertCalls != 0 {
+		t.Errorf("nil 入力時は DB へアクセスしてはならない: findBulkCalls=%d upsertCalls=%d", repo.findBulkCalls, repo.upsertCalls)
+	}
+}
+
+// TestUpsertItems_BatchInternalDuplicate_LastWins はバッチ内で同一性判定上同一とみなされる
+// 記事が重複する場合、最終要素が勝つ（後勝ち）ことを検証する（オーケストレーター確定事項）。
+func TestUpsertItems_BatchInternalDuplicate_LastWins(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	// 同一 guid を持つ新規記事を 3 件並べる（DB には未存在）。
+	parsedItems := []model.ParsedItem{
+		{GuidOrID: "dup-guid", Title: "1番目"},
+		{GuidOrID: "dup-guid", Title: "2番目"},
+		{GuidOrID: "dup-guid", Title: "最後"},
+	}
+
+	inserted, updated, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems)
+	if err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+	// 事前 dedup により 1 件の新規としてのみ書き込まれる。
+	if inserted != 1 || updated != 0 {
+		t.Errorf("(inserted, updated) = (%d, %d), want (1, 0)", inserted, updated)
+	}
+	// 後勝ち: 最終要素のタイトルが採用されること。
+	if repo.lastCreatedItem == nil {
+		t.Fatal("lastCreatedItem should not be nil")
+	}
+	if repo.lastCreatedItem.Title != "最後" {
+		t.Errorf("採用されたタイトル = %q, want %q（後勝ち）", repo.lastCreatedItem.Title, "最後")
+	}
+}
+
+// TestUpsertItems_BatchInternalDuplicate_ExistingLastWins は同一 guid の重複が既存記事に
+// 一致する場合も最終要素が勝つことを検証する（オーケストレーター確定事項 / Requirement 1.4）。
+func TestUpsertItems_BatchInternalDuplicate_ExistingLastWins(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+
+	repo.addExistingItem(&model.Item{
+		ID:       "dup-existing",
+		FeedID:   "feed-1",
+		GuidOrID: "dup-existing-guid",
+		Title:    "既存",
+	})
+
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	parsedItems := []model.ParsedItem{
+		{GuidOrID: "dup-existing-guid", Title: "更新1"},
+		{GuidOrID: "dup-existing-guid", Title: "更新最後"},
+	}
+
+	inserted, updated, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems)
+	if err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+	if inserted != 0 || updated != 1 {
+		t.Errorf("(inserted, updated) = (%d, %d), want (0, 1)", inserted, updated)
+	}
+	if repo.lastUpdatedItem.Title != "更新最後" {
+		t.Errorf("採用されたタイトル = %q, want %q（後勝ち）", repo.lastUpdatedItem.Title, "更新最後")
+	}
+	if repo.lastUpdatedItem.ID != "dup-existing" {
+		t.Errorf("更新対象 id = %q, want %q", repo.lastUpdatedItem.ID, "dup-existing")
 	}
 }

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -131,6 +131,29 @@ type ItemRepository interface {
 
 	// Update は既存記事を上書き更新する。履歴は保持しない。
 	Update(ctx context.Context, item *model.Item) error
+
+	// FindExistingForUpsert は同一性判定に必要な既存記事を一括取得する。
+	// guids / links / hashes は当該バッチに含まれる guid_or_id / link / content_hash の
+	// 候補集合であり、それぞれを定数回（合計 3 回）のバッチ SELECT で引く。
+	// 記事件数に比例した DB 往復を発生させないための一括取得手段。
+	// 戻り値の ExistingItems は呼び出し側の 3 段階優先順位判定に用いる。
+	FindExistingForUpsert(ctx context.Context, feedID string, guids, links, hashes []string) (*ExistingItems, error)
+
+	// BulkUpsert は新規記事の一括 INSERT と既存記事の一括 UPDATE を単一トランザクションで実行する。
+	// 途中でエラーが発生した場合は当該バッチを全件ロールバックし、1 件も永続化しない。
+	// toCreate / toUpdate のいずれかが空でも安全に動作する。
+	BulkUpsert(ctx context.Context, toCreate, toUpdate []*model.Item) error
+}
+
+// ExistingItems は同一性判定のための既存記事を guid_or_id / link / content_hash 別に索引した結果。
+// いずれのマップも feed_id 単位で取得済みの既存記事を保持する。
+type ExistingItems struct {
+	// ByGUID は guid_or_id をキーとする既存記事マップ。
+	ByGUID map[string]*model.Item
+	// ByLink は link をキーとする既存記事マップ。
+	ByLink map[string]*model.Item
+	// ByContentHash は content_hash をキーとする既存記事マップ。
+	ByContentHash map[string]*model.Item
 }
 
 // HatebuItemRepository ははてなブックマーク取得に必要な記事データ操作のインターフェース。

--- a/internal/repository/postgres_item_repo.go
+++ b/internal/repository/postgres_item_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hitoshi/feedman/internal/model"
@@ -384,6 +385,245 @@ func (r *PostgresItemRepo) UpdateHatebuCount(ctx context.Context, itemID string,
 	)
 	if err != nil {
 		return fmt.Errorf("はてなブックマーク数の更新に失敗しました: %w", err)
+	}
+	return nil
+}
+
+// itemSelectColumns は records 取得時に共通利用するカラム列。
+const itemSelectColumns = `id, feed_id, guid_or_id, title, link, content, summary, author,
+	published_at, is_date_estimated, fetched_at, content_hash,
+	hatebu_count, hatebu_fetched_at, created_at, updated_at`
+
+// scanItem は items テーブルの 1 行を model.Item にスキャンする。
+// itemSelectColumns の列順に対応する。
+func scanItem(scanner interface {
+	Scan(dest ...interface{}) error
+}) (*model.Item, error) {
+	item := &model.Item{}
+	var publishedAt sql.NullTime
+	var hatebuFetchedAt sql.NullTime
+	var guidOrID, link, content, summary, author, contentHash sql.NullString
+
+	if err := scanner.Scan(
+		&item.ID, &item.FeedID, &guidOrID, &item.Title, &link,
+		&content, &summary, &author,
+		&publishedAt, &item.IsDateEstimated, &item.FetchedAt, &contentHash,
+		&item.HatebuCount, &hatebuFetchedAt, &item.CreatedAt, &item.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	item.GuidOrID = nullStringValue(guidOrID)
+	item.Link = nullStringValue(link)
+	item.Content = nullStringValue(content)
+	item.Summary = nullStringValue(summary)
+	item.Author = nullStringValue(author)
+	item.ContentHash = nullStringValue(contentHash)
+	if publishedAt.Valid {
+		item.PublishedAt = &publishedAt.Time
+	}
+	if hatebuFetchedAt.Valid {
+		item.HatebuFetchedAt = &hatebuFetchedAt.Time
+	}
+
+	return item, nil
+}
+
+// FindExistingForUpsert は同一性判定に必要な既存記事を一括取得する。
+// guids / links / hashes それぞれを 1 回ずつ（合計最大 3 回）のバッチ SELECT で引くため、
+// DB 往復回数は記事件数に比例しない定数オーダーになる。
+func (r *PostgresItemRepo) FindExistingForUpsert(
+	ctx context.Context,
+	feedID string,
+	guids, links, hashes []string,
+) (*ExistingItems, error) {
+	result := &ExistingItems{
+		ByGUID:        make(map[string]*model.Item),
+		ByLink:        make(map[string]*model.Item),
+		ByContentHash: make(map[string]*model.Item),
+	}
+
+	if err := r.queryItemsByColumn(ctx, feedID, "guid_or_id", guids, result.ByGUID, func(i *model.Item) string { return i.GuidOrID }); err != nil {
+		return nil, fmt.Errorf("GUID による既存記事の一括取得に失敗しました: %w", err)
+	}
+	if err := r.queryItemsByColumn(ctx, feedID, "link", links, result.ByLink, func(i *model.Item) string { return i.Link }); err != nil {
+		return nil, fmt.Errorf("link による既存記事の一括取得に失敗しました: %w", err)
+	}
+	if err := r.queryItemsByColumn(ctx, feedID, "content_hash", hashes, result.ByContentHash, func(i *model.Item) string { return i.ContentHash }); err != nil {
+		return nil, fmt.Errorf("content_hash による既存記事の一括取得に失敗しました: %w", err)
+	}
+
+	return result, nil
+}
+
+// queryItemsByColumn は feed_id と指定カラムの IN 句で既存記事をまとめて取得し、keyFn で索引する。
+// values が空のときは DB へアクセスしない。
+func (r *PostgresItemRepo) queryItemsByColumn(
+	ctx context.Context,
+	feedID, column string,
+	values []string,
+	dest map[string]*model.Item,
+	keyFn func(*model.Item) string,
+) error {
+	if len(values) == 0 {
+		return nil
+	}
+
+	args := make([]interface{}, 0, len(values)+1)
+	args = append(args, feedID)
+	placeholders := make([]string, len(values))
+	for i, v := range values {
+		args = append(args, v)
+		placeholders[i] = fmt.Sprintf("$%d", i+2)
+	}
+
+	query := fmt.Sprintf(
+		`SELECT %s FROM items WHERE feed_id = $1 AND %s IN (%s)`,
+		itemSelectColumns, column, strings.Join(placeholders, ", "),
+	)
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		item, scanErr := scanItem(rows)
+		if scanErr != nil {
+			return scanErr
+		}
+		key := keyFn(item)
+		// 同一キーに複数行が該当する場合は先頭行を採用（既存の単一取得と整合）。
+		if _, exists := dest[key]; !exists {
+			dest[key] = item
+		}
+	}
+	return rows.Err()
+}
+
+// BulkUpsert は新規記事の一括 INSERT と既存記事の一括 UPDATE を単一トランザクションで実行する。
+// 途中でエラーが発生した場合はトランザクションをロールバックし、当該バッチを 1 件も永続化しない。
+func (r *PostgresItemRepo) BulkUpsert(ctx context.Context, toCreate, toUpdate []*model.Item) error {
+	if len(toCreate) == 0 && len(toUpdate) == 0 {
+		return nil
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("バルク UPSERT のトランザクション開始に失敗しました: %w", err)
+	}
+	defer tx.Rollback()
+
+	if err := bulkInsertItems(ctx, tx, toCreate); err != nil {
+		return fmt.Errorf("記事の一括挿入に失敗しました: %w", err)
+	}
+	if err := bulkUpdateItems(ctx, tx, toUpdate); err != nil {
+		return fmt.Errorf("記事の一括更新に失敗しました: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("バルク UPSERT のコミットに失敗しました: %w", err)
+	}
+	return nil
+}
+
+// bulkInsertItems は複数記事を 1 回の INSERT（複数行 VALUES）で挿入する。
+func bulkInsertItems(ctx context.Context, tx *sql.Tx, items []*model.Item) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	const colsPerRow = 16
+	args := make([]interface{}, 0, len(items)*colsPerRow)
+	rowClauses := make([]string, len(items))
+	for i, item := range items {
+		base := i * colsPerRow
+		ph := make([]string, colsPerRow)
+		for j := 0; j < colsPerRow; j++ {
+			ph[j] = fmt.Sprintf("$%d", base+j+1)
+		}
+		rowClauses[i] = "(" + strings.Join(ph, ", ") + ")"
+		args = append(args,
+			item.ID, item.FeedID, nullString(item.GuidOrID), item.Title,
+			nullString(item.Link), nullString(item.Content), nullString(item.Summary),
+			nullString(item.Author), item.PublishedAt, item.IsDateEstimated, item.FetchedAt,
+			nullString(item.ContentHash), item.HatebuCount, item.HatebuFetchedAt,
+			item.CreatedAt, item.UpdatedAt,
+		)
+	}
+
+	query := `INSERT INTO items (id, feed_id, guid_or_id, title, link, content, summary, author,
+		published_at, is_date_estimated, fetched_at, content_hash,
+		hatebu_count, hatebu_fetched_at, created_at, updated_at)
+		VALUES ` + strings.Join(rowClauses, ", ")
+
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		return err
+	}
+	return nil
+}
+
+// bulkUpdateItems は複数記事を 1 回の UPDATE（VALUES 由来の派生テーブルと JOIN）で更新する。
+// 更新カラムは既存の Update と同一（guid_or_id / title / link / content / summary /
+// author / published_at / is_date_estimated / content_hash / updated_at）。
+func bulkUpdateItems(ctx context.Context, tx *sql.Tx, items []*model.Item) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	const colsPerRow = 11
+	args := make([]interface{}, 0, len(items)*colsPerRow)
+	rowClauses := make([]string, len(items))
+	for i, item := range items {
+		base := i * colsPerRow
+		// 型を明示するため id::uuid 等のキャストは VALUES の最初の行で行わず、
+		// UPDATE 側の比較で items.id（uuid）と v.id（text）を ::text 比較する方針を取る。
+		rowClauses[i] = fmt.Sprintf(
+			"($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
+			base+1, base+2, base+3, base+4, base+5, base+6,
+			base+7, base+8, base+9, base+10, base+11,
+		)
+		args = append(args,
+			item.ID, nullString(item.GuidOrID), item.Title, nullString(item.Link),
+			nullString(item.Content), nullString(item.Summary), nullString(item.Author),
+			item.PublishedAt, item.IsDateEstimated, nullString(item.ContentHash),
+			item.UpdatedAt,
+		)
+	}
+
+	// VALUES 由来の派生テーブルではプレースホルダの型推論が NULL 値で失敗し得るため、
+	// SELECT で各カラムに明示キャストを付与してから JOIN する。
+	query := `UPDATE items SET
+		guid_or_id = v.guid_or_id,
+		title = v.title,
+		link = v.link,
+		content = v.content,
+		summary = v.summary,
+		author = v.author,
+		published_at = v.published_at,
+		is_date_estimated = v.is_date_estimated,
+		content_hash = v.content_hash,
+		updated_at = v.updated_at
+	FROM (
+		SELECT
+			t.id::uuid AS id,
+			t.guid_or_id::text AS guid_or_id,
+			t.title::text AS title,
+			t.link::text AS link,
+			t.content::text AS content,
+			t.summary::text AS summary,
+			t.author::text AS author,
+			t.published_at::timestamptz AS published_at,
+			t.is_date_estimated::boolean AS is_date_estimated,
+			t.content_hash::text AS content_hash,
+			t.updated_at::timestamptz AS updated_at
+		FROM (VALUES ` + strings.Join(rowClauses, ", ") + `) AS t(id, guid_or_id, title, link, content, summary, author, published_at, is_date_estimated, content_hash, updated_at)
+	) AS v
+	WHERE items.id = v.id`
+
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## 概要

フィード取得後の記事永続化処理 `UpsertItems` が記事 1 件ごとに最大 3 回の SELECT + 1 回の INSERT/UPDATE を逐次実行していた N+1 構造を解消した。
既存記事の一括取得（バッチ SELECT）→ Go 側での 3 段階同一性判定 → バルク永続化（単一トランザクション）の 3 フェーズに再構成し、DB 往復回数を記事件数に比例させない定数オーダーに改善した。
公開シグネチャ・同一性判定アルゴリズム・サニタイズ処理はすべて変更しておらず、既存の挿入/更新件数の意味も維持している。

## 対応 Issue

Closes #11

## 関連 PR

- 設計 PR: なし（本 Issue は Architect フローなしの直接実装）

## 実装内容

- (Req 2.1 / 2.2 / NFR 3.1 / Task 1) `repository.ItemRepository` に `FindExistingForUpsert` / `BulkUpsert` を追加。既存メソッドのシグネチャは不変
- (Req 1.1〜1.5 / 2.1 / 3.1〜3.4 / 4.1〜4.4 / Task 2) `UpsertItems` をバルク化。バッチ内重複は後勝ち dedup、エラー時は全件ロールバックして `(0, 0, err)` を返す
- (Req 2.1 / 3.1 / NFR 3.1 / Task 3) `PostgresItemRepo` に `IN (...)` バッチ SELECT・複数行 VALUES INSERT・`UPDATE ... FROM (VALUES ...)` を単一トランザクションで実装
- (全 AC / Task 4) 混在 50 件・id 保持・判定結果不変・サニタイズ＆hash 再計算・往復定数オーダー・エラー時挙動・0件/nil/1件・バッチ内重複の各テストを追加

## 受入基準チェック

- [x] R1.1: When 新規記事と既存記事が混在したバッチを渡したとき inserted/updated に分離して返す ← `TestUpsertItems_Mixed50_Counts`
- [x] R1.2: When 50 件混在バッチで inserted=N, updated=M ← `TestUpsertItems_Mixed50_Counts`
- [x] R1.3: When 既存記事を更新するとき id を保持する ← `TestUpsertItems_Update_PreservesID`
- [x] R1.4: 同一性判定結果をバルク化前後で変えない ← `TestUpsertItems_IdentityPriority_*`, `TestUpsertItems_*FallbackTo*`
- [x] R1.5: サニタイズ後コンテンツ・再計算 hash を保存 ← `TestUpsertItems_Update_SanitizedContentAndHash`
- [x] R2.1 / R2.2 / NFR 3.1: DB 往復を定数オーダーに ← `TestUpsertItems_RoundTripsConstant`（1/10/50 件で findBulkCalls=1, upsertCalls=1）
- [x] R3.1: DB エラー時に全件ロールバック ← `TestUpsertItems_DBError_UpsertRollsBackAndReturnsZero`
- [x] R3.2 / R3.3: DB エラー時に `(0, 0, err)` + エラー wrap ← `TestUpsertItems_DBError_FindReturnsZeroAndWrappedError`, `..._UpsertRollsBackAndReturnsZero`
- [x] R4.1: 0 件で DB 非アクセス・(0,0,nil) ← `TestUpsertItems_EmptyItems_NoDBAccess`
- [x] R4.2: nil で DB 非アクセス・(0,0,nil) ← `TestUpsertItems_NilItems_NoDBAccess`
- [x] R4.3: 1 件新規で (1,0,nil) ← `TestUpsertItems_SingleNewItem`
- [x] R4.4: 1 件既存で (0,1,nil) ← `TestUpsertItems_SingleExistingItem`
- [x] NFR 1.1: `UpsertItems` 公開シグネチャ不変 ← `internal/worker/fetch` の呼び出し元に diff なし・build green
- [x] NFR 2.1 / 2.2: 判定ロジック・`computeContentHash`・サニタイズを Go 側に温存（アルゴリズム不変）

## テスト結果

```
ok  	github.com/hitoshi/feedman/internal/item	(cached)
ok  	github.com/hitoshi/feedman/internal/repository	(cached)
ok  	github.com/hitoshi/feedman/internal/worker/cleanup	(cached)
ok  	github.com/hitoshi/feedman/internal/worker/fetch	(cached)
全 4 パッケージ pass
```

## 実装上の判断

- スキーマ変更（`link` / `content_hash` へのユニーク制約追加）を回避し、3 段階同一性判定を Go 側に保持した（requirements の Out of Scope のため）
- バッチ内重複は「事前 dedup（最終要素優先・後勝ち）」を採用。同一 guid の新規 2 件は `inserted=1` となる
- バルク UPDATE の SQL は `VALUES` 派生テーブルで NULL 値の型推論失敗を防ぐため、明示キャスト（`::uuid` / `::timestamptz` 等）を付与している

## 確認事項 / レビュワーへの依頼

- Reviewer の独立レビュー（Round 1）は approve 判定済み。詳細は [docs/specs/11-upsertitems-n-1-upsert/review-notes.md](docs/specs/11-upsertitems-n-1-upsert/review-notes.md) を参照
- **エラー時挙動の変更**: Requirement 3 は現状の「部分成功カウントを返す」挙動から「全件ロールバック・件数 0」への意図的な変更（requirements Open Questions で定義済み）。運用上部分成功カウントの温存が必要な場合は確認が必要
- **ライブ DB テスト不在**: バルク SQL（`IN (...)` SELECT / 複数行 VALUES INSERT / `UPDATE ... FROM (VALUES ...)`）の実 DB 動作は自動テストでカバーされていない（本リポジトリの既存慣習に準拠）。ローカルでの手動検証を推奨
- base ブランチ検証: `--base develop` 指定 / baseRefName: develop / 一致=OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #11 のコメントを参照してください。