### PR TITLE
feat(#17): docker-compose の web サービスにログローテーション設定を追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,11 @@ services:
       # 内部 API 接続先（server-side のみで参照、ブラウザ非公開）。
       # rewrites が /api/* /auth/* をこの URL へ転送する。未設定なら起動時に fail-fast する。
       - API_INTERNAL_URL=${API_INTERNAL_URL:-http://api:8080}
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "14"
     networks:
       - external
       - internal

--- a/docs/specs/17-docker-compose-web/impl-notes.md
+++ b/docs/specs/17-docker-compose-web/impl-notes.md
@@ -1,0 +1,128 @@
+# 実装ノート: Issue #17 docker-compose の web サービスにログローテーション設定を追加
+
+## 概要
+
+`docker-compose.yml` の `web` サービス定義に、`api` / `worker` と整合する `logging` ブロックを
+追加した。これにより `web` のコンテナログにもサイズ上限（`max-size: 10m`）と保持ファイル数
+上限（`max-file: 14`）が効くようになり、長期稼働でのディスク際限消費を防ぐ。
+
+本 Issue には `design.md` / `tasks.md` が存在しない design-less impl のため、`requirements.md` の
+各 AC を直接 1:1 で検証して実装した。
+
+## 実施した変更
+
+- `docker-compose.yml` の `web` サービス定義に以下の `logging` ブロックを追加（`environment`
+  ブロックの直後、`networks` の直前。`api` サービスでの配置順と整合）:
+
+```yaml
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "14"
+```
+
+- `web` の既存設定（`build` / `ports` / `environment` / `networks` / `depends_on` / `restart`
+  / `deploy`）は変更していない。
+- `api` / `worker` / `db` サービス定義は変更していない。
+- diff は `web` サービスへの `logging` ブロック 5 行追加のみ（後述の検証 4 参照）。
+
+## 検証コマンドと結果
+
+### 1. compose ファイルの構文妥当性
+
+`docker compose config`（Docker Compose v5.1.3）で構文検証を試みたが、以下のエラーで停止した:
+
+```
+healthcheck.test must start either by "CMD", "CMD-SHELL" or "NONE"
+```
+
+これは `api` サービスの既存 healthcheck 定義（`test: ["/feedman", "healthcheck"]`）に対する
+Compose v2 系の厳格バリデーションによるもので、**本変更とは無関係の既存事象**である。
+変更前の `docker-compose.yml`（git stash で一時退避した状態）でも同一エラーが再現することを
+確認済み（`git stash` → `docker compose config` → 同エラー → `git stash pop`）。
+
+要件タスクの代替手段の指示に従い、YAML パーサ（PyYAML）で YAML 妥当性および `web` の解決後
+設定を検証した:
+
+```python
+import yaml
+doc = yaml.safe_load(open('docker-compose.yml'))
+svc = doc['services']
+# web/api/worker の logging
+# web -> {'driver': 'json-file', 'options': {'max-size': '10m', 'max-file': '14'}}
+# api -> {'driver': 'json-file', 'options': {'max-size': '10m', 'max-file': '14'}}
+# worker -> {'driver': 'json-file', 'options': {'max-size': '10m', 'max-file': '14'}}
+assert svc['web']['logging'] == svc['api']['logging'] == svc['worker']['logging']
+```
+
+結果: YAML は構文的に valid。`web` サービスの解決後 `logging` 設定に
+`max-size: "10m"` / `max-file: "14"` が含まれることを確認した（AC 1.1 / 1.2 / 1.3）。
+
+### 2. api / worker と web の設定値一致
+
+PyYAML パース結果で `web` / `api` / `worker` の `logging` ブロックが完全に等価
+（`driver: json-file`、`max-size: 10m`、`max-file: 14`）であることをアサートで確認した
+（AC 2.1 / 2.2 / 2.3、NFR 2.1）。`db` サービスは `logging` を持たない（`None`）ことも確認し、
+スコープ外の `db` に変更が及んでいないことを担保した。
+
+### 3. web の既存設定保持
+
+PyYAML パース結果で `web` サービスのキー集合が
+`['build', 'ports', 'environment', 'logging', 'networks', 'depends_on', 'restart', 'deploy']`
+であることを確認。`logging` 追加以外の既存キーがすべて保持されていることを担保した
+（AC 4.1 / 4.2 / 4.3、NFR 2.2）。
+
+### 4. 差分スコープの確認
+
+`git diff docker-compose.yml` により、変更が `web` サービスへの `logging` ブロック 5 行追加
+のみであることを確認（AC 4.2 / 4.3）。`api` / `worker` / `db` への差分は無い。
+
+### 5. 既存テストへの影響
+
+本変更は `docker-compose.yml`（YAML 設定）のみで、Go / TypeScript のユニットテスト対象コードを
+含まない。CI（`.github/workflows/ci.yml` の `go test ./...` / `npm test`）が参照するソースには
+触れていないため、既存テストを壊さない。compose 設定ファイル自体は YAML として valid である
+ことを上記で確認済み。
+
+## AC とテスト（検証）の対応表
+
+| AC ID | 検証方法 |
+|---|---|
+| 1.1 | 検証 1（PyYAML パースで `web.logging` の存在確認） |
+| 1.2 | 検証 1（`max-size: "10m"` の確認） |
+| 1.3 | 検証 1（`max-file: "14"` の確認） |
+| 2.1 | 検証 2（`web` と `api`/`worker` の `max-size` 一致） |
+| 2.2 | 検証 2（`web` と `api`/`worker` の `max-file` 一致） |
+| 2.3 | 検証 2（`web.logging == api.logging == worker.logging` のアサート） |
+| 3.1 | `json-file` ドライバ + `max-size`/`max-file` の組み合わせにより Docker が最古ログから破棄（設定値で担保。検証 1/2） |
+| 3.2 | 同上（保持総量は `max-size` × `max-file` = 10m × 14 で上限化。検証 1/2） |
+| 4.1 | 検証 3（`web` の既存キー保持により従来どおり起動可能） |
+| 4.2 | 検証 2/4（`api`/`worker`/`db` 定義に差分なし） |
+| 4.3 | 検証 4（`git diff` で `logging` 追加以外の差分が無いことを確認） |
+| NFR 1.1 | `max-size` × `max-file` = 10m × 14 ≈ 140MB の上限（検証 1） |
+| NFR 2.1 | 検証 2（`api`/`worker` の既存ログ設定値を変更しない） |
+| NFR 2.2 | 検証 3（`web` の `ports`/`environment`/`networks`/`depends_on`/`restart`/`deploy` を変更しない） |
+
+> AC 3.1 / 3.2 は Docker の `json-file` ログドライバの実行時挙動（上限到達時に最古ファイルから
+> 破棄）に依存するランタイム挙動であり、設定ファイル上は `max-size` / `max-file` の付与で担保
+> される。コンテナ実行を伴う実挙動検証は本ステージ（設定ファイル変更のみ）のスコープ外。
+
+## 確認事項（レビュワー判断ポイント）
+
+- `docker compose config`（Compose v2 系）は `api` サービスの既存 healthcheck 定義
+  `test: ["/feedman", "healthcheck"]` を `must start either by "CMD", "CMD-SHELL" or "NONE"` として
+  reject する。これは本 Issue のスコープ外（`api` サービス定義は変更不可）であり、変更前の
+  ファイルでも再現する**既存の事象**である。本ステージでは要件タスクの代替手段に従い PyYAML で
+  YAML 妥当性と `web` の解決後設定を検証した。`api` の healthcheck 形式を `["CMD", ...]` に
+  揃えるべきかは別 Issue として検討する余地がある（本 Issue では対応しない）。
+- AC 3.1 / 3.2 のランタイム破棄挙動は Docker `json-file` ドライバの標準挙動に依拠しており、実際の
+  コンテナ起動・ログ蓄積を伴う検証は本ステージでは未実施（設定値の付与で担保）。
+
+## 派生タスク候補（次 Issue 検討）
+
+- `api` サービスの healthcheck 定義（`test: ["/feedman", "healthcheck"]`）を Compose v2 系の
+  厳格バリデーションに適合する `["CMD", "/feedman", "healthcheck"]` 形式へ修正する Issue。
+  本 Issue のスコープ外（`api` 定義変更不可）のため別途起票が望ましい。
+
+STATUS: complete

--- a/docs/specs/17-docker-compose-web/requirements.md
+++ b/docs/specs/17-docker-compose-web/requirements.md
@@ -1,0 +1,73 @@
+# Requirements Document
+
+## Introduction
+
+`docker-compose.yml` の `web` サービスにだけログローテーション設定（`logging` ブロック）が無く、
+`api` / `worker` のように上限が効かないため、長期稼働で `web` のコンテナログがディスクを
+際限なく消費する恐れがある。本要件は `web` サービスにも `api` / `worker` と整合する
+ログローテーション設定を追加し、ログのディスク消費量に上限を設けることを目的とする。
+編集対象は `docker-compose.yml` の `web` サービス定義のみで、`api` / `worker` / `db` の
+既存設定や集中ログ基盤への転送は扱わない。
+
+## Requirements
+
+### Requirement 1: web サービスのログローテーション設定
+
+**Objective:** As a 運用者, I want `web` サービスのコンテナログをローテーションさせたい, so that 長期稼働でもログがディスクを際限なく消費しないようにできる
+
+#### Acceptance Criteria
+
+1. The `web` サービス定義 shall ログローテーションを行う `logging` 設定を持つ
+2. The `web` サービスのログ shall 1 ファイルあたりのサイズが `10m` を超えた時点で新しいログファイルへローテーションされる
+3. The `web` サービスのログ shall 保持するログファイル数を `14` 件までに制限する
+
+### Requirement 2: api / worker との設定値整合
+
+**Objective:** As a 運用者, I want `web` のログ上限値を `api` / `worker` と揃えたい, so that サービス間でログ運用の挙動が一貫し、設定の認知負荷を下げられる
+
+#### Acceptance Criteria
+
+1. The `web` サービスのログローテーション設定 shall 1 ファイルあたりのサイズ上限を `api` / `worker` と同じ `10m` とする
+2. The `web` サービスのログローテーション設定 shall 保持ファイル数の上限を `api` / `worker` と同じ `14` とする
+3. While `api` / `worker` の既存ログ設定値が変更されていない状態で, the `web` サービスのログ設定 shall それらと等価な上限値で運用される
+
+### Requirement 3: ログ上限到達時の破棄挙動
+
+**Objective:** As a 運用者, I want 上限を超えたログを自動で破棄させたい, so that ディスク使用量を一定の範囲内に保てる
+
+#### Acceptance Criteria
+
+1. When `web` サービスのログ蓄積量がサイズ上限と保持ファイル数の上限（`10m` × `14`）に達したとき, the `web` サービスのログ管理 shall 最も古いログから順に破棄する
+2. While ログが上限に達して破棄が継続している状態で, the `web` サービスのログ保持総量 shall サイズ上限と保持ファイル数の積で定まる上限を超えない
+
+### Requirement 4: 後方互換（既存サービスの起動・稼働維持）
+
+**Objective:** As a 運用者, I want ログ設定追加後も既存どおりに各サービスが起動・稼働してほしい, so that 既存環境を壊さずに設定変更を取り込める
+
+#### Acceptance Criteria
+
+1. When ログ設定追加後に compose 環境を起動したとき, the `web` サービス shall 従来どおり正常に起動し稼働する
+2. The `api` / `worker` / `db` サービスの定義 shall 本変更によって変更されない
+3. If `web` サービスへの今回のログ設定追加以外の差分が生じたとき, the 変更内容 shall 後方互換違反として扱われ拒否される
+
+## Non-Functional Requirements
+
+### NFR 1: ディスク消費の上限
+
+1. The `web` サービスのコンテナログ shall 1 サービスあたり最大でも `10m` × `14`（= 約 140MB）を超えてディスクを消費しない
+
+### NFR 2: 互換性
+
+1. The 本変更 shall `api` / `worker` の既存ログ設定値（`max-size: 10m` / `max-file: 14`）を変更しない
+2. The 本変更 shall `web` サービスの既存の `ports` / `environment` / `networks` / `depends_on` / `restart` / `deploy` 設定を変更しない
+
+## Out of Scope
+
+- 集中ログ基盤（ELK / Loki 等）へのログ転送機構の導入
+- `api` / `worker` の既存ログ設定値の変更
+- `db` サービスへのログローテーション設定の追加
+- ログのサイズ上限・保持件数の閾値そのものの見直し（`api` / `worker` と整合させる方針を維持する）
+
+## Open Questions
+
+- なし（Issue 本文・コメント・既存 `docker-compose.yml` の確認により、設定値・整合対象・スコープが確定している）

--- a/docs/specs/17-docker-compose-web/review-notes.md
+++ b/docs/specs/17-docker-compose-web/review-notes.md
@@ -1,0 +1,41 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-17-impl-docker-compose-web
+- HEAD commit: a4543ddb205aadbd5d0eae721c49b869a7362650
+- Compared to: develop..HEAD
+
+## Verified Requirements
+
+- 1.1 — `docker-compose.yml:26-30` `web` サービスに `logging` ブロックを追加（ローテーション設定を保持）
+- 1.2 — `docker-compose.yml:29` `max-size: "10m"`（サイズ上限到達でローテーション）
+- 1.3 — `docker-compose.yml:30` `max-file: "14"`（保持ファイル数を 14 件に制限）
+- 2.1 — `web`(L29) と `api`(L74) / `worker`(L122) の `max-size` がいずれも `10m` で一致
+- 2.2 — `web`(L30) と `api`(L75) / `worker`(L123) の `max-file` がいずれも `14` で一致
+- 2.3 — `web` / `api` / `worker` の `logging` ブロックが完全等価（`json-file` / `10m` / `14`）。`api` / `worker` の既存値は本差分で変更されていない
+- 3.1 — `json-file` ドライバ + `max-size`/`max-file` の組み合わせで Docker が上限到達時に最古ログから破棄（設定値で担保）
+- 3.2 — 保持総量は `max-size` × `max-file` = `10m` × `14` で上限化（設定値で担保）
+- 4.1 — `web` の既存キー（`build`/`ports`/`environment`/`networks`/`depends_on`/`restart`/`deploy`）が `docker-compose.yml:14-42` で保持されており従来どおり起動可能
+- 4.2 — `git diff --stat develop..HEAD` で `docker-compose.yml` は 5 行追加のみ。`api`/`worker`/`db` 定義に差分なし
+- 4.3 — `git diff develop..HEAD -- docker-compose.yml` で変更は `web` の `logging` ブロック追加に閉じており、他差分なし
+- NFR 1.1 — `10m` × `14` ≈ 140MB の上限がディスク消費に効く
+- NFR 2.1 — `api` / `worker` の `max-size: 10m` / `max-file: 14` を変更していない
+- NFR 2.2 — `web` の `ports` / `environment` / `networks` / `depends_on` / `restart` / `deploy` を変更していない
+
+## Findings
+
+なし
+
+## Summary
+
+`requirements.md` の全 numeric ID（1.1〜4.3、NFR 1.1 / 2.1 / 2.2）に対し、`web` サービスへの
+`logging` ブロック追加（`json-file` / `max-size: 10m` / `max-file: 14`）が `api` / `worker` と
+等価な設定値で実装され、差分は `web` 1 サービスへの 5 行追加に閉じている（boundary 逸脱なし）。
+設定ファイル（YAML）のみの変更で Go/TS のユニットテスト対象コードを含まず、検証可能な設定値は
+impl-notes.md で YAML パース検証により AC と紐付け済み（missing test なし）。AC 3.1/3.2 は Docker
+`json-file` ドライバの標準ランタイム挙動に依拠し設定値で担保される旨が明記されており妥当。
+
+RESULT: approve


### PR DESCRIPTION
## 概要

`docker-compose.yml` の `web` サービスにログローテーション設定が欠如しており、長期稼働でコンテナログがディスクを際限なく消費する問題があった。本 PR では `api` / `worker` と整合する `logging` ブロック（`driver: json-file`、`max-size: 10m`、`max-file: 14`）を `web` サービスに追加し、サービス間でログ運用の挙動を統一した。変更差分は `web` サービスへの 5 行追加のみで、他サービスの定義には影響しない。

## 対応 Issue

Closes #17

## 関連 PR

- 設計 PR: なし（design-less impl。requirements.md のみで実装を完結）

## 実装内容

- (Req 1 / Req 2) `docker-compose.yml` の `web` サービス定義に `logging` ブロックを追加
  - `driver: json-file`、`max-size: "10m"`、`max-file: "14"` を指定
  - `api` / `worker` と同一の設定値で統一（Req 2.1 / 2.2 / 2.3 を満足）
- (Req 4) `web` の既存設定（`build` / `ports` / `environment` / `networks` / `depends_on` / `restart` / `deploy`）は変更せず後方互換を維持
- (NFR 1) `10m` × `14` ≈ 140MB のログディスク消費上限を実現
- (NFR 2) `api` / `worker` / `db` のサービス定義は一切変更しない

## 受入基準チェック

- [x] Req 1.1: `web` サービス定義 shall ログローテーションを行う `logging` 設定を持つ ← `docker-compose.yml:26-30` に `logging` ブロック追加
- [x] Req 1.2: `max-size` が `10m` ← `docker-compose.yml:29` で確認
- [x] Req 1.3: `max-file` が `14` ← `docker-compose.yml:30` で確認
- [x] Req 2.1 / 2.2 / 2.3: `web` の設定値が `api` / `worker` と等価 ← PyYAML アサートで確認（`web.logging == api.logging == worker.logging`）
- [x] Req 3.1 / 3.2: 上限到達時に最古ログから破棄 ← `json-file` ドライバの標準挙動で担保
- [x] Req 4.1 / 4.2 / 4.3: 後方互換維持 ← `git diff` で `web` への 5 行追加のみ、他サービスに差分なし
- [x] NFR 1.1 / 2.1 / 2.2: ディスク上限・既存設定変更なし ← PyYAML 検証および `git diff` で確認

## テスト結果

```
変更対象: docker-compose.yml（YAML 設定ファイルのみ）
Go / TypeScript のユニットテスト対象コードに変更なし → go test / npm test への影響なし

YAML 妥当性検証（PyYAML）:
- docker-compose.yml: 構文的に valid
- web.logging == api.logging == worker.logging のアサート: pass
- web の既存キー保持確認: pass

git diff --stat develop..HEAD:
  docker-compose.yml | 5 +++++
  1 file changed, 5 insertions(+)
（変更は web サービスへの logging ブロック 5 行追加のみ）
```

## 実装上の判断

- `docker compose config`（Compose v2 系）が `api` サービスの既存 healthcheck 定義（`test: ["/feedman", "healthcheck"]`）を `must start either by "CMD", "CMD-SHELL" or "NONE"` として reject する既存事象が存在する。本変更前から再現しており、本 Issue の変更内容とは無関係。YAML 構文の妥当性確認は代替手段として PyYAML で実施した（詳細は `docs/specs/17-docker-compose-web/impl-notes.md` 参照）。
- AC 3.1 / 3.2 のランタイム破棄挙動は Docker `json-file` ドライバの標準動作に依拠。設定値の付与で担保し、コンテナ実行を伴う実挙動検証は本ステージのスコープ外とした。

## 確認事項

- base ブランチ検証: develop に一致（修正なし）
- `api` サービスの healthcheck 定義を Compose v2 系の厳格バリデーションに適合させる修正は本 Issue のスコープ外。別 Issue としての検討を推奨（詳細: `docs/specs/17-docker-compose-web/impl-notes.md` 「派生タスク候補」節）
- AC 3.1 / 3.2 のランタイム検証（実コンテナ起動・ログ蓄積）は設定値で担保。実挙動確認が必要な場合は手動で `docker compose up web` して確認可能
- Reviewer レビューノート: `docs/specs/17-docker-compose-web/review-notes.md`（RESULT: approve）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
