### PR TITLE
feat(#12): はてブ API レスポンス読み込みサイズに上限を追加

### DIFF
--- a/docs/specs/12--api/impl-notes.md
+++ b/docs/specs/12--api/impl-notes.md
@@ -1,0 +1,82 @@
+# 実装メモ: Issue #12 はてブ API レスポンスの読み込みサイズ上限
+
+## 変更概要
+
+`internal/hatebu/client.go` の `GetBookmarkCounts` に、はてブ API レスポンスボディの
+読み込みサイズ上限（1 MiB）を追加した。上限内の正常レスポンスは従来どおりブックマーク数
+マップを返し、上限超過レスポンスはサイレント切り詰めではなくエラーとして検出・記録する。
+公開シグネチャ・JSON パース・0 件補完・非 200 / 通信失敗の既存エラー処理は変更していない。
+
+## 採用した上限値と定数名
+
+- 上限値: **1 MiB = 1,048,576 バイト**（`1 * 1024 * 1024`）
+- 定数名: `maxResponseBodySize`（`client.go` 冒頭の const ブロック、`defaultEndpoint` /
+  `maxURLsPerRequest` と同じ箇所に追加）
+- マジックナンバーは定数化し、リテラルの散在を排除（NFR 2）
+
+## 上限超過の判定方式
+
+`io.LimitReader(resp.Body, maxResponseBodySize)` でそのまま `io.ReadAll` すると「ちょうど
+上限」と「上限超過」を区別できない（どちらも上限ちょうどのバイト数で打ち切られる）。
+そこで **上限 +1 バイトまで読み込み**（`io.LimitReader(resp.Body, maxResponseBodySize+1)`）、
+読み込み長が上限を超えた（`len(body) > maxResponseBodySize`）場合のみ上限超過と判定する。
+これにより以下を満たす:
+
+- ちょうど 1,048,576 バイト → `len(body) == maxResponseBodySize` でパス（Req 4.1）
+- 1,048,577 バイト（1 バイト超過）→ `len(body) == maxResponseBodySize+1 > maxResponseBodySize`
+  でエラー（Req 4.2）
+
+上限超過時は既存ログ慣習（`c.logger.Error(...)` + `slog` 構造化フィールド）に倣って
+ERROR ログを出力し（`max_response_body_size` / `url_count` を付与）、`fmt.Errorf` で
+日本語メッセージのエラーを返す。マップは返さず `nil` を返す（Req 3.1 / 3.2 / 3.3）。
+
+メモリ消費は `LimitReader` により最大でも上限 +1 バイトに抑えられる（NFR 1）。
+
+## 追加テスト一覧（`internal/hatebu/client_test.go`）
+
+- `TestClient_GetBookmarkCounts_ExactlyMaxSize_ParsesSuccessfully`
+  — ちょうど 1 MiB の有効 JSON がエラーにならずパースされる（境界値 / Req 4.1）
+- `TestClient_GetBookmarkCounts_OneByteOverMaxSize_ReturnsError`
+  — 1 バイト超過でエラー、マップは nil（境界値 / Req 3.1 / Req 4.2）
+- `TestClient_GetBookmarkCounts_OversizedBody_ReturnsErrorAndLogs`
+  — 上限を大きく超える（2 MiB）レスポンスでエラー + ERROR ログ + 上限超過メッセージ、
+    マップは nil（異常系 / Req 3.1 / 3.2 / 3.3）
+- ヘルパー `buildJSONBodyOfExactSize`
+  — `map[string]int` としてパース可能な JSON を **正確なバイト数**で生成（パディングキー名
+    の長さで 1 バイト単位調整。生成後に実バイト長と map パース可否を assert する）
+
+## 受入基準とテストの対応
+
+| Req ID | 担保するテスト |
+|---|---|
+| 1.1 / 1.2 / 1.3 | `ExactlyMaxSize_ParsesSuccessfully`（上限内全量読込）+ 上限定数の存在 |
+| 2.1 | `SingleURL` / `MultipleURLs`（既存。上限内正常パース） |
+| 2.2 | `ZeroBookmarks_MissingFromResponse`（既存。0 件補完） |
+| 2.3 | `EmptyURLList` / `NilURLList`（既存。API 非呼び出し空マップ） |
+| 2.4 | 既存全テスト（戻り値型 `map[string]int` 不変）+ シグネチャ未変更 |
+| 3.1 | `OneByteOverMaxSize_ReturnsError` / `OversizedBody_ReturnsErrorAndLogs`（エラー + nil） |
+| 3.2 | `OversizedBody_ReturnsErrorAndLogs`（ERROR ログ + 上限超過メッセージ） |
+| 3.3 | `OversizedBody_ReturnsErrorAndLogs`（切り詰めボディを正常返却しない / counts==nil） |
+| 4.1 | `ExactlyMaxSize_ParsesSuccessfully` |
+| 4.2 | `OneByteOverMaxSize_ReturnsError` |
+| 5.1 | `HTTPError` / `LogsError`（既存。非 200 ステータスは上限処理に到達せずエラー） |
+| 5.2 | `ContextCancelled`（既存。通信失敗は上限処理に到達せずエラー） |
+| NFR 1 | `LimitReader` により最大読込量を上限 +1 バイトに抑制（`OversizedBody` で間接担保） |
+| NFR 2 | 定数 `maxResponseBodySize` 化（コードレビューで担保） |
+| NFR 3 | 公開シグネチャ不変（既存全テストが無改変で pass） |
+
+## 実装上の判断
+
+- 上限処理の挿入位置はボディ読み取り（`io.ReadAll`）箇所のみとし、非 200 ステータス
+  チェック（client.go:84-90）より後段に配置。これにより Req 5.1 / 5.2（既存エラー処理が
+  上限処理に到達せず先行する）を構造的に保証している。
+- エラーメッセージ・ログメッセージは既存実装の慣習に合わせ日本語ベースで記述した。
+
+## 確認事項
+
+- なし（requirements.md の Open Questions も「なし」。要件は確定済み）。
+- スコープ外メモ: `internal/hatebu/batch.go` は本変更着手前から `gofmt -l` で差分が報告される
+  状態だったが、本 Issue の対象外（Out of Scope）かつ本変更で触れていないため未修正。
+  別 Issue として整形 PR を検討する余地がある（派生タスク候補）。
+
+STATUS: complete

--- a/docs/specs/12--api/requirements.md
+++ b/docs/specs/12--api/requirements.md
@@ -1,0 +1,89 @@
+# Requirements Document
+
+## Introduction
+
+はてなブックマーク連携クライアントは、はてブ一括取得 API のレスポンスボディを全量メモリに
+読み込んでから JSON パースしている。レスポンスが想定外に巨大だった場合（不正なサーバ応答・
+中間プロキシによる挙動など）、読み込みサイズが無制限のためメモリを際限なく消費し、
+ワーカープロセスが OOM に陥るリスクがある。本要件では、はてブ API レスポンスボディの
+読み込みサイズに上限を設け、上限内の正常レスポンスは従来どおりブックマーク数マップとして
+返しつつ、上限を超える異常レスポンスをエラーとして検出・記録できるようにする。後方互換
+（正常レスポンスのパース結果・戻り値の型）は維持し、API エンドポイントやリクエスト方式・
+JSON スキーマには手を加えない。
+
+## Requirements
+
+### Requirement 1: レスポンスボディ読み込みサイズの上限適用
+
+**Objective:** As a Feedman の運用者, I want はてブ API レスポンスの読み込みサイズに明示的な上限が適用されること, so that 巨大な異常レスポンスを受信してもワーカーのメモリ消費が際限なく増大せず OOM を回避できる
+
+#### Acceptance Criteria
+
+1. The HatebuClient shall はてブブックマーク数取得時のレスポンスボディ読み込み量を、あらかじめ定義された上限サイズ以内に制限する
+2. The HatebuClient shall 読み込みサイズの上限値を 1 MiB（1,048,576 バイト）として扱う
+3. While 受信レスポンスボディが上限サイズ以内であるとき, the HatebuClient shall レスポンスボディの全量を読み込む
+
+### Requirement 2: 上限内レスポンスの後方互換なパース
+
+**Objective:** As a Feedman の利用者, I want 上限内の正常レスポンスが従来どおり処理されること, so that ブックマーク数表示の挙動が本変更の前後で変わらない
+
+#### Acceptance Criteria
+
+1. When 上限サイズ以内の正常な JSON レスポンスを受信したとき, the HatebuClient shall 各 URL のブックマーク数を対応付けたマップを呼び出し元に返す
+2. When 上限サイズ以内のレスポンスにリクエストした一部の URL が含まれていないとき, the HatebuClient shall 含まれない URL のブックマーク数を 0 件として補完したマップを返す
+3. When 空の URL リストを受け取ったとき, the HatebuClient shall API を呼び出さず空のブックマーク数マップを返す
+4. The HatebuClient shall 上限内レスポンスに対して、本変更の前と同一の戻り値の型でブックマーク数マップを返す
+
+### Requirement 3: 上限超過レスポンスのエラー検出と記録
+
+**Objective:** As a Feedman の運用者, I want 上限を超える異常レスポンスがサイレントに切り詰められずエラーとして区別されること, so that 不完全なデータを誤ってパースする事故を防ぎ、異常発生を検知できる
+
+#### Acceptance Criteria
+
+1. If 受信レスポンスボディが上限サイズを超過したとき, the HatebuClient shall ブックマーク数マップを返さずエラーを呼び出し元に返す
+2. If 受信レスポンスボディが上限サイズを超過したとき, the HatebuClient shall 上限超過を示すログを出力する
+3. If 受信レスポンスボディが上限サイズを超過したとき, the HatebuClient shall 切り詰めた不完全なボディを正常結果としてパース・返却しない
+
+### Requirement 4: 上限境界の正確な扱い
+
+**Objective:** As a Feedman の開発者, I want 上限ちょうどのサイズのレスポンスが正しく処理されること, so that オフバイワン誤りで正常レスポンスを誤ってエラー扱いしない
+
+#### Acceptance Criteria
+
+1. When ボディサイズが上限値とちょうど等しい正常な JSON レスポンスを受信したとき, the HatebuClient shall そのレスポンスをエラーとせずブックマーク数マップにパースして返す
+2. If ボディサイズが上限値を 1 バイトでも超過したとき, the HatebuClient shall そのレスポンスを上限超過エラーとして扱う
+
+### Requirement 5: 既存エラー処理経路の不変性
+
+**Objective:** As a Feedman の開発者, I want 既存の HTTP ステータス異常・通信失敗時のエラー処理が本変更の影響を受けないこと, so that 本変更が既存のエラーハンドリングを退行させない
+
+#### Acceptance Criteria
+
+1. If はてブ API が 200 以外の HTTP ステータスを返したとき, the HatebuClient shall ボディ読み込み上限処理に到達せずステータス異常エラーを返す
+2. If はてブ API へのリクエスト送信が失敗したとき, the HatebuClient shall ボディ読み込み上限処理に到達せず通信失敗エラーを返す
+
+## Non-Functional Requirements
+
+### NFR 1: メモリ消費の上限
+
+1. While 単一のはてブ API レスポンスを処理しているとき, the HatebuClient shall レスポンスボディ起因のメモリ確保量を上限サイズ（1 MiB）に概ね比例する範囲に抑える
+
+### NFR 2: 保守性（マジックナンバー排除）
+
+1. The HatebuClient shall 読み込み上限値を、意味のある名前を持つ単一の定数として定義し、リテラル値の散在を避ける
+
+### NFR 3: 後方互換性
+
+1. The HatebuClient shall 本変更の前後で、ブックマーク数取得の公開シグネチャ（引数・戻り値の型）を変更しない
+
+## Out of Scope
+
+- はてブ API エンドポイント URL・リクエスト方式（GET / クエリ構築・User-Agent 等）の変更
+- レスポンス JSON スキーマおよびパースロジック（マップへの変換・0 件補完規則）の変更
+- 1 リクエストあたりの最大 URL 数（既存の上限）の変更
+- 上限値を環境変数・設定ファイルで外部から変更可能にする仕組みの追加
+- リトライ・タイムアウト・レート制限など読み込みサイズ以外のエラーハンドリング全般の見直し
+
+## Open Questions
+
+- なし（上限値 1 MiB の採用、および上限超過時にサイレント切り詰めではなくエラーとして区別する方針は、Issue 本文の仮案と既存実装の慣習に沿って PM が確定済み。根拠は Introduction および各 Requirement の Objective に記載）

--- a/docs/specs/12--api/review-notes.md
+++ b/docs/specs/12--api/review-notes.md
@@ -1,0 +1,39 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-25T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-12-impl--api
+- HEAD commit: 0263c3fb54b1abe55d72233f6b1f28a28c1e968e
+- Compared to: develop..HEAD
+
+## Verified Requirements
+
+- 1.1 — `io.LimitReader(resp.Body, maxResponseBodySize+1)`（client.go:98）でボディ読み込み量を上限以内に制限。`ExactlyMaxSize_ParsesSuccessfully` で上限内処理を確認
+- 1.2 — `maxResponseBodySize = 1 * 1024 * 1024`（client.go:22 = 1,048,576 バイト）
+- 1.3 — 上限以内では `len(body) <= maxResponseBodySize` で全量を読み込みパースへ進む（client.go:98-113）。`ExactlyMaxSize_ParsesSuccessfully`
+- 2.1 — 各 URL のブックマーク数マップを返す。既存 `TestClient_GetBookmarkCounts_SingleURL` / `MultipleURLs`（パースロジック client.go:115-132 無改変）
+- 2.2 — 含まれない URL を 0 件補完（client.go:124-132）。既存 `ZeroBookmarks_MissingFromResponse`
+- 2.3 — 空 URL リストで API 非呼び出し・空マップ返却（client.go:47-49）。既存 `EmptyURLList` / `NilURLList`
+- 2.4 — 戻り値型 `map[string]int` 不変、既存全テストが無改変で pass
+- 3.1 — 上限超過時に `nil, error` を返す（client.go:107-113）。`OneByteOverMaxSize_ReturnsError` / `OversizedBody_ReturnsErrorAndLogs`（counts==nil を assert）
+- 3.2 — `c.logger.Error("レスポンスボディが読み込み上限サイズを超過しました", ...)`（client.go:108-111）。`OversizedBody_ReturnsErrorAndLogs`（ERROR ログ + "上限" 文言を assert）
+- 3.3 — 上限超過時は JSON パースに到達せず nil 返却（client.go:107-113、パースは 115 以降）。`OneByteOverMaxSize` / `OversizedBody`（counts==nil）
+- 4.1 — 上限ちょうど（1,048,576 バイト）はエラーにせずパース（`len(body) > maxResponseBodySize` が false）。`ExactlyMaxSize_ParsesSuccessfully`
+- 4.2 — 1 バイト超過でエラー（+1 読込により `len(body) == maxResponseBodySize+1`）。`OneByteOverMaxSize_ReturnsError`
+- 5.1 — 上限処理（client.go:95-113）は非 200 ステータスチェック（client.go:87-93）より後段に配置され、構造的に先行保証。既存 `HTTPError` / `LogsError`
+- 5.2 — 上限処理は通信失敗チェック（client.go:76-83）より後段。既存 `ContextCancelled`
+- NFR 1 — `LimitReader` により読込量を上限 +1 バイトに抑制（client.go:98）。`OversizedBody` で間接担保
+- NFR 2 — 上限値を定数 `maxResponseBodySize` 化（client.go:20-22）、リテラル散在なし
+- NFR 3 — 公開シグネチャ `GetBookmarkCounts(ctx, urls) (map[string]int, error)` 不変、既存全テスト無改変 pass
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric requirement ID（1.1〜5.2 および NFR 1〜3）に対応する実装とテストを確認した。上限処理はボディ読込箇所のみに限定され、非 200 / 通信失敗の既存エラー処理経路や JSON パース・0 件補完ロジックは無改変で、Out of Scope（エンドポイント / スキーマ / URL 上限 / 外部設定化）への逸脱もない。新規境界値・異常系テスト 3 件を含む対象パッケージのテストは green（再実行で確認済み）。Feature Flag Protocol は opt-out のため flag 観点は適用しない。
+
+RESULT: approve

--- a/internal/hatebu/client.go
+++ b/internal/hatebu/client.go
@@ -17,6 +17,9 @@ const (
 	defaultEndpoint = "https://bookmark.hatenaapis.com/count/entries"
 	// maxURLsPerRequest は1リクエストあたりの最大URL数。
 	maxURLsPerRequest = 50
+	// maxResponseBodySize はレスポンスボディの読み込み上限サイズ（1 MiB）。
+	// 巨大な異常レスポンスによるメモリの際限ない消費（OOM）を防ぐための上限。
+	maxResponseBodySize = 1 * 1024 * 1024
 )
 
 // Client ははてなブックマークAPIのクライアント。
@@ -90,12 +93,23 @@ func (c *Client) GetBookmarkCounts(ctx context.Context, urls []string) (map[stri
 	}
 
 	// レスポンスボディ読み取り
-	body, err := io.ReadAll(resp.Body)
+	// 上限ちょうどと上限超過を区別するため、上限+1バイトまで読み込み、
+	// 読み込み長が上限を超えていれば上限超過と判定する。
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize+1))
 	if err != nil {
 		c.logger.Error("レスポンスボディの読み取りに失敗しました",
 			slog.String("error", err.Error()),
 		)
 		return nil, fmt.Errorf("レスポンスボディの読み取りに失敗しました: %w", err)
+	}
+
+	// 読み込みサイズの上限チェック（上限超過はサイレント切り詰めせずエラーとする）
+	if len(body) > maxResponseBodySize {
+		c.logger.Error("レスポンスボディが読み込み上限サイズを超過しました",
+			slog.Int("max_response_body_size", maxResponseBodySize),
+			slog.Int("url_count", len(urls)),
+		)
+		return nil, fmt.Errorf("レスポンスボディが読み込み上限サイズ %d バイトを超過しました", maxResponseBodySize)
 	}
 
 	// JSONデコード

--- a/internal/hatebu/client_test.go
+++ b/internal/hatebu/client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -341,5 +342,134 @@ func TestClient_GetBookmarkCounts_50URLsExactly(t *testing.T) {
 	_, err := c.GetBookmarkCounts(context.Background(), urls)
 	if err != nil {
 		t.Fatalf("50個のURLでエラーが返されるべきではない: %v", err)
+	}
+}
+
+// --- Issue #12: レスポンスボディ読み込みサイズ上限のテスト ---
+
+// buildJSONBodyOfExactSize は、指定URLのブックマーク数を含み、
+// 全体のバイト長がちょうど targetSize になる有効なJSONレスポンスボディ
+// （map[string]int としてパース可能）を生成する。
+// パディング用キー（値は固定の int）のキー名の長さを調整して正確なサイズに合わせる。
+// レスポンスは json.Marshal(map[string]int) と同形のため、本番のパースロジックで
+// そのままデコードできる。
+func buildJSONBodyOfExactSize(t *testing.T, reqURL string, count int, targetSize int) []byte {
+	t.Helper()
+
+	// JSON は手組みで構築し、バイト長を正確に制御する。
+	// 形式: {"<reqURL>":<count>,"<padKey>":0}
+	// padKey の文字数を調整して全体長を targetSize に合わせる。
+	prefix := fmt.Sprintf("{%q:%d,", reqURL, count)
+	suffix := `":0}`
+	openQuote := `"`
+
+	// padKey を空にした最小構成の長さ
+	minSize := len(prefix) + len(openQuote) + len(suffix)
+	if targetSize < minSize {
+		t.Fatalf("targetSize %d が最小サイズ %d より小さい", targetSize, minSize)
+	}
+
+	padKeyLen := targetSize - minSize
+	padKey := strings.Repeat("a", padKeyLen)
+
+	body := prefix + openQuote + padKey + suffix
+	if len(body) != targetSize {
+		t.Fatalf("生成したJSONのサイズ = %d, want %d", len(body), targetSize)
+	}
+
+	// map[string]int としてパース可能であることを検証する（テストの前提条件）
+	var sanity map[string]int
+	if err := json.Unmarshal([]byte(body), &sanity); err != nil {
+		t.Fatalf("生成したJSONが map[string]int にパースできない: %v", err)
+	}
+	return []byte(body)
+}
+
+func TestClient_GetBookmarkCounts_ExactlyMaxSize_ParsesSuccessfully(t *testing.T) {
+	// 境界値: ちょうど 1 MiB（1,048,576 バイト）の有効JSONはエラーにならずパースされる（Req 4.1）
+	const reqURL = "https://example.com/exact-boundary"
+	body := buildJSONBodyOfExactSize(t, reqURL, 7, maxResponseBodySize)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	logger := newTestLogger(&buf)
+
+	c := NewClient(server.Client(), logger)
+	c.endpoint = server.URL
+
+	counts, err := c.GetBookmarkCounts(context.Background(), []string{reqURL})
+	if err != nil {
+		t.Fatalf("上限ちょうど(%d バイト)のレスポンスでエラーが返された: %v", maxResponseBodySize, err)
+	}
+	if counts[reqURL] != 7 {
+		t.Errorf("ブックマーク数 = %d, want 7", counts[reqURL])
+	}
+}
+
+func TestClient_GetBookmarkCounts_OneByteOverMaxSize_ReturnsError(t *testing.T) {
+	// 境界値: 上限を1バイト超過（1,048,577 バイト）したらエラーになる（Req 4.2 / Req 3.1）
+	const reqURL = "https://example.com/one-byte-over"
+	body := buildJSONBodyOfExactSize(t, reqURL, 7, maxResponseBodySize+1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	logger := newTestLogger(&buf)
+
+	c := NewClient(server.Client(), logger)
+	c.endpoint = server.URL
+
+	counts, err := c.GetBookmarkCounts(context.Background(), []string{reqURL})
+	if err == nil {
+		t.Fatal("上限を1バイト超過したレスポンスでエラーが返されるべき")
+	}
+	// 上限超過時はマップを返さない（nil）こと（Req 3.1 / Req 3.3）
+	if counts != nil {
+		t.Errorf("上限超過時はマップを返さず nil であるべき: got %v", counts)
+	}
+}
+
+func TestClient_GetBookmarkCounts_OversizedBody_ReturnsErrorAndLogs(t *testing.T) {
+	// 異常系: ボディが上限を大きく超えるとエラーが返り、ERRORログが出力される（Req 3.1 / 3.2 / 3.3）
+	const reqURL = "https://example.com/oversized"
+	body := buildJSONBodyOfExactSize(t, reqURL, 1, maxResponseBodySize*2)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	logger := newTestLogger(&buf)
+
+	c := NewClient(server.Client(), logger)
+	c.endpoint = server.URL
+
+	counts, err := c.GetBookmarkCounts(context.Background(), []string{reqURL})
+	if err == nil {
+		t.Fatal("上限を大きく超えるレスポンスでエラーが返されるべき")
+	}
+	// 不完全な切り詰めボディを正常結果として返さない（Req 3.3）
+	if counts != nil {
+		t.Errorf("上限超過時はマップを返さず nil であるべき: got %v", counts)
+	}
+
+	// 上限超過を示すERRORログが出力されていること（Req 3.2）
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "ERROR") {
+		t.Errorf("上限超過時にERRORレベルのログが記録されるべき: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "上限") {
+		t.Errorf("上限超過を示すログメッセージが出力されるべき: %s", logOutput)
 	}
 }


### PR DESCRIPTION
## 概要

はてブ一括取得 API のレスポンスボディ読み込みを無制限に行うと、不正なサーバ応答や中間プロキシ
による異常レスポンスを受信したときにワーカーが OOM に陥るリスクがあった。本 PR では
`HatebuClient.GetBookmarkCounts` のボディ読み込みに 1 MiB（1,048,576 バイト）の上限を追加し、
上限内の正常レスポンスは従来どおり処理しつつ、上限超過レスポンスをサイレント切り詰めではなく
エラーとして検出・記録できるようにした。公開シグネチャ・JSON パース・0 件補完・既存エラー処理
経路はすべて無改変。

## 対応 Issue

Closes #12

## 関連 PR

- 設計 PR: なし（設計ゲートなしの小規模 Issue として実装）

## 実装内容

- (Req 1.1 / 1.2 / 1.3) `io.LimitReader(resp.Body, maxResponseBodySize+1)` で読み込み量を上限以内に制限。上限値 1 MiB を定数 `maxResponseBodySize` として定義
- (Req 3.1 / 3.2 / 3.3) 上限超過時は ERROR ログ出力（構造化フィールド `max_response_body_size` / `url_count` 付き）+ エラー返却（マップは nil）
- (Req 4.1 / 4.2) 上限 +1 バイトまで読み込む方式で境界値（ちょうど 1 MiB はパス、1 バイト超過はエラー）を正確に判定
- (NFR 2) 上限値をリテラル散在なしで定数化

## 受入基準チェック

- [x] Req 1.1: レスポンスボディ読み込み量を上限以内に制限 ← `TestClient_GetBookmarkCounts_ExactlyMaxSize_ParsesSuccessfully`
- [x] Req 1.2: 上限値を 1 MiB（1,048,576 バイト）として扱う ← 定数 `maxResponseBodySize = 1 * 1024 * 1024`
- [x] Req 1.3: 上限以内のボディは全量読み込み ← `ExactlyMaxSize_ParsesSuccessfully`
- [x] Req 2.1〜2.4: 上限内の正常レスポンスは後方互換なパース ← 既存テスト群が無改変で pass
- [x] Req 3.1: 上限超過時はエラー返却・マップは nil ← `OneByteOverMaxSize_ReturnsError` / `OversizedBody_ReturnsErrorAndLogs`
- [x] Req 3.2: 上限超過時は ERROR ログ出力 ← `OversizedBody_ReturnsErrorAndLogs`
- [x] Req 3.3: 切り詰めた不完全ボディを正常返却しない ← `OversizedBody_ReturnsErrorAndLogs`（counts==nil）
- [x] Req 4.1: ちょうど 1 MiB はエラーにせずパース ← `ExactlyMaxSize_ParsesSuccessfully`
- [x] Req 4.2: 1 バイト超過はエラー ← `OneByteOverMaxSize_ReturnsError`
- [x] Req 5.1: 非 200 ステータスは上限処理に到達せずエラー ← 既存 `HTTPError` / `LogsError`
- [x] Req 5.2: 通信失敗は上限処理に到達せずエラー ← 既存 `ContextCancelled`
- [x] NFR 1: ボディ起因メモリ確保を上限に概ね比例する範囲に抑える ← `LimitReader` + `OversizedBody`
- [x] NFR 2: 上限値を意味のある名前の定数として定義 ← `maxResponseBodySize`
- [x] NFR 3: 公開シグネチャ不変 ← 既存全テスト無改変 pass

## テスト結果

```
対象パッケージ: internal/hatebu
新規テスト 3 件（境界値・異常系）+ 既存テスト全件 pass
go test ./internal/hatebu/... 全件 pass（review-notes.md 参照: docs/specs/12--api/review-notes.md）
```

## 実装上の判断

- 上限超過の判定は「上限 +1 バイトまで読み込み、読込長が上限を超えた場合のみエラー」とした。
  `io.LimitReader` をそのまま使うとちょうど上限と上限超過を区別できないため（impl-notes.md 参照）。
- 上限処理挿入位置は非 200 ステータスチェック / 通信失敗チェックより後段とし、既存エラー処理経路
  （Req 5.1 / 5.2）が構造的に先行するよう配置。

## 確認事項 / レビュワーへの依頼

- requirements.md の Open Questions は「なし」（上限値 1 MiB および上限超過時エラー方針は確定済み）
- `internal/hatebu/batch.go` は本変更着手前から `gofmt -l` 差分が出る状態だったが、本 Issue の
  Out of Scope として未修正。別途整形 PR を検討できる（impl-notes.md 末尾参照）
- Reviewer による独立レビュー結果は `docs/specs/12--api/review-notes.md` を参照（RESULT: approve）
- base=develop 一致を確認（--base develop 指定 / baseRefName: develop）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #12 のコメントを参照してください。
