### PR TITLE
feat(#9): シャットダウン時に RateLimiter.Stop() を呼び出して goroutine リークを防止

### DIFF
--- a/docs/specs/9-ratelimiter-stop-goroutine/impl-notes.md
+++ b/docs/specs/9-ratelimiter-stop-goroutine/impl-notes.md
@@ -1,0 +1,97 @@
+# 実装ノート: RateLimiter.Stop() をシャットダウン時に呼び出して goroutine リークを防止
+
+Issue #9 / design-less impl（design.md / tasks.md なし）。
+
+## 採用した panic 防止方針とトレードオフ
+
+要件には 2 つの制約の両立が求められた:
+
+- **AC 2.1 / 2.2 / NFR 1.2**: シャットダウン経路（および重複起動シナリオ）で panic を発生させない
+- **AC 2.3 / 2.4**: `RateLimiter.Stop()` の公開シグネチャ・既存挙動を変更しない
+
+現状の `RateLimiter.Stop()` は `close(rl.stopCh)` を呼ぶため、二重呼び出しすると
+`close of closed channel` panic を起こす。既存テスト（`internal/middleware/ratelimit_test.go`）は
+`defer rl.Stop()` で 1 回だけ Stop を呼ぶ前提であり、`Stop()` 本体を変えると既存挙動が変わる。
+
+### 採用方針: app 層で「1 回だけ呼ぶ」を保証（`Stop()` 本体は無変更）
+
+`internal/app/shutdown.go` に `shutdownCoordinator` 構造体を新設し、シャットダウン手続き
+（`server.Shutdown` → `RateLimiter.Stop`）を束ねた。`RateLimiter.Stop()` の呼び出しは
+`sync.Once` で保護し、**シャットダウン経路から高々 1 回だけ**実行されることを保証する。
+
+- `RateLimiter.Stop()` 本体は **一切変更していない**（AC 2.3 / 2.4 を満たす）。
+  既存ミドルウェア・既存テストの挙動は不変。
+- panic 防止は app 層（呼び出し側）の `sync.Once` で実現。これにより、シグナルハンドラの
+  重複・複数経路からの呼び出しなど「シャットダウン経路が重複起動され得る状況」（AC 2.2）でも
+  二重 close panic が発生しない（NFR 1.2 を満たす）。
+
+タスク指示の第一候補（「`Stop()` を厳密に 1 回だけ呼ぶ」）に沿いつつ、シグナル重複等の
+万一の重複起動に対する堅牢性を `sync.Once` で確保した。`Stop()` 自体を `sync.Once` で
+idempotent 化する案は採らなかった（AC 2.4「既存挙動を変更しない」をより厳密に守るため、
+変更は app 層に閉じた）。
+
+### 停止タイミング（AC 3.1 / 3.2）
+
+`shutdownCoordinator.shutdown()` は `server.Shutdown(ctx)`（稼働中 HTTP リクエストの drain 待機）
+の **完了後**に `RateLimiter.Stop()` を呼ぶ順序とした。これにより、稼働中リクエストの処理を
+不当に阻害せず、バックグラウンドのクリーンアップ goroutine だけを終了する。通常稼働中
+（`<-stop` 受信前）には Stop を呼ばない（AC 3.1）。
+
+### 適用範囲（AC 4.1 / 4.2）
+
+- `runServe`（API サーバーモード）のみ RateLimiter を構築・停止する。
+- `runWorker` は RateLimiter を構築しないため変更していない（AC 4.2）。
+  `newShutdownCoordinator` は `rateLimiter == nil` を許容し、その場合 Stop を呼ばない設計だが、
+  worker からは coordinator 自体を呼び出していない。
+
+## 変更ファイル一覧
+
+| ファイル | 変更内容 |
+|---|---|
+| `internal/app/app.go` | `runServe` で `RateLimiter` をインライン構築から変数 `rateLimiter` に切り出し。シャットダウンシーケンスを `shutdownCoordinator` 経由に変更（`server.Shutdown` 直呼びを置換） |
+| `internal/app/shutdown.go` | 新規。`shutdownCoordinator` 構造体と `newShutdownCoordinator` / `shutdown` / `stopRateLimiter` メソッドを定義 |
+| `internal/app/shutdown_test.go` | 新規。goroutine リーク検証・panic 非発生・二重起動 idempotency のテスト |
+
+`RateLimiter.Stop()`（`internal/middleware/ratelimit.go`）は無変更。
+
+## テスト観点と AC 対応
+
+| AC / NFR | 検証テスト | 観点 |
+|---|---|---|
+| AC 1.1 / 1.3 (シャットダウン時に Stop 呼び出し / goroutine 残存させない) | `TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine` | `NewRateLimiter` で goroutine 増加を確認 → `shutdown` 後に `runtime.NumGoroutine()` が起動前水準に収束（goroutine リークなし） |
+| AC 1.2 / 1.4 (稼働中は継続 / 停止は 1 回) | 既存 `internal/middleware/ratelimit_test.go`（稼働中はクリーンアップ goroutine 継続で 429 応答等が機能）+ `TestShutdownCoordinator_DoubleInvocationDoesNotPanic`（1 回しか Stop が呼ばれないこと=二重 close panic なしで担保） | |
+| AC 2.1 (panic を発生させず正常終了) | `TestShutdownCoordinator_DoesNotPanic` | `shutdown` 呼び出しで panic しないこと |
+| AC 2.2 / NFR 1.2 (重複起動でも panic しない / 二重起動の panic 非発生検証) | `TestShutdownCoordinator_DoubleInvocationDoesNotPanic` | `shutdown` を 2 回呼んでも panic せず goroutine も収束（`sync.Once` による idempotency） |
+| AC 2.3 / 2.4 (Stop シグネチャ・既存挙動不変) | 既存 `internal/middleware/ratelimit_test.go` 全件が無変更で pass | `Stop()` 本体を変更していないため既存テストがそのまま green |
+| AC 3.1 / 3.2 (停止タイミング) | `TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine`（`server.Shutdown` 後に Stop を呼ぶ順序を coordinator が保証） | コード上で `server.Shutdown` → `stopRateLimiter` の順序を固定 |
+| AC 4.1 (構築モードは停止する) | `runServe` が coordinator 経由で停止（実コード）+ 上記 goroutine リークテスト | |
+| AC 4.2 (非構築モードは停止しない) | `runWorker` 無変更（RateLimiter を構築しない）。`internal/app/run_test.go` 既存テストが pass | |
+| NFR 1.1 (goroutine 停止を観察可能に検証) | `TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine` の `runtime.NumGoroutine()` 比較（`go.uber.org/goleak` 等の新規依存は追加せず標準 `testing` + `runtime` で実装） | |
+| NFR 2.1 / 2.2 (応答挙動不変 / 既存テスト無変更で通過) | 既存 `internal/middleware/ratelimit_test.go`・`internal/handler/*_test.go` が無変更で pass | |
+
+goroutine 数の比較は非同期停止を考慮し、`waitGoroutineCount`（最大 2 秒のポーリングで
+収束待ち）で flaky を回避。`-race -count=5` でも安定して pass することを確認済み。
+
+## 検証コマンド結果
+
+- `gofmt -l`（変更ファイル）: 差分なし
+- `go vet ./internal/app/... ./internal/middleware/...`: pass
+- `go build ./...`: pass
+- `go test ./...`: 全パッケージ pass（`internal/repository` の DB 結合テストもローカル PostgreSQL で pass）
+- `go test -race -count=5 ./internal/app/...`: pass（goroutine リークテストの安定性確認）
+
+> 環境注記: 本環境のデフォルト Go は 1.22.2 だが go.mod は `go 1.25` を要求するため、
+> `GOTOOLCHAIN=go1.25.0` を明示してツールチェインを取得・実行した。CI（`go test ./...` /
+> `npm test`）は go.mod 準拠で 1.25 系を使う想定。
+
+## 確認事項
+
+- 新規 `shutdownCoordinator` は `runServe` のシャットダウン経路をテスト可能な単位に切り出す
+  ためのもの。`runServe` 全体は DB 接続を要しテストしにくいため、停止ロジックのみを
+  coordinator として分離した（過度な抽象化を避け、責務はシャットダウン手続きの調整に限定）。
+- NFR 1.2 の「二重起動で panic しない」検証は app 層（`shutdownCoordinator`）で担保している。
+  `RateLimiter.Stop()` 単体は依然として二重呼び出しで panic する（既存挙動の維持＝AC 2.4）。
+  仕様の Open Questions でも「停止処理側を idempotent 化するか / 1 回だけ呼ぶかは実装判断に委ねる」
+  とされており、本実装は後者（呼び出し側で 1 回保証 + 重複起動への堅牢性）を採用した。
+
+STATUS: complete

--- a/docs/specs/9-ratelimiter-stop-goroutine/requirements.md
+++ b/docs/specs/9-ratelimiter-stop-goroutine/requirements.md
@@ -1,0 +1,80 @@
+# Requirements Document
+
+## Introduction
+
+API サーバーモード（`serve`）の起動時、レート制限コンポーネント（RateLimiter）は
+バックグラウンドで期限切れエントリのクリーンアップを行う goroutine を起動する。しかし現状の
+サーバー起動シーケンスでは RateLimiter が変数参照を持たない形で構築されており、シャットダウン時に
+その停止処理（`Stop()`）が呼ばれない。このため SIGINT / SIGTERM によるグレースフルシャットダウン後も
+クリーンアップ goroutine が残存し、goroutine リークが発生する。本要件は、シャットダウン経路で
+RateLimiter のバックグラウンド goroutine を確実に停止し、かつその過程で異常終了（panic）を
+起こさないことを定義する。対象は API サーバーモードのみで、ワーカーモードは RateLimiter を
+構築しないため対象外とする。
+
+## Requirements
+
+### Requirement 1: シャットダウン時の RateLimiter 停止
+
+**Objective:** As a 運用者, I want API サーバーのシャットダウン時に RateLimiter のクリーンアップ goroutine が確実に停止されること, so that プロセス終了前後で goroutine リークが発生しないこと
+
+#### Acceptance Criteria
+
+1. When API サーバーが SIGINT または SIGTERM を受信してグレースフルシャットダウンを開始したとき, the API Server shall RateLimiter の停止処理を呼び出す
+2. While API サーバーが稼働中である間, the RateLimiter shall クリーンアップのバックグラウンド goroutine を継続させる
+3. When グレースフルシャットダウンが完了したとき, the API Server shall RateLimiter が起動したクリーンアップ goroutine を残存させない
+4. The API Server shall RateLimiter の停止処理をシャットダウン経路で 1 回だけ実行する
+
+### Requirement 2: 停止経路における異常終了の防止
+
+**Objective:** As a 運用者, I want シャットダウン経路で RateLimiter を停止しても異常終了が起きないこと, so that プロセスが想定どおりに正常終了し終了コードやログが汚染されないこと
+
+#### Acceptance Criteria
+
+1. When シャットダウン経路で RateLimiter の停止処理が実行されたとき, the API Server shall panic を発生させずに正常終了する
+2. If RateLimiter の停止処理がシャットダウン経路で重複して起動され得る状況になったとき, the API Server shall panic を発生させない
+3. The RateLimiter shall 既存の停止処理の公開シグネチャ（引数・戻り値）を変更しない
+4. The RateLimiter shall 停止処理が起動されていない状態で稼働しているテストおよびミドルウェアの既存挙動を変更しない
+
+### Requirement 3: 停止タイミングの妥当性
+
+**Objective:** As a 運用者, I want RateLimiter の停止がシャットダウン手続きの中で適切なタイミングで行われること, so that 稼働中のリクエスト処理を不当に阻害せずにクリーンアップ goroutine だけを終了できること
+
+#### Acceptance Criteria
+
+1. While API サーバーがリクエストを処理している通常稼働中である間, the API Server shall RateLimiter の停止処理を呼び出さない
+2. When シャットダウン手続きが開始されたとき, the API Server shall 稼働中の HTTP リクエスト処理の終了を待機するシャットダウン手続きと整合する順序で RateLimiter を停止する
+
+### Requirement 4: 適用範囲の限定
+
+**Objective:** As a 開発者, I want 本変更の適用範囲が API サーバーモードに限定されること, so that RateLimiter を構築しない他の起動モードに不要な副作用が及ばないこと
+
+#### Acceptance Criteria
+
+1. Where RateLimiter を構築する起動モードである場合, the Application shall シャットダウン時に RateLimiter の停止処理を呼び出す
+2. Where RateLimiter を構築しない起動モードである場合, the Application shall RateLimiter の停止処理を呼び出さない
+
+## Non-Functional Requirements
+
+### NFR 1: 可観測性・検証可能性
+
+1. The Test Suite shall シャットダウン経路で RateLimiter のクリーンアップ goroutine が停止することを観察可能な形で検証できる手段（停止前後の goroutine 数の比較等）を提供する
+2. While 自動テストが RateLimiter の停止挙動を検証している間, the Test Suite shall 停止処理を二重に起動するケースで panic が発生しないことを検証する
+
+### NFR 2: 後方互換性
+
+1. The API Server shall 本変更の前後でレート制限の応答（許可・429 応答・Retry-After ヘッダー）の挙動を変えない
+2. The RateLimiter shall 既存の単体テストおよび結合テスト（停止処理を呼び出すもの・呼び出さないものの双方）を変更なしで通過させる
+
+## Out of Scope
+
+- レート制限アルゴリズムそのもの（トークンバケットの方式・許可判定ロジック）の変更
+- レート制限の設定値（req/min・バーストサイズ）のチューニングや変更
+- クリーンアップ間隔（CleanupInterval）および TTL のチューニングや変更
+- ワーカーモード（RateLimiter を構築しない起動モード）のシャットダウン挙動の変更
+- 429 応答のフォーマット・メッセージ・メトリクスの変更
+- RateLimiter の停止処理を context ベースに作り替えるなど、停止機構の API 形状の刷新
+
+## Open Questions
+
+- 「停止処理を 1 回だけ実行する」ことで panic を防ぐか、停止処理側を多重起動に耐える形（idempotent 化）にするかは design / 実装の判断に委ねる。本要件では「シャットダウン経路で panic が起きない」観察可能な振る舞いのみを要求し、実装方式は指定しない。ただし「既存の停止処理の公開シグネチャ・挙動を変更しない」制約（Requirement 2.3 / 2.4）と「panic を防ぐ」目標（Requirement 2.1 / 2.2）の両立方法に複数案がある点は Architect が明示的に判断すること
+- 上記以外に Issue 本文・既存コメントから読み取れなかった不足情報は現時点でなし

--- a/docs/specs/9-ratelimiter-stop-goroutine/review-notes.md
+++ b/docs/specs/9-ratelimiter-stop-goroutine/review-notes.md
@@ -1,0 +1,46 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-9-impl-ratelimiter-stop-goroutine
+- HEAD commit: 58344173ebec7599525fb1cb01cbb40418168359
+- Compared to: develop..HEAD
+
+本 Issue は design-less impl（`design.md` / `tasks.md` なし）であり、`_Boundary:_`
+アノテーションによる境界制約は存在しない。Feature Flag Protocol は CLAUDE.md で
+`opt-out` 宣言のため、flag 観点の確認は行わず通常の 3 カテゴリ判定のみを適用した。
+
+## Verified Requirements
+
+- 1.1 — `internal/app/app.go` の `runServe` シャットダウン経路で `newShutdownCoordinator(server, rateLimiter)` → `coordinator.shutdown(ctx)` を経由し `internal/app/shutdown.go` の `stopRateLimiter()` が `rateLimiter.Stop()` を呼ぶ。`TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine` で実行確認
+- 1.2 — `RateLimiter.Stop()`（`internal/middleware/ratelimit.go`）本体は無変更でクリーンアップ goroutine は稼働中継続。既存 `internal/middleware/ratelimit_test.go` が無変更で pass
+- 1.3 — `internal/app/shutdown_test.go: TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine` が `runtime.NumGoroutine()` の起動前水準への収束（`waitGoroutineCount`）でリーク非発生を観察検証
+- 1.4 — `shutdown.go` の `stopOnce sync.Once` で `Stop()` を高々 1 回に保証。`TestShutdownCoordinator_DoubleInvocationDoesNotPanic` で二重 close panic 非発生を確認
+- 2.1 — `internal/app/shutdown_test.go: TestShutdownCoordinator_DoesNotPanic` で shutdown 実行時の panic 非発生を検証
+- 2.2 — `TestShutdownCoordinator_DoubleInvocationDoesNotPanic` で重複起動シナリオ（shutdown 2 回）の panic 非発生を検証
+- 2.3 — `func (rl *RateLimiter) Stop()`（引数・戻り値）は `internal/middleware/ratelimit.go` で無変更を確認（diff に同ファイルの変更なし）
+- 2.4 — `Stop()` 本体無変更。panic 防止は app 層の `sync.Once` に閉じており、既存ミドルウェア・既存テストの挙動は不変（middleware テスト無変更 pass）
+- 3.1 — `Stop()` 呼び出しは shutdown 経路（`stop` シグナル受信後）のみで、通常稼働中は呼ばれない構造
+- 3.2 — `shutdown.go` の `shutdown` メソッドが `server.Shutdown(ctx)`（drain 待機）完了後に `stopRateLimiter()` を呼ぶ順序を固定
+- 4.1 — `runServe`（RateLimiter 構築モード）が coordinator 経由で停止
+- 4.2 — `runWorker` は RateLimiter を構築・参照せず（diff・grep で確認）、coordinator も呼ばないため停止処理が走らない
+- NFR 1.1 — goroutine 数比較（`runtime.NumGoroutine()` + `waitGoroutineCount` ポーリング）による観察可能な検証手段を提供
+- NFR 1.2 — `TestShutdownCoordinator_DoubleInvocationDoesNotPanic` が二重起動での panic 非発生を検証
+- NFR 2.1 / 2.2 — レート制限応答挙動は不変。既存 `internal/middleware` / `internal/handler` テストが無変更で pass
+
+## Findings
+
+なし
+
+## Summary
+
+全 AC（1.1〜4.2）および NFR が、新規 `internal/app/shutdown.go` の実装と
+`internal/app/shutdown_test.go` の 3 テストケースで観察可能にカバーされている。
+`RateLimiter.Stop()` 本体は無変更でシグネチャ・既存挙動を保持し、panic 防止は app 層の
+`sync.Once` に閉じている。`go test -race -count=3 -run TestShutdownCoordinator ./internal/app/...`
+および middleware テストの green を再実行で確認した。AC 未カバー / missing test /
+boundary 逸脱のいずれも検出されなかった。
+
+RESULT: approve

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -146,11 +146,15 @@ func runServe(cfg *config.Config) error {
 	// デフォルト値から変更する場合のみ上書き（req/min -> req/sec に変換）
 	// configのRateLimitGeneralはreq/min単位なのでreq/secに変換する
 
+	// RateLimiter はバックグラウンドでクリーンアップ goroutine を起動するため、
+	// シャットダウン時に Stop() を呼べるよう変数参照を保持する（goroutine リーク防止）。
+	rateLimiter := middleware.NewRateLimiter(rateLimiterCfg)
+
 	deps := &handler.RouterDeps{
 		HealthChecker:     db,
 		SessionFinder:     sessionRepo,
 		CORSAllowedOrigin: cfg.CORSAllowedOrigin,
-		RateLimiter:       middleware.NewRateLimiter(rateLimiterCfg),
+		RateLimiter:       rateLimiter,
 		Logger:            slog.Default(),
 
 		AuthService: authService,
@@ -201,8 +205,11 @@ func runServe(cfg *config.Config) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if err := server.Shutdown(ctx); err != nil {
-		return fmt.Errorf("server shutdown failed: %w", err)
+	// グレースフルシャットダウン: 稼働中リクエストの drain 完了後に
+	// RateLimiter のクリーンアップ goroutine を停止する（高々 1 回）。
+	coordinator := newShutdownCoordinator(server, rateLimiter)
+	if err := coordinator.shutdown(ctx); err != nil {
+		return err
 	}
 
 	slog.Info("API server stopped gracefully")

--- a/internal/app/shutdown.go
+++ b/internal/app/shutdown.go
@@ -1,0 +1,63 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/hitoshi/feedman/internal/middleware"
+)
+
+// shutdownCoordinator は API サーバーのグレースフルシャットダウン手続きを束ねる。
+// HTTP リクエスト処理の終了待機（server.Shutdown）と、RateLimiter のクリーンアップ
+// goroutine 停止（RateLimiter.Stop）を、整合する順序で 1 回だけ実行する責務を持つ。
+//
+// RateLimiter.Stop() は内部で stopCh を close するため、複数回呼び出すと panic する。
+// 本 coordinator は sync.Once で Stop() を高々 1 回だけ呼ぶことを保証し、シャットダウン
+// 経路が重複して起動され得る状況でも panic を発生させない（RateLimiter 本体の公開
+// シグネチャ・挙動は変更しない方針）。
+type shutdownCoordinator struct {
+	server      *http.Server
+	rateLimiter *middleware.RateLimiter
+	stopOnce    sync.Once
+}
+
+// newShutdownCoordinator はシャットダウン手続きを束ねる coordinator を生成する。
+// rateLimiter が nil の場合は RateLimiter の停止処理を行わない。
+func newShutdownCoordinator(server *http.Server, rateLimiter *middleware.RateLimiter) *shutdownCoordinator {
+	return &shutdownCoordinator{
+		server:      server,
+		rateLimiter: rateLimiter,
+	}
+}
+
+// shutdown はグレースフルシャットダウンを実行する。
+// 稼働中の HTTP リクエスト処理の終了を待機（server.Shutdown）した後に、
+// RateLimiter のクリーンアップ goroutine を停止する。この順序により、
+// リクエスト処理を不当に阻害せずにバックグラウンド goroutine だけを終了する。
+//
+// RateLimiter の停止は sync.Once で保護されており、shutdown が複数回呼び出されても
+// 高々 1 回だけ実行されるため、二重 close による panic は発生しない。
+func (sc *shutdownCoordinator) shutdown(ctx context.Context) error {
+	// 1. 稼働中の HTTP リクエスト処理の終了を待機する。
+	shutdownErr := sc.server.Shutdown(ctx)
+
+	// 2. リクエスト drain 完了後にクリーンアップ goroutine を停止する（1 回だけ）。
+	sc.stopRateLimiter()
+
+	if shutdownErr != nil {
+		return fmt.Errorf("server shutdown failed: %w", shutdownErr)
+	}
+	return nil
+}
+
+// stopRateLimiter は RateLimiter の停止処理を高々 1 回だけ実行する。
+func (sc *shutdownCoordinator) stopRateLimiter() {
+	if sc.rateLimiter == nil {
+		return
+	}
+	sc.stopOnce.Do(func() {
+		sc.rateLimiter.Stop()
+	})
+}

--- a/internal/app/shutdown_test.go
+++ b/internal/app/shutdown_test.go
@@ -1,0 +1,101 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/hitoshi/feedman/internal/middleware"
+)
+
+// waitGoroutineCount は goroutine 数が target 以下に収束するのを最大 timeout 待つ。
+// goroutine の停止は非同期に行われるため、即時比較ではなくポーリングで収束を待つ。
+func waitGoroutineCount(target int, timeout time.Duration) int {
+	deadline := time.Now().Add(timeout)
+	for {
+		runtime.Gosched()
+		n := runtime.NumGoroutine()
+		if n <= target || time.Now().After(deadline) {
+			return n
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func newTestRateLimiter() *middleware.RateLimiter {
+	return middleware.NewRateLimiter(middleware.RateLimiterConfig{
+		GeneralRate:     2,
+		GeneralBurst:    5,
+		FeedRegRate:     1,
+		FeedRegBurst:    10,
+		CleanupInterval: 1 * time.Minute,
+	})
+}
+
+// TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine は、シャットダウン経路で
+// RateLimiter のクリーンアップ goroutine が停止し、リークしないことを検証する（NFR 1.1, AC 1.3）。
+func TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine(t *testing.T) {
+	// Arrange: クリーンアップ goroutine を起動した RateLimiter と即時 Shutdown 可能なサーバー
+	before := runtime.NumGoroutine()
+
+	rl := newTestRateLimiter()
+
+	// goroutine が起動したことを確認
+	afterStart := runtime.NumGoroutine()
+	if afterStart <= before {
+		t.Fatalf("expected goroutine count to increase after NewRateLimiter, before=%d after=%d", before, afterStart)
+	}
+
+	sc := newShutdownCoordinator(&http.Server{Addr: ":0"}, rl)
+
+	// Act: シャットダウン手続きを実行
+	if err := sc.shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown returned error: %v", err)
+	}
+
+	// Assert: goroutine 数が起動前の水準に戻る（クリーンアップ goroutine が残存しない）
+	after := waitGoroutineCount(before, 2*time.Second)
+	if after > before {
+		t.Errorf("goroutine leaked: before=%d after=%d (cleanup goroutine not stopped)", before, after)
+	}
+}
+
+// TestShutdownCoordinator_DoesNotPanic は、シャットダウン経路で RateLimiter を停止しても
+// panic しないことを検証する（AC 2.1）。
+func TestShutdownCoordinator_DoesNotPanic(t *testing.T) {
+	// Arrange
+	rl := newTestRateLimiter()
+	sc := newShutdownCoordinator(&http.Server{Addr: ":0"}, rl)
+
+	// Act & Assert: panic が起きないこと（panic すれば test が異常終了する）
+	if err := sc.shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown returned error: %v", err)
+	}
+}
+
+// TestShutdownCoordinator_DoubleInvocationDoesNotPanic は、シャットダウン経路が
+// 重複して起動され得る状況でも panic しないことを検証する（AC 2.2, NFR 1.2）。
+// shutdownCoordinator は RateLimiter.Stop() を 1 回だけ実行する idempotent 設計のため、
+// 2 回呼んでも二重 close panic を起こさない。
+func TestShutdownCoordinator_DoubleInvocationDoesNotPanic(t *testing.T) {
+	// Arrange
+	before := runtime.NumGoroutine()
+	rl := newTestRateLimiter()
+	sc := newShutdownCoordinator(&http.Server{Addr: ":0"}, rl)
+
+	// Act: shutdown を 2 回呼ぶ（重複起動シナリオ）
+	if err := sc.shutdown(context.Background()); err != nil {
+		t.Fatalf("first shutdown returned error: %v", err)
+	}
+	if err := sc.shutdown(context.Background()); err != nil {
+		t.Fatalf("second shutdown returned error: %v", err)
+	}
+
+	// Assert: panic せず、goroutine も収束する
+	after := waitGoroutineCount(before, 2*time.Second)
+	if after > before {
+		t.Errorf("goroutine leaked: before=%d after=%d", before, after)
+	}
+}


### PR DESCRIPTION
## 概要

API サーバーモード（`serve`）において、シャットダウン時に `RateLimiter.Stop()` が呼ばれずバックグラウンドのクリーンアップ goroutine がリークする問題を修正する。

新たに `internal/app/shutdown.go` に `shutdownCoordinator` 構造体を導入し、HTTP サーバーの drain 完了後に `sync.Once` で保護した `RateLimiter.Stop()` 呼び出しを実行するシャットダウン手続きを定義した。`RateLimiter.Stop()` 本体は無変更のまま、app 層のみの変更で goroutine リークを防止し、二重起動 panic も抑止する。

## 対応 Issue

Closes #9

## 関連 PR

- 設計 PR: なし（design-less impl）

## 実装内容

- (Req 1.1 / 1.3) `runServe` のシャットダウン経路を `shutdownCoordinator` 経由に変更し、SIGINT/SIGTERM 受信時に `RateLimiter.Stop()` を確実に呼び出す
- (Req 1.4 / 2.2) `sync.Once` による保護で `Stop()` 呼び出しは高々 1 回に保証。重複起動シナリオでも二重 close panic が発生しない
- (Req 2.3 / 2.4) `RateLimiter.Stop()` 本体（`internal/middleware/ratelimit.go`）は無変更。既存シグネチャ・挙動を維持
- (Req 3.2) `shutdown` メソッドは `server.Shutdown(ctx)` の drain 完了後に `stopRateLimiter()` を呼ぶ順序を固定
- (Req 4.2) `runWorker` は RateLimiter を構築しないため変更なし。coordinator も呼び出していない
- (NFR 1.1) `runtime.NumGoroutine()` + `waitGoroutineCount` ポーリングにより goroutine リーク非発生を観察可能な形で検証

## 受入基準チェック

- [x] Req 1.1: When SIGINT/SIGTERM 受信時, the API Server shall RateLimiter の停止処理を呼び出す ← `TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine`
- [x] Req 1.3: When グレースフルシャットダウン完了時, the API Server shall RateLimiter の goroutine を残存させない ← `TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine`
- [x] Req 1.4: The API Server shall Stop を 1 回だけ実行する ← `TestShutdownCoordinator_DoubleInvocationDoesNotPanic`
- [x] Req 2.1: When シャットダウン経路で Stop 実行時, the API Server shall panic しない ← `TestShutdownCoordinator_DoesNotPanic`
- [x] Req 2.2: If Stop が重複起動され得る状況, the API Server shall panic しない ← `TestShutdownCoordinator_DoubleInvocationDoesNotPanic`
- [x] Req 2.3 / 2.4: The RateLimiter shall 既存シグネチャ・挙動を変更しない ← 既存 `internal/middleware/ratelimit_test.go` 無変更 pass
- [x] Req 3.2: When シャットダウン開始時, the API Server shall HTTP drain 完了後に Stop を呼ぶ ← `shutdown.go` の実装順序
- [x] Req 4.1 / 4.2: RateLimiter 構築モード（serve）は停止あり、非構築モード（worker）は停止なし ← コード構造 + 既存テスト

## テスト結果

```
go test -race -count=5 ./internal/app/...

ok      github.com/hitoshiichikawa/feedman/internal/app  (全件 pass、race detector クリーン)

新規テストケース:
- TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine: goroutine リーク非発生
- TestShutdownCoordinator_DoesNotPanic: shutdown 経路での panic 非発生
- TestShutdownCoordinator_DoubleInvocationDoesNotPanic: 二重起動での panic 非発生

go test ./...: 全パッケージ pass
gofmt -l / go vet: 差分なし / pass
```

## 実装上の判断

- `RateLimiter.Stop()` の panic 防止を「Stop 本体を idempotent 化する」のではなく「app 層の `sync.Once` で 1 回だけ呼ぶ」方針を採用した。これにより AC 2.3 / 2.4（既存シグネチャ・挙動の無変更）を厳密に守り、変更範囲を app 層に閉じている（詳細は `docs/specs/9-ratelimiter-stop-goroutine/impl-notes.md` を参照）
- `shutdownCoordinator` は `runServe` のシャットダウン手続きをテスト可能な単位に切り出すためのもの。DB 接続を要する `runServe` 全体はテストしにくいため、停止ロジックのみを分離

## 確認事項

- base: develop / baseRefName: develop / OK
- Reviewer の approve 判定: `docs/specs/9-ratelimiter-stop-goroutine/review-notes.md` 参照（RESULT: approve）
- `RateLimiter.Stop()` 単体は依然として二重呼び出しで panic する（既存挙動の維持 = AC 2.4）。panic 防止は app 層（`shutdownCoordinator`）の `sync.Once` で担保

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #9 のコメントを参照してください。