### PR TITLE
feat(#45): subscription.Service.UpdateSettings の単体テストを追加

### DIFF
--- a/docs/specs/45-subscription-service-updatesettings/impl-notes.md
+++ b/docs/specs/45-subscription-service-updatesettings/impl-notes.md
@@ -1,0 +1,55 @@
+# 実装ノート: Issue #45 `subscription.Service.UpdateSettings` の単体試験追加
+
+## 概要
+
+`internal/subscription/service.go` の `Service.UpdateSettings`（service.go:105-149）に対する
+単体テストを `internal/subscription/service_test.go` の末尾に 7 件追加した。実装コード
+（`service.go`）は変更していない（テスト追加のみ・後方互換 / NFR 1.1）。
+
+`UpdateSettings` 関数の関数カバレッジは追加前 0.0% → 追加後 **100.0%** に到達した。
+
+## 追加したテストと AC の対応（受入基準トレーサビリティ）
+
+| テスト関数 | 検証内容 | 対応 AC |
+|---|---|---|
+| `TestService_UpdateSettings_Success` | 有効間隔(60)・所有者一致・全依存成功で `SubscriptionInfo` を返し、`UpdateFetchInterval` が呼ばれる | Req 1.1 |
+| `TestService_UpdateSettings_WrongUser_ReturnsSubscriptionNotFound` | 別 UserID 所有の購読指定時に `ErrCodeSubscriptionNotFound` を返し、`UpdateFetchInterval` が呼ばれない（`updateCalled == false`） | Req 1.2 / 2.1 / 2.2 |
+| `TestService_UpdateSettings_SubscriptionNotFound` | `FindByID` が `(nil, nil)` を返すとき `ErrCodeSubscriptionNotFound` を返す | Req 1.3 |
+| `TestService_UpdateSettings_FindByIDError` | `FindByID` が `(nil, err)` を返すとき、`errors.Is` で sentinel error が wrap 伝播していることを検証 | Req 1.4 |
+| `TestService_UpdateSettings_UpdateFetchIntervalError` | `UpdateFetchInterval` がエラーを返すとき、`errors.Is` で wrap 伝播を検証 | Req 1.5 |
+| `TestService_UpdateSettings_ListByUserIDWithFeedInfoError` | 所有者一致・更新成功後、`ListByUserIDWithFeedInfo` がエラーを返すとき、`errors.Is` で wrap 伝播を検証 | Req 1.6 |
+| `TestService_UpdateSettings_NotFoundAfterUpdate` | 全依存成功だが再取得結果に対象 `subscriptionID` が含まれない（別 ID のみ）場合に `ErrCodeSubscriptionNotFound` を返す | Req 1.7 |
+
+NFR 2.1（既存テスト非破壊）/ NFR 2.2（1 テスト = 1 検証対象、各分岐を個別ケースに分離）/
+NFR 3.1（永続層・ネットワークに依存せず決定論的）は、既存 `mockSubRepo` を差し替えた
+自己完結テストとして満たしている。バリデーション境界値（Req 1 の前提分岐）は既存
+`TestService_UpdateSettings_BoundaryValues` でカバー済みのため重複追加していない（Out of Scope）。
+
+## 実装上の判断
+
+- 有効なフェッチ間隔は 60（30〜720・30 分刻みの規約を満たす中間値）を使用。これにより
+  バリデーション分岐を通過し、`FindByID` 以降の分岐に到達することを保証した。
+- DB エラー伝播系（Req 1.4 / 1.5 / 1.6）は `errors.New(...)` のローカル sentinel error を
+  定義し、`UpdateSettings` 内の `fmt.Errorf("...: %w", err)` による wrap を `errors.Is` で
+  確認している。エラーコード判定系（Req 1.2 / 1.3 / 1.7）は既存
+  `TestService_UpdateSettings_BoundaryValues` と同じく `err.(*model.APIError)` 型アサーション
+  → `apiErr.Code` 比較で行った。
+- `errors` を import に追加した（既存 import を壊さず追記）。
+- `_WrongUser_` ケースでは `updateCalled` フラグで「認可拒否時に更新処理が呼ばれない」
+  ことを明示的に固定し、#34 同型の IDOR / Broken Access Control 回帰を検知できるようにした。
+
+## 検証結果
+
+- `gofmt -l internal/subscription/`: 整形漏れなし（出力なし）
+- `go vet ./internal/subscription/`: 警告なし（pass）
+- `go test ./internal/subscription/ -run TestService -v`: 追加 7 件 + 既存テスト 全て PASS
+  （`ok github.com/hitoshi/feedman/internal/subscription`）
+- `go test ./internal/subscription/ -run TestService_UpdateSettings -cover`: coverage 27.6%（パッケージ全体）
+- 関数別カバレッジ: `UpdateSettings` = **100.0%**、`isValidFetchInterval` = 100.0%
+
+## 確認事項
+
+- なし。requirements.md の Open Questions も「なし」であり、Issue 本文・既存実装・既存テストで
+  分岐と期待結果が確定しているため、推測による実装は不要だった。
+
+STATUS: complete

--- a/docs/specs/45-subscription-service-updatesettings/requirements.md
+++ b/docs/specs/45-subscription-service-updatesettings/requirements.md
@@ -1,0 +1,66 @@
+# Requirements Document
+
+## Introduction
+
+`internal/subscription/service.go` の `Service.UpdateSettings` は購読のフェッチ間隔を更新する
+サービス層メソッドだが、単体テストカバレッジが 0.0% であり回帰試験が存在しない。特に
+認可チェック（要求ユーザーと購読所有ユーザーの不一致時に `SUBSCRIPTION_NOT_FOUND` を返す経路）を
+守るテストが無く、#34 と同型の IDOR / Broken Access Control が再発しても検知できない。本機能は
+`UpdateSettings` の各分岐を網羅する単体テストを追加し、回帰検知の安全網を整備することを目的とする。
+実装コード（`service.go`）の挙動変更・リファクタは行わず、テスト追加のみをスコープとする。
+
+## Requirements
+
+### Requirement 1: UpdateSettings の正常系・異常系分岐の単体テスト網羅
+
+**Objective:** As a Feedman の保守担当者, I want `Service.UpdateSettings` の各実行分岐が単体テストで検証されること, so that フェッチ間隔更新ロジックの回帰や認可チェックの退行を CI で早期に検知できる
+
+`UpdateSettings` の処理フローは「フェッチ間隔バリデーション → 購読フェッチ（FindByID）→
+nil チェック → 所有ユーザー一致チェック → フェッチ間隔更新 → 更新後の購読一覧再取得 →
+該当 ID 探索 → 結果返却」で構成される。本要件はバリデーション分岐
+（既存 `TestService_UpdateSettings_BoundaryValues` でカバー済み）を除く各分岐を補完する。
+
+#### Acceptance Criteria
+
+1. When 有効なフェッチ間隔と所有者一致の購読 ID が与えられ全ての依存処理が成功する場合, the Subscription Service shall フェッチ間隔を更新し、更新後の購読情報を返すことが単体テストで検証される
+2. If 指定された購読 ID の所有ユーザーが要求ユーザーと一致しない場合, the Subscription Service shall `SUBSCRIPTION_NOT_FOUND` のエラーコードを返すことが単体テストで検証される
+3. If 指定された購読 ID に対応する購読が存在しない（購読フェッチが該当なしを返す）場合, the Subscription Service shall `SUBSCRIPTION_NOT_FOUND` のエラーコードを返すことが単体テストで検証される
+4. If 購読フェッチ処理が永続層エラーを返す場合, the Subscription Service shall 当該エラーを wrap して伝播することが単体テストで検証される
+5. If フェッチ間隔更新処理がエラーを返す場合, the Subscription Service shall 当該エラーを wrap して伝播することが単体テストで検証される
+6. If 更新後の購読一覧再取得処理がエラーを返す場合, the Subscription Service shall 当該エラーを wrap して伝播することが単体テストで検証される
+7. If 更新後の購読一覧再取得結果に対象購読 ID が含まれない場合, the Subscription Service shall `SUBSCRIPTION_NOT_FOUND` のエラーコードを返すことが単体テストで検証される
+
+### Requirement 2: 認可チェック回帰防止の明示
+
+**Objective:** As a Feedman のセキュリティ責任者, I want 他ユーザーの購読 ID 指定が情報漏洩なく拒否されることを単体テストで固定すること, so that #34 と同型の IDOR / Broken Access Control の再発を回帰試験で検知できる
+
+#### Acceptance Criteria
+
+1. If 他ユーザーが所有する購読 ID が要求された場合, the Subscription Service shall 購読の存在を示唆せず `SUBSCRIPTION_NOT_FOUND`（存在しない場合と同一）のエラーコードを返すことが単体テストで検証される
+2. When 認可チェックで拒否される場合, the Subscription Service shall フェッチ間隔更新処理を呼び出さないことが単体テストで検証される
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換（実装挙動の不変性）
+
+1. The Subscription Service shall 本テスト追加の前後で `UpdateSettings` の入出力挙動を変えない（テスト追加に伴う実装コードの挙動変更・リファクタを行わない）
+
+### NFR 2: 既存テストとの非干渉
+
+1. The 単体テストスイート shall 既存テスト（`TestService_UpdateSettings_BoundaryValues` を含む `internal/subscription` パッケージの全テスト）を破壊せず、追加後も全て pass する
+2. The 単体テストスイート shall 1 テスト = 1 検証対象の粒度を保ち、正常系・異常系・境界経路を個別のテストケースとして分離する
+
+### NFR 3: テストの自己完結性
+
+1. The 単体テスト shall 外部の永続層・ネットワークに依存せず、依存処理を差し替えた状態で決定論的に実行できる
+
+## Out of Scope
+
+- `UpdateSettings` 以外のメソッド（`ListSubscriptions` / `Unsubscribe` / `ResumeFetch` 等）のテスト追加（#47 で別途扱う）
+- 実装コード（`internal/subscription/service.go`）の挙動変更・リファクタ・バグ修正
+- フェッチ間隔バリデーション境界値テスト（既存 `TestService_UpdateSettings_BoundaryValues` でカバー済み）
+- 結合テスト・E2E テスト（実 PostgreSQL を介したユースケース検証）
+
+## Open Questions
+
+- なし（Issue 本文・既存実装・既存テストで分岐と期待結果が確定しており、人間判断が必要な決定事項は無い。Issue コメントは triage 自動コメントのみで追加の人間判断は記載されていない）

--- a/docs/specs/45-subscription-service-updatesettings/review-notes.md
+++ b/docs/specs/45-subscription-service-updatesettings/review-notes.md
@@ -1,0 +1,31 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-45-impl-subscription-service-updatesettings
+- HEAD commit: 75e67026086923ead75376a2270b9b427d5b33c8
+- Compared to: develop..HEAD
+
+## Verified Requirements
+
+- 1.1 — `TestService_UpdateSettings_Success`（service_test.go）: 有効間隔(60)・所有者一致・全依存成功で `SubscriptionInfo` を返し `UpdateFetchInterval` 呼び出しを確認
+- 1.2 — `TestService_UpdateSettings_WrongUser_ReturnsSubscriptionNotFound`: 別 UserID 所有の購読指定時に `ErrCodeSubscriptionNotFound` を返すことを検証
+- 1.3 — `TestService_UpdateSettings_SubscriptionNotFound`: `FindByID` が `(nil, nil)` のとき `ErrCodeSubscriptionNotFound` を返すことを検証
+- 1.4 — `TestService_UpdateSettings_FindByIDError`: `FindByID` の永続層エラーが `errors.Is` で wrap 伝播することを検証
+- 1.5 — `TestService_UpdateSettings_UpdateFetchIntervalError`: `UpdateFetchInterval` エラーの wrap 伝播を検証
+- 1.6 — `TestService_UpdateSettings_ListByUserIDWithFeedInfoError`: 再取得エラーの wrap 伝播を検証
+- 1.7 — `TestService_UpdateSettings_NotFoundAfterUpdate`: 再取得結果に対象 ID 不在のとき `ErrCodeSubscriptionNotFound` を返すことを検証
+- 2.1 — `TestService_UpdateSettings_WrongUser_ReturnsSubscriptionNotFound`: 他ユーザー購読を存在示唆なく NOT_FOUND（1.3 と同一コード）で拒否することを固定
+- 2.2 — 同上テストの `updateCalled == false` アサーション: 認可拒否時に `UpdateFetchInterval` が呼ばれないことを検証
+
+## Findings
+
+なし
+
+## Summary
+
+requirements.md の全 numeric AC（1.1〜1.7 / 2.1 / 2.2）に 1 対 1 対応する単体テストが追加され、`go test ./internal/subscription/` は追加 7 件 + 既存テスト含め全て pass。実装コード（service.go）は無変更で NFR 1.1（後方互換）を満たし、変更範囲は test ファイルと spec docs のみで boundary 逸脱なし。
+
+RESULT: approve

--- a/internal/subscription/service_test.go
+++ b/internal/subscription/service_test.go
@@ -2,6 +2,7 @@ package subscription
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -355,5 +356,317 @@ func TestService_ResumeFetch_NotStopped_ReturnsError(t *testing.T) {
 	_, err := svc.ResumeFetch(context.Background(), "user-1", "sub-1")
 	if err == nil {
 		t.Fatal("expected error for non-stopped feed, got nil")
+	}
+}
+
+// TestService_UpdateSettings_Success は有効間隔・所有者一致・全依存成功時に
+// 更新後の購読情報を返し UpdateFetchInterval が呼ばれることを検証する（要件 1.1）。
+func TestService_UpdateSettings_Success(t *testing.T) {
+	// Arrange
+	now := time.Now()
+	updateCalled := false
+	const wantMinutes = 60
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return &model.Subscription{ID: "sub-1", UserID: "user-1", FeedID: "feed-1"}, nil
+		},
+		updateFetchIntervalFn: func(ctx context.Context, id string, minutes int) error {
+			updateCalled = true
+			return nil
+		},
+		listByUserIDWithFeedFn: func(ctx context.Context, userID string) ([]repository.SubscriptionWithFeedInfo, error) {
+			return []repository.SubscriptionWithFeedInfo{
+				{
+					Subscription: model.Subscription{
+						ID:                   "sub-1",
+						UserID:               userID,
+						FeedID:               "feed-1",
+						FetchIntervalMinutes: wantMinutes,
+						CreatedAt:            now,
+					},
+					FeedTitle:   "Test Feed",
+					FeedURL:     "https://example.com/feed.xml",
+					FetchStatus: model.FetchStatusActive,
+					UnreadCount: 3,
+				},
+			}, nil
+		},
+	}
+
+	svc := NewService(subRepo, nil, nil)
+
+	// Act
+	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", wantMinutes)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !updateCalled {
+		t.Error("expected UpdateFetchInterval to be called")
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.ID != "sub-1" {
+		t.Errorf("ID = %q, want %q", result.ID, "sub-1")
+	}
+	if result.FetchIntervalMinutes != wantMinutes {
+		t.Errorf("FetchIntervalMinutes = %d, want %d", result.FetchIntervalMinutes, wantMinutes)
+	}
+	if result.FeedTitle != "Test Feed" {
+		t.Errorf("FeedTitle = %q, want %q", result.FeedTitle, "Test Feed")
+	}
+	if result.UnreadCount != 3 {
+		t.Errorf("UnreadCount = %d, want %d", result.UnreadCount, 3)
+	}
+}
+
+// TestService_UpdateSettings_WrongUser_ReturnsSubscriptionNotFound は
+// 他ユーザー所有の購読 ID 指定時に SUBSCRIPTION_NOT_FOUND を返し、
+// フェッチ間隔更新が呼ばれないことを検証する（要件 1.2 / 2.1 / 2.2）。
+func TestService_UpdateSettings_WrongUser_ReturnsSubscriptionNotFound(t *testing.T) {
+	// Arrange
+	updateCalled := false
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return &model.Subscription{ID: "sub-1", UserID: "user-other", FeedID: "feed-1"}, nil
+		},
+		updateFetchIntervalFn: func(ctx context.Context, id string, minutes int) error {
+			updateCalled = true
+			return nil
+		},
+		listByUserIDWithFeedFn: func(ctx context.Context, userID string) ([]repository.SubscriptionWithFeedInfo, error) {
+			return nil, nil
+		},
+	}
+
+	svc := NewService(subRepo, nil, nil)
+
+	// Act
+	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", 60)
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error for wrong user, got nil")
+	}
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("error type = %T, want *model.APIError", err)
+	}
+	if apiErr.Code != model.ErrCodeSubscriptionNotFound {
+		t.Errorf("error code = %q, want %q", apiErr.Code, model.ErrCodeSubscriptionNotFound)
+	}
+	if updateCalled {
+		t.Error("UpdateFetchInterval should not be called on authorization failure")
+	}
+	if result != nil {
+		t.Errorf("expected nil result, got %+v", result)
+	}
+}
+
+// TestService_UpdateSettings_SubscriptionNotFound は
+// 購読が存在しない（FindByID が nil を返す）場合に
+// SUBSCRIPTION_NOT_FOUND を返すことを検証する（要件 1.3）。
+func TestService_UpdateSettings_SubscriptionNotFound(t *testing.T) {
+	// Arrange
+	updateCalled := false
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return nil, nil
+		},
+		updateFetchIntervalFn: func(ctx context.Context, id string, minutes int) error {
+			updateCalled = true
+			return nil
+		},
+		listByUserIDWithFeedFn: func(ctx context.Context, userID string) ([]repository.SubscriptionWithFeedInfo, error) {
+			return nil, nil
+		},
+	}
+
+	svc := NewService(subRepo, nil, nil)
+
+	// Act
+	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", 60)
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error for missing subscription, got nil")
+	}
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("error type = %T, want *model.APIError", err)
+	}
+	if apiErr.Code != model.ErrCodeSubscriptionNotFound {
+		t.Errorf("error code = %q, want %q", apiErr.Code, model.ErrCodeSubscriptionNotFound)
+	}
+	if updateCalled {
+		t.Error("UpdateFetchInterval should not be called when subscription is missing")
+	}
+	if result != nil {
+		t.Errorf("expected nil result, got %+v", result)
+	}
+}
+
+// TestService_UpdateSettings_FindByIDError は
+// 購読フェッチ（FindByID）が永続層エラーを返す場合に
+// 当該エラーが wrap されて伝播することを検証する（要件 1.4）。
+func TestService_UpdateSettings_FindByIDError(t *testing.T) {
+	// Arrange
+	sentinelErr := errors.New("find by id failed")
+	updateCalled := false
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return nil, sentinelErr
+		},
+		updateFetchIntervalFn: func(ctx context.Context, id string, minutes int) error {
+			updateCalled = true
+			return nil
+		},
+		listByUserIDWithFeedFn: func(ctx context.Context, userID string) ([]repository.SubscriptionWithFeedInfo, error) {
+			return nil, nil
+		},
+	}
+
+	svc := NewService(subRepo, nil, nil)
+
+	// Act
+	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", 60)
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error from FindByID, got nil")
+	}
+	if !errors.Is(err, sentinelErr) {
+		t.Errorf("expected wrapped error to match sentinel, got %v", err)
+	}
+	if updateCalled {
+		t.Error("UpdateFetchInterval should not be called when FindByID fails")
+	}
+	if result != nil {
+		t.Errorf("expected nil result, got %+v", result)
+	}
+}
+
+// TestService_UpdateSettings_UpdateFetchIntervalError は
+// フェッチ間隔更新（UpdateFetchInterval）がエラーを返す場合に
+// 当該エラーが wrap されて伝播することを検証する（要件 1.5）。
+func TestService_UpdateSettings_UpdateFetchIntervalError(t *testing.T) {
+	// Arrange
+	sentinelErr := errors.New("update fetch interval failed")
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return &model.Subscription{ID: "sub-1", UserID: "user-1", FeedID: "feed-1"}, nil
+		},
+		updateFetchIntervalFn: func(ctx context.Context, id string, minutes int) error {
+			return sentinelErr
+		},
+		listByUserIDWithFeedFn: func(ctx context.Context, userID string) ([]repository.SubscriptionWithFeedInfo, error) {
+			return nil, nil
+		},
+	}
+
+	svc := NewService(subRepo, nil, nil)
+
+	// Act
+	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", 60)
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error from UpdateFetchInterval, got nil")
+	}
+	if !errors.Is(err, sentinelErr) {
+		t.Errorf("expected wrapped error to match sentinel, got %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result, got %+v", result)
+	}
+}
+
+// TestService_UpdateSettings_ListByUserIDWithFeedInfoError は
+// 更新後の購読一覧再取得（ListByUserIDWithFeedInfo）がエラーを返す場合に
+// 当該エラーが wrap されて伝播することを検証する（要件 1.6）。
+func TestService_UpdateSettings_ListByUserIDWithFeedInfoError(t *testing.T) {
+	// Arrange
+	sentinelErr := errors.New("list by user id with feed info failed")
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return &model.Subscription{ID: "sub-1", UserID: "user-1", FeedID: "feed-1"}, nil
+		},
+		updateFetchIntervalFn: func(ctx context.Context, id string, minutes int) error {
+			return nil
+		},
+		listByUserIDWithFeedFn: func(ctx context.Context, userID string) ([]repository.SubscriptionWithFeedInfo, error) {
+			return nil, sentinelErr
+		},
+	}
+
+	svc := NewService(subRepo, nil, nil)
+
+	// Act
+	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", 60)
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error from ListByUserIDWithFeedInfo, got nil")
+	}
+	if !errors.Is(err, sentinelErr) {
+		t.Errorf("expected wrapped error to match sentinel, got %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result, got %+v", result)
+	}
+}
+
+// TestService_UpdateSettings_NotFoundAfterUpdate は
+// 更新は成功するが再取得結果に対象購読 ID が含まれない場合に
+// SUBSCRIPTION_NOT_FOUND を返すことを検証する（要件 1.7）。
+func TestService_UpdateSettings_NotFoundAfterUpdate(t *testing.T) {
+	// Arrange
+	now := time.Now()
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return &model.Subscription{ID: "sub-1", UserID: "user-1", FeedID: "feed-1"}, nil
+		},
+		updateFetchIntervalFn: func(ctx context.Context, id string, minutes int) error {
+			return nil
+		},
+		listByUserIDWithFeedFn: func(ctx context.Context, userID string) ([]repository.SubscriptionWithFeedInfo, error) {
+			// 対象 ID（sub-1）を含まない別購読のみを返す
+			return []repository.SubscriptionWithFeedInfo{
+				{
+					Subscription: model.Subscription{
+						ID:                   "sub-other",
+						UserID:               userID,
+						FeedID:               "feed-other",
+						FetchIntervalMinutes: 60,
+						CreatedAt:            now,
+					},
+					FeedTitle:   "Other Feed",
+					FeedURL:     "https://example.com/other.xml",
+					FetchStatus: model.FetchStatusActive,
+				},
+			}, nil
+		},
+	}
+
+	svc := NewService(subRepo, nil, nil)
+
+	// Act
+	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", 60)
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error when target subscription is absent after update, got nil")
+	}
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("error type = %T, want *model.APIError", err)
+	}
+	if apiErr.Code != model.ErrCodeSubscriptionNotFound {
+		t.Errorf("error code = %q, want %q", apiErr.Code, model.ErrCodeSubscriptionNotFound)
+	}
+	if result != nil {
+		t.Errorf("expected nil result, got %+v", result)
 	}
 }


### PR DESCRIPTION
## 概要

`internal/subscription/service.go` の `Service.UpdateSettings`（フェッチ間隔更新メソッド）は単体テストカバレッジが 0.0% で、認可チェック（要求ユーザーと購読所有ユーザーの不一致時に `SUBSCRIPTION_NOT_FOUND` を返す経路）を守るテストが存在しなかった。`#34` と同型の IDOR / Broken Access Control の再発リスクがあるため、各実行分岐を網羅する単体テスト 7 件を `internal/subscription/service_test.go` に追加した。実装コード（`service.go`）は変更なし。

## 対応 Issue

Closes #45

## 関連 PR

- 設計 PR: なし（設計 PR ゲートを経由しない小規模 Issue）

## 実装内容

- (Req 1.1 / NFR 1.1) 正常系テスト追加: 有効間隔・所有者一致・全依存成功で `SubscriptionInfo` を返すことを検証
- (Req 1.2 / 2.1 / 2.2) 認可拒否系テスト追加: 別ユーザー所有の購読 ID 指定時に `SUBSCRIPTION_NOT_FOUND` を返し、更新処理が呼ばれないことを検証（IDOR 回帰防止固定）
- (Req 1.3) 購読未存在系テスト追加: `FindByID` が `(nil, nil)` のとき `SUBSCRIPTION_NOT_FOUND` を返すことを検証
- (Req 1.4) `FindByID` エラー伝播テスト追加: 永続層エラーが `fmt.Errorf("...: %w", err)` で wrap 伝播することを `errors.Is` で検証
- (Req 1.5) `UpdateFetchInterval` エラー伝播テスト追加: 更新処理エラーの wrap 伝播を検証
- (Req 1.6) `ListByUserIDWithFeedInfo` エラー伝播テスト追加: 再取得エラーの wrap 伝播を検証
- (Req 1.7) 再取得後未存在系テスト追加: 再取得結果に対象 ID が含まれない場合に `SUBSCRIPTION_NOT_FOUND` を返すことを検証

## 受入基準チェック

- [x] Req 1.1: 有効なフェッチ間隔と所有者一致の購読 ID で更新成功 ← `TestService_UpdateSettings_Success`
- [x] Req 1.2: 所有ユーザー不一致時に `SUBSCRIPTION_NOT_FOUND` ← `TestService_UpdateSettings_WrongUser_ReturnsSubscriptionNotFound`
- [x] Req 1.3: 購読 ID 存在なし時に `SUBSCRIPTION_NOT_FOUND` ← `TestService_UpdateSettings_SubscriptionNotFound`
- [x] Req 1.4: `FindByID` 永続層エラーの wrap 伝播 ← `TestService_UpdateSettings_FindByIDError`
- [x] Req 1.5: `UpdateFetchInterval` エラーの wrap 伝播 ← `TestService_UpdateSettings_UpdateFetchIntervalError`
- [x] Req 1.6: 再取得エラーの wrap 伝播 ← `TestService_UpdateSettings_ListByUserIDWithFeedInfoError`
- [x] Req 1.7: 再取得後対象 ID 不在時に `SUBSCRIPTION_NOT_FOUND` ← `TestService_UpdateSettings_NotFoundAfterUpdate`
- [x] Req 2.1: 他ユーザー購読が存在示唆なく NOT_FOUND で拒否 ← `TestService_UpdateSettings_WrongUser_ReturnsSubscriptionNotFound`
- [x] Req 2.2: 認可拒否時に更新処理が呼ばれない ← 同テストの `updateCalled == false` アサーション

## テスト結果

```
go test ./internal/subscription/ -run TestService_UpdateSettings -v

--- PASS: TestService_UpdateSettings_BoundaryValues (0.00s)
--- PASS: TestService_UpdateSettings_Success (0.00s)
--- PASS: TestService_UpdateSettings_WrongUser_ReturnsSubscriptionNotFound (0.00s)
--- PASS: TestService_UpdateSettings_SubscriptionNotFound (0.00s)
--- PASS: TestService_UpdateSettings_FindByIDError (0.00s)
--- PASS: TestService_UpdateSettings_UpdateFetchIntervalError (0.00s)
--- PASS: TestService_UpdateSettings_ListByUserIDWithFeedInfoError (0.00s)
--- PASS: TestService_UpdateSettings_NotFoundAfterUpdate (0.00s)
PASS
ok      github.com/hitoshi/feedman/internal/subscription

追加 7 件 + 既存テスト含む全件 PASS
UpdateSettings 関数カバレッジ: 0.0% → 100.0%
```

## 実装上の判断

（`docs/specs/45-subscription-service-updatesettings/impl-notes.md` を参照）

- 有効なフェッチ間隔に 60（30〜720・30 分刻み規約を満たす中間値）を使用し、バリデーション分岐を通過して `FindByID` 以降の分岐に到達することを保証
- エラー伝播系は `errors.New(...)` のローカル sentinel error を定義し `errors.Is` で wrap を確認
- `_WrongUser_` ケースでは `updateCalled` フラグで IDOR 回帰を検知できるよう明示的に固定

## 確認事項

- base=develop 検証: `--base develop` 指定 / `baseRefName: develop` / 一致 OK
- Reviewer による独立レビュー結果（approve 済み）: `docs/specs/45-subscription-service-updatesettings/review-notes.md` を参照

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #45 のコメントを参照してください。
