### PR TITLE
feat(#36): DB 接続の sslmode 固定を解消し外部 DB 接続で require 以上を選択可能にする

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,8 +11,23 @@
 
 # === 必須 ===
 
-# PostgreSQL 接続URL（docker-compose内部ネットワーク用）
-DATABASE_URL=postgres://feedman:feedman@db:5432/feedman?sslmode=disable
+# PostgreSQL 接続URL
+#
+# sslmode は接続先に応じて利用者が明示的に選択すること:
+#   - コンテナ内 DB（`db` ホスト）利用時のみ sslmode=disable が許容される（TLS 無効構成のため）
+#   - 外部 PostgreSQL へ接続する場合は sslmode に require 以上（require / verify-ca / verify-full）を
+#     明示し、平文通信（disable）にしないこと。disable のまま外部 DB へ接続すると平文通信となり
+#     DB 認証情報・ユーザーデータが中間者攻撃で漏洩する導線になる。
+#
+# 本行はデフォルトでコメントアウトしている。未設定のまま docker compose を起動すると、
+# docker-compose.yml がコンテナ内 DB（`db` ホスト, sslmode=disable）向けデフォルトを適用するため、
+# コンテナ内 DB で開発する場合は本行を設定しなくても従来どおり起動できる。
+#
+# コンテナ内 DB を明示する例（sslmode=disable 許容）:
+#   DATABASE_URL=postgres://feedman:feedman@db:5432/feedman?sslmode=disable
+# 外部 PostgreSQL へ接続する例（sslmode は require 以上を明示すること）:
+#   DATABASE_URL=postgres://<user>:<password>@<external-host>:5432/<dbname>?sslmode=require
+# DATABASE_URL=
 
 # Google OAuth 2.0 認証情報
 # https://console.cloud.google.com/ で取得

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ vi .env.production
 | `BASE_URL` | api | ブラウザ可視オリジン（例: `https://<host>`）。callback 後のリダイレクト先・Cookie の Secure 自動判定に利用 |
 | `API_INTERNAL_URL` | web | 内部 API 接続先（例: `http://api:8080`）。**実行時**に web が rewrites の転送先として参照。ブラウザ非公開。未設定なら web は起動時に fail-fast |
 | `POSTGRES_PASSWORD` | db | PostgreSQL パスワード（本番では必ずデフォルトから変更） |
+| `DATABASE_URL` | api / worker | DB 接続 URL。未設定ならコンテナ内 DB（`db` ホスト, `sslmode=disable`）向けデフォルトが適用される。**外部 PostgreSQL 接続時は `sslmode` に `require` 以上を明示すること**（[本番デプロイ時の注意事項](#本番デプロイ時の注意事項)参照） |
 | `CORS_ALLOWED_ORIGIN` | api | CORS 許可オリジン（単一オリジン化で CORS プリフライトは発生しなくなるが、設定撤去は #23 の領分のため残置） |
 
 > **`NEXT_PUBLIC_API_URL` は廃止しました。** 単一オリジン化によりブラウザは常に同一オリジンの
@@ -180,6 +181,17 @@ docker compose --env-file .env.production exec api /feedman migrate
   `web`（:3000）へルーティング**する。`api`（:8080）はブラウザに公開せず内部ネットワークに留める
 - PostgreSQL のパスワードをデフォルト（`feedman`）から変更する
 - DB ポートはデフォルトで非公開。開発時に直接接続が必要な場合のみ `DB_PORT=5432` を設定する
+- **DB 接続の TLS（`sslmode`）設定**:
+  - コンテナ内 DB（`db` ホスト）を利用する場合のみ `sslmode=disable` が許容される（コンテナ間の
+    `internal` ネットワークは外部公開されず、PostgreSQL コンテナも TLS 無効構成のため）
+  - **外部 PostgreSQL へ接続する場合は `DATABASE_URL` の `sslmode` に `require` 以上
+    （`require` / `verify-ca` / `verify-full`）を必須とする**。`sslmode=disable` のまま外部 DB へ
+    接続すると平文通信となり、DB 認証情報・ユーザーデータが中間者攻撃（MITM）で漏洩する導線になる
+  - 接続先に応じて `DATABASE_URL` を環境別に差し替える。外部 DB の例:
+    `DATABASE_URL=postgres://<user>:<password>@<external-host>:5432/<dbname>?sslmode=require`
+  - `.env.sample` の `DATABASE_URL` はデフォルトでコメントアウトしてあり、未設定時は
+    docker-compose がコンテナ内 DB 向けデフォルト（`sslmode=disable`）を適用する。外部 DB を
+    使う場合は `.env.production` で `DATABASE_URL` を `require` 以上の `sslmode` 付きで明示すること
 
 ## ネットワークセキュリティ
 
@@ -322,6 +334,9 @@ npm test
 
 ```bash
 # PostgreSQL を別途起動し、DATABASE_URL を設定
+# ローカル PostgreSQL（localhost, TLS 無効）への接続のみ sslmode=disable を許容する。
+# 外部 PostgreSQL へ接続する場合は sslmode に require 以上（require / verify-ca / verify-full）を
+# 明示すること（平文通信防止）。
 export DATABASE_URL=postgres://feedman:feedman@localhost:5432/feedman?sslmode=disable
 export GOOGLE_CLIENT_ID=...
 export GOOGLE_CLIENT_SECRET=...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,10 @@ services:
     ports:
       - "${SERVER_PORT:-8080}:8080"
     environment:
-      - DATABASE_URL=postgres://${POSTGRES_USER:-feedman}:${POSTGRES_PASSWORD:-feedman}@db:5432/${POSTGRES_DB:-feedman}?sslmode=disable
+      # 未指定時はコンテナ内 DB（`db` ホスト、TLS 無効構成）向けデフォルトを適用する。
+      # 外部 PostgreSQL へ接続する場合は `.env` 等で DATABASE_URL を上書きし、sslmode に
+      # require 以上（require / verify-ca / verify-full）を明示すること（平文通信防止）。
+      - DATABASE_URL=${DATABASE_URL:-postgres://${POSTGRES_USER:-feedman}:${POSTGRES_PASSWORD:-feedman}@db:5432/${POSTGRES_DB:-feedman}?sslmode=disable}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
       # 単一オリジン化後はブラウザ可視オリジン（web のオリジン）配下の callback URL を設定する。
@@ -78,7 +81,10 @@ services:
       dockerfile: Dockerfile
     command: ["worker"]
     environment:
-      - DATABASE_URL=postgres://${POSTGRES_USER:-feedman}:${POSTGRES_PASSWORD:-feedman}@db:5432/${POSTGRES_DB:-feedman}?sslmode=disable
+      # 未指定時はコンテナ内 DB（`db` ホスト、TLS 無効構成）向けデフォルトを適用する。
+      # 外部 PostgreSQL へ接続する場合は `.env` 等で DATABASE_URL を上書きし、sslmode に
+      # require 以上（require / verify-ca / verify-full）を明示すること（平文通信防止）。
+      - DATABASE_URL=${DATABASE_URL:-postgres://${POSTGRES_USER:-feedman}:${POSTGRES_PASSWORD:-feedman}@db:5432/${POSTGRES_DB:-feedman}?sslmode=disable}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-dummy}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-dummy}
       - GOOGLE_REDIRECT_URL=${GOOGLE_REDIRECT_URL:-http://localhost:8080/auth/google/callback}

--- a/docs/specs/36-db-sslmode-disable/impl-notes.md
+++ b/docs/specs/36-db-sslmode-disable/impl-notes.md
@@ -1,0 +1,112 @@
+# 実装ノート: DB 接続 sslmode=disable 固定の解消（Issue #36）
+
+## スコープ
+
+人間が Option B で確定済みのとおり、**設定ファイルとドキュメントの修正のみ**。Go アプリ
+ケーションコード・DB スキーマ・マイグレーションには一切変更を加えていない（NFR 1.2）。
+起動時警告ガードは別 Issue へ分離済み（Out of Scope）。
+
+## 変更ファイル
+
+- `.env.sample`（`DATABASE_URL` 行）
+- `docker-compose.yml`（api / worker 両サービスの `DATABASE_URL`）
+- `README.md`（環境変数表 / 本番デプロイ時の注意事項 / ローカル開発例）
+
+## AC トレーサビリティ（対応表）
+
+| AC | 対応箇所 | 対応内容 |
+|---|---|---|
+| 1.1 | `.env.sample` `DATABASE_URL` 行 | 固定 `?sslmode=disable` を持つ active な `DATABASE_URL` 行を撤去。本行はコメントアウト（`# DATABASE_URL=`）し、固定値を残さない |
+| 1.2 | `.env.sample` `DATABASE_URL` 上のコメント | 「コンテナ内 DB 利用時のみ disable 許容」「外部 DB は require 以上を明示」をコメントで明記 |
+| 1.3 | `.env.sample` `DATABASE_URL` 周辺コメント + コメントアウト構造 | コンテナ内 DB 例（disable）／外部 DB 例（require）を併記し、利用者が接続先に応じて明示選択する構造にした |
+| 2.1 | `docker-compose.yml` api `environment.DATABASE_URL` | `${DATABASE_URL:-<コンテナ内DBデフォルト>}` により未指定時は `db` ホスト・`sslmode=disable` を適用（従来起動を維持） |
+| 2.2 | `docker-compose.yml` worker `environment.DATABASE_URL` | api と同一形式で worker 側も未指定時コンテナ内 DB デフォルトを適用 |
+| 2.3 | `docker-compose.yml` api / worker `DATABASE_URL` | `${DATABASE_URL:-...}` により `.env` 等からの環境別差し替えを許容（両サービス） |
+| 2.4 | `docker-compose.yml` api / worker `DATABASE_URL` | `DATABASE_URL` 未上書き時はコンテナ内 DB 向けデフォルト接続文字列を適用 |
+| 3.1 | `README.md` 本番デプロイ時の注意事項（DB 接続の TLS 設定） | 「コンテナ内 DB 利用時のみ `sslmode=disable` 許容」を明記 |
+| 3.2 | `README.md` 本番デプロイ時の注意事項 + 環境変数表 `DATABASE_URL` 行 | 「外部 PostgreSQL 接続時は `require` 以上を必須」を明記 |
+| 3.3 | `README.md` 本番デプロイ時の注意事項 | `DATABASE_URL` の sslmode を接続先に応じて設定する手順を本番注意事項として追加（外部 DB の `?sslmode=require` 例を含む） |
+| 3.4 | `README.md` ローカル開発（Docker なし）例 / 本番デプロイ時の注意事項 | 外部 DB 接続例で `disable` を推奨せず `require` 以上を案内。ローカル例の `localhost` 接続のみ disable 許容とコメント明記 |
+| NFR 1.1 | `docker-compose.yml` | `${DATABASE_URL:-...}` の `:-` により未指定時は変更前と同一のコンテナ内 DB 接続文字列を生成（後述の検証で確認） |
+| NFR 1.2 | （全体） | Go コード・スキーマ・マイグレーション無変更 |
+| NFR 2.1 | 3 ファイル全体 | sslmode 記述（コンテナ内=disable 許容 / 外部=require 以上）を 3 ファイルで一貫させた |
+
+## `.env.sample` の sslmode 扱いに関する設計判断と根拠
+
+**判断: active な `DATABASE_URL` 行をコメントアウトし、コンテナ内 DB 例（disable）と外部 DB 例
+（require）を併記するコメント構造にした。**
+
+根拠:
+
+- AC 1.1 は「`?sslmode=disable` の固定指定を `.env.sample` の `DATABASE_URL` に残さない」ことを
+  要求する。一方で、`.env.sample` をそのままコピーしてコンテナ内 DB で開発する後方互換を壊さない
+  配慮も求められている。
+- `lib/pq` は接続 URL に `sslmode` を **省略すると既定で `require`** を要求するため、active 行から
+  単に `?sslmode=disable` を外して値を残すと、コンテナ内 DB（TLS 無効構成）への接続が壊れる。
+  そのため「値を残しつつ sslmode だけ削る」案は後方互換を満たせず却下した。
+- 代わりに active 行をコメントアウト（`# DATABASE_URL=`）した。これにより `.env.sample` を
+  `.env.production` にコピーして `docker compose --env-file` で起動しても、`DATABASE_URL` が
+  env に設定されないため `docker-compose.yml` 側の `${DATABASE_URL:-<コンテナ内DBデフォルト>}`
+  が適用され、従来どおりコンテナ内 DB（`sslmode=disable`）で起動できる（AC 2.4 と整合）。
+- 固定 disable 値を active 行として残さないことで AC 1.1 を満たしつつ、コメントで接続先別の
+  明示選択（AC 1.2 / 1.3）を促す形にした。
+
+## 実行した検証コマンドと結果
+
+### 1. `docker-compose.yml` の `DATABASE_URL` 解決の妥当性（AC 2.1〜2.4 / NFR 1.1）
+
+`docker compose config`（compose v2）でフル `docker-compose.yml` を検証したところ、本変更とは
+**無関係な既存の healthcheck 定義**（`test: ["/feedman", "healthcheck"]` の exec-form）が compose v2
+の strict 検証で `healthcheck.test must start either by "CMD", "CMD-SHELL" or "NONE"` と弾かれ、
+フル config のレンダリングが完了しなかった。当該 healthcheck 行は本 PR で変更しておらず
+（`git diff docker-compose.yml` に healthcheck 行は含まれない）、本 Issue のスコープ外の既存事項
+である。
+
+そのため、本変更で実際に編集した `DATABASE_URL` のインターポレーションロジックのみを
+最小 compose ファイルに切り出して検証した:
+
+```
+=== default (unset) ===
+  DATABASE_URL: postgres://feedman:feedman@db:5432/feedman?sslmode=disable   # api / worker 両方
+=== override require ===
+  DATABASE_URL: postgres://u:p@ext:5432/d?sslmode=require                     # api / worker 両方
+=== POSTGRES_* override ===
+  DATABASE_URL: postgres://feeduser:secret@db:5432/feeddb?sslmode=disable     # api / worker 両方
+```
+
+- 未指定時はコンテナ内 DB（`db` ホスト, `sslmode=disable`）向けデフォルトを適用 → AC 2.1 / 2.2 / 2.4 / NFR 1.1 を満たす
+- `DATABASE_URL` 上書き時は外部 DB（`sslmode=require`）にそのまま差し替わる → AC 2.3 を満たす
+- ネストした `POSTGRES_USER/PASSWORD/DB` のデフォルトも従来どおり解決される（後方互換）
+
+### 2. `go vet ./...`
+
+実行を試みたが、本サンドボックス環境では Go 1.25 ツールチェーンが download できず実行不可
+（`go: download go1.25 for linux/amd64: toolchain not available`）。本変更は Go コードを 1 行も
+変更していない（`git diff --name-only` は `.env.sample` / `README.md` / `docker-compose.yml` のみ）
+ため、Go ビルド・テストへの影響はない。
+
+### 3. `.env.sample` / `README.md` の目視確認
+
+- `.env.sample`: 固定 disable 値の active 行が無いこと、コンテナ内/外部の例とコメントが AC 1.1〜1.3 を満たすことを確認。
+- `README.md`: 環境変数表に `DATABASE_URL` 行を追加（AC 3.1/3.2）、本番デプロイ注意事項に sslmode 手順を追加（AC 3.1〜3.3）、外部 DB 例で disable を推奨しないこと（AC 3.4）を確認。
+- 3 ファイルの sslmode 記述（コンテナ内=disable 許容 / 外部=require 以上）が相互に矛盾しないこと（NFR 2.1）を確認。
+
+## 確認事項
+
+- **既存 healthcheck 定義（`test: ["/feedman", "healthcheck"]`）が compose v2 の strict 検証で
+  invalid と判定される**: 本 Issue のスコープ外（DATABASE_URL とは無関係 / 本 PR では未変更）の
+  ため修正していないが、`docker compose config` のフルレンダリングが当該行で失敗する。compose v2
+  運用時に支障となりうるため、別 Issue での修正（`test: ["CMD", "/feedman", "healthcheck"]` への
+  変更等）を検討する価値がある。本 PR では touch しない（spec 書き換え禁止・スコープ厳守のため）。
+- `.env.sample` の active `DATABASE_URL` 行をコメントアウトする方針は requirements の AC を満たす
+  範囲で Developer 判断として確定したもの（上記「設計判断」参照）。別案（コンテナ内 DB のみ
+  active で残し外部は別キー）も理論上可能だが、AC 1.1 の「固定 disable を残さない」を最も素直に
+  満たす本案を採用した。
+
+## 派生タスク候補
+
+- compose v2 strict 検証に適合するよう healthcheck の exec-form を `CMD` prefix 付きに修正する Issue。
+- （別 Issue として分離済み）起動時に `sslmode=disable` かつ外部ホスト接続を検知した場合の警告
+  ログガードの実装。
+
+STATUS: complete

--- a/docs/specs/36-db-sslmode-disable/requirements.md
+++ b/docs/specs/36-db-sslmode-disable/requirements.md
@@ -1,0 +1,67 @@
+# Requirements Document
+
+## Introduction
+
+Feedman の DB 接続文字列（`DATABASE_URL`）は、`.env.sample` と `docker-compose.yml`（api / worker 両サービス）で
+`sslmode=disable` がハードコードされている。サンプルをそのまま本番にコピーして外部 PostgreSQL へ接続すると、
+デフォルトで TLS 無効（平文通信）となり、中間者攻撃（MITM）によって DB 認証情報やユーザーデータが漏洩する導線になる。
+本要件は、開発時（docker-compose のコンテナ内 DB `db` ホスト）では従来どおり無設定で起動できる後方互換を保ちつつ、
+サンプル設定が本番の平文通信導線にならないよう、設定ファイルとドキュメントを通じて利用者に sslmode の明示的選択を促すことを目的とする。
+本 Issue のスコープは設定ファイル（`docker-compose.yml` / `.env.sample`）とドキュメント（`README.md`）の修正に限定し、
+Go アプリケーションコードの変更や起動時警告ガードは扱わない（別 Issue へ分離済み）。
+
+## Requirements
+
+### Requirement 1: サンプル接続文字列のデフォルト平文通信の解消
+
+**Objective:** As a 本番運用者, I want `.env.sample` をそのまま本番にコピーしてもデフォルトで平文 DB 通信にならないこと, so that 設定のコピーミスによる DB 認証情報・データの平文漏洩リスクを避けられる
+
+#### Acceptance Criteria
+
+1. When 運用者が `.env.sample` をそのままコピーして外部 PostgreSQL に接続したとき, the サンプル設定 shall デフォルトで sslmode=disable による平文通信を強制しない（`?sslmode=disable` の固定指定を `.env.sample` の `DATABASE_URL` に残さない）。
+2. The `.env.sample` の `DATABASE_URL` 行 shall コンテナ内 DB 利用時のみ disable が許容される旨と、外部 DB 接続時は require 以上の sslmode を選択する必要がある旨をコメントで明示する。
+3. The `.env.sample` shall sslmode を接続先に応じて利用者が明示的に選択する形式であることを、コメントまたは設定値の構造から読み取れるようにする。
+
+### Requirement 2: docker-compose のコンテナ内 DB 開発起動の後方互換維持
+
+**Objective:** As a 開発者, I want docker-compose のコンテナ内 DB（`db` ホスト）を使う開発時に追加設定なしで従来どおり起動できること, so that 既存の開発フローを壊さずにセキュリティ修正を取り込める
+
+#### Acceptance Criteria
+
+1. When 開発者が追加の環境変数指定なしで docker-compose を起動したとき, the api サービス shall コンテナ内 DB（`db` ホスト）へ接続して従来どおり起動できる。
+2. When 開発者が追加の環境変数指定なしで docker-compose を起動したとき, the worker サービス shall コンテナ内 DB（`db` ホスト）へ接続して従来どおり起動できる。
+3. Where 外部 PostgreSQL を利用する運用構成が選択されたとき, the docker-compose 設定 shall api サービス・worker サービスの両方で `DATABASE_URL` を環境別に差し替え可能とする。
+4. When 外部 DB 接続用に `DATABASE_URL` を上書きせず docker-compose を起動したとき, the docker-compose 設定 shall コンテナ内 DB 向けのデフォルト接続文字列を適用する。
+
+### Requirement 3: 外部 DB 接続時の sslmode 要件のドキュメント化
+
+**Objective:** As a 本番運用者, I want 外部 DB 接続時に require 以上の sslmode が必要であることがドキュメントから読み取れること, so that 本番デプロイ時に正しい TLS 設定で DB 接続を構成できる
+
+#### Acceptance Criteria
+
+1. The README shall コンテナ内 DB（`db` ホスト）利用時のみ sslmode=disable が許容される旨を明記する。
+2. The README shall 外部 PostgreSQL 接続時は sslmode に require 以上を必須とする旨を明記する。
+3. Where 本番デプロイ手順が記載されている箇所において, the README shall `DATABASE_URL` の sslmode を接続先に応じて設定する手順を本番デプロイ時の注意事項として含める。
+4. If 運用者が README のサンプルコマンドや設定例を参照したとき, the README shall 外部 DB 接続例で sslmode=disable を平文接続のまま推奨するような記述を残さない。
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. While コンテナ内 DB（`db` ホスト）を用いた既存の開発用 docker-compose 起動を行っている間, the docker-compose 設定 shall 本変更前と同一の起動結果（コンテナ内 DB への接続成立）を維持する。
+2. The 本変更 shall Go アプリケーションコード・DB スキーマ・マイグレーションに変更を加えずに完結する。
+
+### NFR 2: 設定とドキュメントの整合性
+
+1. The `.env.sample` / `docker-compose.yml` / `README.md` の DB 接続に関する sslmode の記述 shall 相互に矛盾しない一貫した内容とする。
+
+## Out of Scope
+
+- 起動時警告ガード（sslmode=disable かつ DB ホストが localhost/db 以外の場合に警告ログを出す仮案）。Issue コメントで確定した Option B に従い、別 Issue へ分離する。
+- Go アプリケーションコード（`internal/config/` / `internal/database/` 等）の DB ドライバ・接続実装の変更およびそれに伴うテスト追加。
+- DB マイグレーション・スキーマ変更。
+- PostgreSQL サーバ側の TLS 証明書配置・TLS 終端構成・リバースプロキシ設定など、Feedman リポジトリ外のインフラ構成。
+
+## Open Questions
+
+- なし（Issue コメントで Option B が確定済み。スコープは設定・ドキュメント修正のみ）。

--- a/docs/specs/36-db-sslmode-disable/review-notes.md
+++ b/docs/specs/36-db-sslmode-disable/review-notes.md
@@ -1,0 +1,51 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-36-impl-db-sslmode-disable
+- HEAD commit: 69620a27173c1f3bad52c1534bf31d6aa2abc40d
+- Compared to: develop..HEAD
+- 変更ファイル: `.env.sample` / `docker-compose.yml` / `README.md`（+ spec ドキュメント）
+- 補足: 本 spec は `design.md` / `tasks.md` を持たない design-less impl。`_Boundary:_`
+  アノテーションは存在しないため、boundary 判定は requirements の Out of Scope（Go コード /
+  スキーマ / マイグレーション無変更）との突き合わせで実施した。Feature Flag Protocol は
+  CLAUDE.md で `opt-out` 宣言のため flag 観点は適用しない。
+
+## Verified Requirements
+
+- 1.1 — `.env.sample` の固定 `?sslmode=disable` を持つ active な `DATABASE_URL` 行を撤去し
+  `# DATABASE_URL=`（コメントアウト）に変更。固定 disable の active 値は残っていない。
+- 1.2 — `.env.sample` のコメントに「コンテナ内 DB（`db` ホスト）利用時のみ disable 許容」
+  「外部 PostgreSQL は require 以上を明示」を記載（`.env.sample` 16-20 行）。
+- 1.3 — コンテナ内 DB 例（disable）／外部 DB 例（require）を併記し、接続先に応じて利用者が
+  明示選択する構造にした（`.env.sample` 26-30 行）。
+- 2.1 — `docker-compose.yml` api `environment.DATABASE_URL` を
+  `${DATABASE_URL:-postgres://...@db:5432/...?sslmode=disable}` とし、未指定時はコンテナ内 DB へ接続。
+- 2.2 — worker 側も api と同一形式で未指定時コンテナ内 DB デフォルトを適用。
+- 2.3 — `${DATABASE_URL:-...}` により api / worker 両サービスで環境別差し替えを許容。
+- 2.4 — `DATABASE_URL` 未上書き時はコンテナ内 DB 向けデフォルト接続文字列を適用。
+- 3.1 — README 本番デプロイ注意事項に「コンテナ内 DB 利用時のみ `sslmode=disable` 許容」を明記。
+- 3.2 — README 環境変数表 `DATABASE_URL` 行 + 本番注意事項に「外部 PostgreSQL は `require` 以上必須」を明記。
+- 3.3 — README 本番デプロイ注意事項に sslmode 設定手順（外部 DB の `?sslmode=require` 例含む）を追加。
+- 3.4 — 外部 DB 例で disable を推奨せず require 以上を案内。ローカル開発例の `localhost` 接続のみ
+  disable 許容とコメント明記（README 337-339 行付近）。
+- NFR 1.1 — `${DATABASE_URL:-...}` の `:-` により未指定時は変更前と同一のコンテナ内 DB 接続文字列を
+  生成。Developer が最小 compose ファイルで `docker compose config` 検証済み（impl-notes 検証 1）。
+- NFR 1.2 — Go コード・DB スキーマ・マイグレーション無変更（差分は設定/ドキュメント 3 ファイルのみ）。
+- NFR 2.1 — `.env.sample` / `docker-compose.yml` / `README.md` の sslmode 記述
+  （コンテナ内=disable 許容 / 外部=require 以上）が相互に一貫。
+
+## Findings
+
+なし
+
+## Summary
+
+設定ファイルとドキュメントのスコープに閉じた変更で、Requirement 1〜3 と NFR 1〜2 の全 numeric ID
+が差分内でカバーされている。Out of Scope（Go コード / スキーマ / マイグレーション）には触れておらず
+boundary 逸脱なし。本件は実行可能コードを伴わない設定・ドキュメント変更であり、検証は
+`docker compose config` による接続文字列解決確認で担保されているため missing test には当たらない。
+
+RESULT: approve


### PR DESCRIPTION
## 概要

Feedman の DB 接続文字列（`DATABASE_URL`）は `.env.sample` と `docker-compose.yml` で
`sslmode=disable` がハードコードされており、サンプルをそのまま本番にコピーすると
デフォルトで TLS 無効（平文通信）となり MITM による DB 認証情報漏洩のリスクがあった。

本 PR では、以下 3 ファイルを修正して設定・ドキュメントレベルでリスクを解消する。
Go アプリケーションコード・DB スキーマ・マイグレーションへの変更はない。

- `.env.sample`: 固定 `?sslmode=disable` の active 行を撤去し、接続先に応じた明示選択を促す構造に変更
- `docker-compose.yml`: `${DATABASE_URL:-<コンテナ内DBデフォルト>}` 形式に変更し、未指定時は従来どおりコンテナ内 DB（`sslmode=disable`）を維持しつつ外部 DB への差し替えを可能にする
- `README.md`: 外部 PostgreSQL 接続時は `sslmode=require` 以上が必要である旨を本番デプロイ注意事項・環境変数表に明記

## 対応 Issue

Closes #36

## 関連 PR

- 設計 PR: なし（design-less impl）

## 実装内容

- (Req 1.1 / 1.2 / 1.3) `.env.sample` の固定 `sslmode=disable` を持つ active な `DATABASE_URL` 行をコメントアウトし、コンテナ内 DB 例（disable）・外部 DB 例（require）を併記するコメント構造に変更
- (Req 2.1 / 2.2 / 2.3 / 2.4) `docker-compose.yml` の api / worker 両サービスの `DATABASE_URL` を `${DATABASE_URL:-postgres://...@db:5432/...?sslmode=disable}` 形式に変更し、未指定時の後方互換と外部 DB 差し替えを両立
- (Req 3.1 / 3.2 / 3.3 / 3.4) `README.md` の環境変数表と本番デプロイ注意事項に sslmode 要件（コンテナ内=disable 許容 / 外部=require 以上）を追記
- (NFR 1.1) `:-` フォールバック構文により未指定時は変更前と同一のコンテナ内 DB 接続文字列を生成し、既存の開発フローを維持

## 受入基準チェック

- [x] Req 1.1: `?sslmode=disable` の固定指定を `.env.sample` の `DATABASE_URL` に残さない ← `.env.sample` の active 行をコメントアウト
- [x] Req 1.2: コンテナ内 DB 利用時のみ disable 許容の旨をコメントで明示 ← `.env.sample` 16-20 行のコメント
- [x] Req 1.3: 接続先に応じた明示選択の構造 ← `.env.sample` 26-30 行の例示コメント
- [x] Req 2.1 / 2.2: 未指定時はコンテナ内 DB（`db` ホスト）へ接続 ← `docker-compose.yml` の `${DATABASE_URL:-...}` デフォルト値
- [x] Req 2.3: 環境別 `DATABASE_URL` 差し替えが可能 ← `:-` フォールバック構文
- [x] Req 2.4: 未上書き時はコンテナ内 DB デフォルト接続文字列を適用 ← `:-` フォールバック構文
- [x] Req 3.1〜3.4: README に sslmode 要件・手順・外部 DB 例（disable 非推奨）を追記 ← README の環境変数表・本番デプロイ注意事項
- [x] NFR 1.1: コンテナ内 DB の既存起動互換を維持 ← Developer による最小 compose ファイル検証
- [x] NFR 1.2: Go コード・スキーマ・マイグレーション無変更 ← 差分は設定/ドキュメント 3 ファイルのみ
- [x] NFR 2.1: 3 ファイル間の sslmode 記述が相互に一貫 ← `.env.sample` / `docker-compose.yml` / `README.md` を確認

## テスト結果

```
本 PR は実行コードを変更しない設定・ドキュメント変更のため、自動テスト（go test / npm test）への
影響なし。

検証: `docker compose config` による DATABASE_URL インターポレーション確認（最小 compose ファイル）

=== DATABASE_URL 未指定（デフォルト）===
  api / worker 両サービス: postgres://feedman:feedman@db:5432/feedman?sslmode=disable

=== DATABASE_URL を外部 DB 向けに上書き ===
  api / worker 両サービス: postgres://u:p@ext:5432/d?sslmode=require

→ 未指定時はコンテナ内 DB（後方互換）、上書き時は外部 DB 接続文字列が適用されることを確認。
```

## 実装上の判断

- `.env.sample` の active `DATABASE_URL` 行をコメントアウトした理由: `lib/pq` は sslmode を省略すると既定で `require` を要求するため、単に `?sslmode=disable` を外すとコンテナ内 DB（TLS 無効）への接続が壊れる。コメントアウトにより `docker-compose.yml` の `:-` デフォルト値が適用され AC 1.1 と後方互換の両立を実現した。
- 既存の `docker-compose.yml` healthcheck 定義（`test: ["/feedman", "healthcheck"]`）が compose v2 の strict 検証で invalid と判定されるが、本 PR の変更とは無関係であるため修正せずスコープ外として別途 Issue を検討する旨を impl-notes.md に記録した。

詳細は `docs/specs/36-db-sslmode-disable/impl-notes.md` を参照。

## 確認事項

- base ブランチ = develop（検証済み）
- Reviewer の独立レビュー（approve 判定）の詳細は `docs/specs/36-db-sslmode-disable/review-notes.md` を参照
- 派生タスク候補: compose v2 の healthcheck exec-form 修正（本 PR スコープ外）および起動時 sslmode 警告ログガード実装（別 Issue 分離済み）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #36 のコメントを参照してください。
