### PR TITLE
feat(#53): web (Next.js) に CSP セキュリティヘッダーを追加

### DIFF
--- a/docs/specs/53-web-next-js-csp/impl-notes.md
+++ b/docs/specs/53-web-next-js-csp/impl-notes.md
@@ -1,0 +1,129 @@
+# 実装ノート: #53 web (Next.js) に CSP セキュリティヘッダーを設定
+
+## 実装サマリ
+
+`web`（Next.js）が返す全ルートの HTTP レスポンスに `Content-Security-Policy`（CSP）ヘッダーを
+付与した。XSS への多層防御（defense in depth）が目的で、特に記事本文 HTML を
+`dangerouslySetInnerHTML` で描画する箇所に対する追加の安全網となる。
+
+### 変更ファイル
+
+- `web/src/lib/csp.ts`（新規）— CSP 文字列を生成する純粋モジュール。`#41` の `rewrites.ts`
+  パターン（env を引数注入する純粋関数）に倣い、`process.env.NODE_ENV` への直接依存を排して
+  Vitest で単体テスト可能にした。
+  - `CSP_HEADER_NAME`: HTTP ヘッダー名定数（`"Content-Security-Policy"`）
+  - `buildCspDirectives(env)`: 環境に応じたディレクティブの `Map`（挿入順保持）を構築する純粋関数
+  - `buildContentSecurityPolicy(env)`: 上記を `"<directive> <values>; ..."` の 1 行へ直列化する純粋関数
+- `web/src/lib/csp.test.ts`（新規）— Vitest による単体テスト（18 ケース）。
+- `web/next.config.ts`（変更）— 既存の `securityHeaders` 配列に CSP エントリを 1 件追加。
+  既存の 4 ヘッダー（#41 由来）と `rewrites()` は値・構造とも温存。CSP 値は
+  `buildContentSecurityPolicy(process.env)` で生成する。
+
+### 設計判断
+
+- `headers()` による**静的 CSP** を採用（per-request nonce は middleware を要し本 Issue の
+  スコープ＝`next.config.ts` の `headers()` から外れるため）。
+- dev / production の厳格さは `NODE_ENV` で切り替える。`process.env.NODE_ENV !== "production"`
+  を dev 相当（緩め）とし、`NODE_ENV` 未設定も dev 相当に倒した（HMR 環境での機能維持を優先）。
+
+## 採用したディレクティブと根拠
+
+production の生成例:
+```
+default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'
+```
+
+| ディレクティブ | production 値 | dev 追加 | 根拠 / 対応 AC |
+|---|---|---|---|
+| `default-src` | `'self'` | — | 既定取得元を同一オリジンに限定、ワイルドカード不許可（Req 1.3 / 2.1） |
+| `script-src` | `'self' 'unsafe-inline'` | `'unsafe-eval'` | Next.js App Router のブートストラップ inline script 用に `'unsafe-inline'`。dev は HMR/turbopack の eval 用に `'unsafe-eval'`（本番では付けない）（Req 5.1 / 5.3 / NFR 3） |
+| `style-src` | `'self' 'unsafe-inline'` | — | Tailwind / next/font が注入する inline style 用（Req 5.2 / 4.1） |
+| `img-src` | `'self' data: https:` | — | 記事本文 HTML 中の外部画像表示のため data URI と HTTPS 外部画像を許可（平文 http は不許可）。script-src と独立のため画像許可が script 実行へ波及しない（Req 6.1 / 6.2 / 6.3 / 4.3） |
+| `font-src` | `'self'` | — | next/font はビルド時セルフホスト。外部フォント CDN を許可しない（Req 2.3 / 4.4） |
+| `connect-src` | `'self'` | `ws: wss:` | API/認証は #41 で同一オリジン化済み。dev は HMR の websocket を許可（Req 2.2） |
+| `object-src` | `'none'` | — | OWASP 推奨の最小堅牢化（プラグイン埋め込みの全面禁止） |
+| `base-uri` | `'self'` | — | `<base>` 乗っ取りによる相対 URL リダイレクトの防止 |
+| `frame-ancestors` | `'none'` | — | クリックジャッキング対策。`X-Frame-Options: DENY`（#41）と整合 |
+| `form-action` | `'self'` | — | 外部オリジンへの form 送信を防止 |
+
+既存セキュリティヘッダー（`X-Content-Type-Options` / `X-Frame-Options` / `Referrer-Policy` /
+`Permissions-Policy`）は `securityHeaders` 配列内でそのまま温存しており、値は変更していない
+（Req 3.1〜3.4 / NFR 1.1）。
+
+## 受入基準 (AC) とテスト対応
+
+| AC | 担保したテスト / 実装 |
+|---|---|
+| Req 1.1 / 1.2（全ルート付与） | `next.config.ts` の `headers()` が `source: "/(.*)"` で全ルートへ付与（既存構造を踏襲）。CSP エントリ追加で担保 |
+| Req 1.3（default-src 含む） | csp.test.ts `default-src 'self' を含むこと` |
+| Req 2.1（self 限定 / `*` 不許可） | csp.test.ts `default-src 'self'`、`ワイルドカード * を許可しないこと` |
+| Req 2.2（connect-src self） | csp.test.ts `connect-src を production では 'self' のみに限定` |
+| Req 2.3 / 4.4（font-src self / 外部CDN不許可） | csp.test.ts `font-src を 'self' に限定し外部フォント CDN を許可しないこと` |
+| Req 2.4（不要な外部オリジン不許可） | 上記各テストで外部オリジンを許可していないことを担保 |
+| Req 3.1〜3.4（既存ヘッダー温存） | `next.config.ts` で `securityHeaders` の既存 4 件を温存。全 164 テスト green で回帰なし（NFR 1.2） |
+| Req 4.1（CSS 適用） | `style-src 'self' 'unsafe-inline'`（csp.test.ts `style-src に 'unsafe-inline'`） |
+| Req 4.2（スクリプト実行） | `script-src 'self' 'unsafe-inline'`（csp.test.ts `script-src に 'unsafe-inline'`） |
+| Req 4.3（記事本文 HTML 描画） | `img-src 'self' data: https:`（csp.test.ts img-src 系） |
+| Req 4.5 / NFR 1.2（既存テスト合格） | `npm test`（vitest run）全 164 件 green、新規失敗 0 件 |
+| Req 5.1（inline script） | csp.test.ts `script-src に 'unsafe-inline' を含め...` |
+| Req 5.2（inline style） | csp.test.ts `style-src に 'unsafe-inline' を含め...` |
+| Req 5.3（最小許可 / 本番厳格） | csp.test.ts `production のとき 'unsafe-eval' を含めないこと`、`production のとき ws: を含めないこと`、dev のみ追加する 2 ケース |
+| Req 6.1（img-src 明示定義） | csp.test.ts `img-src ディレクティブを明示的に定義すること` |
+| Req 6.2（img-src 一貫した許可範囲） | csp.test.ts `HTTPS 外部画像と data URI を許可しつつ * は許可しないこと` |
+| Req 6.3（画像許可が script へ波及しない） | csp.test.ts `img-src の画像許可が script-src へ波及しないこと` |
+| NFR 2.1（平文ヘッダーで可読） | csp.test.ts `セミコロン区切りの 1 行文字列として直列化` + `next.config.ts` が平文ヘッダーとして付与 |
+| NFR 3.1（本番ビルドで正常） | production 系テスト群で production 値を検証。`script-src` から `'unsafe-eval'` を除外し正常表示可能な値を生成 |
+
+境界・異常系: `NODE_ENV` 未設定（空入力）時に dev 相当を返すこと（csp.test.ts 境界ケース）、
+production / development の分岐両方をカバー。
+
+## テスト・lint 実行結果
+
+- `npm test`（= `vitest run`）: **24 ファイル / 164 テスト 全 pass、新規失敗 0 件**
+  （新規 `csp.test.ts` は 18 テスト pass）
+- `npm run lint`（ESLint）: **0 errors**（既存の警告 6 件のみ。いずれも本変更と無関係の既存箇所）
+
+### 実行環境に関する注記（確認事項ではなく環境メモ）
+
+本ワークステーションの Node は v22.11.0 で、`vite@7.3.1` が要求する `^22.12.0` を僅かに
+下回るため、`vitest run` 起動時に `require()` で vite の ESM をロードできず `ERR_REQUIRE_ESM`
+となる。これは実行環境固有の制約であり、コードの問題ではない。本ステージでは
+`NODE_OPTIONS="--experimental-require-module"` を付与して全テストの green を確認した
+（CI（GitHub Actions）は規定の Node バージョンで `npm test` を実行するため本フラグは不要）。
+
+## 確認事項（人間の最終確認を要する点）
+
+本 Issue の Open Questions に対し、オーケストレーター提示の妥当デフォルトを採用した。
+以下は人間判断を仰ぎたい点。
+
+1. **インライン script / style の許可手段（`'unsafe-inline'` 採用）**:
+   - 現状は `headers()` 静的 CSP の制約上 nonce を使えないため `script-src`/`style-src` に
+     `'unsafe-inline'` を許容した。これは CSP による script injection 防御を弱める。
+   - 将来 middleware を導入して per-request nonce 方式へ寄せれば `'unsafe-inline'` を外して
+     より厳格化できる（別 Issue 化を推奨）。nonce 方式採否は人間判断としたい。
+
+2. **記事本文 HTML 中の外部画像（`img-src 'self' data: https:`）**:
+   - RSS リーダーの記事本文は外部オリジンの画像を多数含むため、外部画像を全ブロックすると
+     既存の閲覧体験（Req 4.3 の後方互換）を壊す。体験寄りに HTTPS 外部画像を許可した。
+   - 安全性を最優先して `img-src 'self' data:` に絞る選択肢もある（外部画像はブロック）。
+     体験寄り / 厳格寄りのいずれを最終方針とするかは人間判断としたい。
+
+3. **dev モードでの `'unsafe-eval'` / websocket 許可**:
+   - HMR / turbopack の動作維持のため dev のみ `script-src 'unsafe-eval'` と
+     `connect-src ws: wss:` を追加した。production には含めない。
+   - dev/production の分岐は `NODE_ENV` 判定であり、`NODE_ENV` 未設定時は dev 相当（緩め）に
+     倒している。本番配信は `NODE_ENV=production` 前提である点を運用で担保する必要がある。
+
+4. **CSP Report-Only / report-uri は未導入**:
+   - Out of Scope の通り、レポーティング運用や Report-Only 段階導入は本 Issue で扱っていない。
+     本番投入後に実機で CSP 違反が観測された場合のディレクティブ調整は別途必要になりうる。
+
+5. **既存テストの tsc 型エラー（本変更とは無関係 / 既存問題）**:
+   - `npx tsc --noEmit` は既存の `src/lib/rewrites.test.ts` で `ProcessEnv` の `NODE_ENV` 必須化
+     由来の型エラーを 8 件報告するが、これは本変更前から存在する既存問題であり、本 Issue の
+     spec 書き換え禁止 / scope 外修正回避の方針から修正していない（CI は `vitest run` と
+     `eslint` を用い、`tsc --noEmit` をゲートにしていないため CI は通る）。新規追加した
+     `csp.ts` / `csp.test.ts` / `next.config.ts` の変更箇所は tsc エラーを生まない。
+     必要なら別 Issue で `rewrites.test.ts` の型を是正することを推奨する。
+
+STATUS: complete

--- a/docs/specs/53-web-next-js-csp/requirements.md
+++ b/docs/specs/53-web-next-js-csp/requirements.md
@@ -1,0 +1,100 @@
+# Requirements Document
+
+## Introduction
+
+Feedman の `web`（Next.js）が配信する HTML レスポンスに Content-Security-Policy（CSP）ヘッダーを付与し、XSS への多層防御（defense in depth）を実現する。記事本文は外部フィード由来の HTML をサニタイズ後に `dangerouslySetInnerHTML` で描画しており、サニタイズをすり抜けた悪性スクリプトに対する追加の安全網として CSP の価値が高い。既存のセキュリティヘッダー（`X-Content-Type-Options` / `X-Frame-Options` / `Referrer-Policy` / `Permissions-Policy`、#41 で導入済み）は温存しつつ CSP を追加する。本機能の最重要制約は、CSP 適用後も既存画面の表示・操作を一切壊さない後方互換性である。
+
+## Requirements
+
+### Requirement 1: CSP ヘッダーの全ルート付与
+
+**Objective:** As a セキュリティ運用者, I want web が返す全ルートのレスポンスに CSP ヘッダーが付与されること, so that フロントエンド全体で XSS に対する多層防御を一律に効かせられる
+
+#### Acceptance Criteria
+
+1. When ブラウザが web の任意のルートに対する HTML レスポンスを受け取ったとき, the Web Frontend shall `Content-Security-Policy` レスポンスヘッダーを 1 つ含める
+2. The Web Frontend shall CSP ヘッダーを特定の画面に限定せず全ルート（トップ画面・記事一覧・記事詳細・認証関連画面を含む）へ一律に付与する
+3. The `Content-Security-Policy` ヘッダー値 shall 少なくとも `default-src` ディレクティブを含み、明示的に許可されていないリソース取得をブラウザが既定で拒否する状態にする
+
+### Requirement 2: 厳格な許可方針（最小許可）
+
+**Objective:** As a セキュリティ運用者, I want CSP が「できるだけ厳しく、必要な許可のみ追加する」方針で構成されること, so that 攻撃面を最小化しつつ正当なリソースのみ許可できる
+
+#### Acceptance Criteria
+
+1. The `default-src` ディレクティブ shall 既定の取得元を同一オリジン（`'self'`）に限定し、ワイルドカード `*` を既定値として許可しない
+2. Where 同一オリジン化済みの API / 認証エンドポイント（`/api/*` / `/auth/*`）への接続が必要な場合, the Web Frontend shall それらの接続を `'self'` の範囲で許可する
+3. Where アプリが利用するフォントが同一オリジンから配信される場合, the Web Frontend shall フォント取得を `'self'` の範囲で許可し、外部フォント CDN への接続を CSP で許可しない
+4. The `Content-Security-Policy` ヘッダー値 shall 機能上必要と確認されていない外部オリジンを許可リストに含めない
+
+### Requirement 3: 既存セキュリティヘッダーの温存（後方互換）
+
+**Objective:** As a セキュリティ運用者, I want CSP 追加後も既存のセキュリティヘッダーが維持されること, so that 既存の防御（クリックジャッキング対策・MIME スニッフィング対策等）が後退しない
+
+#### Acceptance Criteria
+
+1. When CSP ヘッダーが付与されたレスポンスを受け取ったとき, the Web Frontend shall `X-Content-Type-Options: nosniff` ヘッダーを引き続き付与する
+2. When CSP ヘッダーが付与されたレスポンスを受け取ったとき, the Web Frontend shall `X-Frame-Options: DENY` ヘッダーを引き続き付与する
+3. When CSP ヘッダーが付与されたレスポンスを受け取ったとき, the Web Frontend shall `Referrer-Policy: strict-origin-when-cross-origin` ヘッダーを引き続き付与する
+4. When CSP ヘッダーが付与されたレスポンスを受け取ったとき, the Web Frontend shall `Permissions-Policy: camera=(), microphone=(), geolocation=()` ヘッダーを引き続き付与する
+
+### Requirement 4: 既存画面の表示・操作の維持（後方互換・境界）
+
+**Objective:** As a エンドユーザー, I want CSP 適用後も既存画面が今まで通り表示・操作できること, so that セキュリティ強化によって UI が壊れたり機能が使えなくなったりしない
+
+#### Acceptance Criteria
+
+1. When ユーザーが CSP 適用後の画面を開いたとき, the Web Frontend shall 既存の CSS スタイル（Tailwind / shadcn UI のスタイリング）を CSP 違反でブロックされることなく適用する
+2. When ユーザーが CSP 適用後の画面を操作したとき, the Web Frontend shall アプリのスクリプト（ページ初期化・クライアントサイドの操作応答）を CSP 違反でブロックされることなく実行する
+3. When ユーザーが記事を展開したとき, the Web Frontend shall サニタイズ済みの記事本文 HTML を CSP 違反でブロックされることなく描画する
+4. When ユーザーが画面を開いたとき, the Web Frontend shall 同一オリジンから配信されるフォントを CSP 違反でブロックされることなく表示する
+5. The Web Frontend shall CSP 適用前に通っていた既存の自動テスト（表示・操作の検証）を CSP 適用後も合格させる
+
+### Requirement 5: インライン script / style の取り扱い
+
+**Objective:** As a エンドユーザー, I want Next.js が注入するインライン script / style が CSP 下でも正しく機能すること, so that フレームワークが生成するページが CSP 違反で白画面・無操作にならない
+
+#### Acceptance Criteria
+
+1. When フレームワークがページのブートストラップのためにインライン script を注入したとき, the Web Frontend shall そのインライン script を CSP 下で実行可能な状態にする
+2. When フレームワークまたはスタイリング機構がインライン style を注入したとき, the Web Frontend shall そのインライン style を CSP 下で適用可能な状態にする
+3. If 想定外のインライン script / style が CSP によってブロックされたとき, the Web Frontend shall 画面の表示・操作が破綻しない状態を維持する（許可は最小限に留め、無条件な全許可に依存しない）
+
+### Requirement 6: 記事本文 HTML 中の外部リソースの取り扱い
+
+**Objective:** As a エンドユーザー, I want 記事本文に含まれる外部リソース（画像等）の表示可否が一貫した方針で決まること, so that 記事閲覧体験と安全性のトレードオフが予測可能になる
+
+#### Acceptance Criteria
+
+1. The `Content-Security-Policy` ヘッダー値 shall 記事本文 HTML 中の外部画像の取得可否を `img-src` ディレクティブで明示的に定義する
+2. Where 記事本文 HTML 中に外部画像が含まれる場合, the Web Frontend shall その外部画像の表示可否を `img-src` の許可範囲に従って一貫して扱う（許可範囲外のオリジンはブロックする）
+3. The `Content-Security-Policy` ヘッダー値 shall 記事本文 HTML 中のインライン script / 外部 script を `img-src` 以外のディレクティブで個別に制御し、画像の許可が script 実行の許可へ波及しないようにする
+
+## Non-Functional Requirements
+
+### NFR 1: 互換性
+
+1. The Web Frontend shall 本変更の前後で既存の `headers()` 由来レスポンスヘッダー（#41 導入分）の値を変更せず保持する
+2. The Web Frontend shall CSP 適用後も既存の自動テストスイート（`npm test`）を 0 件の新規失敗で完了させる
+
+### NFR 2: セキュリティ可観測性
+
+1. While 開発者がブラウザの開発者ツールでレスポンスヘッダーを確認しているとき, the Web Frontend shall `Content-Security-Policy` ヘッダー値を平文の HTTP ヘッダーとして可読な形で露出し、適用中のポリシーを目視確認可能にする
+
+### NFR 3: 運用・配信環境互換
+
+1. While アプリが本番ビルドとして配信されているとき, the Web Frontend shall CSP ヘッダーを付与した状態でページを正常に表示・操作可能にする
+
+## Out of Scope
+
+- API サーバー（`api`）側の HSTS / CSP 等のセキュリティヘッダー設定（#37 で扱う）
+- バックエンドでの HTML サニタイズ（`bluemonday` で実施済み。本 Issue では再実装・変更しない）
+- CSP 違反レポートの収集・集計基盤（`report-uri` / `report-to` によるレポーティング運用）の構築。本 Issue では CSP の付与と互換性維持に限定する
+- CSP のレポートオンリーモード（`Content-Security-Policy-Report-Only`）での段階導入運用の設計。採用是非は実装判断に委ねる
+- 外部フォント CDN・外部解析スクリプト・外部広告等、現状フロントで利用していない外部オリジンの許可設計（将来利用時に別途要件化）
+
+## Open Questions
+
+- インライン script / style の許可手段として nonce 方式（per-request nonce、ミドルウェアが必要）と `'unsafe-inline'` の一時許容のいずれを採るかは、本要件では「観測可能な振る舞い（インラインが機能し、かつ許可は最小限）」のみを定義し、具体的な実装手段は design / developer に委ねる。dev モード（HMR が eval / websocket を多用）と本番モードで CSP の厳しさを変える余地があるため、その方針も設計判断とする。
+- 記事本文 HTML 中の外部画像を許可するか否か（`img-src` を `'self'` のみに絞るか、外部画像オリジンを広く許可するか）は、安全性と記事閲覧体験のトレードオフであり人間判断が必要。Issue 本文「仮案・判断を委ねたい点」が未回答のため、デフォルト方針（厳格寄り / 体験寄り）の確定を Issue コメントで仰ぐことを推奨する。
+- `connect-src`（API / 認証エンドポイントへの fetch）・`style-src` / `script-src` / `font-src` 等の個別ディレクティブの最終的な許可値は、実際のフロント実装が要求するリソースの洗い出し（実機での CSP 違反観測）を経て確定する必要がある。現時点で外部オリジン接続は確認されていないが、漏れがないことの最終確認は実装フェーズで行う。

--- a/docs/specs/53-web-next-js-csp/review-notes.md
+++ b/docs/specs/53-web-next-js-csp/review-notes.md
@@ -1,0 +1,57 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T12:25:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-53-impl-web-next-js-csp
+- HEAD commit: fdf51878710d1284d134a4fc6fa2d3f2d1e1da0d
+- Compared to: develop..HEAD
+
+差分は 5 ファイル / +566 行（実装は `web/src/lib/csp.ts` 新規 / `web/src/lib/csp.test.ts` 新規 /
+`web/next.config.ts` 変更の 3 ファイル、残り 2 ファイルは spec ドキュメント）。本 spec ディレクトリに
+`design.md` / `tasks.md` は存在せず、`_Boundary:_` アノテーションが無い design-less impl のため、
+boundary 判定は requirements.md の scope と既存コードの突き合わせで実施した。Feature Flag Protocol は
+CLAUDE.md で `**採否**: opt-out` のため flag 観点の確認は行わない（通常の 3 カテゴリ判定）。
+
+## Verified Requirements
+
+- 1.1 — `web/next.config.ts:19` `{ key: CSP_HEADER_NAME, value: buildContentSecurityPolicy(process.env) }` を securityHeaders に追加。CSP ヘッダーを 1 件付与
+- 1.2 — `web/next.config.ts:27` `source: "/(.*)"` で全ルートへ一律付与
+- 1.3 — `csp.ts` `default-src 'self'` を生成 / `csp.test.ts:31` `default-src 'self' を含むこと`
+- 2.1 — `csp.test.ts:42` `default-src にワイルドカード * を既定値として許可しないこと`
+- 2.2 — `csp.ts` `connect-src 'self'`（dev のみ ws:/wss: 追加）/ `csp.test.ts:53` `connect-src を production では 'self' のみに限定`
+- 2.3 — `csp.test.ts:64` `font-src を 'self' に限定し外部フォント CDN を許可しないこと`
+- 2.4 — 各ディレクティブ値に機能上不要な外部オリジンを含めない（`csp.test.ts` 各 not.toContain アサート群）
+- 3.1 — `web/next.config.ts:10` `X-Content-Type-Options: nosniff` を温存（diff で値変更なし）
+- 3.2 — `web/next.config.ts:11` `X-Frame-Options: DENY` を温存
+- 3.3 — `web/next.config.ts:12` `Referrer-Policy: strict-origin-when-cross-origin` を温存
+- 3.4 — `web/next.config.ts:14-16` `Permissions-Policy: camera=(), microphone=(), geolocation=()` を温存
+- 4.1 — `style-src 'self' 'unsafe-inline'` / `csp.test.ts:86` `style-src に 'unsafe-inline'`
+- 4.2 — `script-src 'self' 'unsafe-inline'` / `csp.test.ts:75` `script-src に 'unsafe-inline'`
+- 4.3 — `img-src 'self' data: https:` / `csp.test.ts:152` `HTTPS 外部画像と data URI を許可`
+- 4.4 — `font-src 'self'` / `csp.test.ts:64`
+- 4.5 — `npm test`（vitest run）全 164 件 green（reviewer 側でも再実行確認）。新規失敗 0 件
+- 5.1 — `csp.test.ts:75` `script-src に 'unsafe-inline' を含めブートストラップ inline script を許可`
+- 5.2 — `csp.test.ts:86` `style-src に 'unsafe-inline' を含め inline style を許可`
+- 5.3 — `csp.test.ts:97` `production では 'unsafe-eval' を含めない` / `:108` `ws: を含めない` / dev 追加 2 ケース（`:119` `:130`）
+- 6.1 — `csp.test.ts:141` `img-src ディレクティブを明示的に定義すること`
+- 6.2 — `csp.test.ts:152` `HTTPS 外部画像と data URI を許可しつつ * は許可しないこと`
+- 6.3 — `csp.test.ts:164` `img-src の画像許可が script-src へ波及しないこと`（script-src に https:/data: が混入しない）
+- NFR 1.1 — 既存 4 ヘッダーの値を diff 上で変更せず保持（追加のみ）
+- NFR 1.2 — reviewer 再実行で 24 ファイル / 164 テスト全 pass、新規失敗 0 件
+- NFR 2.1 — `csp.test.ts:191` セミコロン区切り 1 行文字列として直列化（平文ヘッダーで可読）
+- NFR 3.1 — production 系テスト群が production 値（`'unsafe-eval'` / ws: を含まない）を検証
+
+## Findings
+
+なし
+
+## Summary
+
+requirements.md の全 numeric AC（Req 1〜6 / NFR 1〜3）に対応する実装とテストが diff 内に確認できた。
+既存 4 セキュリティヘッダーは値を変更せず温存され、CSP は全ルートへ付与される。reviewer 側でも
+vitest 全 164 件 green を再確認し、新規失敗 0 件。design-less impl のため boundary 逸脱は対象外で、
+変更は web frontend の CSP scope に閉じている。
+
+RESULT: approve

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -3,7 +3,9 @@ import {
   buildRewrites,
   resolveApiInternalUrlForRewrites,
 } from "./src/lib/rewrites";
+import { CSP_HEADER_NAME, buildContentSecurityPolicy } from "./src/lib/csp";
 
+// 既存のセキュリティヘッダー（#41 導入分）。CSP 追加後も値を変更せず温存する（Req 3 / NFR 1）。
 const securityHeaders = [
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "X-Frame-Options", value: "DENY" },
@@ -12,6 +14,9 @@ const securityHeaders = [
     key: "Permissions-Policy",
     value: "camera=(), microphone=(), geolocation=()",
   },
+  // Content-Security-Policy: 全ルートへ一律付与する（Req 1）。dev/production の厳格さは
+  // buildContentSecurityPolicy が NODE_ENV に応じて切り替える（process.env を引数注入）。
+  { key: CSP_HEADER_NAME, value: buildContentSecurityPolicy(process.env) },
 ];
 
 const nextConfig: NextConfig = {

--- a/web/src/lib/csp.test.ts
+++ b/web/src/lib/csp.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from "vitest";
+import {
+  CSP_HEADER_NAME,
+  buildCspDirectives,
+  buildContentSecurityPolicy,
+} from "./csp";
+
+/**
+ * CSP 文字列値をパースして「ディレクティブ名 → 値配列」のマップに変換するテスト用ヘルパー。
+ * Assert を読みやすくするための補助で、テスト対象の実装ロジックは含まない。
+ */
+function parseCsp(value: string): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  for (const part of value.split(";")) {
+    const trimmed = part.trim();
+    if (trimmed === "") continue;
+    const [name, ...values] = trimmed.split(/\s+/);
+    map.set(name, values);
+  }
+  return map;
+}
+
+describe("CSP_HEADER_NAME", () => {
+  it("HTTP ヘッダーの正準名 Content-Security-Policy であること", () => {
+    // Arrange / Act / Assert
+    expect(CSP_HEADER_NAME).toBe("Content-Security-Policy");
+  });
+});
+
+describe("buildContentSecurityPolicy", () => {
+  it("production 環境のとき default-src 'self' を含むこと（Req 1.3 / 2.1）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.get("default-src")).toEqual(["'self'"]);
+  });
+
+  it("default-src にワイルドカード * を既定値として許可しないこと（Req 2.1）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.get("default-src")).not.toContain("*");
+  });
+
+  it("connect-src を production では 'self' のみに限定すること（Req 2.2）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.get("connect-src")).toEqual(["'self'"]);
+  });
+
+  it("font-src を 'self' に限定し外部フォント CDN を許可しないこと（Req 2.3 / 4.4）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.get("font-src")).toEqual(["'self'"]);
+  });
+
+  it("script-src に 'unsafe-inline' を含めブートストラップ inline script を許可すること（Req 5.1）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.get("script-src")).toContain("'unsafe-inline'");
+  });
+
+  it("style-src に 'unsafe-inline' を含め inline style を許可すること（Req 5.2）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.get("style-src")).toContain("'unsafe-inline'");
+  });
+
+  it("production 環境のとき script-src に 'unsafe-eval' を含めないこと（Req 5.3 / NFR 3）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.get("script-src")).not.toContain("'unsafe-eval'");
+  });
+
+  it("production 環境のとき connect-src に websocket（ws:）を含めないこと（Req 2 / 5.3）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.get("connect-src")).not.toContain("ws:");
+  });
+
+  it("development 環境のとき HMR 用に script-src へ 'unsafe-eval' を追加すること（Req 5.3）", () => {
+    // Arrange
+    const env = { NODE_ENV: "development" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.get("script-src")).toContain("'unsafe-eval'");
+  });
+
+  it("development 環境のとき HMR 用に connect-src へ websocket（ws:）を追加すること（Req 5.3）", () => {
+    // Arrange
+    const env = { NODE_ENV: "development" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.get("connect-src")).toContain("ws:");
+  });
+
+  it("img-src ディレクティブを明示的に定義すること（Req 6.1）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.has("img-src")).toBe(true);
+  });
+
+  it("img-src で HTTPS 外部画像と data URI を許可しつつワイルドカード * は許可しないこと（Req 6.2）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.get("img-src")).toEqual(["'self'", "data:", "https:"]);
+    expect(csp.get("img-src")).not.toContain("*");
+  });
+
+  it("img-src の画像許可が script-src へ波及しないこと（Req 6.3）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    // img-src で許可した https: / data: が script-src に混入していないことを検証する。
+    expect(csp.get("script-src")).not.toContain("https:");
+    expect(csp.get("script-src")).not.toContain("data:");
+  });
+
+  it("OWASP 推奨の堅牢化として object-src 'none' / base-uri 'self' / frame-ancestors 'none' / form-action 'self' を含むこと（Req 2）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    expect(csp.get("object-src")).toEqual(["'none'"]);
+    expect(csp.get("base-uri")).toEqual(["'self'"]);
+    expect(csp.get("frame-ancestors")).toEqual(["'none'"]);
+    expect(csp.get("form-action")).toEqual(["'self'"]);
+  });
+
+  it("ディレクティブをセミコロン区切りの 1 行文字列として直列化すること（NFR 2.1）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const value = buildContentSecurityPolicy(env);
+
+    // Assert
+    expect(value).toContain("; ");
+    expect(value.startsWith("default-src 'self'")).toBe(true);
+    expect(value).not.toContain("\n");
+  });
+
+  it("NODE_ENV が未設定（空入力）のとき dev 相当の緩いポリシー（'unsafe-eval' 含む）を生成すること（境界）", () => {
+    // Arrange
+    const env = {};
+
+    // Act
+    const csp = parseCsp(buildContentSecurityPolicy(env));
+
+    // Assert
+    // NODE_ENV 未設定は production ではないため dev 相当（安全側ではなく機能維持側に倒す。HMR 環境想定）。
+    expect(csp.get("script-src")).toContain("'unsafe-eval'");
+  });
+});
+
+describe("buildCspDirectives", () => {
+  it("production 環境のとき全ての必須ディレクティブを含むマップを返すこと（Req 1.3 / 2 / 6.1）", () => {
+    // Arrange
+    const env = { NODE_ENV: "production" };
+
+    // Act
+    const directives = buildCspDirectives(env);
+
+    // Assert
+    const expectedKeys = [
+      "default-src",
+      "script-src",
+      "style-src",
+      "img-src",
+      "font-src",
+      "connect-src",
+      "object-src",
+      "base-uri",
+      "frame-ancestors",
+      "form-action",
+    ];
+    for (const key of expectedKeys) {
+      expect(directives.has(key)).toBe(true);
+    }
+  });
+});

--- a/web/src/lib/csp.ts
+++ b/web/src/lib/csp.ts
@@ -1,0 +1,90 @@
+/**
+ * Content-Security-Policy（CSP）ヘッダー値の生成ロジック。
+ *
+ * `next.config.ts` の `headers()` から静的 CSP を全ルートへ付与するための純粋ロジックを提供する。
+ * 環境（dev / production）を引数で受け取る純粋関数として実装し、`process.env.NODE_ENV` への
+ * 直接依存を排して Vitest から単体テスト可能にする（`rewrites.ts` の env 注入パターンに準拠）。
+ *
+ * 方針: 「できるだけ厳しく、必要な許可のみ追加する」（最小許可）。`headers()` による静的 CSP では
+ * per-request nonce が使えない（nonce は middleware を要し本 Issue のスコープ外）ため、
+ * Next.js App Router のブートストラップ inline script / Tailwind・next/font の inline style 向けに
+ * `'unsafe-inline'` を許容する。dev モードのみ HMR / turbopack 用に `'unsafe-eval'` と websocket を許可する。
+ */
+
+/** CSP ヘッダー名（HTTP ヘッダーの正準名）。 */
+export const CSP_HEADER_NAME = "Content-Security-Policy";
+
+/**
+ * CSP 生成時に参照する環境を表す引数型。
+ *
+ * `NODE_ENV` のみを参照する。`process.env` をそのまま渡すこともできる
+ * （余剰キーは無視される）。
+ */
+export interface CspEnv {
+  /** Node 実行環境。`"production"` のとき本番向けの厳格ポリシーを生成する。 */
+  NODE_ENV?: string;
+}
+
+/**
+ * 与えられた環境に応じた CSP ディレクティブのマップを構築する純粋関数。
+ *
+ * production 以外（dev / test）では HMR / turbopack のために `script-src` へ `'unsafe-eval'` を、
+ * `connect-src` へ websocket（`ws:` / `wss:`）を追加する。production ではこれらを含めない。
+ *
+ * @param env - 参照する環境（既定: `process.env`）。`NODE_ENV` のみ参照する
+ * @returns ディレクティブ名 → 値配列のマップ（挿入順を保持する）
+ */
+export function buildCspDirectives(
+  env: CspEnv = process.env
+): Map<string, string[]> {
+  const isProduction = env.NODE_ENV === "production";
+
+  // script-src: Next.js App Router のブートストラップ inline script 用に 'unsafe-inline' を許容。
+  // dev のみ HMR / turbopack の eval 実行のため 'unsafe-eval' を追加（本番では付けない）。
+  const scriptSrc = ["'self'", "'unsafe-inline'"];
+  if (!isProduction) {
+    scriptSrc.push("'unsafe-eval'");
+  }
+
+  // connect-src: API / 認証は #41 で同一オリジン化済みのため 'self' で足りる。
+  // dev のみ HMR の websocket（ws: / wss:）を許可する。
+  const connectSrc = ["'self'"];
+  if (!isProduction) {
+    connectSrc.push("ws:", "wss:");
+  }
+
+  // 挿入順を保つため Map を使う（CSP 文字列の決定論的な並びを保証する）。
+  const directives = new Map<string, string[]>();
+  directives.set("default-src", ["'self'"]);
+  directives.set("script-src", scriptSrc);
+  // style-src: Tailwind / next/font が注入する inline style 用に 'unsafe-inline' を許容。
+  directives.set("style-src", ["'self'", "'unsafe-inline'"]);
+  // img-src: 記事本文 HTML 中の外部画像を表示するため data: と HTTPS 外部画像を許可（平文 http は不許可）。
+  directives.set("img-src", ["'self'", "data:", "https:"]);
+  directives.set("font-src", ["'self'"]);
+  directives.set("connect-src", connectSrc);
+  // object-src / base-uri / frame-ancestors / form-action: OWASP 推奨の最小堅牢化。
+  // frame-ancestors 'none' は X-Frame-Options: DENY と整合する。
+  directives.set("object-src", ["'none'"]);
+  directives.set("base-uri", ["'self'"]);
+  directives.set("frame-ancestors", ["'none'"]);
+  directives.set("form-action", ["'self'"]);
+
+  return directives;
+}
+
+/**
+ * CSP ヘッダーに設定する文字列値を生成する純粋関数。
+ *
+ * `buildCspDirectives` の結果を `"<directive> <values...>; ..."` 形式の 1 行へ直列化する。
+ *
+ * @param env - 参照する環境（既定: `process.env`）。`NODE_ENV` のみ参照する
+ * @returns CSP ヘッダー値（例: `"default-src 'self'; script-src 'self' 'unsafe-inline'; ..."`）
+ */
+export function buildContentSecurityPolicy(env: CspEnv = process.env): string {
+  const directives = buildCspDirectives(env);
+
+  return Array.from(directives.entries())
+    .map(([name, values]) => `${name} ${values.join(" ")}`)
+    .join("; ");
+}


### PR DESCRIPTION
## 概要

Feedman の `web`（Next.js）が配信するすべての HTML レスポンスに `Content-Security-Policy`（CSP）ヘッダーを付与し、XSS への多層防御（defense in depth）を実現する。記事本文は外部フィード由来の HTML をサニタイズ後に `dangerouslySetInnerHTML` で描画しており、サニタイズをすり抜けた悪性スクリプトに対する追加の安全網として CSP を追加した。

既存の 4 つのセキュリティヘッダー（`X-Content-Type-Options` / `X-Frame-Options` / `Referrer-Policy` / `Permissions-Policy`、#41 で導入済み）は値を変更せず温存し、後方互換を維持している。CSP 文字列生成を純粋関数モジュール（`csp.ts`）として分離し、Vitest で 18 ケースの単体テストを追加した。全 164 テスト green を確認済み。

## 対応 Issue

Closes #53

## 関連 PR

- 設計 PR: なし（design-less impl のため Architect は起動していない）

## 実装内容

- (Req 1 / Req 2) `web/src/lib/csp.ts` を新規作成。`buildCspDirectives(env)` と `buildContentSecurityPolicy(env)` の純粋関数で CSP ディレクティブを生成。`NODE_ENV` による dev/production 切り替え（dev は HMR 用に `'unsafe-eval'` / `ws: wss:` を追加、本番では除外）
- (Req 3 / NFR 1) `web/next.config.ts` の `securityHeaders` 配列に CSP エントリを 1 件追加。既存 4 ヘッダーは値変更なく温存
- (Req 4 / Req 5 / Req 6) `style-src`・`script-src` に `'unsafe-inline'`、`img-src` に `'self' data: https:` を付与し、Tailwind / shadcn-ui のインライン style、Next.js ブートストラップ inline script、外部フィード記事本文の外部画像が CSP 違反でブロックされないように設定
- `web/src/lib/csp.test.ts` を新規作成。18 ケース（全 AC に対応する正常系・境界値・異常系）すべて green

## 受入基準チェック

- [x] Req 1.1 / 1.2: 全ルートへ CSP ヘッダーを付与 ← `next.config.ts` の `source: "/(.*)"` + 全テスト green
- [x] Req 1.3: `default-src` 必須 ← `csp.test.ts` `default-src 'self' を含むこと`
- [x] Req 2.1: `default-src 'self'` / `*` 不許可 ← `csp.test.ts` `ワイルドカード * を許可しないこと`
- [x] Req 2.2: `connect-src 'self'` ← `csp.test.ts` `production では 'self' のみ`
- [x] Req 2.3 / 4.4: `font-src 'self'` ← `csp.test.ts` `外部フォント CDN を許可しないこと`
- [x] Req 3.1〜3.4: 既存 4 ヘッダー温存 ← `next.config.ts` diff 変更なし / 全テスト green
- [x] Req 4.1〜4.5: 既存 CSS / スクリプト / 記事本文描画 / フォント 維持 ← 各 csp.test.ts / 全 164 件 green
- [x] Req 5.1〜5.3: inline script / style の許可と最小化 ← csp.test.ts production `'unsafe-eval'` 排除確認
- [x] Req 6.1〜6.3: `img-src` 明示・外部画像許可・script 汚染なし ← csp.test.ts img-src 系 3 ケース
- [x] NFR 1.2: 既存テスト 0 件新規失敗 ← vitest 全 164 件 green

## テスト結果

```
全 24 ファイル / 164 テスト pass（新規失敗 0 件）
うち新規追加 csp.test.ts: 18 テスト pass

npm run lint: 0 errors
（既存の警告 6 件のみ。本変更と無関係の既存箇所）
```

## 実装上の判断

- **静的 CSP 採用（nonce 不使用）**: `headers()` 関数はリクエストごとに値を変えられないため、per-request nonce を使う場合は middleware が必要となる。本 Issue スコープは `next.config.ts` の `headers()` に限定されているため `'unsafe-inline'` 方式を採用した。将来 middleware を導入すれば nonce 方式へ移行でき、`'unsafe-inline'` を外してより厳格化できる（別 Issue 推奨）。
- **`img-src 'self' data: https:`**: RSS リーダーの記事本文は外部オリジンの画像を多数含むため、外部画像を全ブロックすると後方互換（Req 4.3）が壊れる。体験寄りに HTTPS 外部画像を許可した（詳細は impl-notes.md 確認事項 2 を参照）。
- **`NODE_ENV` 未設定を dev 相当に倒す**: HMR 環境での動作維持を優先。本番は `NODE_ENV=production` で配信する前提。

## 確認事項 / レビュワーへの依頼

- `'unsafe-inline'` の採用（インライン script / style の許可手段）の妥当性を最終確認してください（impl-notes.md 確認事項 1 参照）
- `img-src` で外部 HTTPS 画像を許可する方針の最終確認をお願いします（impl-notes.md 確認事項 2 参照）
- dev モードでの `'unsafe-eval'` / `ws: wss:` 付与の方針確認（impl-notes.md 確認事項 3 参照）
- Reviewer の独立レビュー判定（approve）は `docs/specs/53-web-next-js-csp/review-notes.md` を参照してください
- base: develop / baseRefName: develop / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #53 のコメントを参照してください。
