### PR TITLE
feat(#51): CI にフロントエンドの lint（eslint）と依存脆弱性スキャン（npm audit）を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,45 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  frontend-lint:
+    name: Frontend Lint (eslint)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+  frontend-audit:
+    name: Frontend Dependency Vulnerability Scan (npm audit)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit (fail on high or above)
+        run: npm audit --audit-level=high

--- a/docs/specs/51-ci-lint-npm-audit-eslint/impl-notes.md
+++ b/docs/specs/51-ci-lint-npm-audit-eslint/impl-notes.md
@@ -1,0 +1,142 @@
+# 実装ノート（Issue #51: CI フロントエンド lint / npm audit 追加）
+
+## 概要
+
+CI（`.github/workflows/ci.yml`）にフロントエンド（`web/`）の lint（eslint）と依存脆弱性
+スキャン（`npm audit --audit-level=high`）を追加した。既存 `govulncheck` の独立ジョブ方式に
+合わせて、`frontend-lint` / `frontend-audit` の 2 つの独立ジョブを追加している。
+
+本 Issue は requirements.md のみを入力とする design-less impl（design.md / tasks.md なし）で
+あり、tasks.md が存在しないため stage-a-verify gate の対象外。番号順タスク消化ではなく、
+requirements.md の AC を起点に実装した。
+
+## 実装方針と job 構成の判断理由
+
+### 独立ジョブ化 vs frontend ジョブへの step 追加
+
+NFR 2.1（lint / audit の成否を PR チェック一覧で他ジョブと区別可能な独立ステータスとして
+表示）および Req 3.3（lint / audit の失敗を `npm test` の成否とは独立に判定）を確実に満たす
+ため、`frontend` ジョブへの step 追加ではなく **独立ジョブ化** を採用した。
+
+- **採用理由**:
+  - 既存 `govulncheck` が独立ジョブ（脆弱性検出でジョブを失敗させるブロッキング方式）で
+    あり、フロントエンド側もこの既存方針と一貫させられる（NFR 1.1）。
+  - 独立ジョブにすると GitHub PR チェック一覧に `Frontend Lint (eslint)` /
+    `Frontend Dependency Vulnerability Scan (npm audit)` という独立ステータスが並ぶため、
+    どのチェックが失敗したかが一目で分かる（NFR 2.1）。
+  - 同一ジョブ内の step 追加だと、`npm test` の前段 step が失敗するとジョブ全体が `Frontend
+    Tests` の 1 ステータスにまとまってしまい、lint / audit / test のどれが原因かが
+    チェック一覧から判別しづらく、また step が直列実行されるため早期 step の失敗で
+    後続 step が走らない（Req 3.3 の「独立判定」を満たしにくい）。
+
+- **トレードオフ（記録）**:
+  - 独立ジョブ化により、`checkout` / `setup-node` / `npm ci` の setup が `frontend` /
+    `frontend-lint` / `frontend-audit` の 3 ジョブで重複実行される。`npm ci` が 3 回走る
+    分の実行時間・CI リソースの増加がデメリット。
+  - ただし各ジョブは並列実行されるため wall-clock 時間の増加は限定的であり、`setup-node`
+    の npm キャッシュ（`cache: npm` / `cache-dependency-path: web/package-lock.json`）が
+    効くため依存ダウンロードコストは緩和される。可観測性（NFR 2.1）と独立判定（Req 3.3）の
+    明確さを優先し、setup 重複のコストを許容する判断とした。
+
+### lint の実行
+
+- `npm run lint`（= `web/package.json` の `"lint": "eslint"`）をそのまま実行する。eslint は
+  lint 違反検出時に非ゼロ終了するため、ジョブが失敗し PR チェックが fail になる（Req 1.2）。
+  違反なしなら成功（Req 1.3）。eslint は違反内容を stdout に出力するためジョブログに残る
+  （Req 1.4）。
+- Out of Scope に従い eslint ルールセット（`web/eslint.config.mjs` / `eslint-config-next`）は
+  一切変更していない。
+
+### npm audit の実行
+
+- `npm audit --audit-level=high` を実行する（Req 2.1 / 2.2）。`npm audit` は閾値（`--audit-level`）
+  以上の脆弱性が見つかった場合にのみ非ゼロ終了する。
+  - high / critical 検出時 → 非ゼロ終了 → ジョブ失敗（Req 2.3、NFR 1.1）。
+  - moderate / low / info のみ → ゼロ終了 → ジョブ成功（Req 2.4）。
+  - high 以上の検出なし → ゼロ終了 → ジョブ成功（Req 2.5）。
+- `npm audit` は `package-lock.json` を参照して依存ツリーを評価する。確実性のため audit ジョブ
+  でも先に `npm ci`（lockfile に基づくインストール）を実行してから `npm audit` を走らせる
+  構成にした。検出された脆弱性一覧は stdout に出力されジョブログに残る（Req 2.6）。
+
+### 既存ジョブの後方互換
+
+- `backend` / `go-vet` / `govulncheck` / `frontend`（`npm test`）の各ジョブ定義は一切変更して
+  いない（Req 3.1 / 3.2）。トリガー（`push` / `pull_request` to `main`/`develop`）も無変更で
+  あり、Out of Scope の「トリガー設定踏襲」を満たす。
+
+## 受入基準とテストの対応
+
+本 Issue の成果物は GitHub Actions ワークフロー定義（YAML）であり、アプリケーションコードの
+単体テストを書く対象ではない。AC の担保は (a) ワークフロー定義の静的検証と (b) ローカルでの
+コマンド挙動確認の 2 段で行った。各 AC と検証手段の対応は以下のとおり。
+
+| AC | 内容 | 担保した検証 |
+|---|---|---|
+| 1.1 | PR 時に `web/` で `npm run lint` を実行 | `frontend-lint` ジョブが `working-directory: web` / `run: npm run lint` を持ち、`pull_request: [main, develop]` トリガー配下にあることを YAML parse で確認 |
+| 1.2 | lint 違反でジョブ失敗 | eslint の非ゼロ終了で GitHub Actions の step が fail する仕様に依拠。`npm run lint` を直接実行（exit code 抑制なし） |
+| 1.3 | lint 違反なしでジョブ成功 | 同上（eslint ゼロ終了でジョブ成功） |
+| 1.4 | lint 結果をログ出力 | `npm run lint` の stdout がジョブログに出力される（追加抑制なし） |
+| 2.1 | PR 時に `web/` で `npm audit` を実行 | `frontend-audit` ジョブが `working-directory: web` / `run: npm audit ...` を持つことを YAML parse で確認 |
+| 2.2 | `--audit-level=high` で実行 | `run: npm audit --audit-level=high` を確認 |
+| 2.3 | high 以上でジョブ失敗 | `npm audit --audit-level=high` が high/critical 検出時に非ゼロ終了する仕様に依拠 |
+| 2.4 | high 未満のみなら成功 | 同上（moderate 以下では `--audit-level=high` 指定時にゼロ終了） |
+| 2.5 | high 以上の検出なしで成功 | 同上（ゼロ終了） |
+| 2.6 | audit 結果をログ出力 | `npm audit` の stdout がジョブログに出力される（追加抑制なし） |
+| 3.1 | 既存 `npm test` の成否維持 | `frontend` ジョブを無変更とし diff が新規ジョブ追加のみであることを確認 |
+| 3.2 | 既存 backend / go-vet / govulncheck 維持 | 同上（既存 4 ジョブ定義に変更なし） |
+| 3.3 | lint / audit を `npm test` と独立判定 | lint / audit を `frontend` とは別の独立ジョブにし、ジョブ間に `needs` 依存を張らず並列・独立に成否判定されることを確認 |
+| NFR 1.1 | govulncheck と同じブロッキング方針 | 独立ジョブ + 非ゼロ終了でジョブ失敗、という govulncheck と同型の構成を採用 |
+| NFR 1.2 | moderate 以下でブロックしない | `--audit-level=high` の足切りに依拠（2.4 と同根拠） |
+| NFR 2.1 | PR チェック一覧で独立ステータス表示 | `frontend-lint` / `frontend-audit` を独立ジョブにし、各々固有の `name` を付与（`Frontend Lint (eslint)` / `Frontend Dependency Vulnerability Scan (npm audit)`）したことを確認 |
+
+## 検証結果
+
+### 1. ワークフロー YAML の構文・構成検証（実施・成功）
+
+`python3` の `yaml.safe_load` で `.github/workflows/ci.yml` をパースし、以下を確認した
+（`actionlint` はこの環境に未インストールのため Python yaml で代替検証）:
+
+- YAML として正しくパースできる（構文崩れなし）。
+- jobs キーが `backend` / `go-vet` / `govulncheck` / `frontend` / `frontend-lint` /
+  `frontend-audit` の 6 件であること（既存 4 件は無変更、新規 2 件追加）。
+- トリガー `on` が `push: [main, develop]` / `pull_request: [main, develop]` のまま変化が
+  ないこと。
+- `frontend-lint`: `working-directory: web`、steps が
+  checkout → setup-node → `npm ci` → `npm run lint`。
+- `frontend-audit`: `working-directory: web`、steps が
+  checkout → setup-node → `npm ci` → `npm audit --audit-level=high`。
+
+### 2. `web/` でのローカル lint / audit 実行（未実施 — 環境制約）
+
+本実行環境（worktree のサンドボックス）に **node / npm が存在しない**（`command -v node` /
+`command -v npm` がいずれも未検出、`node_modules` も未生成）。このため
+`npm ci` / `npm run lint` / `npm audit --audit-level=high` のローカル実行による
+「現状の web/ で lint がクリーンに通るか」「audit が high 以上を検出しないか」の事前確認は
+**実施できなかった**。下記「確認事項」に明記する。
+
+### 3. 既存 `npm test` の確認（未実施 — 同上の環境制約）
+
+`npm test` も node/npm 不在のため実行不可。ただし `frontend` ジョブ定義は無変更であり、
+CI 上の `npm test` の挙動は本変更の影響を受けない。
+
+## 確認事項（レビュワー / 人間の判断ポイント）
+
+1. **ローカルでの lint / audit 未検証（環境制約）**: 本実装環境に node / npm が無いため、
+   現状の `web/` で `npm run lint` がクリーンに通るか、`npm audit --audit-level=high` が
+   high 以上の脆弱性を検出しないかを **ローカルで事前確認できていない**。新ジョブが追加
+   された瞬間に、もし既存コードベースに lint 違反または high 以上の脆弱性が存在すれば
+   `frontend-lint` / `frontend-audit` ジョブが即座に fail する。CI 上での初回実行結果
+   （PR チェック）で green になることを確認いただきたい。これはテストを弱める / 握り潰す
+   ことを避け、実態（ブロッキング方式）をそのまま反映した結果である。
+2. **setup 重複のトレードオフ**: 独立ジョブ化により `npm ci` が `frontend` /
+   `frontend-lint` / `frontend-audit` の 3 ジョブで重複実行される（上記「判断理由」参照）。
+   可観測性・独立判定を優先した判断だが、CI 時間 / リソースをよりタイトに抑えたい場合は
+   `frontend` ジョブ内の step 集約も選択肢となる。その場合 NFR 2.1（独立ステータス）/
+   Req 3.3（独立判定）の満たし方を別途検討する必要がある。
+
+## 派生タスク候補
+
+- `actionlint` を CI に組み込む（ワークフロー定義自体の静的検証）案。本 Issue のスコープ外
+  だが、今後ワークフローを増やす際の品質担保として別 Issue 化を検討可能。
+
+STATUS: complete

--- a/docs/specs/51-ci-lint-npm-audit-eslint/requirements.md
+++ b/docs/specs/51-ci-lint-npm-audit-eslint/requirements.md
@@ -1,0 +1,72 @@
+# Requirements Document
+
+## Introduction
+
+Feedman の CI（`.github/workflows/ci.yml`）の `frontend` ジョブは現在 `npm ci` + `npm test` のみを実行しており、フロントエンド（`web/`）の依存パッケージ脆弱性スキャン（`npm audit`）と静的解析（eslint）が CI に組み込まれていない。このため脆弱な npm 依存や lint で検出可能な問題が PR 段階で検知されず、main に混入し得る。本要件は umbrella #40 をフロントエンド側に分割したもので、PR の作成・更新時にフロントエンドの脆弱性スキャンと lint を自動実行し、結果を CI に反映させることをゴールとする。バックエンド側には既に `govulncheck`（脆弱性検出でジョブを失敗させるブロッキング方式）が存在しており、フロントエンド側もこの既存方針との一貫性を取る。
+
+## Requirements
+
+### Requirement 1: フロントエンド lint（eslint）の CI 実行
+
+**Objective:** As a リポジトリのメンテナ, I want PR 上でフロントエンドの eslint が自動実行されること, so that lint で検出可能な問題が main に混入する前に検知できる
+
+#### Acceptance Criteria
+
+1. When PR が `main` または `develop` 向けに作成または更新されたとき, the CI shall `web/` 配下で `npm run lint`（eslint）を実行する
+2. If eslint が lint 違反を検出したとき, the CI shall 該当ジョブを失敗させ PR チェックを fail 状態にする
+3. When eslint が lint 違反を検出しなかったとき, the CI shall 該当ジョブを成功させる
+4. The CI shall lint の実行結果（違反内容を含むログ）を当該ジョブのログに出力する
+
+### Requirement 2: フロントエンド依存脆弱性スキャン（npm audit）の CI 実行
+
+**Objective:** As a リポジトリのメンテナ, I want PR 上でフロントエンドの依存脆弱性スキャンが自動実行されること, so that 脆弱な npm 依存が main に混入する前に検知できる
+
+#### Acceptance Criteria
+
+1. When PR が `main` または `develop` 向けに作成または更新されたとき, the CI shall `web/` 配下で `npm audit` を実行する
+2. The CI shall `npm audit` の閾値を `--audit-level=high` に設定して実行する
+3. If `npm audit` が `high` 以上（high または critical）の脆弱性を検出したとき, the CI shall 該当ジョブを失敗させ PR チェックを fail 状態にする
+4. While 検出された脆弱性が `high` 未満（moderate / low / info）のみであるとき, the CI shall 該当ジョブを成功させる
+5. When `npm audit` が `high` 以上の脆弱性を検出しなかったとき, the CI shall 該当ジョブを成功させる
+6. The CI shall `npm audit` の実行結果（検出された脆弱性の一覧を含むログ）を当該ジョブのログに出力する
+
+### Requirement 3: 既存 CI ジョブとの後方互換性
+
+**Objective:** As a リポジトリのメンテナ, I want 新しい lint / audit の追加が既存の CI ジョブを壊さないこと, so that 既存のテスト・静的解析が従来どおり機能し続ける
+
+#### Acceptance Criteria
+
+1. The CI shall 既存の `npm test`（フロントエンドテスト）を引き続き実行し、変更前と同一の成否判定を維持する
+2. The CI shall 既存の `backend` / `go-vet` / `govulncheck` の各ジョブを変更前と同一の挙動で維持する
+3. Where lint または audit のジョブが失敗したとき, the CI shall その失敗を `npm test` の成否とは独立に判定する
+
+## Non-Functional Requirements
+
+### NFR 1: 一貫性と誤検知への配慮
+
+1. The CI shall フロントエンドの脆弱性スキャンを、バックエンドの `govulncheck` と同じく「閾値以上の検出でブロッキングする」方針で運用する
+2. While `npm audit` の transitive 依存由来の検出が含まれるとき, the CI shall `--audit-level=high` の閾値による足切りを適用し、moderate 以下の検出ではブロックしない（誤検知・更新待ちの多い低重大度検出での PR ブロックを回避するため）
+
+### NFR 2: 可観測性
+
+1. The CI shall lint ジョブと audit ジョブの成否を、GitHub の PR チェック一覧で他ジョブと区別可能な独立したステータスとして表示する
+
+## Out of Scope
+
+- Go 側の静的解析・脆弱性スキャン（既存 `go-vet` / `govulncheck` ジョブで対応済み。本 Issue では変更しない）。
+- コンテナイメージスキャン（Trivy 等。別 Issue）。
+- `npm audit fix` 等による脆弱性の自動修正（検知のみを対象とする）。
+- eslint ルールセット自体の追加・変更（既存 `web/eslint.config.mjs` / `eslint-config-next` の設定をそのまま用いる）。
+- 検出された脆弱性に対する例外許可リスト（allowlist）機構の導入。
+- `develop` 以外のブランチや push トリガーに対する実行ポリシーの変更（既存 `ci.yml` のトリガー設定を踏襲する）。
+
+## Open Questions
+
+本 Issue 本文「判断を委ねたい点」（block/warn ポリシー・`--audit-level` 閾値）について人間からの追加回答コメントは存在しないため、PM が以下の defensible なデフォルトを選定し、本 requirements に明記した。残課題はなし。
+
+- npm audit の block/warn 方針: **`high` 以上の検出でブロッキング**（Req 2.3、NFR 1.1）。
+  - 根拠: 既存 `govulncheck` ジョブが脆弱性検出でジョブを失敗させるブロッキング方式であり、フロントエンド側もこれと一貫させる。
+  - 却下した代替案（警告のみ）: 脆弱性を検知しても PR がマージ可能だと混入リスクが残るため不採用。
+- `--audit-level` 閾値: **`high`**（Req 2.2）。
+  - 根拠: transitive 依存由来の low / moderate 検出は誤検知・更新待ちが多く、これらでブロックすると PR 運用が頻繁に阻害される。`high` で足切りすることで重大な脆弱性に限定してブロックする（NFR 1.2）。
+  - 却下した代替案（`critical` のみ）: high の脆弱性（実害が大きいものを含む）を見逃すため、`critical` より緩い `high` を採用。

--- a/docs/specs/51-ci-lint-npm-audit-eslint/review-notes.md
+++ b/docs/specs/51-ci-lint-npm-audit-eslint/review-notes.md
@@ -1,0 +1,57 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-51-impl-ci-lint-npm-audit-eslint
+- HEAD commit: 5073112bb8bb626e3fa2e0b2d2e98e9021d45209
+- Compared to: develop..HEAD
+
+本 Issue は design-less impl（`design.md` / `tasks.md` なし）。`_Boundary:_` アノテーションが
+存在しないため boundary 逸脱判定は「Issue スコープ（CI ワークフロー変更）に閉じているか」で
+代替確認した。Feature Flag Protocol は CLAUDE.md で `opt-out` 宣言のため flag 観点の確認は
+行わない（通常の 3 カテゴリ判定のみ）。差分は `.github/workflows/ci.yml`（新規 2 ジョブ追加）と
+spec docs（requirements.md / impl-notes.md）のみで、scope 内に閉じている。
+
+## Verified Requirements
+
+- 1.1 — `frontend-lint` ジョブが `on.pull_request.branches: [main, develop]` 配下で
+  `defaults.run.working-directory: web` + `run: npm run lint` を実行（ci.yml:73-92）。
+  `web/package.json` の `"lint": "eslint"` も確認済み。
+- 1.2 — `npm run lint`（eslint）は lint 違反検出時に非ゼロ終了し、exit code 抑制（`|| true` 等）が
+  無いため step が fail → ジョブ失敗 → PR チェック fail（ci.yml:91-92）。
+- 1.3 — eslint がゼロ終了すればジョブ成功（同上、追加抑制なし）。
+- 1.4 — `npm run lint` の stdout はジョブログに出力（出力リダイレクト・抑制なし、ci.yml:92）。
+- 2.1 — `frontend-audit` ジョブが PR トリガー配下で `working-directory: web` +
+  `run: npm audit --audit-level=high` を実行（ci.yml:94-113）。
+- 2.2 — `--audit-level=high` を明示指定（ci.yml:113）。
+- 2.3 — `npm audit --audit-level=high` は high/critical 検出時に非ゼロ終了 → ジョブ失敗
+  （exit code 抑制なし、ci.yml:112-113）。
+- 2.4 — `--audit-level=high` 指定時、moderate 以下のみならゼロ終了 → ジョブ成功（同上）。
+- 2.5 — high 以上の検出なしならゼロ終了 → ジョブ成功（同上）。
+- 2.6 — `npm audit` の検出一覧 stdout はジョブログに出力（抑制なし、ci.yml:113）。
+- 3.1 — 既存 `frontend`（`npm test`）ジョブ定義は無変更（diff は新規 2 ジョブ追加のみ、ci.yml:52-71）。
+- 3.2 — 既存 `backend` / `go-vet` / `govulncheck` の各ジョブ定義は無変更（diff に含まれず、
+  ci.yml:9-50）。トリガー `on`（push/pull_request to main/develop）も無変更（ci.yml:3-7）。
+- 3.3 — lint / audit を `frontend` とは別の独立ジョブにし、ジョブ間に `needs` 依存を張らないため
+  並列・独立に成否判定される（ci.yml:73-113）。
+- NFR 1.1 — 独立ジョブ + 非ゼロ終了でブロックという govulncheck と同型の構成（ci.yml:36-50 と
+  73-113 が同型）。
+- NFR 1.2 — `--audit-level=high` の足切りにより moderate 以下ではブロックしない（2.4 と同根拠）。
+- NFR 2.1 — `frontend-lint` / `frontend-audit` を独立ジョブとし、固有の `name`
+  （`Frontend Lint (eslint)` / `Frontend Dependency Vulnerability Scan (npm audit)`）を付与
+  したため PR チェック一覧で他ジョブと区別可能（ci.yml:74, 95）。
+
+## Findings
+
+なし
+
+## Summary
+
+requirements.md の全 numeric ID（1.1-1.4 / 2.1-2.6 / 3.1-3.3 / NFR 1.1 / 1.2 / 2.1）が
+ci.yml の新規 2 ジョブ追加と既存ジョブ無変更で裏付けられている。成果物は GitHub Actions YAML
+であり Feedman の規約上 CI 定義に対する単体テストは要求されず、impl-notes.md に各 AC と
+検証手段の対応が明記されているため missing test に該当しない。boundary 逸脱もなし。
+
+RESULT: approve


### PR DESCRIPTION
## 概要

Feedman の CI（`.github/workflows/ci.yml`）にフロントエンド（`web/`）の lint（eslint）と
依存脆弱性スキャン（`npm audit --audit-level=high`）を追加した。

これまで `frontend` ジョブは `npm ci` + `npm test` のみを実行しており、lint 違反や
高重大度の npm 依存脆弱性が PR 段階で検知されず main に混入し得る状態だった。
本 PR では `frontend-lint` / `frontend-audit` の 2 つの独立ジョブを追加し、
PR 作成・更新時に自動チェックされるようにした。

既存の `govulncheck`（Go 側の脆弱性スキャン）と同じくブロッキング方式（検出でジョブ失敗）を採用。
`npm audit` の閾値は `--audit-level=high` とし、low / moderate のみの検出では PR をブロックしない。

## 対応 Issue

Closes #51

## 関連 PR

- 設計 PR: なし（design-less impl — requirements.md のみを入力とした小規模実装）

## 実装内容

- (Req 1.x) `frontend-lint` ジョブを追加: `web/` で `npm run lint`（eslint）を実行し、lint 違反検出でジョブ失敗
- (Req 2.x) `frontend-audit` ジョブを追加: `web/` で `npm audit --audit-level=high` を実行し、high/critical 脆弱性検出でジョブ失敗
- (Req 3.x) 既存の `backend` / `go-vet` / `govulncheck` / `frontend`（`npm test`）の各ジョブは無変更。lint / audit の失敗は `npm test` の成否と独立に判定される
- (NFR 2.1) 各ジョブに固有名（`Frontend Lint (eslint)` / `Frontend Dependency Vulnerability Scan (npm audit)`）を付与し、PR チェック一覧で他ジョブと区別可能

## 受入基準チェック

- [x] Req 1.1: PR 時に `web/` で `npm run lint` を実行 — `frontend-lint` ジョブが `pull_request` トリガー配下に存在
- [x] Req 1.2: lint 違反でジョブ失敗 — eslint 非ゼロ終了で step fail（exit code 抑制なし）
- [x] Req 1.3: lint 違反なしでジョブ成功 — 同上（ゼロ終了でジョブ成功）
- [x] Req 1.4: lint 結果をジョブログに出力 — stdout リダイレクト・抑制なし
- [x] Req 2.1: PR 時に `web/` で `npm audit` を実行 — `frontend-audit` ジョブが `pull_request` トリガー配下に存在
- [x] Req 2.2: `--audit-level=high` で実行 — ci.yml に明示指定
- [x] Req 2.3: high 以上でジョブ失敗 — npm audit 非ゼロ終了で step fail
- [x] Req 2.4: high 未満のみなら成功 — `--audit-level=high` 指定時の仕様
- [x] Req 2.5: high 以上の検出なしで成功 — 同上
- [x] Req 2.6: audit 結果をジョブログに出力 — stdout 抑制なし
- [x] Req 3.1: 既存 `npm test` の成否維持 — `frontend` ジョブ無変更
- [x] Req 3.2: 既存 backend 系ジョブ維持 — diff に含まれず
- [x] Req 3.3: lint / audit を `npm test` と独立判定 — 独立ジョブで `needs` 依存なし

## テスト結果

```
本 Issue の成果物は GitHub Actions ワークフロー定義（YAML）のみ。
アプリケーションコードの単体テスト対象ではないため、Feedman の規約上 CI 定義に対する
単体テストは要求されない。

検証内容:
- Python yaml.safe_load で ci.yml をパース → 構文エラーなし
- jobs キーが 6 件（既存 4 + 新規 2）であることを確認
- トリガー設定（push/pull_request to main/develop）が無変更であることを確認
- 各新規ジョブの working-directory / steps 構成を確認

ローカルでの npm run lint / npm audit 実行は node/npm 不在の環境制約により未実施。
CI 上での初回実行結果（PR チェック）で green になることを確認いただきたい。
（詳細は impl-notes.md の「確認事項」セクションを参照）
```

## 実装上の判断

- **独立ジョブ化を採用**: `frontend` ジョブへの step 追加ではなく独立ジョブ化を選択した。
  NFR 2.1（PR チェック一覧で独立ステータス）と Req 3.3（lint/audit と npm test の独立判定）を
  確実に満たすため。setup（checkout / setup-node / npm ci）が 3 ジョブで重複するトレードオフは
  並列実行とキャッシュで緩和される。
- **`--audit-level=high` を採用**: transitive 依存の low/moderate 検出は誤検知・更新待ちが多く
  PR 運用を頻繁に阻害するため、govulncheck と同じブロッキング方針を保ちつつ閾値を `high` に設定。

詳細は `docs/specs/51-ci-lint-npm-audit-eslint/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- **ローカルでの lint / audit 未検証（環境制約）**: 現状の `web/` で `npm run lint` がクリーンに通るか、`npm audit --audit-level=high` が high 以上の脆弱性を検出しないかを事前確認できていない。CI 上での初回実行（PR チェック）で green になることをご確認ください。
- **setup 重複のトレードオフ**: 可観測性・独立判定を優先して独立ジョブ化した判断について、CI 時間をよりタイトに抑えたい場合は step 集約も選択肢となる（impl-notes.md 参照）。
- Reviewer の判定: `docs/specs/51-ci-lint-npm-audit-eslint/review-notes.md` — `RESULT: approve`
- base ブランチ検証: `--base develop` 指定 / baseRefName: develop / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #51 のコメントを参照してください。
