### PR TITLE
feat(#37): HSTS / CSP セキュリティヘッダーを API サーバーミドルウェアに追加

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -95,3 +95,11 @@ CORS_ALLOWED_ORIGIN=http://localhost:3000
 
 # Cookie設定
 # COOKIE_DOMAIN=                     # Cookieのドメイン（クロスサブドメイン時に設定、例: .example.com）
+
+# セキュリティヘッダー設定
+# HSTS（Strict-Transport-Security）の出力可否。既定: false（未設定時は HSTS 非出力）。
+# HTTPS 終端を伴う本番デプロイ（Cloudflare / リバースプロキシ配下で X-Forwarded-Proto: https が
+# 信頼できる構成）でのみ true にすること。true かつ HTTPS 配信と判定された場合に
+# `Strict-Transport-Security: max-age=31536000; includeSubDomains` を付与する。
+# HTTP 開発環境では false のままにする（HTTP 配信では true でも HSTS は付与されない）。
+# HSTS_ENABLED=false

--- a/docs/specs/37-hsts-csp/impl-notes.md
+++ b/docs/specs/37-hsts-csp/impl-notes.md
@@ -1,0 +1,121 @@
+# 実装ノート: Issue #37 HSTS / CSP セキュリティヘッダー
+
+本 Issue は Architect を経由しない design-less impl（`design.md` / `tasks.md` 不在）。
+要件定義（`requirements.md`）に基づき Developer が実装方針を決定した。
+
+## 実装方針の決定
+
+### CSP（Content-Security-Policy） — Requirement 1
+
+- 全レスポンスに常時 `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'` を付与。
+- HTTP / HTTPS いずれの配信でも同一値（フラグ非依存・無条件付与）。値は定数
+  `contentSecurityPolicyValue` に集約（マジックストリングの定数化）。
+
+### HSTS（Strict-Transport-Security） — Requirement 2, 3
+
+- HSTS 値: `Strict-Transport-Security: max-age=31536000; includeSubDomains`（定数
+  `strictTransportSecurityValue`）。**`preload` は付与しない**（確認事項 1 の方針）。
+- HSTS 有効化フラグ: 環境変数 **`HSTS_ENABLED`**（bool、**既定値 `false`**）を `config.Config.HSTSEnabled`
+  に追加。未設定時 false = 本機能導入前と等価（NFR 1.2）。不正値時は既定値 false を採用し
+  `slog.Warn` を出力して起動継続（Requirement 3.3）。`config.getEnvBool` ヘルパーを新設
+  （既存 `getEnvInt` / `getEnvDuration` の Warn パターンに準拠、`strconv.ParseBool` を使用）。
+- HTTPS 配信判定（`middleware.isHTTPS`）:
+  1. `X-Forwarded-Proto` ヘッダー値が `https` のとき HTTPS と判定（リバースプロキシ配下の主経路、
+     Requirement 2.3）。
+  2. それ以外で `r.TLS != nil` のとき HTTPS と判定（直結 TLS 終端のフォールバック）。
+  3. 上記いずれでもなければ HTTP 扱い（`X-Forwarded-Proto` が `http` または欠落、Requirement 2.4）。
+- 付与条件: `HSTSEnabled == true` **かつ** HTTPS 判定時のみ HSTS を付与（Requirement 2.1 / 3.2）。
+  フラグ無効時は HTTPS 判定でも非付与（Requirement 3.1）、HTTP 配信時はフラグに関わらず非付与
+  （Requirement 2.2）。
+
+### ミドルウェアのシグネチャ変更
+
+- `middleware.NewSecurityHeadersMiddleware()` → `NewSecurityHeadersMiddleware(hstsEnabled bool)` に変更。
+- ヘッダー設定は全て `http.Header.Set`（`Add` ではない）を使用し、各ヘッダー名につき 1 値のみ
+  設定（重複ヘッダーを生成しない、NFR 2.2）。
+
+### wiring 変更ファイル一覧
+
+- `internal/config/config.go`: `Config.HSTSEnabled` フィールド追加 / `HSTS_ENABLED` 読み込み /
+  `getEnvBool` ヘルパー新設。
+- `internal/handler/router.go`: `RouterDeps.HSTSEnabled` フィールド追加 /
+  `NewSecurityHeadersMiddleware(deps.HSTSEnabled)` 呼び出しに変更（適用位置は従来どおり
+  Recovery の次・CORS の前で全ルートに効く）。
+- `internal/app/app.go`: `RouterDeps` 構築時に `HSTSEnabled: cfg.HSTSEnabled` を渡す
+  （`CORSAllowedOrigin` の流し方に倣う）。
+- `internal/middleware/security_headers.go`: ミドルウェア本体実装。
+- `.env.sample`: `HSTS_ENABLED`（既定 false）を解説付きでコメントアウト追記。
+
+### 後方互換
+
+- 既存 4 ヘッダー（`X-Content-Type-Options: nosniff` / `X-Frame-Options: DENY` /
+  `Referrer-Policy: strict-origin-when-cross-origin` /
+  `Permissions-Policy: camera=(), microphone=(), geolocation=()`）の値・全ルート適用を
+  一字一句維持（Requirement 4 / NFR 1.1）。CSP は新規常時付与（ヘッダー追加のみで既存挙動非破壊）。
+  HSTS は既定 false で非出力のため、未設定環境では導入前と完全に等価。
+
+## AC トレーサビリティ（どのテストで担保したか）
+
+| AC | 担保テスト |
+|---|---|
+| Req 1.1 CSP を全レスポンスに付与 | `TestSecurityHeaders_CSP`（HTTP / HTTPS 両サブテスト） |
+| Req 1.2 `default-src 'none'` を含む | `TestSecurityHeaders_CSP`（値の完全一致で `default-src 'none'` を含む） |
+| Req 1.3 `frame-ancestors 'none'` を含む | `TestSecurityHeaders_CSP`（値の完全一致で `frame-ancestors 'none'` を含む） |
+| Req 1.4 HTTP 配信時も HTTPS と同一 CSP | `TestSecurityHeaders_CSP/HTTPリクエストのときCSPが付与される`（HTTP でも同一 `wantCSP`） |
+| Req 2.1 HTTPS 判定時に HSTS 付与 | `TestSecurityHeaders_HSTS/HSTS有効かつXForwardedProtoがhttpsのとき…`、`TestSecurityHeaders_HSTS_DirectTLS`（r.TLS フォールバック） |
+| Req 2.2 HTTP 判定時は HSTS 非付与 | `TestSecurityHeaders_HSTS/…XForwardedProtoがhttpのとき…`、`…欠落のとき…` |
+| Req 2.3 `X-Forwarded-Proto: https` → HTTPS | `TestSecurityHeaders_HSTS/…XForwardedProtoがhttpsのとき…` |
+| Req 2.4 `X-Forwarded-Proto` が https 以外 → HTTP | `TestSecurityHeaders_HSTS/…httpのとき…`（http）、`…欠落のとき…`（欠落） |
+| Req 3.1 フラグ無効時は HTTPS でも非付与 | `TestSecurityHeaders_HSTS/HSTS無効かつHTTPS判定でもHSTSが付与されない` |
+| Req 3.2 フラグ有効 + HTTPS で付与 | `TestSecurityHeaders_HSTS/HSTS有効かつXForwardedProtoがhttpsのとき…` |
+| Req 3.3 未指定・不正値時は既定値で起動継続 | `TestLoad_HSTSEnabled`（未設定 false / 不正値 false かつ err なし）、`TestGetEnvBool`（不正値 Warn + フォールバック） |
+| Req 4.1-4.4 既存 4 ヘッダーの値維持 | `TestSecurityHeaders_ExistingHeaders` |
+| Req 4.5 全ルートに付与 | 既存 `router_integration_test.go` のミドルウェア適用順序検証 + `router.go` 適用位置（Recovery→SecurityHeaders→CORS、全ルート最上位）を不変 |
+| NFR 1.1 既存 4 ヘッダー値不変 | `TestSecurityHeaders_ExistingHeaders` |
+| NFR 1.2 フラグ未設定時 HSTS 非出力 | `TestLoad_HSTSEnabled/…未設定のとき…false`、`TestSecurityHeaders_HSTS/HSTS無効…`（既定 false 経路） |
+| NFR 2.1 CSP を常時欠落させない | `TestSecurityHeaders_CSP`（HTTP / HTTPS 双方で付与） |
+| NFR 2.2 重複ヘッダーを生成しない | `TestSecurityHeaders_NoDuplicateHeaders`（各ヘッダー出現回数 1） |
+| 確認事項 1（preload 非付与） | `TestSecurityHeaders_HSTS_NoPreload` |
+
+> Req 4.5 について: ミドルウェアの全ルート適用は `router.go` の `r.Use(...)` 配置（chi の
+> 全ルート共通ミドルウェア）で構造的に担保される。本変更では適用位置・適用範囲を変更して
+> いないため、既存の統合テストが全ルート適用の退行を検出する。
+
+## 確認事項（requirements.md Open Questions の引き継ぎ・人間判断が必要）
+
+- **確認事項 1（preload 非付与の方針確定）**: 本実装では `Strict-Transport-Security` に
+  `preload` を **付与しない**方針を採用した（HSTS 値 = `max-age=31536000; includeSubDomains`）。
+  `TestSecurityHeaders_HSTS_NoPreload` で preload 不在を検証済み。preload list 登録は一度登録
+  すると当該ドメイン・サブドメインが恒久的に HTTPS 強制となり取り消しに時間を要するため、
+  運用判断（preload list への登録是非）が確定するまでは付与しない。将来 preload 登録を行う
+  場合は別途要件化が必要。**この方針で確定してよいか人間の確認を求める。**
+
+- **確認事項 2（X-Forwarded-Proto の信頼境界）**: 本実装は `X-Forwarded-Proto: https` を
+  無条件に信頼して HTTPS 配信と判定する（リバースプロキシ配下前提）。Go サーバーへの到達経路が
+  信頼できるプロキシ（Cloudflare / リバースプロキシ）経由に限定されていない構成では、信頼できない
+  ネットワークから直接到達できる場合にヘッダー偽装で判定を欺かれ得る。ただし HSTS の偽装付与は
+  クライアント側に HTTPS 強制を課すのみで、攻撃者にとって直接の利得は乏しい（むしろ可用性低下方向）。
+  **実運用で Go サーバーの到達経路が信頼プロキシ経由に限定されている前提でよいか、デプロイ構成に
+  依存する判断のため人間の確認を求める。** 信頼プロキシ経由でない構成を許容する必要が出た場合は、
+  信頼するプロキシ IP / ヘッダーの allowlist 機構を別途要件化する。
+
+## 追加した環境変数
+
+| 環境変数 | 型 | 既定値 | 用途 |
+|---|---|---|---|
+| `HSTS_ENABLED` | bool | `false` | HSTS ヘッダーの出力可否。`true` かつ HTTPS 配信判定時のみ HSTS を付与。`false`（既定）の場合は HTTPS でも非付与（後方互換）。`.env.sample` に解説付きで追記済み。 |
+
+## 検証結果
+
+- `go test ./...`: 全パッケージ green（`internal/middleware` / `internal/config` の新規テスト含む）。
+- `go vet ./...`: クリーン（exit 0）。
+- `go build ./...`: 成功（exit 0）。
+- `gofmt -l`: 変更ファイル全て整形済み（差分なし）。
+- Red 観測: HSTS 判定を一時的に無効化して HSTS 系テストが落ちることを確認後、復元して green を再確認。
+
+> 環境補足: ローカルの Go は 1.22.2 だが go.mod は `go 1.25` を要求するため、テスト/ビルドは
+> `GOTOOLCHAIN=go1.25.0`（完全バージョン指定）で実行した。`GOTOOLCHAIN=auto` のままだと
+> `go1.25`（パッチ無し文字列）の toolchain 解決に失敗するため、CI 等で同様の事象が出る場合は
+> 完全バージョン指定が必要。これは本機能の実装内容とは独立した環境上の注意点。
+
+STATUS: complete

--- a/docs/specs/37-hsts-csp/requirements.md
+++ b/docs/specs/37-hsts-csp/requirements.md
@@ -1,0 +1,98 @@
+# Requirements Document
+
+## Introduction
+
+API サーバーのセキュリティヘッダー付与ミドルウェアは現在 `X-Content-Type-Options` /
+`X-Frame-Options` / `Referrer-Policy` / `Permissions-Policy` の 4 ヘッダーのみを全レスポンスに
+付与しており、HTTPS 通信の強制（HSTS / Strict-Transport-Security）と、コンテンツ読み込み元の
+制限（CSP / Content-Security-Policy）が欠落している。本機能は JSON のみを返す API サーバーに
+適した厳格な CSP と、HTTPS 配信時の HSTS を追加し、既存 4 ヘッダーの挙動を維持したまま
+セキュリティ態勢を強化する。本リポジトリは Cloudflare / リバースプロキシ ingress 配下で
+TLS 終端の内側（平文 HTTP）で動作するため、HTTPS 配信かどうかの判定は運用構成に依存する点を
+要件として扱う。スコープは API サーバー側ミドルウェアに限定し、フロントエンド（Next.js）側の
+CSP 設定は Sibling Issue #53 で扱う。
+
+## Requirements
+
+### Requirement 1: CSP（Content-Security-Policy）ヘッダーの付与
+
+**Objective:** As an API 運用者, I want すべての API レスポンスに JSON 専用 API に適した厳格な CSP が付与されること, so that XSS・クリックジャッキング・リソース読み込みを起点とした攻撃面を最小化できる
+
+#### Acceptance Criteria
+
+1. The セキュリティヘッダーミドルウェア shall すべてのレスポンスに `Content-Security-Policy` ヘッダーを付与する
+2. The セキュリティヘッダーミドルウェア shall `Content-Security-Policy` の値に `default-src 'none'` ディレクティブを含める
+3. The セキュリティヘッダーミドルウェア shall `Content-Security-Policy` の値に `frame-ancestors 'none'` ディレクティブを含める
+4. When HTTP 配信時（非 TLS）であるとき, the セキュリティヘッダーミドルウェア shall HTTPS 配信時と同一の `Content-Security-Policy` を付与する
+
+### Requirement 2: HSTS（Strict-Transport-Security）ヘッダーの条件付き付与
+
+**Objective:** As an API 運用者, I want HTTPS 配信時のレスポンスにのみ HSTS ヘッダーが付与されること, so that 本番 HTTPS では通信の暗号化を強制しつつ開発用 HTTP 環境の動作を壊さない
+
+#### Acceptance Criteria
+
+1. While HTTPS 配信と判定される状態であるとき, the セキュリティヘッダーミドルウェア shall レスポンスに `Strict-Transport-Security: max-age=31536000; includeSubDomains` を付与する
+2. While HTTP 配信（非 TLS）と判定される状態であるとき, the セキュリティヘッダーミドルウェア shall `Strict-Transport-Security` ヘッダーを付与しない
+3. Where リバースプロキシ配下で `X-Forwarded-Proto` を信頼する設定が有効化されているとき, the セキュリティヘッダーミドルウェア shall `X-Forwarded-Proto` の値が `https` の場合に HTTPS 配信と判定する
+4. Where リバースプロキシ配下で `X-Forwarded-Proto` を信頼する設定が有効化されているとき, the セキュリティヘッダーミドルウェア shall `X-Forwarded-Proto` の値が `https` 以外（`http` または欠落）の場合に HTTP 配信と判定する
+
+### Requirement 3: HSTS 有効化フラグによる出力制御
+
+**Objective:** As an API 運用者, I want 設定フラグで HSTS の出力有無を切り替えられること, so that デプロイ構成（HTTPS 終端の有無）に応じて HSTS を安全に有効化・無効化できる
+
+#### Acceptance Criteria
+
+1. While HSTS 有効化フラグが無効であるとき, the セキュリティヘッダーミドルウェア shall HTTPS 配信と判定される場合でも `Strict-Transport-Security` ヘッダーを付与しない
+2. While HSTS 有効化フラグが有効かつ HTTPS 配信と判定される状態であるとき, the セキュリティヘッダーミドルウェア shall `Strict-Transport-Security` ヘッダーを付与する
+3. If HSTS 有効化フラグの設定値が未指定または不正値であるとき, the 設定読み込み処理 shall 既定値を採用して起動を継続する
+
+### Requirement 4: 既存セキュリティヘッダーの後方互換維持
+
+**Objective:** As an API 運用者, I want 既存 4 ヘッダーの値と付与挙動が変わらないこと, so that 本変更によって既存のセキュリティ保証やクライアント挙動が退行しない
+
+#### Acceptance Criteria
+
+1. The セキュリティヘッダーミドルウェア shall すべてのレスポンスに `X-Content-Type-Options: nosniff` を付与する
+2. The セキュリティヘッダーミドルウェア shall すべてのレスポンスに `X-Frame-Options: DENY` を付与する
+3. The セキュリティヘッダーミドルウェア shall すべてのレスポンスに `Referrer-Policy: strict-origin-when-cross-origin` を付与する
+4. The セキュリティヘッダーミドルウェア shall すべてのレスポンスに `Permissions-Policy: camera=(), microphone=(), geolocation=()` を付与する
+5. The セキュリティヘッダーミドルウェア shall 既存 4 ヘッダーを全ルート（認証要否を問わない全エンドポイント）に対して付与する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The セキュリティヘッダーミドルウェア shall 本機能導入前から付与されていた 4 ヘッダーの値を変更しない
+2. Where HSTS 有効化フラグが未設定であるとき, the セキュリティヘッダーミドルウェア shall 本機能導入前と等価な HSTS 非出力挙動を保つ
+
+### NFR 2: 観測可能性
+
+1. The API サーバー shall いずれのレスポンスに対しても `Content-Security-Policy` ヘッダーを欠落させない（HTTP / HTTPS いずれの配信でも常時付与する）
+2. When 同一リクエストに対して複数のセキュリティヘッダーを付与するとき, the セキュリティヘッダーミドルウェア shall 各ヘッダー名につき 1 つの値のみを設定する（重複ヘッダーを生成しない）
+
+## Out of Scope
+
+- フロントエンド（Next.js）側の CSP 設定（`web/next.config.ts`）— Sibling Issue #53 で対応
+- インラインスクリプトの nonce ベース移行 — Sibling Issue #53 で対応
+- CSP の `report-uri` / `report-to` による違反レポート収集機構
+- `Strict-Transport-Security` の `preload` 付与（確認事項 1 参照。本要件では付与しない方針）
+- セキュリティヘッダー以外のミドルウェア（CORS / レート制限 / ロギング等）の挙動変更
+- HSTS の `max-age` 値や CSP ディレクティブを実行時に動的変更する仕組み
+
+## Open Questions
+
+- 確認事項 1: `Strict-Transport-Security` に `preload` を付与するか。`preload` は HSTS preload list
+  への登録を前提とし、一度登録すると当該ドメインおよびサブドメインが恒久的に HTTPS 強制となる
+  （取り消しに時間を要する）。本要件では `preload` を **付与しない**方針（Requirement 2.1 の値）
+  とし、将来 preload list 登録を運用判断する場合は別途要件化する。この方針で問題ないか人間に確認したい。
+- 確認事項 2: HTTPS 配信判定について。本リポジトリは Cloudflare / リバースプロキシ ingress 配下で
+  TLS 終端の内側（平文 HTTP）で Go サーバーが動作するため、Go ランタイムの TLS 接続情報のみでは
+  本番でも HTTPS と判定できない。このため `X-Forwarded-Proto` を信頼する判定経路（Requirement 2.3 /
+  2.4）を前提としている。`X-Forwarded-Proto` を無条件に信頼すると、信頼できないネットワークから
+  直接到達できる構成ではヘッダー偽装により判定を欺かれ得る。実運用で Go サーバーへの到達経路が
+  信頼できるプロキシ経由に限定されている前提でよいか、人間に確認したい（信頼境界の確定はデプロイ
+  構成依存のため PM では確定しない）。
+
+## 関連
+
+- Sibling: #53

--- a/docs/specs/37-hsts-csp/review-notes.md
+++ b/docs/specs/37-hsts-csp/review-notes.md
@@ -1,0 +1,50 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-37-impl-hsts-csp
+- HEAD commit: ea7189a22ee54736df10487dae07263d0af01d47
+- Compared to: develop..HEAD
+
+備考: 本 Issue は design-less impl（`design.md` / `tasks.md` 不在）。`_Boundary:_` アノテーションが
+存在しないため境界判定は要件スコープ（API サーバーのセキュリティヘッダーミドルウェアとその wiring）と
+変更ファイルの突き合わせで行った。CLAUDE.md の `## Feature Flag Protocol` の `**採否**:` は `opt-out`
+のため、flag 観点の細目判定は適用せず通常の 3 カテゴリ判定のみを実施した。
+
+## Verified Requirements
+
+- 1.1 — `security_headers.go` で `h.Set("Content-Security-Policy", contentSecurityPolicyValue)` を無条件付与 / `TestSecurityHeaders_CSP`
+- 1.2 — CSP 値 `default-src 'none'; frame-ancestors 'none'` に `default-src 'none'` を含む / `TestSecurityHeaders_CSP`（値の完全一致）
+- 1.3 — 同値に `frame-ancestors 'none'` を含む / `TestSecurityHeaders_CSP`（値の完全一致）
+- 1.4 — CSP はフラグ・配信種別非依存で同一値 / `TestSecurityHeaders_CSP/HTTPリクエストのとき…`（HTTP でも同一 `wantCSP`）
+- 2.1 — `if hstsEnabled && isHTTPS(r)` で HTTPS 判定時に HSTS 付与 / `TestSecurityHeaders_HSTS/HSTS有効かつXForwardedProtoがhttps…`、`TestSecurityHeaders_HSTS_DirectTLS`
+- 2.2 — HTTP 判定時は HSTS 非付与 / `TestSecurityHeaders_HSTS`（http / 欠落サブケースで present=false）
+- 2.3 — `isHTTPS` が `X-Forwarded-Proto == "https"` で HTTPS 判定 / `TestSecurityHeaders_HSTS/…https…`
+- 2.4 — `X-Forwarded-Proto` が https 以外（http / 欠落）は HTTP 判定 / `TestSecurityHeaders_HSTS`（http / 欠落サブケース）
+- 3.1 — フラグ無効時は HTTPS 判定でも非付与（`hstsEnabled` の AND 条件）/ `TestSecurityHeaders_HSTS/HSTS無効かつHTTPS判定でも…`
+- 3.2 — フラグ有効 + HTTPS 判定時に付与 / `TestSecurityHeaders_HSTS/HSTS有効かつXForwardedProtoがhttps…`
+- 3.3 — 未指定・不正値時は既定値 false 採用で起動継続（`getEnvBool` が Warn + フォールバック、err 返さず）/ `TestLoad_HSTSEnabled`（未設定 / 不正値）、`TestGetEnvBool`（不正値 Warn）
+- 4.1 — `X-Content-Type-Options: nosniff` 維持 / `TestSecurityHeaders_ExistingHeaders`
+- 4.2 — `X-Frame-Options: DENY` 維持 / `TestSecurityHeaders_ExistingHeaders`
+- 4.3 — `Referrer-Policy: strict-origin-when-cross-origin` 維持 / `TestSecurityHeaders_ExistingHeaders`
+- 4.4 — `Permissions-Policy: camera=(), microphone=(), geolocation=()` 維持 / `TestSecurityHeaders_ExistingHeaders`
+- 4.5 — 全ルート適用 / `router.go` の `r.Use(NewSecurityHeadersMiddleware(deps.HSTSEnabled))` 配置（Recovery→SecurityHeaders→CORS）を不変に維持。既存 `internal/handler` 統合テスト群が green（適用順序・適用範囲の退行なし）
+- NFR 1.1 — 既存 4 ヘッダー値不変 / `TestSecurityHeaders_ExistingHeaders`
+- NFR 1.2 — フラグ未設定時 HSTS 非出力（既定 false 経路）/ `TestLoad_HSTSEnabled/…未設定…`、`TestLoad_DefaultValues`（HSTSEnabled=false）
+- NFR 2.1 — CSP を HTTP / HTTPS 双方で常時付与 / `TestSecurityHeaders_CSP`（両サブテスト）
+- NFR 2.2 — 各ヘッダー 1 値のみ（全て `Set` 使用）/ `TestSecurityHeaders_NoDuplicateHeaders`
+
+## Findings
+
+なし
+
+## Summary
+
+CSP 無条件付与（Req 1）、HSTS のフラグ + HTTPS 判定による条件付き付与（Req 2 / 3）、既存 4 ヘッダーの
+後方互換維持（Req 4 / NFR 1）、CSP 常時付与・重複排除（NFR 2）の全 numeric ID に対応する実装とテストを
+確認した。`go test ./internal/middleware/... ./internal/config/... ./internal/handler/...` は green。
+boundary 逸脱・AC 未カバー・missing test のいずれも検出されなかった。
+
+RESULT: approve

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -155,6 +155,7 @@ func runServe(cfg *config.Config) error {
 		SessionFinder:     sessionRepo,
 		CORSAllowedOrigin: cfg.CORSAllowedOrigin,
 		RateLimiter:       rateLimiter,
+		HSTSEnabled:       cfg.HSTSEnabled,
 		Logger:            slog.Default(),
 
 		AuthService: authService,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,11 @@ type Config struct {
 
 	// CORS
 	CORSAllowedOrigin string
+
+	// Security
+	// HSTSEnabled は HSTS（Strict-Transport-Security）ヘッダーの出力可否を制御する。
+	// 既定値は false（HSTS 非出力 = 本機能導入前と等価）。
+	HSTSEnabled bool
 }
 
 // Load は環境変数からConfigを読み込む。
@@ -114,6 +119,7 @@ func Load() (*Config, error) {
 	cfg.CookieSecure = strings.HasPrefix(cfg.BaseURL, "https://")
 	cfg.CookieDomain = getEnvString("COOKIE_DOMAIN", "")
 	cfg.CORSAllowedOrigin = getEnvString("CORS_ALLOWED_ORIGIN", "http://localhost:3000")
+	cfg.HSTSEnabled = getEnvBool("HSTS_ENABLED", false)
 
 	return cfg, nil
 }
@@ -123,6 +129,26 @@ func getEnvString(key, defaultVal string) string {
 		return v
 	}
 	return defaultVal
+}
+
+// getEnvBool は環境変数を bool として読み込む。
+// 未設定（空文字）の場合は defaultVal を返す。
+// 不正値（strconv.ParseBool が受け付けない値）の場合は Warn ログを出力し defaultVal を返して起動を継続する。
+func getEnvBool(key string, defaultVal bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		slog.Warn("環境変数のパースに失敗したためデフォルト値を採用します",
+			slog.String("key", key),
+			slog.String("value", v),
+			slog.Bool("default", defaultVal),
+		)
+		return defaultVal
+	}
+	return b
 }
 
 func getEnvInt(key string, defaultVal int) int {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -162,6 +162,66 @@ func TestLoad_DefaultValues(t *testing.T) {
 	if cfg.ServerPort != "8080" {
 		t.Errorf("ServerPort = %q, want %q", cfg.ServerPort, "8080")
 	}
+
+	// Security defaults: HSTS は未設定時 false（本機能導入前と等価）。
+	if cfg.HSTSEnabled != false {
+		t.Errorf("HSTSEnabled = %v, want %v (default)", cfg.HSTSEnabled, false)
+	}
+}
+
+// TestLoad_HSTSEnabled は HSTS_ENABLED 環境変数の読み込みを検証する。
+// Requirement 3.3（未指定・不正値時は既定値採用で起動継続）と NFR 1.2 に対応。
+func TestLoad_HSTSEnabled(t *testing.T) {
+	t.Run("HSTS_ENABLEDがtrueのときHSTSEnabledがtrueになる", func(t *testing.T) {
+		// Arrange
+		setRequiredEnvVars(t)
+		t.Setenv("HSTS_ENABLED", "true")
+
+		// Act
+		cfg, err := Load()
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !cfg.HSTSEnabled {
+			t.Error("HSTSEnabled = false, want true")
+		}
+	})
+
+	t.Run("HSTS_ENABLEDが未設定のときHSTSEnabledがfalseになる", func(t *testing.T) {
+		// Arrange
+		setRequiredEnvVars(t)
+		t.Setenv("HSTS_ENABLED", "")
+
+		// Act
+		cfg, err := Load()
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if cfg.HSTSEnabled {
+			t.Error("HSTSEnabled = true, want false (default for unset)")
+		}
+	})
+
+	t.Run("HSTS_ENABLEDが不正値のときHSTSEnabledが既定値falseになり起動を継続する", func(t *testing.T) {
+		// Arrange
+		setRequiredEnvVars(t)
+		t.Setenv("HSTS_ENABLED", "not-a-bool")
+
+		// Act
+		cfg, err := Load()
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error (should continue startup with default), got %v", err)
+		}
+		if cfg.HSTSEnabled {
+			t.Error("HSTSEnabled = true, want false (default for invalid value)")
+		}
+	})
 }
 
 func TestLoad_CustomValues(t *testing.T) {
@@ -503,6 +563,83 @@ func TestGetEnvDuration(t *testing.T) {
 
 		// Act
 		got := getEnvDuration(key, defaultVal)
+
+		// Assert
+		if got != defaultVal {
+			t.Errorf("got = %v, want %v (default fallback)", got, defaultVal)
+		}
+		if n := len(h.warnRecords()); n != 0 {
+			t.Errorf("warn records = %d, want 0", n)
+		}
+	})
+}
+
+// TestGetEnvBool は getEnvBool のパース失敗時警告ログ・フォールバック・正常系を検証する。
+// Requirement 3.3（未指定・不正値時は既定値採用で起動継続）に対応。
+func TestGetEnvBool(t *testing.T) {
+	const key = "TEST_GET_ENV_BOOL"
+	const defaultVal = false
+
+	t.Run("不正値のときデフォルト値を採用しWarnを1件出力する", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "yesnt")
+
+		// Act
+		got := getEnvBool(key, defaultVal)
+
+		// Assert
+		if got != defaultVal {
+			t.Errorf("got = %v, want %v (default fallback)", got, defaultVal)
+		}
+		if n := len(h.warnRecords()); n != 1 {
+			t.Fatalf("warn records = %d, want 1", n)
+		}
+	})
+
+	t.Run("不正値のときWarnログにキー名・不正値・デフォルト値を構造化フィールドで含める", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "yesnt")
+
+		// Act
+		getEnvBool(key, defaultVal)
+
+		// Assert
+		recs := h.warnRecords()
+		if len(recs) != 1 {
+			t.Fatalf("warn records = %d, want 1", len(recs))
+		}
+		r := recs[0]
+		assertAttr(t, r, "key", key)
+		assertAttr(t, r, "value", "yesnt")
+		assertAttr(t, r, "default", "false")
+	})
+
+	t.Run("正常値のとき値を採用しWarnを出力しない", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "true")
+
+		// Act
+		got := getEnvBool(key, defaultVal)
+
+		// Assert
+		if got != true {
+			t.Errorf("got = %v, want %v", got, true)
+		}
+		if n := len(h.warnRecords()); n != 0 {
+			t.Errorf("warn records = %d, want 0", n)
+		}
+	})
+
+	t.Run("未設定（空文字）のときデフォルト値を採用しWarnを出力しない", func(t *testing.T) {
+		// Arrange
+		h := installCaptureLogger(t)
+		t.Setenv(key, "")
+
+		// Act
+		got := getEnvBool(key, defaultVal)
 
 		// Assert
 		if got != defaultVal {

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -43,6 +43,10 @@ type RouterDeps struct {
 	CORSAllowedOrigin string
 	RateLimiter       *middleware.RateLimiter
 
+	// HSTSEnabled は HSTS（Strict-Transport-Security）ヘッダーの出力可否。
+	// false（既定）の場合は HTTPS 配信でも HSTS を付与しない。
+	HSTSEnabled bool
+
 	// アクセスログ出力に使用する構造化ロガー。
 	// nil の場合は slog.Default() にフォールバックする（後方互換）。
 	Logger *slog.Logger
@@ -85,7 +89,7 @@ func NewRouter(deps *RouterDeps) http.Handler {
 	r.Use(middleware.NewRecoveryMiddleware())
 
 	// セキュリティヘッダーを適用（全ルートに効く）
-	r.Use(middleware.NewSecurityHeadersMiddleware())
+	r.Use(middleware.NewSecurityHeadersMiddleware(deps.HSTSEnabled))
 
 	// CORS ミドルウェアを適用（全ルートに効く）
 	r.Use(middleware.NewCORSMiddleware(deps.CORSAllowedOrigin))

--- a/internal/middleware/security_headers.go
+++ b/internal/middleware/security_headers.go
@@ -2,15 +2,54 @@ package middleware
 
 import "net/http"
 
+const (
+	// contentSecurityPolicyValue は JSON 専用 API に適した厳格な CSP の値。
+	// default-src 'none' で全リソース読み込みを禁止し、frame-ancestors 'none' で
+	// クリックジャッキングを防止する。HTTP / HTTPS いずれの配信でも同一値を付与する。
+	contentSecurityPolicyValue = "default-src 'none'; frame-ancestors 'none'"
+
+	// strictTransportSecurityValue は HTTPS 配信時に付与する HSTS の値。
+	// max-age=1 年・サブドメイン込み。preload は付与しない（運用判断が必要なため）。
+	strictTransportSecurityValue = "max-age=31536000; includeSubDomains"
+)
+
 // NewSecurityHeadersMiddleware はセキュリティ関連のHTTPレスポンスヘッダーを付与するミドルウェアを返す。
-func NewSecurityHeadersMiddleware() func(next http.Handler) http.Handler {
+//
+// 全レスポンスに以下を常時付与する:
+//   - X-Content-Type-Options / X-Frame-Options / Referrer-Policy / Permissions-Policy（既存4ヘッダー）
+//   - Content-Security-Policy（JSON 専用 API 向けの厳格な値、HTTP / HTTPS 共通）
+//
+// hstsEnabled が true かつ HTTPS 配信と判定される場合に限り Strict-Transport-Security を付与する。
+// HTTPS 配信判定は、リバースプロキシ配下を想定して X-Forwarded-Proto: https を信頼するほか、
+// Go ランタイムが直接 TLS 接続を終端している場合（r.TLS != nil）もフォールバックで HTTPS とみなす。
+func NewSecurityHeadersMiddleware(hstsEnabled bool) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("X-Content-Type-Options", "nosniff")
-			w.Header().Set("X-Frame-Options", "DENY")
-			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
-			w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+			h := w.Header()
+			h.Set("X-Content-Type-Options", "nosniff")
+			h.Set("X-Frame-Options", "DENY")
+			h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			h.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+			h.Set("Content-Security-Policy", contentSecurityPolicyValue)
+
+			if hstsEnabled && isHTTPS(r) {
+				h.Set("Strict-Transport-Security", strictTransportSecurityValue)
+			}
+
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// isHTTPS はリクエストが HTTPS 配信であるかを判定する。
+//
+// 本リポジトリは Cloudflare / リバースプロキシ配下で TLS 終端の内側（平文 HTTP）で
+// 動作するため、X-Forwarded-Proto の値が "https" の場合に HTTPS 配信と判定する。
+// X-Forwarded-Proto が "https" 以外（"http" または欠落）の場合は HTTP 配信とみなす。
+// Go ランタイムが直接 TLS を終端している構成（r.TLS != nil）はフォールバックで HTTPS と判定する。
+func isHTTPS(r *http.Request) bool {
+	if r.Header.Get("X-Forwarded-Proto") == "https" {
+		return true
+	}
+	return r.TLS != nil
 }

--- a/internal/middleware/security_headers_test.go
+++ b/internal/middleware/security_headers_test.go
@@ -1,0 +1,225 @@
+package middleware
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newSecurityHeadersHandler はテスト用に HSTS フラグ・X-Forwarded-Proto を組み合わせて
+// セキュリティヘッダーミドルウェアを適用したハンドラを返す。
+func newSecurityHeadersHandler(hstsEnabled bool) http.Handler {
+	mw := NewSecurityHeadersMiddleware(hstsEnabled)
+	return mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+// TestSecurityHeaders_CSP は CSP ヘッダーが全レスポンスに付与されることを検証する。
+// Requirement 1（1.1/1.2/1.3/1.4）に対応。
+func TestSecurityHeaders_CSP(t *testing.T) {
+	const wantCSP = "default-src 'none'; frame-ancestors 'none'"
+
+	t.Run("HTTPリクエストのときCSPが付与される", func(t *testing.T) {
+		// Arrange
+		handler := newSecurityHeadersHandler(false)
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req.Header.Set("X-Forwarded-Proto", "http")
+		w := httptest.NewRecorder()
+
+		// Act
+		handler.ServeHTTP(w, req)
+
+		// Assert
+		got := w.Result().Header.Get("Content-Security-Policy")
+		if got != wantCSP {
+			t.Errorf("Content-Security-Policy = %q, want %q", got, wantCSP)
+		}
+	})
+
+	t.Run("HTTPS判定のときHTTPと同一のCSPが付与される", func(t *testing.T) {
+		// Arrange
+		handler := newSecurityHeadersHandler(true)
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req.Header.Set("X-Forwarded-Proto", "https")
+		w := httptest.NewRecorder()
+
+		// Act
+		handler.ServeHTTP(w, req)
+
+		// Assert
+		got := w.Result().Header.Get("Content-Security-Policy")
+		if got != wantCSP {
+			t.Errorf("Content-Security-Policy = %q, want %q", got, wantCSP)
+		}
+	})
+}
+
+// TestSecurityHeaders_HSTS は HSTS ヘッダーの条件付き付与を検証する。
+// Requirement 2（2.1/2.2/2.3/2.4）と Requirement 3（3.1/3.2）に対応。
+func TestSecurityHeaders_HSTS(t *testing.T) {
+	const wantHSTS = "max-age=31536000; includeSubDomains"
+
+	tests := []struct {
+		name            string
+		hstsEnabled     bool
+		forwardedProto  string // 空文字はヘッダー欠落を表す
+		wantHSTSPresent bool
+		wantHSTSValue   string
+	}{
+		{
+			name:            "HSTS有効かつXForwardedProtoがhttpsのときHSTSが付与される",
+			hstsEnabled:     true,
+			forwardedProto:  "https",
+			wantHSTSPresent: true,
+			wantHSTSValue:   wantHSTS,
+		},
+		{
+			name:            "HSTS有効かつXForwardedProtoがhttpのときHSTSが付与されない",
+			hstsEnabled:     true,
+			forwardedProto:  "http",
+			wantHSTSPresent: false,
+		},
+		{
+			name:            "HSTS有効かつXForwardedProtoが欠落のときHSTSが付与されない",
+			hstsEnabled:     true,
+			forwardedProto:  "",
+			wantHSTSPresent: false,
+		},
+		{
+			name:            "HSTS無効かつHTTPS判定でもHSTSが付与されない",
+			hstsEnabled:     false,
+			forwardedProto:  "https",
+			wantHSTSPresent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			handler := newSecurityHeadersHandler(tt.hstsEnabled)
+			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+			if tt.forwardedProto != "" {
+				req.Header.Set("X-Forwarded-Proto", tt.forwardedProto)
+			}
+			w := httptest.NewRecorder()
+
+			// Act
+			handler.ServeHTTP(w, req)
+
+			// Assert
+			got, present := w.Result().Header["Strict-Transport-Security"]
+			if present != tt.wantHSTSPresent {
+				t.Fatalf("Strict-Transport-Security present = %v, want %v", present, tt.wantHSTSPresent)
+			}
+			if tt.wantHSTSPresent && got[0] != tt.wantHSTSValue {
+				t.Errorf("Strict-Transport-Security = %q, want %q", got[0], tt.wantHSTSValue)
+			}
+		})
+	}
+}
+
+// TestSecurityHeaders_HSTS_NoPreload は HSTS 値に preload が含まれないことを検証する。
+// requirements.md Open Questions 確認事項 1 の「preload 非付与」方針に対応。
+func TestSecurityHeaders_HSTS_NoPreload(t *testing.T) {
+	// Arrange
+	handler := newSecurityHeadersHandler(true)
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert
+	got := w.Result().Header.Get("Strict-Transport-Security")
+	if got == "" {
+		t.Fatal("Strict-Transport-Security should be present for HTTPS with HSTS enabled")
+	}
+	if strings.Contains(got, "preload") {
+		t.Errorf("Strict-Transport-Security = %q, should not contain preload", got)
+	}
+}
+
+// TestSecurityHeaders_HSTS_DirectTLS は r.TLS による直結 TLS 検知のフォールバックを検証する。
+// Requirement 2.1（HTTPS 配信判定）に対応。
+func TestSecurityHeaders_HSTS_DirectTLS(t *testing.T) {
+	const wantHSTS = "max-age=31536000; includeSubDomains"
+
+	// Arrange
+	handler := newSecurityHeadersHandler(true)
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.TLS = &tls.ConnectionState{}
+
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert
+	got := w.Result().Header.Get("Strict-Transport-Security")
+	if got != wantHSTS {
+		t.Errorf("Strict-Transport-Security = %q, want %q (direct TLS should be detected as HTTPS)", got, wantHSTS)
+	}
+}
+
+// TestSecurityHeaders_ExistingHeaders は既存 4 ヘッダーの値が維持されることを検証する。
+// Requirement 4（4.1/4.2/4.3/4.4）と NFR 1.1 に対応。
+func TestSecurityHeaders_ExistingHeaders(t *testing.T) {
+	// Arrange
+	handler := newSecurityHeadersHandler(false)
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert
+	resp := w.Result()
+	tests := []struct {
+		header string
+		want   string
+	}{
+		{"X-Content-Type-Options", "nosniff"},
+		{"X-Frame-Options", "DENY"},
+		{"Referrer-Policy", "strict-origin-when-cross-origin"},
+		{"Permissions-Policy", "camera=(), microphone=(), geolocation=()"},
+	}
+	for _, tt := range tests {
+		got := resp.Header.Get(tt.header)
+		if got != tt.want {
+			t.Errorf("%s = %q, want %q", tt.header, got, tt.want)
+		}
+	}
+}
+
+// TestSecurityHeaders_NoDuplicateHeaders は各セキュリティヘッダーが 1 値のみ設定されることを検証する。
+// NFR 2.2（重複ヘッダーを生成しない）に対応。
+func TestSecurityHeaders_NoDuplicateHeaders(t *testing.T) {
+	// Arrange
+	handler := newSecurityHeadersHandler(true)
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert
+	resp := w.Result()
+	headers := []string{
+		"Content-Security-Policy",
+		"Strict-Transport-Security",
+		"X-Content-Type-Options",
+		"X-Frame-Options",
+		"Referrer-Policy",
+		"Permissions-Policy",
+	}
+	for _, h := range headers {
+		if n := len(resp.Header[h]); n != 1 {
+			t.Errorf("header %s appears %d times, want 1", h, n)
+		}
+	}
+}


### PR DESCRIPTION
## 概要

API サーバーのセキュリティヘッダーミドルウェアに HSTS（Strict-Transport-Security）および
CSP（Content-Security-Policy）ヘッダーを追加する。

- CSP は JSON 専用 API に適した `default-src 'none'; frame-ancestors 'none'` を全レスポンスに常時付与
- HSTS は `HSTS_ENABLED` 環境変数（既定 false）と HTTPS 配信判定（`X-Forwarded-Proto` ベース）の両条件が
  揃った場合のみ `max-age=31536000; includeSubDomains` を付与
- 既存 4 ヘッダー（X-Content-Type-Options / X-Frame-Options / Referrer-Policy / Permissions-Policy）の
  値・挙動を後方互換維持したまま追加

## 対応 Issue

Closes #37

## 関連 PR

- 設計 PR: なし（本 Issue は design-less impl。Architect フェーズ不使用）

## 実装内容

- (Req 1.1〜1.4) `internal/middleware/security_headers.go`: CSP 無条件付与、HSTS 条件付き付与、`isHTTPS` ヘルパー実装
- (Req 3.3) `internal/config/config.go`: `HSTSEnabled` フィールド追加、`HSTS_ENABLED` 環境変数読み込み、`getEnvBool` ヘルパー新設
- (Req 4 / NFR) `internal/handler/router.go`: `RouterDeps.HSTSEnabled` 追加、`NewSecurityHeadersMiddleware(deps.HSTSEnabled)` に変更
- (Req 4 / NFR) `internal/app/app.go`: `RouterDeps` 構築時に `HSTSEnabled: cfg.HSTSEnabled` を渡す
- `.env.sample`: `HSTS_ENABLED`（既定 false）を解説付きでコメントアウト追記

## 受入基準チェック

- [x] Req 1.1: CSP を全レスポンスに付与 ← `TestSecurityHeaders_CSP`
- [x] Req 1.2: `default-src 'none'` を含む ← `TestSecurityHeaders_CSP`（値の完全一致）
- [x] Req 1.3: `frame-ancestors 'none'` を含む ← `TestSecurityHeaders_CSP`（値の完全一致）
- [x] Req 1.4: HTTP 配信時も HTTPS と同一 CSP ← `TestSecurityHeaders_CSP/HTTPリクエストのときCSPが付与される`
- [x] Req 2.1: HTTPS 判定時に HSTS 付与 ← `TestSecurityHeaders_HSTS/HSTS有効かつXForwardedProtoがhttps…`、`TestSecurityHeaders_HSTS_DirectTLS`
- [x] Req 2.2: HTTP 判定時は HSTS 非付与 ← `TestSecurityHeaders_HSTS`（http / 欠落サブケース）
- [x] Req 2.3: `X-Forwarded-Proto: https` → HTTPS 判定 ← `TestSecurityHeaders_HSTS`
- [x] Req 2.4: `X-Forwarded-Proto` が https 以外 → HTTP 判定 ← `TestSecurityHeaders_HSTS`（http / 欠落）
- [x] Req 3.1: フラグ無効時は HTTPS でも非付与 ← `TestSecurityHeaders_HSTS/HSTS無効かつHTTPS判定でも…`
- [x] Req 3.2: フラグ有効 + HTTPS で付与 ← `TestSecurityHeaders_HSTS/HSTS有効かつXForwardedProtoがhttps…`
- [x] Req 3.3: 未指定・不正値時は既定値で起動継続 ← `TestLoad_HSTSEnabled`、`TestGetEnvBool`
- [x] Req 4.1〜4.5: 既存 4 ヘッダーの値・全ルート適用を維持 ← `TestSecurityHeaders_ExistingHeaders`、`router.go` 適用位置不変
- [x] NFR 1.1: 既存 4 ヘッダー値不変 ← `TestSecurityHeaders_ExistingHeaders`
- [x] NFR 1.2: フラグ未設定時 HSTS 非出力 ← `TestLoad_HSTSEnabled`（未設定 false）
- [x] NFR 2.1: CSP を常時欠落させない ← `TestSecurityHeaders_CSP`（HTTP / HTTPS 双方）
- [x] NFR 2.2: 重複ヘッダーを生成しない ← `TestSecurityHeaders_NoDuplicateHeaders`

## テスト結果

```
go test ./...: 全パッケージ green（internal/middleware / internal/config の新規テスト含む）
go vet ./...: クリーン（exit 0）
go build ./...: 成功（exit 0）
gofmt -l: 変更ファイル全て整形済み（差分なし）
```

## 実装上の判断

詳細は `docs/specs/37-hsts-csp/impl-notes.md` を参照。主な判断点:

- HSTS の `preload` は付与しない方針（確認事項 1）。preload list 登録は恒久的 HTTPS 強制のため運用判断が確定するまで留保
- HTTPS 配信判定は `X-Forwarded-Proto` ヘッダーを信頼（Cloudflare / リバースプロキシ配下前提、確認事項 2）
- ミドルウェアシグネチャを `NewSecurityHeadersMiddleware(hstsEnabled bool)` に変更（wiring 点は `router.go` / `app.go` のみ）
- HSTS 既定値 `false` で後方互換維持（`HSTS_ENABLED` 未設定環境では導入前と完全に等価）

## 確認事項 / レビュワーへの依頼

- base ブランチ検証: `--base develop` 指定 / `baseRefName: develop` / OK（PR 作成後に検証済み）
- Reviewer 独立レビュー: `docs/specs/37-hsts-csp/review-notes.md` 参照（`RESULT: approve`。全 AC / NFR カバー確認済み、Findings なし）
- 確認事項 1（preload 非付与の方針）: `Strict-Transport-Security` に `preload` を付与しない方針で実装済み。将来 HSTS preload list 登録を行う場合は別途要件化が必要。**この方針で確定してよいか人間の確認を求める**
- 確認事項 2（X-Forwarded-Proto の信頼境界）: Go サーバーへの到達経路が信頼できるプロキシ（Cloudflare / リバースプロキシ）経由に限定されている前提で実装済み。**実運用での信頼境界について人間の確認を求める**

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #37 のコメントを参照してください。
