### PR TITLE
feat(#43): SSRF ブロック対象ホスト名リストを拡充する

### DIFF
--- a/docs/specs/43-ssrf/impl-notes.md
+++ b/docs/specs/43-ssrf/impl-notes.md
@@ -1,0 +1,86 @@
+# 実装メモ: Issue #43 SSRF ブロック対象ホスト名リストの拡充
+
+## 実装サマリ
+
+SSRF 事前検証 `ValidateURL`（`internal/security/ssrf_guard.go`）で使用する
+ブロック対象ホスト名リスト `blockedHostnames` を `localhost` 1 件から 6 件に拡充した。
+
+### 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `internal/security/ssrf_guard.go` | `blockedHostnames` を 6 ホスト名（`localhost` / `localhost.localdomain` / `ip6-localhost` / `ip6-loopback` / `metadata.google.internal` / `metadata`）へ拡充。各ホスト名の意図（ループバック別名・メタデータ別名）をコメントで明示。`blockedHostnames` および `isBlockedHostname` の docstring に「ホスト名の静的な完全一致ブロックのみを担い、DNS 解決後の宛先 IP 検証はフェッチ層（`NewSafeClient` の safeurl Dialer フック）の責務である」旨を明記（Requirement 5 対応）。完全一致判定ロジック自体（`lower == blocked`）は不変。 |
+| `internal/security/ssrf_guard_test.go` | 拡充ホスト名・部分一致回避・大文字小文字非依存・接尾辞回避の各観点を table-driven / `t.Run` でテスト追加。 |
+
+## 設計判断
+
+### 事前 DNS 解決を導入せず docstring で責務分担を明記した理由
+
+Issue 本文「判断を委ねたい点」の 2 番（事前 DNS 解決 `net.LookupHost` を入れるか／
+safeurl 委譲方針を docstring に明記するに留めるか）について、**事前 DNS 解決は導入せず、
+責務分担を docstring に明記する方針**を採った。理由は以下:
+
+- **(a)** requirements.md の Out of Scope で「事前検証での DNS 解決の導入有無」「DNS
+  リバインディング全般への対策強化」をスコープ外と明示している。
+- **(b)** DNS 解決後の宛先 IP 検証はフェッチ層 `NewSafeClient` の safeurl Dialer フック
+  （`net.Dialer` の Control フック）が既に担保しており（多層防御の役割分担）、事前検証へ
+  二重に DNS 解決を持ち込む必要がない。
+- **(c)** `ValidateURL` は docstring（`ssrf_guard.go` 95-99 行）で「DNS 解決を伴わない静的な
+  検証」と明記している。事前検証へ DNS 解決を入れると静的検証でなくなり責務が混濁する。
+
+→ Requirement 5（責務分担の明示）に対応するため、`blockedHostnames` / `isBlockedHostname`
+の docstring に役割分担を参照可能な形で記述した。
+
+### 完全一致判定の維持
+
+Requirement 4 の要請に従い `isBlockedHostname` の完全一致判定（`lower == blocked`）を
+維持した。部分一致・接尾辞一致には変更せず、`localhost.example.com` /
+`metadata.example.com` / `notlocalhost` が誤ブロックされないことをテストで担保した。
+
+## AC ↔ テストケース対応表
+
+| Requirement / AC | 検証テスト | 観点 |
+|---|---|---|
+| Req 1.1 (`localhost`) | `TestValidateURL_BlockedHostnames/http://localhost/feed`（既存 `TestValidateURL_LoopbackAddress` でもカバー） | 異常系 |
+| Req 1.2 (`localhost.localdomain`) | `TestValidateURL_BlockedHostnames/http://localhost.localdomain/feed` | 異常系 |
+| Req 1.3 (`ip6-localhost`) | `TestValidateURL_BlockedHostnames/http://ip6-localhost/feed` | 異常系 |
+| Req 1.4 (`ip6-loopback`) | `TestValidateURL_BlockedHostnames/http://ip6-loopback/feed` | 異常系 |
+| Req 1.5 (`metadata.google.internal`) | `TestValidateURL_BlockedHostnames/http://metadata.google.internal/feed` | 異常系 |
+| Req 1.6 (`metadata`) | `TestValidateURL_BlockedHostnames/http://metadata/feed` | 異常系 |
+| Req 2.1 (`example.com` 通過) | 既存 `TestValidateURL_PublicURL` | 正常系 |
+| Req 2.2 (`localhost.example.com` 通過) | `TestValidateURL_BlockedHostnameSubstring/http://localhost.example.com/feed` | 正常系（部分一致回避） |
+| Req 2.3 (`metadata.example.com` 通過) | `TestValidateURL_BlockedHostnameSubstring/http://metadata.example.com/feed` | 正常系（部分一致回避） |
+| Req 3.1 (`LocalHost` ブロック) | `TestValidateURL_BlockedHostnameCaseInsensitive/http://LocalHost/feed` | 境界値（大文字小文字混在） |
+| Req 3.2 (`LOCALHOST` ブロック) | `TestValidateURL_BlockedHostnameCaseInsensitive/http://LOCALHOST/feed` | 境界値（全大文字） |
+| Req 4.1 (完全一致判定) | `TestValidateURL_BlockedHostnameSubstring` / `TestValidateURL_BlockedHostnameSuffix` で間接的に担保 | 実装維持 |
+| Req 4.2 (`notlocalhost` 通過) | `TestValidateURL_BlockedHostnameSuffix` | 境界値（接尾辞回避） |
+| Req 5.1 (責務分担の明示) | `blockedHostnames` / `isBlockedHostname` の docstring に記述（コードレビューで確認可能） | docstring |
+| NFR 1.1 (後方互換・正当 URL 通過) | 既存 `TestValidateURL_PublicURL` | 後方互換 |
+| NFR 1.2 (後方互換・拒否維持) | 既存 `TestValidateURL_PrivateIP` / `_LoopbackAddress` / `_LinkLocalAddress` / `_MetadataIP` / `_IPv6Loopback` / `_ZeroAddress` | 後方互換 |
+| NFR 2.1 (単体テストで検証可能) | 上記追加テスト群全体 | 検証可能性 |
+
+> 補足: Req 4.1（完全一致判定の維持）は実装側の不変条件であり、部分一致・接尾辞ケース
+> （Req 2.2 / 2.3 / 4.2）の正常系テストが通過することで「完全一致以外でブロックしない」
+> ことを間接的に担保している。Req 5.1 は user/operator-observable な挙動ではなく docstring
+> による明示であるため、実行テストではなくコードレビューで確認する。
+
+## 検証コマンドの実行結果
+
+- `gofmt -l internal/security/ssrf_guard.go internal/security/ssrf_guard_test.go`
+  → 出力なし（差分なし・整形済み）
+- `go vet ./internal/security/...`
+  → 出力なし（pass）
+- `go test ./internal/security/...`
+  → `ok  github.com/hitoshi/feedman/internal/security`（全テスト pass。追加した
+    `TestValidateURL_Blocked*` 4 関数および既存テストすべて green）
+
+Red→Green 確認: 実装前に拡充 5 ホスト名（`localhost.localdomain` / `ip6-localhost` /
+`ip6-loopback` / `metadata.google.internal` / `metadata`）のブロックテストが FAIL する
+ことを観測し、実装後に PASS することを確認した（`localhost` は既存実装で既にブロック済み）。
+
+## 確認事項
+
+なし。requirements.md と Issue 本文の委譲点（事前 DNS 解決の扱い）について矛盾はなく、
+Out of Scope の記述に沿って docstring 明記方針で実装した。
+
+STATUS: complete

--- a/docs/specs/43-ssrf/requirements.md
+++ b/docs/specs/43-ssrf/requirements.md
@@ -1,0 +1,84 @@
+# Requirements Document
+
+## Introduction
+
+SSRF 対策の事前検証 `ValidateURL`（`internal/security/ssrf_guard.go`）は、URL のスキーム・ホスト・
+IP アドレスを静的に検証し、危険な宛先へのリクエスト送信前にエラーを返す多層防御の一層である。
+しかしホスト名ベースのブロック判定で用いるブロック対象ホスト名リストが `localhost` 1 件のみで、
+ループバック別名やクラウドメタデータエンドポイントのホスト名表記を取りこぼす網羅性の低さがある。
+本要件では、事前検証のブロック対象ホスト名リストを拡充し、既存の正当な URL の通過挙動・大文字
+小文字非依存判定・完全一致判定（部分一致での過剰ブロック回避）を維持することを定義する。
+
+## Requirements
+
+### Requirement 1: ブロック対象ホスト名の拡充
+
+**Objective:** As a Feedman の運用者, I want ループバック別名やメタデータエンドポイントのホスト名表記を事前検証で確実に拒否してほしい, so that フィード登録経路における内部宛先への意図しないリクエスト送信のリスクを多層防御として下げられる
+
+#### Acceptance Criteria
+
+1. If `localhost` をホスト名とする URL が事前検証に渡されたとき, the SSRF Guard shall ブロック対象ホストとしてエラーを返す
+2. If `localhost.localdomain` をホスト名とする URL が事前検証に渡されたとき, the SSRF Guard shall ブロック対象ホストとしてエラーを返す
+3. If `ip6-localhost` をホスト名とする URL が事前検証に渡されたとき, the SSRF Guard shall ブロック対象ホストとしてエラーを返す
+4. If `ip6-loopback` をホスト名とする URL が事前検証に渡されたとき, the SSRF Guard shall ブロック対象ホストとしてエラーを返す
+5. If `metadata.google.internal` をホスト名とする URL が事前検証に渡されたとき, the SSRF Guard shall ブロック対象ホストとしてエラーを返す
+6. If `metadata` をホスト名とする URL が事前検証に渡されたとき, the SSRF Guard shall ブロック対象ホストとしてエラーを返す
+
+### Requirement 2: 正当なホスト名の通過維持
+
+**Objective:** As a フィードを登録する利用者, I want 正当な外部フィードのホスト名が従来どおり検証を通過してほしい, so that ブロックリスト拡充によって正常な購読登録が妨げられない
+
+#### Acceptance Criteria
+
+1. When 通常の外部ホスト名（例: `example.com`）の URL が事前検証に渡されたとき, the SSRF Guard shall エラーを返さず検証を通過させる
+2. When ブロック対象ホスト名を部分文字列として含むだけの正当なホスト名（例: `localhost.example.com`）の URL が事前検証に渡されたとき, the SSRF Guard shall エラーを返さず検証を通過させる
+3. When ブロック対象ホスト名を部分文字列として含むだけの正当なホスト名（例: `metadata.example.com`）の URL が事前検証に渡されたとき, the SSRF Guard shall エラーを返さず検証を通過させる
+
+### Requirement 3: 大文字小文字非依存のブロック判定
+
+**Objective:** As a Feedman の運用者, I want ホスト名の大文字小文字表記に関わらずブロック対象が一貫して拒否されてほしい, so that 表記揺れによる事前検証のすり抜けを防げる
+
+#### Acceptance Criteria
+
+1. If 大文字小文字混在のブロック対象ホスト名（例: `LocalHost`）の URL が事前検証に渡されたとき, the SSRF Guard shall 小文字化した上でブロック対象ホストとしてエラーを返す
+2. If 全大文字のブロック対象ホスト名（例: `LOCALHOST`）の URL が事前検証に渡されたとき, the SSRF Guard shall 小文字化した上でブロック対象ホストとしてエラーを返す
+
+### Requirement 4: ブロック判定の完全一致維持
+
+**Objective:** As a 本コードベースの保守担当者, I want ホスト名のブロック判定が完全一致で行われることを維持したい, so that 部分一致導入による正当なホスト名の過剰ブロックを防げる
+
+#### Acceptance Criteria
+
+1. The SSRF Guard shall ブロック対象ホスト名の判定をホスト名全体の完全一致で行う
+2. When ブロック対象ホスト名を接尾辞として含む正当なホスト名（例: `notlocalhost`）の URL が事前検証に渡されたとき, the SSRF Guard shall エラーを返さず検証を通過させる
+
+### Requirement 5: 事前検証とフェッチ層の責務分担の明示
+
+**Objective:** As a 本コードベースの保守担当者, I want 事前検証のブロックリストとフェッチ層の検証（IP レンジ・DNS 解決後検証）の責務分担が明示されていてほしい, so that 事前検証の網羅性に過度に依存せず多層防御の前提を誤解しない
+
+#### Acceptance Criteria
+
+1. The SSRF Guard shall 事前検証がホスト名・スキーム・静的 IP の検証を担い、DNS 解決後の宛先 IP 検証はフェッチ層の責務であることを参照可能な形で明示する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. When 本変更導入前に検証を通過していた正当な外部 URL が事前検証に渡されたとき, the SSRF Guard shall 本変更導入前と同一に検証を通過させる
+2. When 本変更導入前に拒否されていた URL（`localhost`・プライベート IP・ループバック IP・メタデータ IP 等）が事前検証に渡されたとき, the SSRF Guard shall 本変更導入前と同一に拒否する
+
+### NFR 2: 検証可能性
+
+1. The SSRF Guard shall 拡充後の各ブロック対象ホスト名・大文字小文字混在表記・部分一致回避ケースに対する受理／拒否を単体テストで検証可能な形で提供する
+
+## Out of Scope
+
+- フェッチ層 `safeurl` Dialer フック実装の変更
+- IP レンジ（`blockedNetworks` / IP アドレスのブロック判定）の拡充
+- DNS リバインディング全般への対策強化
+- 事前検証での DNS 解決の導入有無（実装詳細として design 領分に委ねる）
+- ブロック対象ホスト名リストの外部設定化・動的更新
+
+## Open Questions
+
+- なし（Issue 本文・既存コメント・既存実装で受入基準を確定できた。Triage 自動コメント以外に人間の追加決定事項なし。Issue 本文「仮案・判断を委ねたい点」の事前 DNS 解決導入有無 / safeurl 委譲方針の docstring 明記は実装者・レビュアー判断とし、requirements では責務分担の明示を Requirement 5 で user/operator-observable な粒度に正規化した）

--- a/docs/specs/43-ssrf/review-notes.md
+++ b/docs/specs/43-ssrf/review-notes.md
@@ -1,0 +1,40 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-25T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-43-impl-ssrf
+- HEAD commit: 1cf614baeeb63738d58f40e8bf235cd81a9bec0c（実装+テストは 2fd2074、docs は 1cf614b）
+- Compared to: develop..HEAD
+- 変更ファイル: `internal/security/ssrf_guard.go` / `internal/security/ssrf_guard_test.go` / `docs/specs/43-ssrf/`
+
+## Verified Requirements
+
+- 1.1 — `blockedHostnames` に `localhost`（ssrf_guard.go:165）／`TestValidateURL_BlockedHostnames/http://localhost/feed`
+- 1.2 — `localhost.localdomain`（ssrf_guard.go:166）／同 `TestValidateURL_BlockedHostnames` ケース
+- 1.3 — `ip6-localhost`（ssrf_guard.go:167）／同ケース
+- 1.4 — `ip6-loopback`（ssrf_guard.go:168）／同ケース
+- 1.5 — `metadata.google.internal`（ssrf_guard.go:170）／同ケース
+- 1.6 — `metadata`（ssrf_guard.go:171）／同ケース
+- 2.1 — `ValidateURL` の静的検証で外部ホストは通過、既存 `TestValidateURL_PublicURL`（`example.com` 系）
+- 2.2 — 完全一致のため `localhost.example.com` は通過、`TestValidateURL_BlockedHostnameSubstring/http://localhost.example.com/feed`
+- 2.3 — `metadata.example.com` は通過、`TestValidateURL_BlockedHostnameSubstring/http://metadata.example.com/feed`
+- 3.1 — `isBlockedHostname` が `strings.ToLower` で小文字化後に比較（ssrf_guard.go:181）／`TestValidateURL_BlockedHostnameCaseInsensitive/http://LocalHost/feed`
+- 3.2 — 同上ロジック／`.../http://LOCALHOST/feed`
+- 4.1 — 完全一致判定 `lower == blocked`（ssrf_guard.go:183）を不変維持
+- 4.2 — 接尾辞 `notlocalhost` は通過、`TestValidateURL_BlockedHostnameSuffix`
+- 5.1 — `blockedHostnames`（ssrf_guard.go:159-162）／`isBlockedHostname`（ssrf_guard.go:174-179）の docstring に「静的な完全一致ブロックのみを担い、DNS 解決後の宛先 IP 検証はフェッチ層（safeurl Dialer フック）の責務」と参照可能な形で明示。事前 DNS 解決を導入せず docstring 明記とする判断は Issue で実装者・レビュアーに委ねられた点であり Out of Scope と整合
+- NFR 1.1 — 完全一致ロジック不変・既存 `TestValidateURL_PublicURL` 維持で後方互換（正当 URL 通過）
+- NFR 1.2 — `blockedNetworks` 不変・既存 `_PrivateIP` / `_LoopbackAddress` / `_LinkLocalAddress` / `_MetadataIP` / `_IPv6Loopback` / `_ZeroAddress` 維持で後方互換（拒否維持）
+- NFR 2.1 — 追加した `TestValidateURL_Blocked*` 4 関数で受理／拒否を単体テスト検証可能
+
+## Findings
+
+なし
+
+## Summary
+
+Feature Flag Protocol は opt-out のため flag 観点は適用せず通常 3 カテゴリで判定。Req 1〜5・NFR 1〜2 のすべてに対応する実装・テストが diff または既存コードに存在し、`go test ./internal/security/...` は green。変更は `internal/security/ssrf_guard.go` とその近傍テストに閉じ、Out of Scope（safeurl Dialer・IP レンジ・DNS リバインディング）への逸脱なし。完全一致判定（`lower == blocked`）も維持されている。
+
+RESULT: approve

--- a/internal/security/ssrf_guard.go
+++ b/internal/security/ssrf_guard.go
@@ -156,12 +156,27 @@ func isBlockedIP(ip net.IP) bool {
 	return false
 }
 
-// blockedHostnames はブロック対象のホスト名。
+// blockedHostnames はブロック対象のホスト名（完全一致）。
+// ループバック別名・クラウドメタデータエンドポイントのホスト名表記を拒否する。
+// 本リストはホスト名の完全一致ブロックのみを担い、DNS解決後の宛先IP検証は
+// フェッチ層（NewSafeClientが生成するsafeurl Dialerフック）の責務である。
 var blockedHostnames = []string{
+	// ループバック別名
 	"localhost",
+	"localhost.localdomain",
+	"ip6-localhost",
+	"ip6-loopback",
+	// クラウドメタデータエンドポイントのホスト名表記
+	"metadata.google.internal", // GCP メタデータ
+	"metadata",                 // 一般的なメタデータ別名
 }
 
 // isBlockedHostname はホスト名がブロック対象かを検証する。
+// 判定は小文字化した上でブロック対象ホスト名との完全一致で行う（大文字小文字非依存）。
+// 部分一致・接尾辞一致では拒否しないため、localhost.example.com や notlocalhost 等の
+// 正当なホスト名を過剰ブロックしない。
+// なお本関数はホスト名の静的な完全一致ブロックのみを担い、DNS解決後の宛先IP検証は
+// フェッチ層（NewSafeClientが生成するsafeurl Dialerフック）の責務である。
 func isBlockedHostname(host string) bool {
 	lower := strings.ToLower(host)
 	for _, blocked := range blockedHostnames {

--- a/internal/security/ssrf_guard_test.go
+++ b/internal/security/ssrf_guard_test.go
@@ -153,9 +153,9 @@ func TestValidateURL_MetadataIP(t *testing.T) {
 	guard := NewSSRFGuard()
 
 	metadataURLs := []string{
-		"http://169.254.169.254/latest/meta-data/",             // AWS
+		"http://169.254.169.254/latest/meta-data/",                        // AWS
 		"http://169.254.169.254/metadata/instance?api-version=2021-02-01", // Azure
-		"http://169.254.169.254/computeMetadata/v1/",           // GCP
+		"http://169.254.169.254/computeMetadata/v1/",                      // GCP
 	}
 
 	for _, u := range metadataURLs {
@@ -165,6 +165,84 @@ func TestValidateURL_MetadataIP(t *testing.T) {
 				t.Errorf("ValidateURL(%q) should have returned error for metadata IP", u)
 			}
 		})
+	}
+}
+
+// TestValidateURL_BlockedHostnames は拡充したブロック対象ホスト名の拒否をテストする。
+// Requirement 1: ループバック別名・メタデータエンドポイントのホスト名表記を拒否する。
+func TestValidateURL_BlockedHostnames(t *testing.T) {
+	guard := NewSSRFGuard()
+
+	blockedURLs := []string{
+		"http://localhost/feed",
+		"http://localhost.localdomain/feed",
+		"http://ip6-localhost/feed",
+		"http://ip6-loopback/feed",
+		"http://metadata.google.internal/feed",
+		"http://metadata/feed",
+	}
+
+	for _, u := range blockedURLs {
+		t.Run(u, func(t *testing.T) {
+			err := guard.ValidateURL(u)
+			if err == nil {
+				t.Errorf("ValidateURL(%q) should have returned error for blocked hostname", u)
+			}
+		})
+	}
+}
+
+// TestValidateURL_BlockedHostnameSubstring はブロック対象ホスト名を部分文字列として
+// 含むだけの正当なホスト名が通過することをテストする。
+// Requirement 2: 過剰ブロック回避（部分文字列一致では拒否しない）。
+func TestValidateURL_BlockedHostnameSubstring(t *testing.T) {
+	guard := NewSSRFGuard()
+
+	allowedURLs := []string{
+		"http://localhost.example.com/feed",
+		"http://metadata.example.com/feed",
+	}
+
+	for _, u := range allowedURLs {
+		t.Run(u, func(t *testing.T) {
+			err := guard.ValidateURL(u)
+			if err != nil {
+				t.Errorf("ValidateURL(%q) returned error for legitimate hostname: %v", u, err)
+			}
+		})
+	}
+}
+
+// TestValidateURL_BlockedHostnameCaseInsensitive は大文字小文字混在・全大文字の
+// ブロック対象ホスト名が小文字化された上で拒否されることをテストする。
+// Requirement 3: 大文字小文字非依存のブロック判定。
+func TestValidateURL_BlockedHostnameCaseInsensitive(t *testing.T) {
+	guard := NewSSRFGuard()
+
+	blockedURLs := []string{
+		"http://LocalHost/feed",
+		"http://LOCALHOST/feed",
+	}
+
+	for _, u := range blockedURLs {
+		t.Run(u, func(t *testing.T) {
+			err := guard.ValidateURL(u)
+			if err == nil {
+				t.Errorf("ValidateURL(%q) should have returned error for case-variant blocked hostname", u)
+			}
+		})
+	}
+}
+
+// TestValidateURL_BlockedHostnameSuffix はブロック対象ホスト名を接尾辞として含むだけの
+// 正当なホスト名が通過することをテストする。
+// Requirement 4: 完全一致維持（接尾辞での誤ブロック回避）。
+func TestValidateURL_BlockedHostnameSuffix(t *testing.T) {
+	guard := NewSSRFGuard()
+
+	err := guard.ValidateURL("http://notlocalhost/feed")
+	if err != nil {
+		t.Errorf("ValidateURL(\"http://notlocalhost/feed\") returned error for legitimate hostname: %v", err)
 	}
 }
 


### PR DESCRIPTION
## 概要

フィードリーダー Feedman の SSRF 事前検証（`ValidateURL`）で使用するブロック対象ホスト名リストを `localhost` 1 件から 6 件に拡充した。ループバック別名（`localhost.localdomain` / `ip6-localhost` / `ip6-loopback`）およびクラウドメタデータエンドポイント（`metadata.google.internal` / `metadata`）を追加し、表記揺れによるすり抜けを防ぐ大文字小文字非依存判定・正当なホスト名の過剰ブロックを防ぐ完全一致判定はいずれも維持している。また事前検証とフェッチ層の責務分担を docstring に明記し、多層防御の前提を可読化した。

## 対応 Issue

Closes #43

## 関連 PR

- 設計 PR: なし（Architect が走らない小規模 Issue のため設計 PR ゲートなし）

## 実装内容

- (Req 1.1–1.6 / Task 実装) `blockedHostnames` を 6 ホスト名（`localhost` / `localhost.localdomain` / `ip6-localhost` / `ip6-loopback` / `metadata.google.internal` / `metadata`）に拡充
- (Req 3) ホスト名の大文字小文字非依存ブロック判定を維持（`strings.ToLower` 後に比較）
- (Req 4) 完全一致判定（`lower == blocked`）を維持し部分一致・接尾辞一致でのブロックなし
- (Req 5 / NFR 2) `blockedHostnames` / `isBlockedHostname` の docstring に「静的な完全一致ブロックのみを担い、DNS 解決後の宛先 IP 検証はフェッチ層（safeurl Dialer フック）の責務」を参照可能な形で明記
- (NFR 1) 正当外部 URL 通過・既存拒否 URL 拒否の後方互換を維持

## 受入基準チェック

- [x] Req 1.1: If `localhost` をホスト名とする URL が渡されたとき, the SSRF Guard shall エラーを返す ← `TestValidateURL_BlockedHostnames/http://localhost/feed`
- [x] Req 1.2: If `localhost.localdomain` をホスト名とする URL が渡されたとき ← 同テスト関数（localdomain ケース）
- [x] Req 1.3: If `ip6-localhost` をホスト名とする URL が渡されたとき ← 同テスト関数
- [x] Req 1.4: If `ip6-loopback` をホスト名とする URL が渡されたとき ← 同テスト関数
- [x] Req 1.5: If `metadata.google.internal` をホスト名とする URL が渡されたとき ← 同テスト関数
- [x] Req 1.6: If `metadata` をホスト名とする URL が渡されたとき ← 同テスト関数
- [x] Req 2.1: When `example.com` の URL が渡されたとき, the SSRF Guard shall 通過させる ← `TestValidateURL_PublicURL`
- [x] Req 2.2: When `localhost.example.com` が渡されたとき, 通過させる ← `TestValidateURL_BlockedHostnameSubstring/http://localhost.example.com/feed`
- [x] Req 2.3: When `metadata.example.com` が渡されたとき, 通過させる ← 同テスト関数
- [x] Req 3.1: If `LocalHost` が渡されたとき, ブロックする ← `TestValidateURL_BlockedHostnameCaseInsensitive/http://LocalHost/feed`
- [x] Req 3.2: If `LOCALHOST` が渡されたとき, ブロックする ← `TestValidateURL_BlockedHostnameCaseInsensitive/http://LOCALHOST/feed`
- [x] Req 4.1: 完全一致判定を維持 ← `TestValidateURL_BlockedHostnameSubstring` / `TestValidateURL_BlockedHostnameSuffix` で間接担保
- [x] Req 4.2: When `notlocalhost` が渡されたとき, 通過させる ← `TestValidateURL_BlockedHostnameSuffix`
- [x] Req 5.1: 責務分担を参照可能な形で明示 ← `blockedHostnames` / `isBlockedHostname` の docstring（コードレビューで確認）
- [x] NFR 1.1 / 1.2: 後方互換 ← 既存テスト群 green 維持
- [x] NFR 2.1: 単体テストで検証可能 ← 追加した `TestValidateURL_Blocked*` 4 関数

## テスト結果

```
ok  github.com/hitoshi/feedman/internal/security
（全テスト pass: 追加した TestValidateURL_Blocked* 4 関数 + 既存テスト群すべて green）
gofmt -l → 出力なし（整形済み）
go vet ./internal/security/... → 出力なし（pass）
```

## 実装上の判断

- 事前 DNS 解決は導入せず docstring 明記で責務分担を示す方針を採った。`ValidateURL` は「DNS 解決を伴わない静的検証」として設計されており、DNS 解決後 IP 検証はフェッチ層の safeurl Dialer フックが担保している（多層防御の役割分担）。詳細は `docs/specs/43-ssrf/impl-notes.md` 参照。

## 確認事項 / レビュワーへの依頼

- Reviewer による独立レビュー判定: `docs/specs/43-ssrf/review-notes.md` 参照（RESULT: approve）
- base ブランチ検証: --base 指定値 = develop / baseRefName = develop / OK
- 実装は `internal/security/ssrf_guard.go` と近傍テスト `ssrf_guard_test.go` のみに閉じており、Out of Scope（safeurl Dialer・IP レンジ・DNS リバインディング）への逸脱なし

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #43 のコメントを参照してください。
