### PR TITLE
feat(#14): LOG_LEVEL 環境変数でログレベルを変更可能にする

### DIFF
--- a/docs/specs/14-/impl-notes.md
+++ b/docs/specs/14-/impl-notes.md
@@ -1,0 +1,78 @@
+# 実装ノート（Issue #14: ログレベルを環境変数で変更可能にする）
+
+## 採用した設計判断
+
+- **環境変数の読み取り箇所は logger パッケージ側**: `internal/app/app.go` の `Init` で
+  `logger.SetupDefault(w)` が `config.Load()` より前に呼ばれており（「設定読み込み前に
+  ログを使えるようにする」制約）、ログレベル決定は `config.Config` 構造体を経由できない。
+  そのため logger パッケージ内に `resolveLevel`（`os.Getenv("LOG_LEVEL")` を読み、
+  case-insensitive で `slog.Level` にマッピングする関数）を新設し、`Setup` の
+  `HandlerOptions.Level` に渡す方式を採用した（requirements.md Introduction / Open Questions
+  と整合）。
+- **起動時 1 回のみ反映（Req 1.5 / Out of Scope のランタイム変更非対応）**: `Setup` 呼び出し時に
+  `os.Getenv` を 1 回読み取って `slog.Level` を固定し、以後はプロセス実行中に再評価しない。
+- **不正値時の警告ログを「フォールバック後のロガー自身」で出力（Req 3.2 / NFR 2.1）**:
+  不正値検出時はまず INFO レベルでハンドラ/ロガーを生成し、その生成済みロガー自身で
+  `logger.Warn(...)` を出力する。フォールバック先が INFO のため WARN レベルの本警告は必ず
+  出力され、出力先 writer（本番は `os.Stdout`、テストは `bytes.Buffer`）と整合する形で
+  確実に観測できる。
+- **既存 config パッケージの警告パターンに揃えた（Req 3.2 / NFR 2.2）**: メッセージ文言
+  `"環境変数のパースに失敗したためデフォルト値を採用します"` と属性 `key` / `value` /
+  `default` を `internal/config/config.go` の `getEnvBool` / `getEnvInt` 等と同一形に統一。
+  `default` 属性は `slog.Level.String()`（"INFO"）を文字列で格納する。
+- **マジックストリングの定数化（コード規約）**: `envLogLevel`（"LOG_LEVEL"）/ `defaultLevel`
+  （`slog.LevelInfo`）/ `invalidLevelWarnMsg` を定数化。exported 関数 `Setup` / `SetupDefault`
+  の doc comment を更新した。
+- **シグネチャ互換維持**: `Setup(io.Writer) *slog.Logger` / `SetupDefault(io.Writer)` の
+  シグネチャは変更せず、既存テスト・既存呼び出し（`internal/app/app.go`）に影響を与えない。
+
+## Feature Flag
+
+- 本リポジトリの `CLAUDE.md` `## Feature Flag Protocol` は **採否: opt-out** のため、
+  Feature Flag は導入していない（通常の単一実装パス）。
+
+## テスト観点（AC との対応）
+
+`internal/logger/logger_test.go` に table-driven テストおよび個別テストを追加した。
+
+| Requirement / AC | 検証テスト |
+|---|---|
+| 1.1（DEBUG で全レベル出力） | `TestSetup_RespectsLogLevelEnv/DEBUGのとき全レベル出力` |
+| 1.2（INFO で DEBUG 抑制） | `TestSetup_RespectsLogLevelEnv/INFOのときDEBUG抑制` |
+| 1.3（WARN で DEBUG/INFO 抑制） | `TestSetup_RespectsLogLevelEnv/WARNのときDEBUGとINFO抑制` |
+| 1.4（ERROR で ERROR のみ） | `TestSetup_RespectsLogLevelEnv/ERRORのときERRORのみ出力` |
+| 1.5（起動時 1 回のみ反映） | `Setup` が `os.Getenv` を 1 回読むのみである実装で担保。境界は 1.1〜1.4 の出力境界テストでカバー |
+| 2.1（未設定は INFO） | `TestSetup_RespectsLogLevelEnv/未設定のときINFO相当`（既存 `TestSetup_*` も env 未設定で INFO 動作を担保） |
+| 2.2（空文字は未設定と同一） | `TestSetup_RespectsLogLevelEnv/空文字のときINFO相当` |
+| 3.1（不正値は INFO フォールバック） | `TestSetup_RespectsLogLevelEnv/不正値VERBOSEのときINFOフォールバックと警告` |
+| 3.2（警告ログにキー・値・デフォルト） | `TestSetup_InvalidLevelWarnIncludesContext` |
+| 3.3（異常終了せず継続） | `TestSetup_InvalidLevelDoesNotFail`（nil を返さず継続） + 不正値ケースが正常に後続ログを出力する点で担保 |
+| 4.1（小文字を同一視） | `TestSetup_RespectsLogLevelEnv/小文字debugのときDEBUG扱い` |
+| 4.2（大文字小文字混在を同一視） | `TestSetup_RespectsLogLevelEnv/混在Warnのときwarn扱い` |
+| NFR 1.1（後方互換 INFO 維持） | 未設定/空文字ケース + 既存 `TestSetup_*`（変更なしで pass） |
+| NFR 2.1（一貫したフォールバック手順） | `TestSetup_RespectsLogLevelEnv` 不正値ケース + `TestSetup_InvalidLevelWarnIncludesContext` |
+| NFR 2.2（他環境変数と一貫した警告形式） | `TestSetup_InvalidLevelWarnIncludesContext`（`key`/`value`/`default` 属性を config パターンと同形で検証） |
+
+- 環境変数を使うテストは `t.Setenv` を使用（テストスコープで自動復元）。未設定ケースは
+  `t.Setenv` で復元対象に登録した上で `os.Unsetenv` で実際に未設定状態を作る。
+- 異常系・境界値: 不正値（VERBOSE / NOPE）、空文字、各レベルの出力境界（DEBUG/INFO/WARN/ERROR）
+  をカバー。
+
+## テスト結果
+
+- `go test ./...`: 全パッケージ pass（`internal/logger` 含む）。
+- `go vet ./...`: 指摘なし。
+- `gofmt -l internal/logger/`: 差分なし（clean）。
+
+## 確認事項（レビュワー判断ポイント）
+
+- 不正値時の警告ログは「INFO ハンドラ生成後にそのロガー自身で出力」する方式とした。
+  仮にデフォルトレベルが将来 WARN より上（ERROR）に変更されると本警告が抑制される懸念が
+  あるが、本要件のデフォルトは INFO 固定（後方互換）であり現状は問題ない。デフォルトを
+  変更する将来要件が出た場合は警告出力経路の再設計が必要になる旨を申し送る。
+- ログレベルの読み取りは `Setup` 呼び出し時に行うため、`Setup` を複数回呼ぶと都度
+  `os.Getenv` を再評価する。アプリ起動時は `SetupDefault` が `Init` で 1 回だけ呼ばれる
+  ため Req 1.5（起動時 1 回反映）は満たすが、テスト等で `Setup` を複数回呼ぶ場合は呼び出し
+  時点の env が反映される点に留意（テストはこの性質を利用して各ケースを検証している）。
+
+STATUS: complete

--- a/docs/specs/14-/requirements.md
+++ b/docs/specs/14-/requirements.md
@@ -1,0 +1,74 @@
+# Requirements Document
+
+## Introduction
+
+Feedman のロガーは出力レベルが `slog.LevelInfo` にハードコードされており、環境変数で切り替えられない。
+このため開発時に DEBUG ログを有効化したり、本番で WARN 以上に絞ったりするには再ビルドが必要になっている。
+本要件は、環境変数（仮称 `LOG_LEVEL`）により起動時にログレベルを選択可能とし、運用環境ごとにログ量を
+調整できるようにすることを目的とする。なお、ロガーは設定読み込み（`config.Load`）より前に初期化される制約
+（「設定読み込み前にログを使えるようにする」というアプリ初期化順序）があるため、ログレベルの決定は config 構造体を
+経由できない前提となる。後方互換（未設定時 INFO）と不正値時のサイレント失敗回避を非機能要件として維持する。
+
+## Requirements
+
+### Requirement 1: 環境変数によるログレベル選択
+
+**Objective:** As a 運用者, I want 環境変数でログレベルを選択して起動できること, so that 再ビルドなしで開発時は詳細ログ・本番は重要ログのみに切り替えられる
+
+#### Acceptance Criteria
+
+1. When `LOG_LEVEL=DEBUG` を指定して起動したとき, the Logger shall DEBUG 以上のレベル（DEBUG / INFO / WARN / ERROR）のログを出力する。
+2. When `LOG_LEVEL=INFO` を指定して起動したとき, the Logger shall INFO 以上のレベル（INFO / WARN / ERROR）のログを出力し DEBUG を抑制する。
+3. When `LOG_LEVEL=WARN` を指定して起動したとき, the Logger shall WARN 以上のレベル（WARN / ERROR）のログを出力し DEBUG / INFO を抑制する。
+4. When `LOG_LEVEL=ERROR` を指定して起動したとき, the Logger shall ERROR レベルのログのみを出力し DEBUG / INFO / WARN を抑制する。
+5. The Logger shall 起動時に決定したログレベルを当該プロセスの実行中は固定して適用する（起動時の 1 回のみ反映する）。
+
+### Requirement 2: 未設定時の後方互換
+
+**Objective:** As a 既存運用者, I want 環境変数を設定しないとき従来どおりの挙動になること, so that 本変更を取り込んでも既存の起動構成を変更せずに済む
+
+#### Acceptance Criteria
+
+1. When 環境変数 `LOG_LEVEL` が未設定のまま起動したとき, the Logger shall INFO 以上のレベル（INFO / WARN / ERROR）のログを出力する。
+2. If 環境変数 `LOG_LEVEL` が空文字で指定されたとき, the Logger shall INFO 以上のレベルを適用し未設定時と同一の挙動とする。
+
+### Requirement 3: 不正値指定時のフォールバック
+
+**Objective:** As a 運用者, I want 不正なレベル文字列を指定してもサイレントに失敗せず一貫した挙動になること, so that 設定ミスに気づきつつアプリの起動継続を妨げない
+
+#### Acceptance Criteria
+
+1. If `LOG_LEVEL` に許容値（DEBUG / INFO / WARN / ERROR）以外の文字列（例 `VERBOSE`）が指定されたとき, the Logger shall デフォルトの INFO レベルにフォールバックして起動を継続する。
+2. If `LOG_LEVEL` に不正値が指定されてフォールバックが発生したとき, the Logger shall 指定キー・指定値・採用したデフォルトレベルを含む警告ログを出力する。
+3. If `LOG_LEVEL` に不正値が指定されたとき, the Logger shall プロセスを異常終了させずに起動を継続する。
+
+### Requirement 4: 大文字小文字非依存の解釈
+
+**Objective:** As a 運用者, I want レベル文字列の大文字小文字を区別せず指定できること, so that 表記ゆれを意識せずに環境変数を設定できる
+
+#### Acceptance Criteria
+
+1. When `LOG_LEVEL` にレベル名を小文字（例 `debug`）で指定したとき, the Logger shall 対応する大文字表記（`DEBUG`）と同一のログレベルを適用する。
+2. When `LOG_LEVEL` にレベル名を大文字小文字混在（例 `Warn`）で指定したとき, the Logger shall 大文字小文字を区別せず対応するログレベルを適用する。
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. While 環境変数 `LOG_LEVEL` を設定していない状態で起動している間, the Logger shall 本変更導入前と同一の出力レベル（INFO 以上）を維持する。
+
+### NFR 2: 障害耐性（サイレント失敗回避）
+
+1. While 不正な `LOG_LEVEL` 値が指定された状態で起動した間, the Logger shall 警告ログ出力とデフォルトレベル採用を毎回同じ手順で一貫して行い、サイレントに失敗しない。
+2. The Logger shall 環境変数の不正値に対する挙動を、本プロジェクトの他環境変数で採用済みの「警告ログ出力 + デフォルト採用」方針と運用者から見て一貫した形にする。
+
+## Out of Scope
+
+- ログフォーマットの変更（JSON 構造化ログ以外の形式への切り替え）。
+- ログ出力先の切り替え（標準出力以外への出力先指定）。
+- ランタイム中の動的なログレベル変更（起動後にレベルを変更する機構）。
+- ログレベル以外の環境変数（出力先・サンプリング・ローテーション等）の追加。
+
+## Open Questions
+
+- なし（環境変数名 `LOG_LEVEL`・不正値時は INFO フォールバック + 警告・大文字小文字非依存、を本要件で確定。実装手段（環境変数の読み取り箇所が logger 側か config 経由か）は design / 実装の領分）。

--- a/docs/specs/14-/review-notes.md
+++ b/docs/specs/14-/review-notes.md
@@ -1,0 +1,45 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-14-impl-
+- HEAD commit: 076f7e976fac880e58d7db1a8ae0e9b4bca782c7
+- Compared to: develop..HEAD
+- 備考: 本 spec は design-less impl のため `design.md` / `tasks.md` は存在しない。
+  `_Boundary:_` アノテーションが無いため、boundary 逸脱は「変更が機能の自然なコンポーネント
+  （logger パッケージ）に閉じているか」で評価した。
+- Feature Flag Protocol: `CLAUDE.md` の `**採否**: opt-out` のため flag 観点は適用せず、
+  通常の 3 カテゴリ判定のみを実施した。
+
+## Verified Requirements
+
+- 1.1 — `internal/logger/logger.go:31` `resolveLevel` が `DEBUG` を `slog.LevelDebug` へマップ / テスト `TestSetup_RespectsLogLevelEnv/DEBUGのとき全レベル出力`
+- 1.2 — `internal/logger/logger.go:33` `INFO` → `slog.LevelInfo` / テスト `.../INFOのときDEBUG抑制`
+- 1.3 — `internal/logger/logger.go:35` `WARN` → `slog.LevelWarn` / テスト `.../WARNのときDEBUGとINFO抑制`
+- 1.4 — `internal/logger/logger.go:37` `ERROR` → `slog.LevelError` / テスト `.../ERRORのときERRORのみ出力`
+- 1.5 — `Setup`（logger.go:51）が `os.Getenv` を呼び出し時に 1 回だけ読み handler の Level に固定。ランタイム再評価なし（出力境界テスト 1.1〜1.4 で担保）
+- 2.1 — `resolveLevel` の `raw == ""` 分岐（logger.go:27）で `defaultLevel`(INFO) / テスト `.../未設定のときINFO相当`
+- 2.2 — 空文字も同一分岐 / テスト `.../空文字のときINFO相当`
+- 3.1 — `resolveLevel` の `default` 分岐（logger.go:39）が defaultLevel と invalid=true を返す / テスト `.../不正値VERBOSEのときINFOフォールバックと警告`
+- 3.2 — `Setup` の `logger.Warn`（logger.go:60）が `key`/`value`/`default` 属性を付与 / テスト `TestSetup_InvalidLevelWarnIncludesContext`
+- 3.3 — `Setup` が nil を返さず警告後も継続（logger.go:67） / テスト `TestSetup_InvalidLevelDoesNotFail`
+- 4.1 — `strings.ToUpper`（logger.go:30）で小文字を同一視 / テスト `.../小文字debugのときDEBUG扱い`
+- 4.2 — 同上で大文字小文字混在を同一視 / テスト `.../混在Warnのときwarn扱い`
+- NFR 1.1 — defaultLevel=INFO（logger.go:15）で後方互換維持 / 未設定・空文字ケース + 既存 `TestSetup_*`（無改変で pass）
+- NFR 2.1 — 不正値時の警告 + INFO フォールバックを毎回同一手順で実行（logger.go:58-65） / テスト `TestSetup_InvalidLevelWarnIncludesContext`
+- NFR 2.2 — メッセージ文言と `key`/`value`/`default` 属性を config パッケージのパターンに統一（logger.go:19, 60-64） / 上記テストで属性形を検証
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric ID（1.1〜1.5 / 2.1〜2.2 / 3.1〜3.3 / 4.1〜4.2 / NFR 1.1 / NFR 2.1〜2.2）に
+対応する実装とテストが揃い、正常系・異常系（不正値）・境界値（各レベル出力境界）・空入力を
+カバー。変更は logger パッケージと spec docs に閉じており boundary 逸脱なし。
+`go test ./internal/logger/...` を再実行し全テスト green を確認した。
+
+RESULT: approve

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -4,18 +4,71 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 )
 
+// envLogLevel は出力ログレベルを指定する環境変数名。
+const envLogLevel = "LOG_LEVEL"
+
+// defaultLevel は LOG_LEVEL が未設定・空文字・不正値のときに採用するデフォルトレベル。
+// 本変更導入前のハードコード値（INFO）と等価であり、後方互換を維持する。
+const defaultLevel = slog.LevelInfo
+
+// invalidLevelWarnMsg は不正な LOG_LEVEL が指定されデフォルトへフォールバックした際に
+// 出力する警告ログのメッセージ。config パッケージの環境変数パース失敗時の文言と揃える。
+const invalidLevelWarnMsg = "環境変数のパースに失敗したためデフォルト値を採用します"
+
+// resolveLevel は環境変数 LOG_LEVEL を読み取り、対応する slog.Level を返す。
+// 未設定・空文字の場合は defaultLevel（INFO）を返し、後方互換を維持する。
+// 許容値（DEBUG / INFO / WARN / ERROR）以外が指定された場合は defaultLevel を返し、
+// invalid に true をセットする（呼び出し側で警告ログを出力させるため）。
+// 値の解釈は大文字小文字を区別しない。
+func resolveLevel(raw string) (level slog.Level, invalid bool) {
+	if raw == "" {
+		return defaultLevel, false
+	}
+	switch strings.ToUpper(raw) {
+	case "DEBUG":
+		return slog.LevelDebug, false
+	case "INFO":
+		return slog.LevelInfo, false
+	case "WARN":
+		return slog.LevelWarn, false
+	case "ERROR":
+		return slog.LevelError, false
+	default:
+		return defaultLevel, true
+	}
+}
+
 // Setup はJSON構造化ログ出力のslog.Loggerを生成して返す。
+// 出力レベルは起動時に環境変数 LOG_LEVEL から1回だけ決定する
+// （未設定・空文字・不正値の場合は INFO へフォールバックする）。
+// 不正値が指定された場合は INFO で起動を継続しつつ、フォールバックを示す警告ログを
+// 同じ writer へ出力する（サイレント失敗を回避する）。
 // writerが指定された場合はそのwriterに出力する。
 func Setup(w io.Writer) *slog.Logger {
+	level, invalid := resolveLevel(os.Getenv(envLogLevel))
+
 	handler := slog.NewJSONHandler(w, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: level,
 	})
-	return slog.New(handler)
+	logger := slog.New(handler)
+
+	if invalid {
+		// フォールバックは INFO のため WARN レベルの本ログは必ず出力される。
+		logger.Warn(invalidLevelWarnMsg,
+			slog.String("key", envLogLevel),
+			slog.String("value", os.Getenv(envLogLevel)),
+			slog.String("default", defaultLevel.String()),
+		)
+	}
+
+	return logger
 }
 
 // SetupDefault はJSON構造化ログ出力をグローバルロガーとして設定する。
+// 出力レベルは Setup と同様に環境変数 LOG_LEVEL から決定する。
 // writerが指定された場合はそのwriterに出力する。
 // 本番ではos.Stdoutを渡すことを想定している。
 func SetupDefault(w io.Writer) {

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"log/slog"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -112,5 +114,152 @@ func TestSetupDefault_SetsGlobalLogger(t *testing.T) {
 	}
 	if entry["test_key"] != "test_val" {
 		t.Errorf("test_key = %q, want %q", entry["test_key"], "test_val")
+	}
+}
+
+// parseLogEntries はバッファ内の改行区切り JSON ログを 1 件ずつパースして返すヘルパー。
+func parseLogEntries(t *testing.T, raw string) []map[string]interface{} {
+	t.Helper()
+	var entries []map[string]interface{}
+	for _, line := range strings.Split(strings.TrimSpace(raw), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("failed to parse JSON line %q: %v", line, err)
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// emitAllLevels は対象 logger に DEBUG / INFO / WARN / ERROR の 4 レベルを 1 件ずつ出力する。
+func emitAllLevels(l *slog.Logger) {
+	l.Debug("debug msg")
+	l.Info("info msg")
+	l.Warn("warn msg")
+	l.Error("error msg")
+}
+
+// Requirement 1.1〜1.4 / 2.1 / 2.2 / 4.1 / 4.2: LOG_LEVEL の値に応じた出力境界を検証する。
+func TestSetup_RespectsLogLevelEnv(t *testing.T) {
+	cases := []struct {
+		name     string
+		setEnv   bool
+		envValue string
+		wantMsgs []string // 出力されるべき msg
+		wantWarn bool     // 不正値フォールバック警告ログが出るか
+	}{
+		// Requirement 1.1: DEBUG は全レベル出力
+		{name: "DEBUGのとき全レベル出力", setEnv: true, envValue: "DEBUG", wantMsgs: []string{"debug msg", "info msg", "warn msg", "error msg"}},
+		// Requirement 1.2: INFO は DEBUG 抑制
+		{name: "INFOのときDEBUG抑制", setEnv: true, envValue: "INFO", wantMsgs: []string{"info msg", "warn msg", "error msg"}},
+		// Requirement 1.3: WARN は DEBUG/INFO 抑制
+		{name: "WARNのときDEBUGとINFO抑制", setEnv: true, envValue: "WARN", wantMsgs: []string{"warn msg", "error msg"}},
+		// Requirement 1.4: ERROR は ERROR のみ
+		{name: "ERRORのときERRORのみ出力", setEnv: true, envValue: "ERROR", wantMsgs: []string{"error msg"}},
+		// Requirement 2.1: 未設定は INFO 相当
+		{name: "未設定のときINFO相当", setEnv: false, wantMsgs: []string{"info msg", "warn msg", "error msg"}},
+		// Requirement 2.2: 空文字は未設定と同一
+		{name: "空文字のときINFO相当", setEnv: true, envValue: "", wantMsgs: []string{"info msg", "warn msg", "error msg"}},
+		// Requirement 4.1: 小文字は大文字と同一視
+		{name: "小文字debugのときDEBUG扱い", setEnv: true, envValue: "debug", wantMsgs: []string{"debug msg", "info msg", "warn msg", "error msg"}},
+		// Requirement 4.2: 大文字小文字混在も同一視
+		{name: "混在Warnのときwarn扱い", setEnv: true, envValue: "Warn", wantMsgs: []string{"warn msg", "error msg"}},
+		// Requirement 3.1 / 3.2 / 3.3: 不正値は INFO フォールバック + 警告ログ
+		{name: "不正値VERBOSEのときINFOフォールバックと警告", setEnv: true, envValue: "VERBOSE", wantMsgs: []string{"info msg", "warn msg", "error msg"}, wantWarn: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			if tc.setEnv {
+				t.Setenv("LOG_LEVEL", tc.envValue)
+			} else {
+				t.Setenv("LOG_LEVEL", "")
+				os.Unsetenv("LOG_LEVEL")
+			}
+			var buf bytes.Buffer
+
+			// Act
+			l := Setup(&buf)
+			emitAllLevels(l)
+
+			// Assert
+			entries := parseLogEntries(t, buf.String())
+			var gotMsgs []string
+			gotWarn := false
+			for _, e := range entries {
+				msg, _ := e["msg"].(string)
+				if msg == invalidLevelWarnMsg {
+					gotWarn = true
+					continue
+				}
+				gotMsgs = append(gotMsgs, msg)
+			}
+
+			if len(gotMsgs) != len(tc.wantMsgs) {
+				t.Fatalf("emitted msgs = %v, want %v", gotMsgs, tc.wantMsgs)
+			}
+			for i, want := range tc.wantMsgs {
+				if gotMsgs[i] != want {
+					t.Errorf("msg[%d] = %q, want %q", i, gotMsgs[i], want)
+				}
+			}
+			if gotWarn != tc.wantWarn {
+				t.Errorf("invalid-value warn emitted = %v, want %v", gotWarn, tc.wantWarn)
+			}
+		})
+	}
+}
+
+// Requirement 3.2: 不正値フォールバック時の警告ログにキー・値・採用デフォルトが含まれることを検証する。
+func TestSetup_InvalidLevelWarnIncludesContext(t *testing.T) {
+	// Arrange
+	t.Setenv("LOG_LEVEL", "VERBOSE")
+	var buf bytes.Buffer
+
+	// Act
+	Setup(&buf)
+
+	// Assert
+	entries := parseLogEntries(t, buf.String())
+	var warnEntry map[string]interface{}
+	for _, e := range entries {
+		if e["msg"] == invalidLevelWarnMsg {
+			warnEntry = e
+			break
+		}
+	}
+	if warnEntry == nil {
+		t.Fatalf("expected warn entry %q, got entries: %s", invalidLevelWarnMsg, buf.String())
+	}
+	if warnEntry["level"] != "WARN" {
+		t.Errorf("warn level = %q, want WARN", warnEntry["level"])
+	}
+	if warnEntry["key"] != envLogLevel {
+		t.Errorf("warn key = %q, want %q", warnEntry["key"], envLogLevel)
+	}
+	if warnEntry["value"] != "VERBOSE" {
+		t.Errorf("warn value = %q, want %q", warnEntry["value"], "VERBOSE")
+	}
+	if warnEntry["default"] != "INFO" {
+		t.Errorf("warn default = %q, want %q", warnEntry["default"], "INFO")
+	}
+}
+
+// Requirement 3.3: 不正値でも Setup は nil を返さず起動を継続できることを検証する。
+func TestSetup_InvalidLevelDoesNotFail(t *testing.T) {
+	// Arrange
+	t.Setenv("LOG_LEVEL", "NOPE")
+	var buf bytes.Buffer
+
+	// Act
+	l := Setup(&buf)
+
+	// Assert
+	if l == nil {
+		t.Fatal("expected non-nil logger even with invalid LOG_LEVEL")
 	}
 }


### PR DESCRIPTION
## 概要

Feedman のロガーは出力レベルが `slog.LevelInfo` にハードコードされており、再ビルドなしで変更できなかった。
本 PR では環境変数 `LOG_LEVEL` を起動時に読み取り、DEBUG / INFO / WARN / ERROR のいずれかに設定できるようにした。
未設定・空文字の場合は従来どおり INFO（後方互換）、不正値の場合は INFO にフォールバックして警告ログを出力する。
大文字小文字は区別しない。

## 対応 Issue

Closes #14

## 関連 PR

なし

## 実装内容

- (Req 1.1〜1.4) `internal/logger/logger.go` に `resolveLevel` 関数を追加し、`LOG_LEVEL` env を case-insensitive で `slog.Level` にマッピング
- (Req 1.5) `Setup` 呼び出し時に 1 回だけ `os.Getenv` を読み取り、プロセス実行中はレベルを固定
- (Req 2.1〜2.2) 未設定・空文字の場合は `defaultLevel`（`slog.LevelInfo`）を適用して後方互換を維持
- (Req 3.1〜3.3) 不正値時は INFO にフォールバックし、生成済みロガー自身で警告ログ（`key`/`value`/`default` 属性付き）を出力してプロセスを継続
- (Req 4.1〜4.2) `strings.ToUpper` で大文字小文字を正規化し、`debug` / `Warn` 等の表記ゆれを許容
- (NFR 2.2) 警告メッセージ文言・属性キーを `internal/config/config.go` の `getEnvBool` / `getEnvInt` パターンと統一

## 受入基準チェック

- [x] Req 1.1: `When LOG_LEVEL=DEBUG`, the Logger shall DEBUG 以上を出力 ← `TestSetup_RespectsLogLevelEnv/DEBUGのとき全レベル出力`
- [x] Req 1.2: `When LOG_LEVEL=INFO`, the Logger shall INFO 以上を出力・DEBUG を抑制 ← `.../INFOのときDEBUG抑制`
- [x] Req 1.3: `When LOG_LEVEL=WARN`, the Logger shall WARN 以上を出力 ← `.../WARNのときDEBUGとINFO抑制`
- [x] Req 1.4: `When LOG_LEVEL=ERROR`, the Logger shall ERROR のみ出力 ← `.../ERRORのときERRORのみ出力`
- [x] Req 2.1: 未設定時は INFO ← `.../未設定のときINFO相当`
- [x] Req 2.2: 空文字は未設定と同一 ← `.../空文字のときINFO相当`
- [x] Req 3.1: 不正値は INFO フォールバック ← `.../不正値VERBOSEのときINFOフォールバックと警告`
- [x] Req 3.2: フォールバック時に key/value/default 属性付き警告ログ ← `TestSetup_InvalidLevelWarnIncludesContext`
- [x] Req 3.3: 不正値でも異常終了しない ← `TestSetup_InvalidLevelDoesNotFail`
- [x] Req 4.1〜4.2: 小文字・混在大文字小文字を同一視 ← `.../小文字debugのときDEBUG扱い` / `.../混在Warnのときwarn扱い`
- [x] NFR 1.1: 未設定時の後方互換（INFO 維持）← 既存 `TestSetup_*` が無改変で pass
- [x] NFR 2.1〜2.2: 一貫したフォールバック手順・警告形式 ← `TestSetup_InvalidLevelWarnIncludesContext`

## テスト結果

```
go test ./...: 全パッケージ pass（internal/logger を含む）
go vet ./...: 指摘なし
gofmt -l internal/logger/: 差分なし（clean）
```

## 実装上の判断

- ログレベル決定は `config.Load` 呼び出し前に `logger.SetupDefault` が実行される制約があるため、`config.Config` 構造体を経由せず logger パッケージ内で `os.Getenv` を直接読む方式を採用した。
- 不正値時の警告ログは「INFO ハンドラ生成後にそのロガー自身で出力」する方式とした。デフォルトが将来 WARN より上に変更される場合は警告出力経路の再設計が必要になる（現状は INFO 固定のため問題なし）。
- `Setup` を複数回呼ぶと都度 `os.Getenv` を再評価するが、アプリ起動時は `SetupDefault` が `Init` で 1 回だけ呼ばれるため Req 1.5（起動時 1 回反映）を満たす。

## 確認事項 / レビュワーへの依頼

- 独立 Reviewer による全 AC 確認済み（RESULT: approve）。詳細は `docs/specs/14-/review-notes.md` を参照。
- base 検証: `--base develop` 指定 / baseRefName: develop / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #14 のコメントを参照してください。
