### PR TITLE
feat(#6): ログ出力からの平文セッションID除去（ハッシュ短縮値へ置換）

### DIFF
--- a/docs/specs/6--id/impl-notes.md
+++ b/docs/specs/6--id/impl-notes.md
@@ -1,0 +1,68 @@
+# 実装ノート: Issue #6 ログからセッションIDを除去する
+
+## 変更点の要約
+
+`internal/auth/service.go` の `Logout` メソッドが、ログアウト成功ログ（`user logged out`）で
+セッション ID を `slog.String("session_id", sessionID)` として平文出力していた。これを要件
+Option B 方針（人間確定済み）に従い、復元不能なハッシュ短縮値に置き換えた。
+
+- **新設**: `hashSessionIDForLog(sessionID string) string`（package 内 unexported / 純粋関数）
+  - 標準 `crypto/sha256` で SHA-256 ハッシュを計算し、`encoding/hex` の hex 表現の先頭 8 文字を返す。
+  - 副作用なし・error を返さない。空文字を含む任意入力に対しパニックせず安全に値を返す
+    （`sha256.Sum256([]byte(""))` が自然に動作する）。
+  - 意図明示のため doc comment を付与（`// hashSessionIDForLog は ...` 形式）。
+- **変更**: `Logout` 内のログ出力を
+  `slog.Info("user logged out", slog.String("session_id_hash", hashSessionIDForLog(sessionID)))`
+  に変更。
+  - ログレベル `slog.Info` とメッセージ `user logged out` は従来どおり維持（Req 4.3 / NFR 2.1）。
+  - **ログキー名を `session_id` → `session_id_hash` に変更**。これにより、ログ閲覧者が
+    「この値は生の ID ではなくハッシュ短縮値である」と判別でき、平文 ID と誤認するのを防ぐ
+    （Req 1.3 / NFR 1.2 への配慮）。
+- **不変**: `Logout` 冒頭の `if sessionID == "" { return error }` ガードは変更なし（Req 4.2）。
+  既存テスト `TestLogout_EmptySessionID_ReturnsError` を破壊しないことを確認済み。
+- import に `crypto/sha256` を追加（service.go）、`strings` を追加（service_test.go）。
+
+## 各 AC とテストの対応表
+
+| AC | 内容 | 担保するテスト |
+|---|---|---|
+| Req 1.1 | ログ出力に生のセッション ID を含めない | 実装（`session_id` キー削除）+ `TestLogout_DeletesSession`（ログ出力が `session_id_hash=...` になることを実行時に確認）/ `TestHashSessionIDForLog_ReturnsEightCharsWithoutRawInput`（出力が生入力を含まない） |
+| Req 1.2 | 復元できない短縮値に変換して記録 | `TestHashSessionIDForLog_ReturnsEightCharsWithoutRawInput`（8 文字のみ・生入力非包含 = 一方向短縮） |
+| Req 1.3 | 短縮値をハッシュ値の先頭 8 文字に限定 | `TestHashSessionIDForLog_ReturnsEightCharsWithoutRawInput`（`len == 8`） |
+| Req 2.1 | 同一入力→同一短縮値 | `TestHashSessionIDForLog_SameInput_ReturnsSameValue` |
+| Req 2.2 | 異なる入力→区別可能な短縮値 | `TestHashSessionIDForLog_DifferentInput_ReturnsDistinctValue` |
+| Req 3.1 | 空入力でパニックせず短縮値を返す | `TestHashSessionIDForLog_EmptyInput_ReturnsValueWithoutPanic` |
+| Req 3.2 | 任意入力に対し副作用なく完了 | 純粋関数として実装（外部状態を読み書きしない）+ 上記ヘルパテスト群が副作用なしで再現可能なことで担保 |
+| Req 4.1 | 有効なセッション ID で従来どおり破棄・正常完了 | `TestLogout_DeletesSession`（既存・非破壊） |
+| Req 4.2 | 空文字ではログ到達前にエラー | `TestLogout_EmptySessionID_ReturnsError`（既存・非破壊） |
+| Req 4.3 | 成功時に従来どおり Info レベルで出力 | 実装（`slog.Info` 維持）+ `TestLogout_DeletesSession` の実行ログで `INFO user logged out` を確認 |
+| NFR 1.1 | ログ出力にセッション ID 原文を一切含めない | 実装（生 `session_id` フィールド削除）+ `TestHashSessionIDForLog_ReturnsEightCharsWithoutRawInput` |
+| NFR 1.2 | 一方向変換を用いる | SHA-256（一方向ハッシュ）を採用 + 短縮 8 文字で全体復元不能 |
+| NFR 2.1 | 観測可能な挙動（破棄・エラー条件・ログ有無/レベル）を本機能導入前と同一に保つ | `TestLogout_DeletesSession` / `TestLogout_EmptySessionID_ReturnsError`（いずれも既存テスト非破壊） |
+
+## テスト・lint・vet の実行結果
+
+- `gofmt -l internal/auth/`: 出力なし（整形済み）
+- `go vet ./internal/auth/...`: 出力なし（pass）
+- `go test ./internal/auth/...`: 全 PASS（`ok github.com/hitoshi/feedman/internal/auth`）
+  - 新規 4 テスト含め auth パッケージ全テストが green。
+  - 実行ログで `INFO user logged out session_id_hash=6f02c597` となり、生 `session_id` が
+    出力されないことを確認。
+
+## 実装上の判断
+
+- ログキー名を `session_id` から `session_id_hash` に変更した。要件 NFR 2.1 は「観測可能な挙動
+  （破棄・エラー条件・ログ有無/レベル）を同一に保つ」ことを求めており、ログ**フィールド名**の
+  完全一致までは要求していない。むしろ Req 1.3 / NFR 1.2 の趣旨（ハッシュ短縮値であることを
+  明示し平文誤認を防ぐ）を優先してキー名を変更した。本判断はタスク指示にも沿っている。
+- Logout のログ出力に生 `session_id` が含まれないことの直接検証は、slog ハンドラ差し替えが
+  必要で複雑になるため、ヘルパ関数を純粋関数として切り出し単体テストで担保する方針を採った
+  （CLAUDE.md テスト規約: 単体テストが最も数の多い層）。Logout がヘルパを呼ぶ事実は
+  コードレビューおよび `TestLogout_DeletesSession` 実行時のログ出力（`session_id_hash=...`）で
+  間接的に確認できる。
+
+## 確認事項
+
+- なし。
+
+STATUS: complete

--- a/docs/specs/6--id/requirements.md
+++ b/docs/specs/6--id/requirements.md
@@ -1,0 +1,72 @@
+# Requirements Document
+
+## Introduction
+
+認証サービスのログアウト処理は、処理完了時に「user logged out」ログを出力する際、セッション ID を平文のまま
+記録している。セッション ID は認証トークン相当の機密情報であり、平文でログに残るとログ閲覧権限を持つ者による
+セッション乗っ取りのリスクを生む。本機能では、ログアウト時のログにセッション ID が平文で残らないようにしつつ、
+障害調査・追跡に必要な最低限の識別情報を復元不能な短縮値として残すことで、機密性と運用上の追跡可能性を両立する。
+Issue コメントの人間判断により、セッション ID を完全削除せず、ハッシュ化した先頭 8 文字を残す方式（Option B）を
+採用する。
+
+## Requirements
+
+### Requirement 1: ログアウト時のセッション ID 機密化
+
+**Objective:** As a 運用者, I want ログアウト時のログにセッション ID が平文で残らないこと, so that ログ閲覧経由でのセッション乗っ取りリスクを排除できる
+
+#### Acceptance Criteria
+
+1. When ログアウト処理がログを出力するとき, the Auth Service shall ログ出力に生のセッション ID を含めない
+2. When ログアウト処理がセッション ID をログに残すとき, the Auth Service shall 元のセッション ID を復元できない短縮値に変換して記録する
+3. The Auth Service shall ログに残す短縮値をハッシュ値の先頭 8 文字に限定する
+
+### Requirement 2: 追跡可能性の維持
+
+**Objective:** As a 運用者, I want 同一セッションのログアウトが一貫した短縮値で記録されること, so that 機密性を保ったままログ上でセッション単位の追跡ができる
+
+#### Acceptance Criteria
+
+1. When 同一のセッション ID から短縮値を生成したとき, the Auth Service shall 常に同一の短縮値を返す
+2. When 異なるセッション ID から短縮値を生成したとき, the Auth Service shall それぞれ区別可能な短縮値を返す
+
+### Requirement 3: 短縮値生成の堅牢性
+
+**Objective:** As a 運用者, I want 短縮値生成が空入力でも安全に動作すること, so that 入力値に依存してログ処理が異常終了することを防げる
+
+#### Acceptance Criteria
+
+1. If 空文字のセッション ID が短縮値生成に渡された場合, the Auth Service shall パニックを起こさず短縮値を返す
+2. The Auth Service shall 任意の入力文字列に対して短縮値生成を副作用なく完了する
+
+### Requirement 4: ログアウト挙動の後方互換性
+
+**Objective:** As a エンドユーザー, I want 機密化対応後もログアウトが従来どおり完了すること, so that 認証フローの挙動が変わらず利用を継続できる
+
+#### Acceptance Criteria
+
+1. When 有効なセッション ID でログアウトが要求されたとき, the Auth Service shall 従来どおりセッションを破棄し正常完了する
+2. If 空文字のセッション ID でログアウトが要求された場合, the Auth Service shall 従来どおりログ出力に到達する前にエラーを返す
+3. The Auth Service shall ログアウト成功時に従来どおりログレベル Info で完了ログを出力する
+
+## Non-Functional Requirements
+
+### NFR 1: セキュリティ
+
+1. The Auth Service shall ログ出力に機密トークン相当のセッション ID 原文を一切含めない
+2. The Auth Service shall ログに記録する短縮値から元のセッション ID 全体を復元できない一方向変換を用いる
+
+### NFR 2: 後方互換
+
+1. The Auth Service shall ログアウトの観測可能な挙動（セッション破棄・エラー条件・ログ出力の有無とレベル）を本機能導入前と同一に保つ
+
+## Out of Scope
+
+- ログアウト以外でセッション ID をログ出力している箇所の機密化（本 Issue ではログアウト処理のみを対象とする）
+- 既に出力済みの既存ログに含まれるセッション ID の遡及的マスキング・削除
+- セッション ID 以外の機密値（OAuth トークン・メールアドレス等）のログ機密化方針の見直し
+- ログフォーマット全体の刷新やログ基盤の変更
+
+## Open Questions
+
+- なし（主要論点である「完全削除（Option A）か短縮値保持（Option B）か」は Issue コメントで Option B 採用に確定済み。短縮値の長さも「先頭 8 文字」で確定済み）。

--- a/docs/specs/6--id/review-notes.md
+++ b/docs/specs/6--id/review-notes.md
@@ -1,0 +1,44 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T12:43:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-6-impl--id
+- HEAD commit: 6153d0f56ba8b644727dc531fd51cc20f1aae306
+- Compared to: develop..HEAD
+- Note: design-less impl（`design.md` / `tasks.md` 不在）。`_Boundary:_` アノテーションが
+  存在しないため、boundary 判定は requirements.md の対象（Auth Service / `internal/auth/`）と
+  差分ファイルパスの突き合わせで実施した。Feature Flag Protocol は opt-out のため flag 観点は不適用。
+
+## Verified Requirements
+
+- 1.1 — `service.go:149` で `slog.String("session_id", sessionID)` を削除し
+  `session_id_hash=hashSessionIDForLog(...)` に置換。実行ログ `INFO user logged out session_id_hash=6f02c597`
+  で生 ID 非出力を確認 / `TestHashSessionIDForLog_ReturnsEightCharsWithoutRawInput`
+- 1.2 — SHA-256 + 先頭 8 文字切り出し（`service.go:157-160`）。`TestHashSessionIDForLog_ReturnsEightCharsWithoutRawInput`
+  が生入力非包含を検証
+- 1.3 — `hex.EncodeToString(sum[:])[:8]`。`TestHashSessionIDForLog_ReturnsEightCharsWithoutRawInput`（`len == 8`）
+- 2.1 — `TestHashSessionIDForLog_SameInput_ReturnsSameValue`
+- 2.2 — `TestHashSessionIDForLog_DifferentInput_ReturnsDistinctValue`
+- 3.1 — `TestHashSessionIDForLog_EmptyInput_ReturnsValueWithoutPanic`（空入力で 8 文字を返しパニックなし）
+- 3.2 — `hashSessionIDForLog` は外部状態を読み書きしない純粋関数。ヘルパテスト群が副作用なしで再現可能
+- 4.1 — `Logout` のセッション破棄ロジック不変。`TestLogout_DeletesSession`（既存・非破壊）
+- 4.2 — `if sessionID == ""` ガード不変（`service.go:141-143`）。`TestLogout_EmptySessionID_ReturnsError`
+- 4.3 — `slog.Info("user logged out", ...)` のレベル・メッセージ維持。verbose 実行で `INFO user logged out` を確認
+- NFR 1.1 — 生 `session_id` フィールドを削除。実装 + `TestHashSessionIDForLog_ReturnsEightCharsWithoutRawInput`
+- NFR 1.2 — 一方向ハッシュ（SHA-256）+ 8 文字切り出しで全体復元不能
+- NFR 2.1 — 破棄・エラー条件・ログ有無/レベルを維持（`TestLogout_DeletesSession` / `TestLogout_EmptySessionID_ReturnsError`）。
+  ログキー名 `session_id` → `session_id_hash` の変更はあるが、NFR 2.1 が要求する観測可能な挙動
+  （破棄・エラー条件・ログ出力の有無とレベル）は不変であり、Req 1.3 / NFR 1.2 の趣旨に沿った妥当な変更。AC 違反に該当しない
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric AC（Req 1.1-4.3 / NFR 1.1-2.1）に対応する実装とテストを確認。`go test ./internal/auth/...`
+は全 PASS（新規 4 テスト含む）、verbose 実行で生セッション ID 非出力を確認。boundary 逸脱・missing test なし。
+
+RESULT: approve

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -4,6 +4,7 @@ package auth
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"log/slog"
@@ -145,8 +146,17 @@ func (s *Service) Logout(ctx context.Context, sessionID string) error {
 		return fmt.Errorf("failed to delete session: %w", err)
 	}
 
-	slog.Info("user logged out", slog.String("session_id", sessionID))
+	slog.Info("user logged out", slog.String("session_id_hash", hashSessionIDForLog(sessionID)))
 	return nil
+}
+
+// hashSessionIDForLog はセッションIDをログ出力用の復元不能な短縮値に変換する。
+// SHA-256 ハッシュの hex 表現の先頭 8 文字を返す純粋関数であり、副作用を持たず
+// error も返さない。空文字を含む任意の入力に対してパニックせず安全に値を返す。
+// 生のセッションIDをログに残さずセッション単位の追跡可能性を維持するために用いる。
+func hashSessionIDForLog(sessionID string) string {
+	sum := sha256.Sum256([]byte(sessionID))
+	return hex.EncodeToString(sum[:])[:8]
 }
 
 // GetCurrentUser はセッションから現在のユーザーを取得する。

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -431,6 +432,67 @@ func TestLogout_EmptySessionID_ReturnsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty session ID")
 	}
+}
+
+func TestHashSessionIDForLog_SameInput_ReturnsSameValue(t *testing.T) {
+	// Req 2.1: 同一のセッション ID から短縮値を生成すると常に同一の短縮値を返す
+	// Arrange
+	sessionID := "session-consistent-123"
+
+	// Act
+	first := hashSessionIDForLog(sessionID)
+	second := hashSessionIDForLog(sessionID)
+
+	// Assert
+	if first != second {
+		t.Errorf("same input must yield same value, got %q and %q", first, second)
+	}
+}
+
+func TestHashSessionIDForLog_DifferentInput_ReturnsDistinctValue(t *testing.T) {
+	// Req 2.2: 異なるセッション ID から短縮値を生成するとそれぞれ区別可能な短縮値を返す
+	// Arrange
+	idA := "session-a"
+	idB := "session-b"
+
+	// Act
+	hashA := hashSessionIDForLog(idA)
+	hashB := hashSessionIDForLog(idB)
+
+	// Assert
+	if hashA == hashB {
+		t.Errorf("different inputs must yield distinct values, both got %q", hashA)
+	}
+}
+
+func TestHashSessionIDForLog_ReturnsEightCharsWithoutRawInput(t *testing.T) {
+	// Req 1.3 / NFR 1.2: 短縮値はハッシュ値の先頭 8 文字に限定され、生入力を復元・露出しない
+	// Arrange
+	sessionID := "super-secret-session-token-value"
+
+	// Act
+	hash := hashSessionIDForLog(sessionID)
+
+	// Assert
+	if len(hash) != 8 {
+		t.Errorf("hash length = %d, want 8", len(hash))
+	}
+	if strings.Contains(hash, sessionID) {
+		t.Errorf("hash %q must not contain raw session ID %q", hash, sessionID)
+	}
+}
+
+func TestHashSessionIDForLog_EmptyInput_ReturnsValueWithoutPanic(t *testing.T) {
+	// Req 3.1: 空文字のセッション ID が渡されてもパニックせず短縮値を返す
+	t.Run("空文字入力のときパニックせず8文字の値を返す", func(t *testing.T) {
+		// Act
+		hash := hashSessionIDForLog("")
+
+		// Assert
+		if len(hash) != 8 {
+			t.Errorf("hash length for empty input = %d, want 8", len(hash))
+		}
+	})
 }
 
 func TestGetCurrentUser_ValidSession_ReturnsUser(t *testing.T) {


### PR DESCRIPTION
## 概要

認証サービスのログアウト処理が、完了ログ（`user logged out`）にセッション ID を平文で出力していた問題を修正する。
セッション ID は認証トークン相当の機密情報であり、ログ閲覧権限を持つ者によるセッション乗っ取りリスクを生む。
本 PR では、平文セッション ID を SHA-256 ハッシュ値の先頭 8 文字（ハッシュ短縮値）に置き換えることで、
機密性と運用上の追跡可能性（同一セッションの一貫した識別）を両立する。
完全削除ではなく短縮値保持（Option B）は Issue コメントにより人間が確定済み。

## 対応 Issue

Closes #6

## 関連 PR

- 設計 PR: なし（design-less impl。小規模な 1 ファイル変更のため Architect ゲートなし）

## 実装内容

- (Req 1.1〜1.3) `internal/auth/service.go` の `Logout` ログ出力を `session_id`（平文）から `session_id_hash`（SHA-256 ハッシュ先頭 8 文字）に変更
- (Req 2.1〜2.2) `hashSessionIDForLog(sessionID string) string` を新設（package 内 unexported 純粋関数）。同一入力→同一値・異なる入力→区別可能な値を保証
- (Req 3.1〜3.2) 空文字入力でもパニックせず安全に短縮値を返す（`sha256.Sum256([]byte(""))` が自然に動作）
- (Req 4.1〜4.3 / NFR 2.1) セッション破棄ロジック・空文字ガード・ログレベル `Info`・メッセージ `user logged out` はすべて不変

## 受入基準チェック

- [x] Req 1.1: ログ出力に生のセッション ID を含めない ← `TestHashSessionIDForLog_ReturnsEightCharsWithoutRawInput`（生入力非包含）
- [x] Req 1.2: 復元できない短縮値に変換して記録 ← SHA-256 一方向ハッシュ + 8 文字切り出し
- [x] Req 1.3: 短縮値をハッシュ値の先頭 8 文字に限定 ← `TestHashSessionIDForLog_ReturnsEightCharsWithoutRawInput`（`len == 8`）
- [x] Req 2.1: 同一入力→同一短縮値 ← `TestHashSessionIDForLog_SameInput_ReturnsSameValue`
- [x] Req 2.2: 異なる入力→区別可能な短縮値 ← `TestHashSessionIDForLog_DifferentInput_ReturnsDistinctValue`
- [x] Req 3.1: 空入力でパニックせず短縮値を返す ← `TestHashSessionIDForLog_EmptyInput_ReturnsValueWithoutPanic`
- [x] Req 4.1: 有効なセッション ID で従来どおり破棄・正常完了 ← `TestLogout_DeletesSession`（既存・非破壊）
- [x] Req 4.2: 空文字ではログ到達前にエラー ← `TestLogout_EmptySessionID_ReturnsError`（既存・非破壊）
- [x] Req 4.3: 成功時に従来どおり Info レベルで出力 ← `slog.Info` 維持
- [x] NFR 1.1: ログ出力にセッション ID 原文を一切含めない ← 実装 + `TestHashSessionIDForLog_ReturnsEightCharsWithoutRawInput`
- [x] NFR 1.2: 一方向変換を用いる ← SHA-256 採用
- [x] NFR 2.1: 観測可能な挙動（破棄・エラー条件・ログ有無/レベル）を維持 ← 既存テスト 2 件が非破壊で pass

## テスト結果

```
ok  github.com/hitoshi/feedman/internal/auth  （全 PASS、新規 4 テスト含む）
INFO user logged out session_id_hash=6f02c597  ← verbose 実行で生 session_id 非出力を確認
gofmt -l internal/auth/: 出力なし（整形済み）
go vet ./internal/auth/...: 出力なし（pass）
```

## 実装上の判断

- ログキー名を `session_id` → `session_id_hash` に変更した。NFR 2.1 が要求する「観測可能な挙動」（セッション破棄・エラー条件・ログ出力の有無とレベル）には変更なく、Req 1.3 / NFR 1.2 の趣旨（ハッシュ短縮値であることを明示し平文誤認を防ぐ）を優先した変更。
- `hashSessionIDForLog` を純粋関数として切り出し単体テストで AC を担保した（slog ハンドラ差し替えによる複雑な結合テストを避けるため）。

## 確認事項 / レビュワーへの依頼

- base ブランチ検証: `--base develop` 指定 / baseRefName: develop / OK
- レビュー詳細（全 AC の確認結果・Findings）は `docs/specs/6--id/review-notes.md` を参照
- **ログキー名 `session_id` → `session_id_hash` への変更**はレビュワーの確認を要する判断ポイント。既存のログ監視・アラート設定でキー名 `session_id` を参照している場合は `session_id_hash` への更新が必要（詳細は `impl-notes.md` の「実装上の判断」節を参照）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #6 のコメントを参照してください。