### PR TITLE
feat(#13): 退会処理（Withdraw）を DB トランザクションで原子化する

### DIFF
--- a/docs/specs/13--withdraw-db/impl-notes.md
+++ b/docs/specs/13--withdraw-db/impl-notes.md
@@ -1,0 +1,144 @@
+# 実装メモ — Issue #13 退会処理（Withdraw）の DB トランザクション原子化
+
+## 採用した設計方式（transaction-aware 化の手法）
+
+`database/sql` の `*sql.DB` と `*sql.Tx` が共通して満たす **`DBTX` querier 抽象**
+（`ExecContext` / `QueryContext` / `QueryRowContext`）を `internal/repository/tx.go` に導入し、
+各リポジトリの削除メソッドを transaction-aware 化した。Go の定石（querier インターフェースで
+DB ハンドルとトランザクションを統一的に扱う）に従っている。
+
+### レイヤごとの変更点
+
+1. **repository 層（`internal/repository/`）**
+   - `tx.go`: `DBTX` querier 抽象、`SQLTx`（`*sql.Tx` ラッパー + `Querier()` / `Commit()` /
+     `Rollback()`）、`SQLTxBeginner`（`*sql.DB` から `BeginTx(ctx)` でトランザクション開始）を追加。
+   - 各リポジトリに共有トランザクション上で実行する `*Exec` バリアントを追加し、
+     既存メソッドはそれに `r.db` を渡して委譲する形にリファクタした（挙動は不変）:
+     - `PostgresItemStateRepo.DeleteByUserIDExec(ctx, q DBTX, userID)`
+     - `PostgresSubscriptionRepo.DeleteByUserIDExec(ctx, q DBTX, userID)`
+     - `PostgresSessionRepo.DeleteByUserIDExec(ctx, q DBTX, userID)`
+     - `PostgresUserRepo.DeleteByIDExec(ctx, q DBTX, id)`（`rowsAffected == 0` でエラーを返す既存挙動を維持）
+   - 既存の `DeleteByUserID` / `DeleteByID` は `*Exec` に `r.db` を渡すだけになり、
+     これらを使う他の呼び出し元（購読解除など）の挙動は完全に等価。
+
+2. **user 層（`internal/user/service.go`）**
+   - `Tx`（`Commit` / `Rollback`）・`TxBeginner`（`BeginTx(ctx) (Tx, error)`）抽象と、
+     トランザクション対応 deleter インターフェース（`TxUserDeleter` / `TxSessionDeleter` /
+     `TxSubscriptionDeleter` / `TxItemStateDeleter`）を導入。`*sql.Tx` に直接依存せず
+     抽象に依存させることで、DB なしの単体テストで fake に差し替え可能にした。
+   - `Service` に `txBeginner` 系フィールドを追加。`NewServiceWithTx(...)` でトランザクション
+     パスを組み立てる。`Withdraw` は `txBeginner != nil` のとき単一トランザクション上で
+     item_states → subscriptions → sessions → user の順に削除し、**全成功時のみ Commit、
+     途中失敗時は defer 経由で全 Rollback** する。
+   - 既存の `NewService(...)` は後方互換のため温存し、`txBeginner == nil` のときは旧来の
+     逐次削除パス（`withdrawLegacy`）にフォールバックする（既存のモックベース単体テスト互換）。
+
+3. **app 層（`internal/app/withdraw_wiring.go`）**
+   - `user` 層は `repository` を import しているため、`repository` 側で `user.Tx*` を
+     実装すると import cycle になる。これを避けるため、両者を結ぶアダプタを `app` 層に配置した。
+   - `txBeginnerAdapter` が `*repository.SQLTxBeginner` を `user.TxBeginner` に適合させ、
+     各 `tx*DeleterAdapter` が `user.Tx`（実体は `*repository.SQLTx`）から `Querier()` で
+     `DBTX` を取り出してリポジトリの `*Exec` メソッドへ委譲する。
+   - `app.go` の本番配線を `user.NewService(...)` から `newTxUserService(...)` に変更し、
+     `repository.NewSQLTxBeginner(db)` を渡してトランザクションパスを有効化した。
+
+### nil チェックの維持
+
+旧実装の `s.stateDeleter != nil` 等の nil ガードは、トランザクションパス（`withdrawTx`）でも
+`s.txStateDeleter != nil` 等として維持している（`userDeleter` は存在確認に必須のため非 nil 前提）。
+
+## 各 AC とテストの対応
+
+| AC | 内容 | 担保するテスト |
+|---|---|---|
+| 1.1 | 全削除ステップ成功時に item_states/subscriptions/sessions/user を全削除 | `TestService_Withdraw`（legacy）/ `TestService_Withdraw_Tx_CommitsOnSuccess`（tx・削除順序も検証） |
+| 1.2 | user 削除に連動して CASCADE 対象（identities/user_settings）を削除 | `PostgresUserRepo.DeleteByIDExec` が `DELETE FROM users` を実行（CASCADE は DB スキーマ責務）。`TestService_Withdraw_Tx_CommitsOnSuccess` で user 削除呼び出しを検証 |
+| 1.3 | feeds と items を削除せず残存 | 削除対象テーブルに feeds/items を含めないことで担保（削除呼び出しは 4 対象のみ）。`TestService_Withdraw_Tx_CommitsOnSuccess` の `rec.order` が `[item_states, subscriptions, sessions, user]` のみであることを検証 |
+| 1.4 | エラーを返さず正常終了 | `TestService_Withdraw_Tx_CommitsOnSuccess`（err == nil を検証） |
+| 2.1 | 削除ステップ失敗時に同一処理内の全削除を取り消す | `TestService_Withdraw_Tx_RollsBackOnDeleteError`（rolledBack == true / committed == false） |
+| 2.2 | 失敗時に退会前と同一状態のまま残す | 単一トランザクション + Rollback で担保。`TestService_Withdraw_Tx_RollsBackOnDeleteError`（失敗後の後続削除 user が呼ばれないこと + ロールバックを検証） |
+| 2.3 | 発生したエラーを呼び出し元へ返す | `TestService_Withdraw_Tx_RollsBackOnDeleteError`（`errors.Is` で wrap 検証）/ `TestService_Withdraw_Tx_CommitError` / `TestService_Withdraw_Tx_BeginError` |
+| 3.1 | 存在しないユーザーで `UserNotFound` を返す | `TestService_Withdraw_UserNotFound`（legacy）/ `TestService_Withdraw_Tx_UserNotFound`（`ErrCodeUserNotFound` を検証） |
+| 3.2 | 存在しないユーザーで削除を確定しない | `TestService_Withdraw_Tx_UserNotFound`（beginCalled == false / committed == false / 削除 0 件） |
+| 4.1 | 関連データ 0 件でもエラーを返さず完了 | `TestService_Withdraw_Tx_NoRelatedData`（err == nil） |
+| 4.2 | 関連データ無しユーザーの user（+ CASCADE）削除 | `TestService_Withdraw_Tx_NoRelatedData`（committed == true / user 削除呼び出しを検証） |
+| NFR 1.1 | `Withdraw` シグネチャ不変 | `Withdraw(ctx, userID) error` を維持（変更なし）。既存 handler テスト群（`go test ./...`）が green |
+| NFR 1.2 | 削除対象テーブル + CASCADE 集合不変 | 削除対象 4 テーブル + CASCADE（identities/user_settings）を維持。`TestService_Withdraw_Tx_CommitsOnSuccess` の `rec.order` で検証 |
+| NFR 1.3 | 成功時の最終削除結果が不変 | 同上（同一テーブル群が削除済み） |
+| NFR 2.1 | 子→親の削除順序（外部キー制約順守） | `TestService_Withdraw_Tx_CommitsOnSuccess`（`[item_states, subscriptions, sessions, user]` の順序を厳密検証） |
+| NFR 3.1 | 退会開始ログ（user_id 含む）1 件 | `withdrawTx` で `slog.Info("退会処理を開始します", user_id)` を出力（既存挙動踏襲） |
+| NFR 3.2 | 退会完了ログ（user_id 含む）1 件 | `withdrawTx` で Commit 成功後に `slog.Info("退会処理が完了しました", user_id)` を出力 |
+
+## 後方互換の担保方法
+
+- `Withdraw(ctx, userID) error` のシグネチャを変更していない（NFR 1.1）。
+- 削除順序（item_states → subscriptions → sessions → user）・CASCADE 対象・削除する
+  テーブル集合を変更していない（NFR 1.2 / 2.1 / Out of Scope）。
+- リポジトリの既存メソッド（`DeleteByUserID` / `DeleteByID`）は `*Exec` バリアントに
+  `r.db` を渡して委譲するのみで、購読解除など他経路の挙動は完全に等価。
+- 旧 `NewService(...)` を温存し、トランザクション抽象が未配線（`txBeginner == nil`）の場合は
+  旧来の逐次削除パスにフォールバックする。これにより既存のモックベース単体テストも無改変で通る。
+- 退会 API エンドポイントのレスポンス仕様・HTTP ステータスは変更していない（Out of Scope）。
+
+## テスト戦略（結合 or 単体とその理由）
+
+**単体テスト（fake/stub querier + fake トランザクション）を採用した。**
+
+理由:
+- 本リポジトリの既存 `internal/repository/*_test.go` は実 PostgreSQL に接続せず、インター
+  フェース充足やモデル構築の「コンセプト／単体テスト」のみで構成されている。テスト用
+  PostgreSQL のセットアップ機構（接続ヘルパ・スキップ条件・`testdata/` フィクスチャ等）は
+  リポジトリ内に存在しない。このため DB 結合テストを新規に持ち込むと、この Issue のスコープ
+  外のテスト基盤整備（DSN 取得・migration 適用・CI への DB サービス追加）が必要になる。
+- ロールバック／コミットの境界はサービス層の制御フロー（成功時 Commit・失敗時 Rollback・
+  存在しないユーザーでトランザクション未開始）に集約されている。`TxBeginner` / `Tx` を
+  抽象化したことで、fake が Commit / Rollback の呼び出しを観測でき、トランザクション境界・
+  ロールバック発生・コミット未発生を単体テストで確実に検証できる。
+- 削除順序（NFR 2.1）も各 deleter の fake が呼び出し順序を記録することで厳密に検証している。
+
+CASCADE（identities / user_settings の連動削除）の実挙動は DB スキーマ（外部キー制約）に
+依存するため単体テストでは直接検証していない。これは本変更で導入したものではなく既存挙動の
+踏襲であり、`DELETE FROM users` を同一トランザクション上で実行する点のみ検証している。
+実 DB を用いた CASCADE / ロールバックの E2E 検証は、テスト用 PostgreSQL 基盤の整備を伴う
+別 Issue として切り出すことを推奨する（下記「派生タスク」参照）。
+
+## 確認事項（レビュワー判断ポイント）
+
+1. **DB 結合テストの不在**: 上記理由により、実 PostgreSQL を用いたロールバック / CASCADE の
+   結合テストは本 PR に含めていない（既存テスト基盤に実 DB 接続の枠組みが無いため）。要件は
+   「テスト用 DB が利用できない環境では単体テストでも可」としており、それに従った。実 DB での
+   検証が必須と判断される場合は、テスト基盤整備を含む別 Issue 化を提案する。
+2. **トランザクション分離レベル**: `BeginTx` は `opts = nil`（PostgreSQL 既定の READ COMMITTED）で
+   開始している。退会は単一ユーザーの削除のみで分離レベル引き上げの要件は無いと判断したが、
+   要件外の前提のため明記する。
+3. **import cycle 回避の配置**: `user → repository` の既存依存があるため、`user.Tx*` を満たす
+   アダプタを `repository` ではなく `app` 層に配置した。これは設計判断であり、専用の adapter
+   パッケージへ切り出す選択肢もあるが、既存の配線が `app.go` に集約されている慣習に合わせた。
+
+## 派生タスク（次 Issue 候補）
+
+- テスト用 PostgreSQL 基盤（接続ヘルパ / migration 適用 / CI サービス）を整備し、退会処理の
+  ロールバック・CASCADE 連動削除を実 DB で検証する結合テストを追加する。
+
+## 変更ファイル一覧
+
+- `internal/repository/tx.go`（新規）
+- `internal/repository/tx_test.go`（新規）
+- `internal/repository/postgres_user_repo.go`
+- `internal/repository/postgres_session_repo.go`
+- `internal/repository/postgres_subscription_repo.go`
+- `internal/repository/postgres_item_state_repo.go`
+- `internal/user/service.go`
+- `internal/user/service_test.go`
+- `internal/app/app.go`
+- `internal/app/withdraw_wiring.go`（新規）
+- `internal/app/withdraw_wiring_test.go`（新規）
+
+## 検証コマンドと結果
+
+- `go test ./...` — 全パッケージ pass（実 DB を用いた skip テストは存在しない＝skip なし）
+- `gofmt -l`（対象パッケージ）— 差分なし
+- `go vet ./...` — 警告なし
+- `go build ./...` — 成功
+
+STATUS: complete

--- a/docs/specs/13--withdraw-db/requirements.md
+++ b/docs/specs/13--withdraw-db/requirements.md
@@ -1,0 +1,82 @@
+# Requirements Document
+
+## Introduction
+
+ユーザー管理サービスの退会処理（`Withdraw`）は、記事状態・購読・セッション・ユーザー本体を
+個別の削除呼び出しで item_states → subscriptions → sessions → user の順に順次削除している。
+途中のいずれかのステップで失敗すると、それまでに削除済みのデータだけが消えた部分削除状態が
+残り、退会という不可逆操作で関連データの整合性が壊れるリスクがある。本要件は、一連の削除を
+原子的に扱い、全成功時のみ確定・途中失敗時は全ロールバックして退会前の状態へ戻すことで
+部分削除を残さない挙動を定義する不具合修正である。共有キャッシュである feeds / items の削除や
+GC、アカウント復旧・論理削除化は本件のスコープ外とする。
+
+## Requirements
+
+### Requirement 1: 退会処理の原子的な完了
+
+**Objective:** As a 退会するユーザー, I want 退会時に自分の関連データが全削除されること, so that 退会後に自分のデータが部分的に残存しない
+
+#### Acceptance Criteria
+
+1. When 既存ユーザーに対して退会処理が実行され全ての削除ステップが成功したとき, the User Service shall 当該ユーザーの item_states・subscriptions・sessions・user を全て削除する
+2. When 既存ユーザーに対して退会処理が成功したとき, the User Service shall user の削除に連動して CASCADE 対象（identities・user_settings）を削除する
+3. When 既存ユーザーに対して退会処理が成功したとき, the User Service shall 共有キャッシュである feeds と items を削除せず残存させる
+4. When 既存ユーザーに対して退会処理が成功したとき, the User Service shall エラーを返さず正常終了する
+
+### Requirement 2: 途中失敗時のロールバック
+
+**Objective:** As a 退会するユーザー, I want 退会処理が途中で失敗したら何も削除されないこと, so that 中途半端に一部データだけ消えた不整合状態に陥らない
+
+#### Acceptance Criteria
+
+1. If 退会処理の削除ステップ（item_states・subscriptions・sessions・user のいずれか）でエラーが発生したとき, the User Service shall 同一退会処理内で実施した全ての削除を取り消す
+2. If 退会処理の削除ステップでエラーが発生したとき, the User Service shall 当該ユーザーおよびその関連データ（item_states・subscriptions・sessions・identities・user_settings）を退会処理開始前と同一の状態のまま残す
+3. If 退会処理の削除ステップでエラーが発生したとき, the User Service shall 発生したエラーを呼び出し元へ返す
+
+### Requirement 3: 存在しないユーザーの扱い
+
+**Objective:** As a 開発者, I want 存在しないユーザー ID での退会要求を従来どおり扱えること, so that 無効な入力で予期しないデータ操作が起きない
+
+#### Acceptance Criteria
+
+1. If 存在しないユーザー ID を指定して退会処理が実行されたとき, the User Service shall `UserNotFound` を返す
+2. If 存在しないユーザー ID を指定して退会処理が実行されたとき, the User Service shall いずれのテーブルに対しても削除を確定しない
+
+### Requirement 4: 関連データが無いユーザーの退会
+
+**Objective:** As a 退会するユーザー, I want 購読やセッションが 1 件も無くても退会できること, so that 利用実績の少ないアカウントでも問題なく退会できる
+
+#### Acceptance Criteria
+
+1. When item_states・subscriptions・sessions のいずれにも関連データを持たない既存ユーザーに対して退会処理が実行されたとき, the User Service shall エラーを返さず退会を完了する
+2. When 関連データを持たない既存ユーザーの退会が完了したとき, the User Service shall 当該 user（および CASCADE 対象）を削除する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The User Service shall `Withdraw` の呼び出しシグネチャ（引数・返り値）を本変更前と同一に保つ
+2. The User Service shall 退会処理が削除する対象テーブルと CASCADE 対象（identities・user_settings）の集合を本変更前と同一に保つ
+3. When 退会処理が成功するとき, the User Service shall 本変更前と同一の最終削除結果（同一テーブル群が削除済みであること）を返す
+
+### NFR 2: 整合性（削除順序）
+
+1. The User Service shall 退会処理における削除を外部キー制約を満たす順序（子テーブル item_states・subscriptions・sessions を先に、親テーブル user を後に削除する順序）で実施する
+
+### NFR 3: 可観測性
+
+1. When 退会処理が開始されるとき, the User Service shall 対象ユーザー識別子を含む退会開始のログを 1 件出力する
+2. When 退会処理が成功し確定したとき, the User Service shall 対象ユーザー識別子を含む退会完了のログを 1 件出力する
+
+## Out of Scope
+
+- 共有キャッシュである feeds / items の削除・参照カウント・GC ロジックの導入や変更
+- 退会後のアカウント復旧・取り消し機能
+- 物理削除から論理削除（ソフトデリート）への切り替え（物理削除を維持する）
+- `Withdraw` の削除順序・CASCADE 対象・シグネチャの変更（後方互換として維持する）
+- 退会処理の原子化を実現する具体的な実装手段（トランザクション境界の張り方・リポジトリ層の IF 変更など。design / impl の領分）
+- 退会 API エンドポイント（`DELETE /api/users/me`）のレスポンス仕様・HTTP ステータスの変更
+
+## Open Questions
+
+- なし（Issue 本文・受入基準候補・既存実装で挙動が確定しており、人間による追加決定事項コメントも存在しないため、現時点で要件レベルの曖昧点はない）

--- a/docs/specs/13--withdraw-db/review-notes.md
+++ b/docs/specs/13--withdraw-db/review-notes.md
@@ -1,37 +1,37 @@
 # Review Notes
 
-<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-25T10:22:02Z -->
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-25T00:00:00Z -->
 
 ## Reviewed Scope
 
 - Branch: claude/issue-13-impl--withdraw-db
-- HEAD commit: 1ee633de1ec32e8f2c46dfc0bdafdf8fbea4a506
-- Compared to: 4595bde..HEAD
+- HEAD commit: e0177a3f70a882a5688ba27d7ffb23c97e9f3f6d
+- Compared to: develop..HEAD
 
-本 Issue には `tasks.md` が存在しないため、`_Boundary:_` アノテーションの代わりに
-`requirements.md` の Out of Scope（feeds/items 削除・復旧・論理削除化・シグネチャ/削除順序/CASCADE 変更）を
-境界基準として照合した。Feature Flag Protocol は CLAUDE.md で `opt-out` 宣言のため
-flag 観点の確認は行わず、通常の 3 カテゴリ判定のみを適用した。`go test ./...` を実行し全パッケージ pass を確認。
+本 Issue には `tasks.md` が存在しないため（Architect 非経由）、`_Boundary:_` アノテーションの
+代わりに `requirements.md` の Out of Scope（feeds/items 削除・復旧・論理削除化・シグネチャ/
+削除順序/CASCADE 変更・退会 API レスポンス変更）を境界基準として照合した。Feature Flag Protocol は
+CLAUDE.md で `opt-out` 宣言のため flag 観点の確認は行わず、通常の 3 カテゴリ判定のみを適用した。
+`go test`（user/repository/app）/ `go build ./...` / `go vet` を実行し pass を確認。
 
 ## Verified Requirements
 
-- 1.1 — `internal/user/service.go` `withdrawTx` が item_states/subscriptions/sessions/user を全削除。`TestService_Withdraw_Tx_CommitsOnSuccess`（order 検証）/ `TestService_Withdraw`（legacy）で担保
-- 1.2 — `PostgresUserRepo.DeleteByIDExec` が `DELETE FROM users` を実行（identities/user_settings の CASCADE は既存 DB スキーマ責務、本変更で未改変）。user 削除呼び出しを `TestService_Withdraw_Tx_CommitsOnSuccess` で検証
-- 1.3 — 削除対象は 4 テーブルのみで feeds/items を含めない。`rec.order` が `[item_states, subscriptions, sessions, user]` のみであることを検証
-- 1.4 — `TestService_Withdraw_Tx_CommitsOnSuccess` で `err == nil` を検証
-- 2.1 — `withdrawTx` の defer rollback + commit-only-on-success 制御フロー。`TestService_Withdraw_Tx_RollsBackOnDeleteError`（rolledBack==true / committed==false）で検証
-- 2.2 — 単一トランザクション + rollback により退会前状態を維持。同テストで失敗後の後続 user 削除が呼ばれないこと + rollback 発生を検証
-- 2.3 — `fmt.Errorf("...: %w", err)` で wrap し呼び出し元へ伝播。`TestService_Withdraw_Tx_RollsBackOnDeleteError` / `_CommitError` / `_BeginError` で `errors.Is` 検証
-- 3.1 — `withdrawTx` が `user == nil` で `model.NewUserNotFoundError()` を返す。`TestService_Withdraw_Tx_UserNotFound`（ErrCodeUserNotFound）/ `TestService_Withdraw_UserNotFound`（legacy）
-- 3.2 — 存在確認をトランザクション開始前に実施。`TestService_Withdraw_Tx_UserNotFound`（beginCalled==false / committed==false / 削除 0 件）
-- 4.1 — `TestService_Withdraw_Tx_NoRelatedData`（`err == nil`）。0 件削除でもエラーにならない制御フロー
-- 4.2 — 同テストで committed==true / user 削除呼び出しを検証
-- NFR 1.1 — `Withdraw(ctx, userID) error` シグネチャ不変。旧 `NewService` を温存し新規 `NewServiceWithTx` を追加。既存 handler テスト群が green
-- NFR 1.2 — 削除対象 4 テーブル + CASCADE 集合を不変に維持。`rec.order` で検証
-- NFR 1.3 — 成功時の最終削除結果（同一テーブル群削除済み）が不変
+- 1.1 — `internal/user/service.go` `withdrawTx` が単一 tx 上で item_states → subscriptions → sessions → user を全削除し成功時 Commit / `TestService_Withdraw_Tx_CommitsOnSuccess`（order 検証）, `TestService_Withdraw`（legacy）
+- 1.2 — `PostgresUserRepo.DeleteByIDExec` が `DELETE FROM users` を実行（identities/user_settings の CASCADE は DB スキーマ責務で本変更では不変）/ `TestService_Withdraw_Tx_CommitsOnSuccess`（user 削除呼び出しを検証）
+- 1.3 — `withdrawTx` の削除対象が 4 テーブルのみで feeds/items 削除呼び出しを持たない / `rec.order == [item_states, subscriptions, sessions, user]` で残存を担保
+- 1.4 — `TestService_Withdraw_Tx_CommitsOnSuccess`（`err == nil` を検証）
+- 2.1 — `withdrawTx` の `defer` ロールバック + 途中失敗で early return / `TestService_Withdraw_Tx_RollsBackOnDeleteError`（rolledBack==true / committed==false）, `TestService_Withdraw_Tx_BeginError`
+- 2.2 — 単一トランザクション + Rollback により退会前状態を維持 / `TestService_Withdraw_Tx_RollsBackOnDeleteError`（失敗後に user 削除が呼ばれないこと + ロールバックを検証）
+- 2.3 — `fmt.Errorf("...: %w", err)` でエラーを wrap し返却 / `TestService_Withdraw_Tx_RollsBackOnDeleteError` / `_CommitError` / `_BeginError`（いずれも `errors.Is` で wrap 検証）
+- 3.1 — `withdrawTx` が `FindByID` で nil を検出し `model.NewUserNotFoundError()` を返す / `TestService_Withdraw_Tx_UserNotFound`（`ErrCodeUserNotFound`）, `TestService_Withdraw_UserNotFound`（legacy）
+- 3.2 — 存在確認をトランザクション開始前に実施し未検出時は `BeginTx` を呼ばない / `TestService_Withdraw_Tx_UserNotFound`（beginCalled==false / committed==false / 削除 0 件）
+- 4.1 — `TestService_Withdraw_Tx_NoRelatedData`（関連 0 件でも `err == nil`）
+- 4.2 — `TestService_Withdraw_Tx_NoRelatedData`（committed==true / user 削除呼び出しを検証）
+- NFR 1.1 — `Withdraw(ctx, userID) error` シグネチャ不変（旧 `NewService` 温存 + 新規 `NewServiceWithTx` 追加。`go build ./...` 成功、既存テスト群 green）
+- NFR 1.2 / 1.3 — 削除対象 4 テーブル + CASCADE 集合を維持 / `rec.order` で検証
 - NFR 2.1 — 子→親の削除順序を `TestService_Withdraw_Tx_CommitsOnSuccess` で厳密検証
-- NFR 3.1 — `withdrawTx` が FindByID 後に `slog.Info("退会処理を開始します", user_id)` を 1 件出力
-- NFR 3.2 — Commit 成功後に `slog.Info("退会処理が完了しました", user_id)` を 1 件出力
+- NFR 3.1 — `withdrawTx` で `slog.Info("退会処理を開始します", user_id)` を出力（実装上で観測可能）
+- NFR 3.2 — `withdrawTx` で Commit 成功後に `slog.Info("退会処理が完了しました", user_id)` を出力（実装上で観測可能）
 
 ## Findings
 
@@ -39,6 +39,13 @@ flag 観点の確認は行わず、通常の 3 カテゴリ判定のみを適用
 
 ## Summary
 
-全 AC（1.1〜4.2）および NFR（1.1〜3.2）に対応する実装とテストが存在し、コミット/ロールバック/削除順序/トランザクション未開始（UserNotFound）/関連データ 0 件境界を単体テストで検証している。シグネチャ・削除順序・CASCADE 対象・旧逐次パスはいずれも温存され後方互換性が保たれている。CASCADE と実 DB ロールバックの結合検証は Out of Scope として別 Issue 化が impl-notes に明記されており、本 AC（User Service の制御フロー）のカバレッジ判定には影響しない。`go test ./...` 全 pass。3 カテゴリ（AC 未カバー / missing test / boundary 逸脱）いずれにも該当しない。
+全 AC（Req 1〜4 / NFR 1〜3）に対応する `withdrawTx` の単一トランザクション原子化実装と単体テスト
+（commit / rollback / begin error / commit error / UserNotFound / 関連データ 0 件 / 子→親削除順序）が
+確認できた。repository 層の `*Exec` バリアントは旧メソッドに `r.db` を委譲する等価リファクタで
+legacy パスも温存され、後方互換（NFR 1.1〜1.3）を満たす。Out of Scope（feeds/items 削除・シグネチャ・
+エンドポイント変更・論理削除化）への逸脱はなく、boundary 逸脱なし。`go test`（user/repository/app）/
+`go build ./...` / `go vet` も pass。CASCADE と実 DB ロールバックの結合検証は Out of Scope として
+別 Issue 化が impl-notes に明記済みで、本 AC（User Service の制御フロー）カバレッジ判定には影響しない。
+3 カテゴリ（AC 未カバー / missing test / boundary 逸脱）いずれにも該当しない。
 
 RESULT: approve

--- a/docs/specs/13--withdraw-db/review-notes.md
+++ b/docs/specs/13--withdraw-db/review-notes.md
@@ -1,0 +1,44 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-25T10:22:02Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-13-impl--withdraw-db
+- HEAD commit: 1ee633de1ec32e8f2c46dfc0bdafdf8fbea4a506
+- Compared to: 4595bde..HEAD
+
+本 Issue には `tasks.md` が存在しないため、`_Boundary:_` アノテーションの代わりに
+`requirements.md` の Out of Scope（feeds/items 削除・復旧・論理削除化・シグネチャ/削除順序/CASCADE 変更）を
+境界基準として照合した。Feature Flag Protocol は CLAUDE.md で `opt-out` 宣言のため
+flag 観点の確認は行わず、通常の 3 カテゴリ判定のみを適用した。`go test ./...` を実行し全パッケージ pass を確認。
+
+## Verified Requirements
+
+- 1.1 — `internal/user/service.go` `withdrawTx` が item_states/subscriptions/sessions/user を全削除。`TestService_Withdraw_Tx_CommitsOnSuccess`（order 検証）/ `TestService_Withdraw`（legacy）で担保
+- 1.2 — `PostgresUserRepo.DeleteByIDExec` が `DELETE FROM users` を実行（identities/user_settings の CASCADE は既存 DB スキーマ責務、本変更で未改変）。user 削除呼び出しを `TestService_Withdraw_Tx_CommitsOnSuccess` で検証
+- 1.3 — 削除対象は 4 テーブルのみで feeds/items を含めない。`rec.order` が `[item_states, subscriptions, sessions, user]` のみであることを検証
+- 1.4 — `TestService_Withdraw_Tx_CommitsOnSuccess` で `err == nil` を検証
+- 2.1 — `withdrawTx` の defer rollback + commit-only-on-success 制御フロー。`TestService_Withdraw_Tx_RollsBackOnDeleteError`（rolledBack==true / committed==false）で検証
+- 2.2 — 単一トランザクション + rollback により退会前状態を維持。同テストで失敗後の後続 user 削除が呼ばれないこと + rollback 発生を検証
+- 2.3 — `fmt.Errorf("...: %w", err)` で wrap し呼び出し元へ伝播。`TestService_Withdraw_Tx_RollsBackOnDeleteError` / `_CommitError` / `_BeginError` で `errors.Is` 検証
+- 3.1 — `withdrawTx` が `user == nil` で `model.NewUserNotFoundError()` を返す。`TestService_Withdraw_Tx_UserNotFound`（ErrCodeUserNotFound）/ `TestService_Withdraw_UserNotFound`（legacy）
+- 3.2 — 存在確認をトランザクション開始前に実施。`TestService_Withdraw_Tx_UserNotFound`（beginCalled==false / committed==false / 削除 0 件）
+- 4.1 — `TestService_Withdraw_Tx_NoRelatedData`（`err == nil`）。0 件削除でもエラーにならない制御フロー
+- 4.2 — 同テストで committed==true / user 削除呼び出しを検証
+- NFR 1.1 — `Withdraw(ctx, userID) error` シグネチャ不変。旧 `NewService` を温存し新規 `NewServiceWithTx` を追加。既存 handler テスト群が green
+- NFR 1.2 — 削除対象 4 テーブル + CASCADE 集合を不変に維持。`rec.order` で検証
+- NFR 1.3 — 成功時の最終削除結果（同一テーブル群削除済み）が不変
+- NFR 2.1 — 子→親の削除順序を `TestService_Withdraw_Tx_CommitsOnSuccess` で厳密検証
+- NFR 3.1 — `withdrawTx` が FindByID 後に `slog.Info("退会処理を開始します", user_id)` を 1 件出力
+- NFR 3.2 — Commit 成功後に `slog.Info("退会処理が完了しました", user_id)` を 1 件出力
+
+## Findings
+
+なし
+
+## Summary
+
+全 AC（1.1〜4.2）および NFR（1.1〜3.2）に対応する実装とテストが存在し、コミット/ロールバック/削除順序/トランザクション未開始（UserNotFound）/関連データ 0 件境界を単体テストで検証している。シグネチャ・削除順序・CASCADE 対象・旧逐次パスはいずれも温存され後方互換性が保たれている。CASCADE と実 DB ロールバックの結合検証は Out of Scope として別 Issue 化が impl-notes に明記されており、本 AC（User Service の制御フロー）のカバレッジ判定には影響しない。`go test ./...` 全 pass。3 カテゴリ（AC 未カバー / missing test / boundary 逸脱）いずれにも該当しない。
+
+RESULT: approve

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hitoshi/feedman/internal/repository"
 	"github.com/hitoshi/feedman/internal/security"
 	"github.com/hitoshi/feedman/internal/subscription"
-	"github.com/hitoshi/feedman/internal/user"
 	"github.com/hitoshi/feedman/internal/worker/cleanup"
 	fetchpkg "github.com/hitoshi/feedman/internal/worker/fetch"
 )
@@ -129,7 +128,9 @@ func runServe(cfg *config.Config) error {
 	itemService := item.NewItemService(itemRepo, itemStateRepo)
 
 	subService := subscription.NewService(subRepo, itemStateRepo, feedRepo)
-	userService := user.NewService(userRepo, sessionRepo, subRepo, itemStateRepo)
+	// 退会処理は単一トランザクションで原子化する（途中失敗時は全ロールバック）。
+	txBeginner := repository.NewSQLTxBeginner(db)
+	userService := newTxUserService(txBeginner, userRepo, sessionRepo, subRepo, itemStateRepo)
 
 	// 5. ハンドラーアダプタの構築
 	subServiceAdapter := handler.NewSubscriptionServiceAdapter(subService)

--- a/internal/app/withdraw_wiring.go
+++ b/internal/app/withdraw_wiring.go
@@ -1,0 +1,121 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hitoshi/feedman/internal/model"
+	"github.com/hitoshi/feedman/internal/repository"
+	"github.com/hitoshi/feedman/internal/user"
+)
+
+// 本ファイルは退会処理（user.Service）をトランザクション対応で組み立てるための
+// 配線（wiring）アダプタを提供する。repository パッケージは user パッケージを
+// import できない（user → repository の依存があるため）ことから、両者を結ぶ
+// アダプタを app パッケージ側に置く。
+
+// txBeginnerAdapter は *repository.SQLTxBeginner を user.TxBeginner に適合させる。
+type txBeginnerAdapter struct {
+	beginner *repository.SQLTxBeginner
+}
+
+// BeginTx はトランザクションを開始し、user.Tx として返す。
+func (a *txBeginnerAdapter) BeginTx(ctx context.Context) (user.Tx, error) {
+	tx, err := a.beginner.BeginTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return tx, nil
+}
+
+// querierFromTx は user.Tx から共有トランザクションの DBTX を取り出す。
+// 本配線では user.Tx の実体は必ず *repository.SQLTx であり、その Querier() を用いる。
+func querierFromTx(tx user.Tx) (repository.DBTX, error) {
+	sqlTx, ok := tx.(*repository.SQLTx)
+	if !ok {
+		return nil, fmt.Errorf("予期しないトランザクション型です: %T", tx)
+	}
+	return sqlTx.Querier(), nil
+}
+
+// txItemStateDeleterAdapter は記事状態リポジトリを user.TxItemStateDeleter に適合させる。
+type txItemStateDeleterAdapter struct {
+	repo *repository.PostgresItemStateRepo
+}
+
+func (a *txItemStateDeleterAdapter) DeleteByUserIDTx(ctx context.Context, tx user.Tx, userID string) error {
+	q, err := querierFromTx(tx)
+	if err != nil {
+		return err
+	}
+	return a.repo.DeleteByUserIDExec(ctx, q, userID)
+}
+
+// txSubscriptionDeleterAdapter は購読リポジトリを user.TxSubscriptionDeleter に適合させる。
+type txSubscriptionDeleterAdapter struct {
+	repo *repository.PostgresSubscriptionRepo
+}
+
+func (a *txSubscriptionDeleterAdapter) DeleteByUserIDTx(ctx context.Context, tx user.Tx, userID string) error {
+	q, err := querierFromTx(tx)
+	if err != nil {
+		return err
+	}
+	return a.repo.DeleteByUserIDExec(ctx, q, userID)
+}
+
+// txSessionDeleterAdapter はセッションリポジトリを user.TxSessionDeleter に適合させる。
+type txSessionDeleterAdapter struct {
+	repo *repository.PostgresSessionRepo
+}
+
+func (a *txSessionDeleterAdapter) DeleteByUserIDTx(ctx context.Context, tx user.Tx, userID string) error {
+	q, err := querierFromTx(tx)
+	if err != nil {
+		return err
+	}
+	return a.repo.DeleteByUserIDExec(ctx, q, userID)
+}
+
+// txUserDeleterAdapter はユーザーリポジトリを user.TxUserDeleter に適合させる。
+type txUserDeleterAdapter struct {
+	repo *repository.PostgresUserRepo
+}
+
+func (a *txUserDeleterAdapter) FindByID(ctx context.Context, id string) (*model.User, error) {
+	return a.repo.FindByID(ctx, id)
+}
+
+func (a *txUserDeleterAdapter) DeleteByIDTx(ctx context.Context, tx user.Tx, id string) error {
+	q, err := querierFromTx(tx)
+	if err != nil {
+		return err
+	}
+	return a.repo.DeleteByIDExec(ctx, q, id)
+}
+
+// newTxUserService はトランザクション対応の退会サービスを組み立てる。
+func newTxUserService(
+	beginner *repository.SQLTxBeginner,
+	userRepo *repository.PostgresUserRepo,
+	sessionRepo *repository.PostgresSessionRepo,
+	subRepo *repository.PostgresSubscriptionRepo,
+	itemStateRepo *repository.PostgresItemStateRepo,
+) *user.Service {
+	return user.NewServiceWithTx(
+		&txBeginnerAdapter{beginner: beginner},
+		&txUserDeleterAdapter{repo: userRepo},
+		&txSessionDeleterAdapter{repo: sessionRepo},
+		&txSubscriptionDeleterAdapter{repo: subRepo},
+		&txItemStateDeleterAdapter{repo: itemStateRepo},
+	)
+}
+
+// compile-time interface checks
+var (
+	_ user.TxBeginner            = (*txBeginnerAdapter)(nil)
+	_ user.TxItemStateDeleter    = (*txItemStateDeleterAdapter)(nil)
+	_ user.TxSubscriptionDeleter = (*txSubscriptionDeleterAdapter)(nil)
+	_ user.TxSessionDeleter      = (*txSessionDeleterAdapter)(nil)
+	_ user.TxUserDeleter         = (*txUserDeleterAdapter)(nil)
+)

--- a/internal/app/withdraw_wiring_test.go
+++ b/internal/app/withdraw_wiring_test.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/hitoshi/feedman/internal/repository"
+	"github.com/hitoshi/feedman/internal/user"
+)
+
+// fakeUserTx は *repository.SQLTx 以外の user.Tx 実装。
+// querierFromTx が予期しない型を拒否することを検証するために用いる。
+type fakeUserTx struct{}
+
+func (fakeUserTx) Commit() error   { return nil }
+func (fakeUserTx) Rollback() error { return nil }
+
+// TestQuerierFromTx_RejectsUnexpectedType は user.Tx の実体が
+// *repository.SQLTx でない場合にエラーを返すことを検証する。
+func TestQuerierFromTx_RejectsUnexpectedType(t *testing.T) {
+	// Arrange
+	var tx user.Tx = fakeUserTx{}
+
+	// Act
+	_, err := querierFromTx(tx)
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error for unexpected tx type, got nil")
+	}
+}
+
+// TestNewTxUserService_Constructs はトランザクション対応の退会サービスが
+// 配線できることを検証する（nil リポジトリでも構築自体は成功する）。
+func TestNewTxUserService_Constructs(t *testing.T) {
+	beginner := repository.NewSQLTxBeginner(nil)
+	svc := newTxUserService(
+		beginner,
+		repository.NewPostgresUserRepo(nil),
+		repository.NewPostgresSessionRepo(nil),
+		repository.NewPostgresSubscriptionRepo(nil),
+		repository.NewPostgresItemStateRepo(nil),
+	)
+	if svc == nil {
+		t.Fatal("expected non-nil user.Service")
+	}
+}
+
+// TestWithdrawWiringAdapters_SatisfyInterfaces は各アダプタが
+// user パッケージのトランザクション対応インターフェースを満たすことを検証する。
+func TestWithdrawWiringAdapters_SatisfyInterfaces(t *testing.T) {
+	var _ user.TxBeginner = (*txBeginnerAdapter)(nil)
+	var _ user.TxItemStateDeleter = (*txItemStateDeleterAdapter)(nil)
+	var _ user.TxSubscriptionDeleter = (*txSubscriptionDeleterAdapter)(nil)
+	var _ user.TxSessionDeleter = (*txSessionDeleterAdapter)(nil)
+	var _ user.TxUserDeleter = (*txUserDeleterAdapter)(nil)
+}

--- a/internal/repository/postgres_item_state_repo.go
+++ b/internal/repository/postgres_item_state_repo.go
@@ -169,7 +169,13 @@ func (r *PostgresItemStateRepo) DeleteByUserAndFeed(ctx context.Context, userID,
 
 // DeleteByUserID はユーザーIDに関連する全ての記事状態を削除する。
 func (r *PostgresItemStateRepo) DeleteByUserID(ctx context.Context, userID string) error {
-	_, err := r.db.ExecContext(ctx,
+	return r.DeleteByUserIDExec(ctx, r.db, userID)
+}
+
+// DeleteByUserIDExec は指定の DBTX（*sql.DB または共有トランザクション）上で
+// ユーザーIDに関連する全ての記事状態を削除する。
+func (r *PostgresItemStateRepo) DeleteByUserIDExec(ctx context.Context, q DBTX, userID string) error {
+	_, err := q.ExecContext(ctx,
 		`DELETE FROM item_states WHERE user_id = $1`,
 		userID,
 	)

--- a/internal/repository/postgres_session_repo.go
+++ b/internal/repository/postgres_session_repo.go
@@ -65,7 +65,13 @@ func (r *PostgresSessionRepo) DeleteByID(ctx context.Context, id string) error {
 
 // DeleteByUserID は指定ユーザーの全セッションを削除する。
 func (r *PostgresSessionRepo) DeleteByUserID(ctx context.Context, userID string) error {
-	_, err := r.db.ExecContext(ctx,
+	return r.DeleteByUserIDExec(ctx, r.db, userID)
+}
+
+// DeleteByUserIDExec は指定の DBTX（*sql.DB または共有トランザクション）上で
+// 指定ユーザーの全セッションを削除する。
+func (r *PostgresSessionRepo) DeleteByUserIDExec(ctx context.Context, q DBTX, userID string) error {
+	_, err := q.ExecContext(ctx,
 		`DELETE FROM sessions WHERE user_id = $1`,
 		userID,
 	)

--- a/internal/repository/postgres_subscription_repo.go
+++ b/internal/repository/postgres_subscription_repo.go
@@ -162,7 +162,13 @@ func (r *PostgresSubscriptionRepo) Delete(ctx context.Context, id string) error 
 
 // DeleteByUserID はユーザーの全購読を削除する。
 func (r *PostgresSubscriptionRepo) DeleteByUserID(ctx context.Context, userID string) error {
-	_, err := r.db.ExecContext(ctx,
+	return r.DeleteByUserIDExec(ctx, r.db, userID)
+}
+
+// DeleteByUserIDExec は指定の DBTX（*sql.DB または共有トランザクション）上で
+// ユーザーの全購読を削除する。
+func (r *PostgresSubscriptionRepo) DeleteByUserIDExec(ctx context.Context, q DBTX, userID string) error {
+	_, err := q.ExecContext(ctx,
 		`DELETE FROM subscriptions WHERE user_id = $1`,
 		userID,
 	)

--- a/internal/repository/postgres_user_repo.go
+++ b/internal/repository/postgres_user_repo.go
@@ -74,7 +74,14 @@ func (r *PostgresUserRepo) CreateWithIdentity(ctx context.Context, user *model.U
 // DeleteByID は指定IDのユーザーを削除する。
 // 関連するidentities、user_settingsはCASCADE削除される。
 func (r *PostgresUserRepo) DeleteByID(ctx context.Context, id string) error {
-	result, err := r.db.ExecContext(ctx,
+	return r.DeleteByIDExec(ctx, r.db, id)
+}
+
+// DeleteByIDExec は指定の DBTX（*sql.DB または共有トランザクション）上で
+// 指定IDのユーザーを削除する。関連する identities / user_settings は CASCADE 削除される。
+// 対象が存在しない場合はエラーを返す（既存の DeleteByID と同一挙動）。
+func (r *PostgresUserRepo) DeleteByIDExec(ctx context.Context, q DBTX, id string) error {
+	result, err := q.ExecContext(ctx,
 		`DELETE FROM users WHERE id = $1`,
 		id,
 	)

--- a/internal/repository/tx.go
+++ b/internal/repository/tx.go
@@ -1,0 +1,63 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// DBTX は *sql.DB と *sql.Tx が共通して満たすクエリ実行インターフェース。
+// リポジトリのデータ操作をトランザクション対応（transaction-aware）にするために用いる。
+// 非トランザクション時は *sql.DB を、トランザクション時は *sql.Tx を渡す。
+type DBTX interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// 静的検査: *sql.DB と *sql.Tx がともに DBTX を満たすこと。
+var (
+	_ DBTX = (*sql.DB)(nil)
+	_ DBTX = (*sql.Tx)(nil)
+)
+
+// SQLTx は *sql.Tx をラップし、共有トランザクションのクエリ実行ハンドルと
+// 確定／取り消し操作を提供する。
+type SQLTx struct {
+	tx *sql.Tx
+}
+
+// Querier はこのトランザクション上でクエリを実行するための DBTX を返す。
+func (t *SQLTx) Querier() DBTX {
+	return t.tx
+}
+
+// Commit はトランザクションを確定する。
+func (t *SQLTx) Commit() error {
+	return t.tx.Commit()
+}
+
+// Rollback はトランザクションを取り消す。
+// すでに確定済みの場合、database/sql は sql.ErrTxDone を返す。
+func (t *SQLTx) Rollback() error {
+	return t.tx.Rollback()
+}
+
+// SQLTxBeginner は *sql.DB をラップし、トランザクションを開始する。
+type SQLTxBeginner struct {
+	db *sql.DB
+}
+
+// NewSQLTxBeginner は *sql.DB から SQLTxBeginner を生成する。
+func NewSQLTxBeginner(db *sql.DB) *SQLTxBeginner {
+	return &SQLTxBeginner{db: db}
+}
+
+// BeginTx は新しいトランザクションを開始し、SQLTx でラップして返す。
+func (b *SQLTxBeginner) BeginTx(ctx context.Context) (*SQLTx, error) {
+	tx, err := b.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	return &SQLTx{tx: tx}, nil
+}

--- a/internal/repository/tx_test.go
+++ b/internal/repository/tx_test.go
@@ -1,0 +1,36 @@
+package repository
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// TestDBTX_SatisfiedBySQLTypes は *sql.DB と *sql.Tx がともに DBTX を満たすことを検証する。
+func TestDBTX_SatisfiedBySQLTypes(t *testing.T) {
+	var _ DBTX = (*sql.DB)(nil)
+	var _ DBTX = (*sql.Tx)(nil)
+}
+
+// TestNewSQLTxBeginner_Initializes は SQLTxBeginner が初期化できることを検証する。
+func TestNewSQLTxBeginner_Initializes(t *testing.T) {
+	b := NewSQLTxBeginner(nil)
+	if b == nil {
+		t.Fatal("expected non-nil SQLTxBeginner")
+	}
+}
+
+// TestSQLTx_QuerierReturnsUnderlyingTx は SQLTx.Querier が
+// ラップしている *sql.Tx を DBTX として返すことを検証する。
+func TestSQLTx_QuerierReturnsUnderlyingTx(t *testing.T) {
+	tx := &sql.Tx{}
+	wrapped := &SQLTx{tx: tx}
+
+	q := wrapped.Querier()
+	if q == nil {
+		t.Fatal("expected non-nil querier")
+	}
+	// Querier が返す DBTX はラップ元の *sql.Tx と同一であること。
+	if got, ok := q.(*sql.Tx); !ok || got != tx {
+		t.Errorf("Querier() = %v, want underlying *sql.Tx %v", q, tx)
+	}
+}

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -10,26 +10,81 @@ import (
 	"github.com/hitoshi/feedman/internal/repository"
 )
 
-// SubscriptionDeleter は購読の一括削除インターフェース。
+// SubscriptionDeleter は購読の一括削除インターフェース（レガシー・非トランザクション）。
 type SubscriptionDeleter interface {
 	DeleteByUserID(ctx context.Context, userID string) error
 }
 
-// ItemStateDeleter は記事状態の一括削除インターフェース。
+// ItemStateDeleter は記事状態の一括削除インターフェース（レガシー・非トランザクション）。
 type ItemStateDeleter interface {
 	DeleteByUserID(ctx context.Context, userID string) error
 }
 
-// Service はユーザー管理のサービス層。
-// 退会処理のビジネスロジックを提供する。
-type Service struct {
-	userRepo      repository.UserRepository
-	sessionRepo   repository.SessionRepository
-	subDeleter    SubscriptionDeleter
-	stateDeleter  ItemStateDeleter
+// Tx は退会処理で共有するトランザクションハンドル。
+// database/sql の *sql.Tx が満たす Commit / Rollback の最小集合であり、
+// テストでは fake 実装に差し替えられるよう抽象化している。
+type Tx interface {
+	// Commit はトランザクションを確定する。
+	Commit() error
+	// Rollback はトランザクションを取り消す。確定済みの場合は sql.ErrTxDone を返す。
+	Rollback() error
 }
 
-// NewService はServiceの新しいインスタンスを生成する。
+// TxBeginner はトランザクションを開始するインターフェース。
+type TxBeginner interface {
+	// BeginTx は新しいトランザクションを開始する。
+	BeginTx(ctx context.Context) (Tx, error)
+}
+
+// TxUserDeleter はユーザーの存在確認と、共有トランザクション上での削除を行うインターフェース。
+type TxUserDeleter interface {
+	// FindByID は指定IDのユーザーを取得する。見つからない場合はnilを返す。
+	FindByID(ctx context.Context, id string) (*model.User, error)
+	// DeleteByIDTx は共有トランザクション上でユーザーを削除する。
+	// 関連する identities / user_settings は CASCADE 削除される。
+	DeleteByIDTx(ctx context.Context, tx Tx, id string) error
+}
+
+// TxSessionDeleter は共有トランザクション上でセッションを一括削除するインターフェース。
+type TxSessionDeleter interface {
+	DeleteByUserIDTx(ctx context.Context, tx Tx, userID string) error
+}
+
+// TxSubscriptionDeleter は共有トランザクション上で購読を一括削除するインターフェース。
+type TxSubscriptionDeleter interface {
+	DeleteByUserIDTx(ctx context.Context, tx Tx, userID string) error
+}
+
+// TxItemStateDeleter は共有トランザクション上で記事状態を一括削除するインターフェース。
+type TxItemStateDeleter interface {
+	DeleteByUserIDTx(ctx context.Context, tx Tx, userID string) error
+}
+
+// Service はユーザー管理のサービス層。
+// 退会処理のビジネスロジックを提供する。
+//
+// txBeginner が設定されている場合、退会処理は単一トランザクションで原子的に実行され、
+// 途中失敗時は全削除がロールバックされる（推奨パス）。txBeginner が nil の場合は、
+// 後方互換のためレガシーの逐次削除パス（非原子）にフォールバックする。
+type Service struct {
+	// レガシー（非トランザクション）パス用のフィールド。
+	userRepo     repository.UserRepository
+	sessionRepo  repository.SessionRepository
+	subDeleter   SubscriptionDeleter
+	stateDeleter ItemStateDeleter
+
+	// トランザクションパス用のフィールド（txBeginner != nil のとき使用）。
+	txBeginner       TxBeginner
+	txUserDeleter    TxUserDeleter
+	txSessionDeleter TxSessionDeleter
+	txSubDeleter     TxSubscriptionDeleter
+	txStateDeleter   TxItemStateDeleter
+}
+
+// NewService は Service の新しいインスタンスを生成する（レガシー・非トランザクションパス）。
+//
+// 後方互換のためシグネチャを維持している。原子的な退会処理を行う場合は
+// NewServiceWithTx を使用すること。
 func NewService(
 	userRepo repository.UserRepository,
 	sessionRepo repository.SessionRepository,
@@ -44,10 +99,108 @@ func NewService(
 	}
 }
 
+// NewServiceWithTx はトランザクション対応の Service を生成する。
+//
+// 退会処理は txBeginner が開始する単一トランザクション上で
+// item_states → subscriptions → sessions → user の順に削除し、
+// 全成功時のみコミット、途中失敗時は全ロールバックする。
+func NewServiceWithTx(
+	txBeginner TxBeginner,
+	userDeleter TxUserDeleter,
+	sessionDeleter TxSessionDeleter,
+	subDeleter TxSubscriptionDeleter,
+	stateDeleter TxItemStateDeleter,
+) *Service {
+	return &Service{
+		txBeginner:       txBeginner,
+		txUserDeleter:    userDeleter,
+		txSessionDeleter: sessionDeleter,
+		txSubDeleter:     subDeleter,
+		txStateDeleter:   stateDeleter,
+	}
+}
+
 // Withdraw はユーザーの退会処理を実行する。
 // 削除順序: item_states → subscriptions → sessions → user（+ CASCADE: identities, user_settings）
 // feeds と items は共有キャッシュとして残す。
+//
+// txBeginner が設定されている場合は単一トランザクションで原子的に削除し、
+// 途中失敗時は全ロールバックする。設定されていない場合はレガシーの逐次削除を行う。
 func (s *Service) Withdraw(ctx context.Context, userID string) error {
+	if s.txBeginner != nil {
+		return s.withdrawTx(ctx, userID)
+	}
+	return s.withdrawLegacy(ctx, userID)
+}
+
+// withdrawTx は単一トランザクション上で原子的に退会処理を実行する。
+func (s *Service) withdrawTx(ctx context.Context, userID string) error {
+	// ユーザー存在確認（トランザクション外で実施。存在しなければ何も削除しない）。
+	user, err := s.txUserDeleter.FindByID(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("ユーザーの取得に失敗しました: %w", err)
+	}
+	if user == nil {
+		return model.NewUserNotFoundError()
+	}
+
+	slog.Info("退会処理を開始します",
+		slog.String("user_id", userID),
+	)
+
+	tx, err := s.txBeginner.BeginTx(ctx)
+	if err != nil {
+		return fmt.Errorf("トランザクションの開始に失敗しました: %w", err)
+	}
+	// 確定前に関数を抜けた場合は必ずロールバックする。コミット済みなら no-op。
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// 1. 記事状態を削除
+	if s.txStateDeleter != nil {
+		if err := s.txStateDeleter.DeleteByUserIDTx(ctx, tx, userID); err != nil {
+			return fmt.Errorf("記事状態の削除に失敗しました: %w", err)
+		}
+	}
+
+	// 2. 購読を削除
+	if s.txSubDeleter != nil {
+		if err := s.txSubDeleter.DeleteByUserIDTx(ctx, tx, userID); err != nil {
+			return fmt.Errorf("購読の削除に失敗しました: %w", err)
+		}
+	}
+
+	// 3. セッションを削除
+	if s.txSessionDeleter != nil {
+		if err := s.txSessionDeleter.DeleteByUserIDTx(ctx, tx, userID); err != nil {
+			return fmt.Errorf("セッションの削除に失敗しました: %w", err)
+		}
+	}
+
+	// 4. ユーザーを削除（identities, user_settings は CASCADE 削除）
+	if err := s.txUserDeleter.DeleteByIDTx(ctx, tx, userID); err != nil {
+		return fmt.Errorf("ユーザーの削除に失敗しました: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("トランザクションの確定に失敗しました: %w", err)
+	}
+	committed = true
+
+	slog.Info("退会処理が完了しました",
+		slog.String("user_id", userID),
+	)
+
+	return nil
+}
+
+// withdrawLegacy は後方互換のための非トランザクション逐次削除パス。
+// txBeginner が設定されていない場合に使用する。
+func (s *Service) withdrawLegacy(ctx context.Context, userID string) error {
 	// ユーザー存在確認
 	user, err := s.userRepo.FindByID(ctx, userID)
 	if err != nil {

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -2,12 +2,14 @@ package user
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"testing"
 
 	"github.com/hitoshi/feedman/internal/model"
 )
 
-// --- モック ---
+// --- モック（非トランザクションのレガシーパス用） ---
 
 type mockUserRepo struct {
 	findByIDFn   func(ctx context.Context, id string) (*model.User, error)
@@ -60,9 +62,119 @@ func (m *mockItemStateRepo) DeleteByUserID(ctx context.Context, userID string) e
 	return m.deleteByUserIDFn(ctx, userID)
 }
 
-// --- テスト ---
+// --- トランザクション対応 fake ---
 
-// TestService_Withdraw は退会処理が全関連データを削除することを検証する。
+// fakeTx は *sql.Tx の代わりに渡す不透明なトランザクションハンドル。
+type fakeTx struct{}
+
+// fakeTxBeginner は TxBeginner を満たし、コミット／ロールバックの呼び出しを記録する。
+type fakeTxBeginner struct {
+	beginErr     error
+	committed    bool
+	rolledBack   bool
+	commitErr    error
+	beginCalled  bool
+	commitCalled bool
+}
+
+func (b *fakeTxBeginner) BeginTx(ctx context.Context) (Tx, error) {
+	b.beginCalled = true
+	if b.beginErr != nil {
+		return nil, b.beginErr
+	}
+	return &recordingTx{owner: b}, nil
+}
+
+// recordingTx は Tx を満たし、Commit / Rollback を所有者へ記録する。
+type recordingTx struct {
+	owner *fakeTxBeginner
+}
+
+func (t *recordingTx) Commit() error {
+	t.owner.commitCalled = true
+	if t.owner.commitErr != nil {
+		return t.owner.commitErr
+	}
+	t.owner.committed = true
+	return nil
+}
+
+func (t *recordingTx) Rollback() error {
+	// 既にコミット済みなら no-op（database/sql の sql.ErrTxDone 相当）。
+	if t.owner.committed {
+		return sql.ErrTxDone
+	}
+	t.owner.rolledBack = true
+	return nil
+}
+
+// txCall は各 deleter が受け取った tx と呼び出し順序を記録する。
+type txRecorder struct {
+	order []string
+}
+
+// txItemStateDeleter は TxItemStateDeleter を満たす fake。
+type txItemStateDeleter struct {
+	rec *txRecorder
+	err error
+}
+
+func (d *txItemStateDeleter) DeleteByUserIDTx(ctx context.Context, tx Tx, userID string) error {
+	d.rec.order = append(d.rec.order, "item_states")
+	return d.err
+}
+
+type txSubDeleter struct {
+	rec *txRecorder
+	err error
+}
+
+func (d *txSubDeleter) DeleteByUserIDTx(ctx context.Context, tx Tx, userID string) error {
+	d.rec.order = append(d.rec.order, "subscriptions")
+	return d.err
+}
+
+type txSessionDeleter struct {
+	rec *txRecorder
+	err error
+}
+
+func (d *txSessionDeleter) DeleteByUserIDTx(ctx context.Context, tx Tx, userID string) error {
+	d.rec.order = append(d.rec.order, "sessions")
+	return d.err
+}
+
+type txUserDeleter struct {
+	rec          *txRecorder
+	findByIDFn   func(ctx context.Context, id string) (*model.User, error)
+	deleteErr    error
+	deleteCalled bool
+}
+
+func (d *txUserDeleter) FindByID(ctx context.Context, id string) (*model.User, error) {
+	return d.findByIDFn(ctx, id)
+}
+
+func (d *txUserDeleter) DeleteByIDTx(ctx context.Context, tx Tx, id string) error {
+	d.deleteCalled = true
+	d.rec.order = append(d.rec.order, "user")
+	return d.deleteErr
+}
+
+// newTxService はトランザクション対応の Service を組み立てるテストヘルパ。
+func newTxService(
+	beginner *fakeTxBeginner,
+	user *txUserDeleter,
+	session *txSessionDeleter,
+	sub *txSubDeleter,
+	state *txItemStateDeleter,
+) *Service {
+	return NewServiceWithTx(beginner, user, session, sub, state)
+}
+
+// --- レガシー（非トランザクション）パスのテスト ---
+
+// TestService_Withdraw は退会処理が全関連データを削除することを検証する（AC 1.1）。
 func TestService_Withdraw(t *testing.T) {
 	userDeleteCalled := false
 	sessionDeleteCalled := false
@@ -117,7 +229,7 @@ func TestService_Withdraw(t *testing.T) {
 	}
 }
 
-// TestService_Withdraw_UserNotFound は存在しないユーザーの退会がエラーになることを検証する。
+// TestService_Withdraw_UserNotFound は存在しないユーザーの退会がエラーになることを検証する（AC 3.1）。
 func TestService_Withdraw_UserNotFound(t *testing.T) {
 	userRepo := &mockUserRepo{
 		findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
@@ -130,5 +242,234 @@ func TestService_Withdraw_UserNotFound(t *testing.T) {
 	err := svc.Withdraw(context.Background(), "nonexistent-user")
 	if err == nil {
 		t.Fatal("expected error for nonexistent user, got nil")
+	}
+}
+
+// --- トランザクション対応パスのテスト ---
+
+// TestService_Withdraw_Tx_CommitsOnSuccess は全削除成功時にコミットされ、
+// 子→親の順序で削除されることを検証する（AC 1.1 / 1.4 / NFR 2.1）。
+func TestService_Withdraw_Tx_CommitsOnSuccess(t *testing.T) {
+	// Arrange
+	rec := &txRecorder{}
+	beginner := &fakeTxBeginner{}
+	user := &txUserDeleter{
+		rec: rec,
+		findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+			return &model.User{ID: id, Email: "test@example.com"}, nil
+		},
+	}
+	svc := newTxService(beginner,
+		user,
+		&txSessionDeleter{rec: rec},
+		&txSubDeleter{rec: rec},
+		&txItemStateDeleter{rec: rec},
+	)
+
+	// Act
+	err := svc.Withdraw(context.Background(), "user-1")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("Withdraw returned error: %v", err)
+	}
+	if !beginner.committed {
+		t.Error("expected transaction to be committed")
+	}
+	if beginner.rolledBack {
+		t.Error("expected no rollback on success")
+	}
+	want := []string{"item_states", "subscriptions", "sessions", "user"}
+	if len(rec.order) != len(want) {
+		t.Fatalf("delete order = %v, want %v", rec.order, want)
+	}
+	for i := range want {
+		if rec.order[i] != want[i] {
+			t.Errorf("delete order[%d] = %q, want %q", i, rec.order[i], want[i])
+		}
+	}
+}
+
+// TestService_Withdraw_Tx_RollsBackOnDeleteError は途中の削除失敗時に
+// ロールバックされコミットされないことを検証する（AC 2.1 / 2.2 / 2.3）。
+func TestService_Withdraw_Tx_RollsBackOnDeleteError(t *testing.T) {
+	// Arrange
+	rec := &txRecorder{}
+	beginner := &fakeTxBeginner{}
+	deleteErr := errors.New("subscription delete failed")
+	user := &txUserDeleter{
+		rec: rec,
+		findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+			return &model.User{ID: id}, nil
+		},
+	}
+	svc := newTxService(beginner,
+		user,
+		&txSessionDeleter{rec: rec},
+		&txSubDeleter{rec: rec, err: deleteErr},
+		&txItemStateDeleter{rec: rec},
+	)
+
+	// Act
+	err := svc.Withdraw(context.Background(), "user-1")
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error from failing delete, got nil")
+	}
+	if !errors.Is(err, deleteErr) {
+		t.Errorf("expected error to wrap %v, got %v", deleteErr, err)
+	}
+	if beginner.committed {
+		t.Error("expected no commit when a delete fails")
+	}
+	if !beginner.rolledBack {
+		t.Error("expected rollback when a delete fails")
+	}
+	// 失敗した subscriptions より後の sessions / user は実行されないこと。
+	if user.deleteCalled {
+		t.Error("expected user delete NOT to be called after earlier failure")
+	}
+}
+
+// TestService_Withdraw_Tx_UserNotFound は存在しないユーザーでは
+// トランザクションを開始も確定もしないことを検証する（AC 3.1 / 3.2）。
+func TestService_Withdraw_Tx_UserNotFound(t *testing.T) {
+	// Arrange
+	rec := &txRecorder{}
+	beginner := &fakeTxBeginner{}
+	user := &txUserDeleter{
+		rec: rec,
+		findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+			return nil, nil
+		},
+	}
+	svc := newTxService(beginner,
+		user,
+		&txSessionDeleter{rec: rec},
+		&txSubDeleter{rec: rec},
+		&txItemStateDeleter{rec: rec},
+	)
+
+	// Act
+	err := svc.Withdraw(context.Background(), "nonexistent-user")
+
+	// Assert
+	var apiErr *model.APIError
+	if !errors.As(err, &apiErr) || apiErr.Code != model.ErrCodeUserNotFound {
+		t.Fatalf("expected UserNotFound error, got %v", err)
+	}
+	if beginner.beginCalled {
+		t.Error("expected no transaction to be started for nonexistent user")
+	}
+	if beginner.committed {
+		t.Error("expected no commit for nonexistent user")
+	}
+	if len(rec.order) != 0 {
+		t.Errorf("expected no deletes, got %v", rec.order)
+	}
+}
+
+// TestService_Withdraw_Tx_NoRelatedData は関連データが 0 件でも退会が
+// 成功しコミットされることを検証する（AC 4.1 / 4.2）。
+func TestService_Withdraw_Tx_NoRelatedData(t *testing.T) {
+	// Arrange: 各 deleter は 0 件削除でもエラーを返さない（DELETE ... WHERE は 0 行でも成功）。
+	rec := &txRecorder{}
+	beginner := &fakeTxBeginner{}
+	user := &txUserDeleter{
+		rec: rec,
+		findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+			return &model.User{ID: id}, nil
+		},
+	}
+	svc := newTxService(beginner,
+		user,
+		&txSessionDeleter{rec: rec},
+		&txSubDeleter{rec: rec},
+		&txItemStateDeleter{rec: rec},
+	)
+
+	// Act
+	err := svc.Withdraw(context.Background(), "lonely-user")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("Withdraw returned error: %v", err)
+	}
+	if !beginner.committed {
+		t.Error("expected commit even with no related data")
+	}
+	if !user.deleteCalled {
+		t.Error("expected user (and CASCADE targets) to be deleted")
+	}
+}
+
+// TestService_Withdraw_Tx_RollsBackOnCommitError はコミット失敗時に
+// エラーを返すことを検証する（AC 2.3）。
+func TestService_Withdraw_Tx_CommitError(t *testing.T) {
+	// Arrange
+	rec := &txRecorder{}
+	commitErr := errors.New("commit failed")
+	beginner := &fakeTxBeginner{commitErr: commitErr}
+	user := &txUserDeleter{
+		rec: rec,
+		findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+			return &model.User{ID: id}, nil
+		},
+	}
+	svc := newTxService(beginner,
+		user,
+		&txSessionDeleter{rec: rec},
+		&txSubDeleter{rec: rec},
+		&txItemStateDeleter{rec: rec},
+	)
+
+	// Act
+	err := svc.Withdraw(context.Background(), "user-1")
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error on commit failure, got nil")
+	}
+	if !errors.Is(err, commitErr) {
+		t.Errorf("expected error to wrap %v, got %v", commitErr, err)
+	}
+	if beginner.committed {
+		t.Error("expected committed flag to remain false on commit error")
+	}
+}
+
+// TestService_Withdraw_Tx_BeginError はトランザクション開始失敗時に
+// エラーを返し削除を実行しないことを検証する（AC 2.1 / 2.3）。
+func TestService_Withdraw_Tx_BeginError(t *testing.T) {
+	// Arrange
+	rec := &txRecorder{}
+	beginErr := errors.New("begin failed")
+	beginner := &fakeTxBeginner{beginErr: beginErr}
+	user := &txUserDeleter{
+		rec: rec,
+		findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+			return &model.User{ID: id}, nil
+		},
+	}
+	svc := newTxService(beginner,
+		user,
+		&txSessionDeleter{rec: rec},
+		&txSubDeleter{rec: rec},
+		&txItemStateDeleter{rec: rec},
+	)
+
+	// Act
+	err := svc.Withdraw(context.Background(), "user-1")
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error on begin failure, got nil")
+	}
+	if !errors.Is(err, beginErr) {
+		t.Errorf("expected error to wrap %v, got %v", beginErr, err)
+	}
+	if len(rec.order) != 0 {
+		t.Errorf("expected no deletes when begin fails, got %v", rec.order)
 	}
 }


### PR DESCRIPTION
## 概要

退会処理（`Withdraw`）の部分削除問題を解消するため、`item_states → subscriptions → sessions → user`
の 4 テーブル削除を単一 DB トランザクション内で原子化した。全ステップが成功した場合のみ Commit し、
いずれかのステップでエラーが発生した場合は即時 Rollback して退会前の状態に戻す。
呼び出しシグネチャ（`Withdraw(ctx, userID) error`）・削除対象テーブル・削除順序・CASCADE 対象は
本変更前と同一に保ち、後方互換を維持している。

## 対応 Issue

Closes #13

## 関連 PR

- 設計 PR: なし（Architect 非経由の小規模 Issue）

## 実装内容

- (Req 1 / Req 2) `internal/repository/tx.go` に `DBTX` querier 抽象・`SQLTx`・`SQLTxBeginner` を追加し、各リポジトリの削除メソッドに `*Exec` バリアント（transaction-aware）を追加
- (Req 1 / Req 2) `internal/user/service.go` に `TxBeginner` / `Tx` 抽象と `withdrawTx` を実装。全成功時のみ Commit、defer による全 Rollback を保証
- (Req 1 / Req 2) `internal/app/withdraw_wiring.go` に import cycle 回避アダプタを配置し、本番配線を `newTxUserService` に変更してトランザクションパスを有効化
- (NFR 1) 既存 `NewService(...)` を温存し、`txBeginner == nil` 時は旧来の逐次削除パス（`withdrawLegacy`）にフォールバック

## 受入基準チェック

- [x] Req 1.1: When 全削除ステップが成功したとき item_states/subscriptions/sessions/user を全削除 ← `TestService_Withdraw_Tx_CommitsOnSuccess`
- [x] Req 1.2: CASCADE 対象（identities/user_settings）を user 削除に連動して削除 ← `TestService_Withdraw_Tx_CommitsOnSuccess`（user 削除呼び出し検証）
- [x] Req 1.3: feeds と items を削除せず残存 ← `TestService_Withdraw_Tx_CommitsOnSuccess`（`rec.order` が 4 テーブルのみ）
- [x] Req 1.4: エラーを返さず正常終了 ← `TestService_Withdraw_Tx_CommitsOnSuccess`（`err == nil`）
- [x] Req 2.1: 削除ステップ失敗時に全削除を取り消す ← `TestService_Withdraw_Tx_RollsBackOnDeleteError`
- [x] Req 2.2: 失敗時に退会前と同一状態のまま残す ← `TestService_Withdraw_Tx_RollsBackOnDeleteError`（user 削除未呼び出し + ロールバック検証）
- [x] Req 2.3: エラーを呼び出し元へ返す ← `TestService_Withdraw_Tx_RollsBackOnDeleteError` / `_CommitError` / `_BeginError`
- [x] Req 3.1: 存在しないユーザーで `UserNotFound` を返す ← `TestService_Withdraw_Tx_UserNotFound`
- [x] Req 3.2: 存在しないユーザーで削除を確定しない ← `TestService_Withdraw_Tx_UserNotFound`（beginCalled==false）
- [x] Req 4.1: 関連データ 0 件でもエラーを返さず完了 ← `TestService_Withdraw_Tx_NoRelatedData`
- [x] Req 4.2: 関連データ無しユーザーの user (+CASCADE) 削除 ← `TestService_Withdraw_Tx_NoRelatedData`（committed==true）
- [x] NFR 1.1: `Withdraw` シグネチャ不変 ← `go build ./...` 成功・既存テスト green
- [x] NFR 1.2/1.3: 削除対象テーブル + CASCADE 集合不変 ← `rec.order` で検証
- [x] NFR 2.1: 子→親の削除順序 ← `TestService_Withdraw_Tx_CommitsOnSuccess`（順序厳密検証）
- [x] NFR 3.1/3.2: 開始・完了ログの出力 ← `withdrawTx` で `slog.Info` を出力

## テスト結果

```
go test ./... — 全パッケージ pass（skip なし）
go build ./... — 成功
go vet ./... — 警告なし
gofmt -l（対象パッケージ）— 差分なし
```

## 実装上の判断

- **DBTX querier 抽象**: `*sql.DB` と `*sql.Tx` を統一的に扱う Go の定石パターンを採用。repository 層の既存メソッドは `*Exec` バリアントへの委譲に変更し、他の呼び出し元への影響はゼロ
- **import cycle 回避**: `user → repository` の既存依存があるため、両者を結ぶアダプタを `app` 層に配置（既存配線が `app.go` に集約されている慣習に合わせた）
- **単体テスト採用**: 既存リポジトリに実 DB 接続基盤が存在しないため、`TxBeginner` / `Tx` を抽象化して fake に差し替え可能にし、コミット / ロールバック境界・削除順序を単体テストで検証

## 確認事項 / レビュワーへの依頼

- **Reviewer の判定**: 詳細は `docs/specs/13--withdraw-db/review-notes.md` を参照（RESULT: approve）
- **DB 結合テストの不在**: 実 PostgreSQL を用いたロールバック / CASCADE の結合テストは本 PR に含めていない。既存テスト基盤に実 DB 接続の枠組みが無いため（`impl-notes.md` に経緯記載）。必要であれば別 Issue での基盤整備を提案
- **トランザクション分離レベル**: `BeginTx` は `opts = nil`（PostgreSQL 既定の READ COMMITTED）で開始。退会は単一ユーザー削除のみで分離レベル引き上げの要件は無いと判断
- **import cycle 回避の配置**: アダプタを `app` 層に配置した設計判断については `impl-notes.md` を参照
- base ブランチ = develop を検証済み（一致）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #13 のコメントを参照してください。
