### PR TITLE
feat(#15): メトリクス Collector と /metrics エンドポイントの本番組み込み

### DIFF
--- a/docs/specs/15--collector-metrics/impl-notes.md
+++ b/docs/specs/15--collector-metrics/impl-notes.md
@@ -1,0 +1,42 @@
+# 実装ノート（Issue #15: メトリクス Collector と /metrics エンドポイントの本番組み込み）
+
+## 受入基準とテストの対応（本起動分: task 1）
+
+| Requirement ID | 担保するテスト |
+|---|---|
+| 5.1（後方互換維持 / NopCollector が既定値として安全） | `internal/metrics/nop_test.go` の `TestNopCollector_ImplementsMetricsCollector` / `TestNopCollector_MethodsDoNotPanic` / `TestNopCollector_ZeroValueIsUsable` |
+| NFR 1.2（既存テストスイートを失敗させない / nil 安全） | 同上 + `go test ./...` 全 green を確認 |
+| 4.1（信頼 CIDR の設定読み込み） | `internal/config/config_test.go` の `TestLoad_MetricsTrustedCIDRs`（単一/複数/空白トリム/空要素除外/不正値保持/未設定）、`TestLoad_MetricsPort` |
+| NFR 2.1（未設定時は空のまま保持し検証はミドルウェアに委譲） | `TestLoad_MetricsTrustedCIDRs` の「未設定（空文字）のとき空スライスを保持する」「空白のみのとき空スライスを保持する」、`TestLoad_DefaultValues`（Metrics defaults） |
+
+> NFR 2.1 の「安全側（アクセス拒否）に倒す」挙動自体は後続 task 2.1（TrustedCIDRMiddleware）で
+> 担保する。本 task では config パース段階で空スライスを保持することまでを検証する（tasks.md L13
+> の方針に準拠）。
+
+## Implementation Notes
+
+### Task 1
+
+- **採用方針**: design.md L263-273 のシグネチャに準拠した no-op 実装 `NopCollector` と、config への
+  `TrustedCIDRs` / `MetricsPort` フィールド追加を、既存実装（`metrics.go` の interface / `config.go` の
+  env ヘルパパターン）に非破壊で追加した。
+- **重要な判断**:
+  - `NopCollector` は value receiver（`func (NopCollector) ...`）で実装し、ゼロ値 `NopCollector{}` を
+    そのまま既定値として使える（nil 安全・ポインタ不要）形にした。既存 interface の
+    `RecordFetchFailure(feedID string, reason string)` と design の `(feedID, reason string)` は
+    同一シグネチャのため整合する。
+  - CIDR のカンマ区切りパースは config 内に `parseCommaSeparated` ヘルパとして切り出し、TrimSpace +
+    空要素除外を行う。不正 CIDR の判定はパース段階では行わず（tasks.md L13 / NFR 2.1 の方針どおり）
+    後続のミドルウェアに委譲するため、不正文字列もそのまま保持する（テストで明示）。
+  - `MetricsPort` は既存の `getEnvString("METRICS_PORT", "9090")` ヘルパを流用し、既定 "9090" とした。
+- **残存課題**: なし（task 2 以降の TrustedCIDRMiddleware / Fetcher・Upsert への WithMetrics 注入 /
+  ルーター登録 / wiring は別 task で実装される。本 task の `NopCollector` と config フィールドは
+  それらの前提として提供済み）。
+
+## 確認事項（レビュワー判断ポイント）
+
+- requirements.md / design.md / tasks.md との矛盾は本 task の範囲では検出していない。
+- 本起動は per-task ループの **task 1（子 1.1 / 1.2）のみ**を実装している。task 2〜6 は未着手で、
+  orchestrator が後続起動で順次消化する。
+
+STATUS: complete

--- a/docs/specs/15--collector-metrics/impl-notes.md
+++ b/docs/specs/15--collector-metrics/impl-notes.md
@@ -33,10 +33,86 @@
   ルーター登録 / wiring は別 task で実装される。本 task の `NopCollector` と config フィールドは
   それらの前提として提供済み）。
 
+## 是正対応（Reviewer round=1 reject を受けた追加実装: task 2〜6）
+
+Reviewer round=1 が「`/metrics` 本体・メトリクス記録組み込み・worker listener・CIDR 制限が未実装」
+（Finding 1〜5）として reject したため、tasks.md の task 2〜6 を依存順に実装した。task 1
+（`NopCollector` / config フィールド）は前提として温存し変更していない。
+
+### Reviewer Finding への対応サマリ
+
+| Finding | 内容 | 対応 |
+|---|---|---|
+| Finding 1（Target 1.1/1.2/1.3） | `/metrics` エンドポイント本体未実装 | task 5.1（serve ルーター条件登録）+ task 6.1/6.2（worker listener + wiring）を実装。`internal/handler/router_metrics_test.go` / `internal/app/metrics_listener_test.go` で結合検証 |
+| Finding 2（Target 2.1〜2.6） | フェッチ/UPSERT メトリクス記録組み込み未実装 | task 3.1（Fetcher.WithMetrics + 各分岐の記録挿入）+ task 4.1（ItemUpsertService.WithMetrics + 件数記録）を実装。モック Collector 注入テストで各記録呼び出しを検証 |
+| Finding 3（Target 3.1/3.2/3.3） | worker 専用 registry + listener のスクレイプ経路未実装 | task 6.1/6.2 を実装。`TestStartWorkerMetricsListener_FetchSuccessReflected` でフェッチ成功記録が同一プロセスの `/metrics` 応答へ反映されることを検証 |
+| Finding 4（Target 4.1〜4.3） | 信頼 CIDR アクセス制限の実挙動未実装 | task 2.1（`internal/middleware/trusted_cidr.go`）を実装。範囲内 200 / 範囲外・未設定・パース不能 403 / 不正 CIDR スキップ / 拒否時本文非包含を単体テストで検証 |
+| Finding 5（Target 5.1〜5.3, NFR 1.1/2.1/2.2） | 既存ルーティング不変性・既存 timeout 維持・起動直後 200・未設定時 403・拒否時本文非包含の実装/テスト不足 | router の nil 分岐テスト（既存ルート不変）、serve timeout 不変（app.go で server timeout を変更していない）、起動直後 200 と系列出力、空 CIDR 全拒否、拒否時本文非包含を各テストで担保 |
+
+### 追加した実装・テストと対応 AC のマッピング（task 2〜6）
+
+| Requirement ID | 実装 | 担保するテスト |
+|---|---|---|
+| 1.1（信頼 CIDR 内から Prometheus 形式応答） | `router.go`（serve 条件登録）/ `metrics_listener.go`（worker） | `TestNewRouter_Metrics_NonNilHandler_InRange_Returns200` / `TestStartWorkerMetricsListener_StartupExposesSeries` |
+| 1.2（起動完了で即スクレイプ可能） | `metrics_listener.go` / `app.go` の listener 起動 | `TestStartWorkerMetricsListener_StartupExposesSeries`（起動直後 200） |
+| 1.3（全 6 系列を応答に含める） | `app.go` の `NewCollector(registry)` 登録 | `TestStartWorkerMetricsListener_StartupExposesSeries`（ラベルなし 5 系列）+ `TestStartWorkerMetricsListener_HTTPStatusSeriesAppearsAfterRecord`（`feedman_http_status_total`、後述「確認事項」参照） |
+| 2.1（フェッチ成功で成功数増加） | `fetcher.go` 200/304 成功時 `RecordFetchSuccess` | `TestFetcher_Fetch_Metrics_Success200` / `TestFetcher_Fetch_Metrics_304Success` |
+| 2.2（フェッチ失敗で失敗数増加） | `fetcher.go` SSRF/HTTP/stop/backoff/parse/upsert 失敗時 `RecordFetchFailure` | `TestFetcher_Fetch_Metrics_HTTPFailure` / `TestFetcher_Fetch_Metrics_ParseFailure` / `TestFetcher_Fetch_Metrics_HTTPStatusRecordedOnBackoff` |
+| 2.3（パース失敗でパース失敗数増加） | `fetcher.go` parse 失敗時 `RecordParseFailure` | `TestFetcher_Fetch_Metrics_ParseFailure` |
+| 2.4（HTTP ステータス別レスポンス数増加） | `fetcher.go` レスポンス受信直後 `RecordHTTPStatus` | `TestFetcher_Fetch_Metrics_Success200`（200）/ `TestFetcher_Fetch_Metrics_HTTPStatusRecordedOnBackoff`（500） |
+| 2.5（フェッチ完了で所要時間記録） | `fetcher.go` defer `RecordFetchLatency` | `TestFetcher_Fetch_Metrics_Success200` / `TestFetcher_Fetch_Metrics_HTTPFailure`（失敗時も defer で記録） |
+| 2.6（UPSERT 完了で件数加算） | `upsert.go` BulkUpsert 成功後 `RecordItemsUpserted(inserted+updated)` | `TestUpsertItems_Metrics_RecordsUpsertedCount` / `TestUpsertItems_Metrics_NotRecordedOnError` / `TestUpsertItems_Metrics_EmptyInputNotRecorded` |
+| 3.1（フェッチプロセスのメトリクスをスクレイプ可能に） | `metrics_listener.go` worker 独立 listener | `TestStartWorkerMetricsListener_StartupExposesSeries` |
+| 3.2（成功数増加分を同一プロセス応答に反映） | worker registry 共有（`app.go`） | `TestStartWorkerMetricsListener_FetchSuccessReflected` |
+| 3.3（別プロセス応答に依存せず観測可能） | serve/worker で独立 registry（`app.go`） | `TestStartWorkerMetricsListener_FetchSuccessReflected`（worker 単独 registry で反映） |
+| 4.1（CIDR 範囲外は 403） | `trusted_cidr.go` | `TestTrustedCIDRMiddleware`（範囲外 403 / 空 CIDR 全拒否 / パース不能拒否） |
+| 4.2（CIDR 範囲内はメトリクス応答） | `trusted_cidr.go` | `TestTrustedCIDRMiddleware`（範囲内 200） |
+| 4.3（IP のみで判定・秘匿情報不要） | `trusted_cidr.go`（`RemoteAddr` のみ、X-Forwarded-For 非信頼） | `TestTrustedCIDRMiddleware`（ヘッダ要求なしで判定） |
+| 5.1（既存ルーティング・レスポンス維持） | `router.go` MetricsHandler nil 分岐 | `TestNewRouter_Metrics_NilHandler_NotRegistered` / `TestNewRouter_Metrics_NilHandler_ExistingRoutesUnchanged` / `TestNewRouter_Metrics_NonNilHandler_ExistingRoutesUnchanged` + 既存 `router_full_test.go` 全 green |
+| 5.2（タイムアウト設定維持） | `app.go` runServe の server timeout を変更せず | `go build ./...` + 既存 serve テスト（timeout 値の変更なし） |
+| 5.3（起動直後の未記録でも正常応答） | `metrics_listener.go` / promhttp 既定 | `TestStartWorkerMetricsListener_StartupExposesSeries`（200） |
+| NFR 1.1（未記録でも 2xx） | promhttp 既定の空 gather | `TestStartWorkerMetricsListener_StartupExposesSeries` |
+| NFR 1.2（既存テストスイートを失敗させない） | 全 option/nil 分岐の後方互換 | `TestNewFetcher_DefaultMetricsIsNopAndNilSafe` / `TestNewItemUpsertService_DefaultMetricsIsNopAndNilSafe` + `go test ./...` 全 green |
+| NFR 2.1（CIDR 未設定時は全拒否） | `trusted_cidr.go` 空 nets で deny | `TestTrustedCIDRMiddleware`（空 CIDR 全拒否） |
+| NFR 2.2（拒否時に本文非包含） | `trusted_cidr.go` next 未呼び出し | `TestTrustedCIDRMiddleware`（拒否時本文にメトリクス文字列なし）/ `TestNewRouter_Metrics_NonNilHandler_OutOfRange_Returns403` / `TestStartWorkerMetricsListener_OutOfRangeForbidden` |
+
+### 重要な実装判断
+
+- **304 を成功扱い**: `Fetch` の 304 NotModified 分岐は「変更なしで取得成功」とみなし
+  `RecordFetchSuccess` を記録する（design.md L360-361 / tasks.md L33 の方針に準拠）。
+- **失敗系の記録範囲**: task / design が明示した SSRF / HTTP（client.Do）/ stop / backoff / parse に加え、
+  body 読み取り失敗・予期しないステータス default・UPSERT 失敗・状態更新失敗の各 return path にも
+  `RecordFetchFailure` を挿入した（いずれも Req 2.2「フェッチ失敗」に該当するため。成功と失敗の二重計上が
+  起きないよう、各 return は単一の終端記録に閉じている）。`RecordFetchLatency` は defer で全 return を
+  通過時に 1 度だけ記録する。
+- **worker listener の graceful stop**: `startWorkerMetricsListener` は ctx キャンセルで
+  `server.Shutdown` する watcher goroutine と `ListenAndServe` 本体 goroutine の 2 本を起動し、
+  ctx キャンセルで listener を確実に停止する（goroutine リーク防止）。起動失敗（`ListenAndServe` が
+  `http.ErrServerClosed` 以外）はエラーログにとどめ worker 本体を落とさない。
+- **RouterDeps の nil 分岐**: `MetricsHandler` が nil なら `/metrics` を登録せず既存ルーティングを完全に
+  不変に保つ。`MetricsHandler` 非 nil かつ `MetricsMiddleware` が nil のケースは chi の `With(nil)` が
+  panic するため、素通しラッパ（`func(next) http.Handler { return next }`）にフォールバックして安全側に
+  倒した（実運用の app.go は常に CIDR mw を渡すため通常は通らない経路）。
+- **後方互換の functional options**: `NewFetcher` / `NewItemUpsertService` とも既存の位置引数を不変に保ち、
+  末尾に `opts ...Option` を追加。未指定時は `metrics.NopCollector{}` を既定値とし、既存 50+ call site は
+  コンパイル・挙動とも不変（NFR 1.2）。
+
 ## 確認事項（レビュワー判断ポイント）
 
-- requirements.md / design.md / tasks.md との矛盾は本 task の範囲では検出していない。
-- 本起動は per-task ループの **task 1（子 1.1 / 1.2）のみ**を実装している。task 2〜6 は未着手で、
-  orchestrator が後続起動で順次消化する。
+- **`feedman_http_status_total` の起動直後出力（Req 1.3 の解釈）**: 既存 `internal/metrics/metrics.go`
+  （変更禁止）では `feedman_http_status_total` をラベル付き `CounterVec`（`status_code` ラベル）として
+  定義している。Prometheus テキスト公開形式の仕様上、`CounterVec` はラベル値が 1 度も記録されるまで
+  HELP/TYPE/系列のいずれも出力されない。したがって **起動直後（未記録）の `/metrics` 応答には
+  ラベルなし 5 系列のみが現れ、`feedman_http_status_total` はステータス記録後に初めて現れる**。
+  本実装はこれを正直に検証する 2 本のテスト（`...StartupExposesSeries` で 5 系列 / `...HTTPStatusSeriesAppearsAfterRecord`
+  で 6 系列目）に分割した。Req 1.3「起動直後に全 6 系列名を含む」を厳密に満たすには `metrics.go` 側で
+  起動時に `RecordHTTPStatus` 相当の初期化（ゼロ値ラベルのプリセット）が必要だが、これは
+  「既存メトリクス実装本体は一切変更しない」（design.md L18-19 / Out of Scope）と矛盾するため
+  **本実装では metrics.go を変更していない**。Req 1.3 の厳密充足を要する場合は、metrics.go の初期化を
+  許容する設計変更（別 Issue）が必要であり、Architect / PM への差し戻しが妥当と判断する。
+- 上記以外に requirements.md / design.md / tasks.md との矛盾は検出していない。
+- serve プロセスは本機能ではフェッチ系記録経路を持たないため、serve の `/metrics` は初期値（0）公開と
+  なる（design.md の Architecture Decision 表に明記された想定どおり）。フェッチ系メトリクスの主役は
+  worker 側 listener。
 
 STATUS: complete

--- a/docs/specs/15--collector-metrics/review-notes.md
+++ b/docs/specs/15--collector-metrics/review-notes.md
@@ -1,0 +1,95 @@
+# Review Notes
+
+<!-- idd-claude:review round=2 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-15-impl--collector-metrics
+- HEAD commit: 78f17940d6b7e188d55b138fdbd07392aeb2b33c
+- Compared to: develop..HEAD
+
+> 補足: `develop..HEAD` の diff には `.github/workflows/ci.yml` の削除や
+> `docs/specs/51-ci-lint-npm-audit-eslint/` 配下の削除が現れるが、これらは
+> 本ブランチの commit による変更ではなく（`git log develop..HEAD -- <paths>` が空）、
+> base ブランチ `develop` が merge-base（3e99aea）より先行していることに起因する
+> base 進行差分である（round 1 でも同様に確認済み）。本ブランチの実変更は Issue #15
+> 関連ファイルに閉じており boundary 逸脱は無い。
+
+## Verified Requirements
+
+ROUND=1 で AC 未カバーだった Requirement 1〜5 / NFR が、task 2〜6 の追加実装で
+カバーされたことを確認した。
+
+- 1.1 — serve: `router.go` の `/metrics` 条件登録（CIDR mw 前段）+ `app.go` runServe の
+  `MetricsHandler`/`MetricsMiddleware` 注入。worker: `metrics_listener.go`。
+  `TestNewRouter_Metrics_NonNilHandler_InRange_Returns200` /
+  `TestStartWorkerMetricsListener_StartupExposesSeries` で検証。
+- 1.2 — `metrics_listener.go` / `app.go` で listener を起動完了時に公開。
+  `TestStartWorkerMetricsListener_StartupExposesSeries`（起動直後 200）で検証。
+- 1.3 — `app.go` の `NewCollector(registry)` で全 6 Collector を登録。
+  `TestStartWorkerMetricsListener_StartupExposesSeries`（ラベルなし 5 系列）+
+  `TestStartWorkerMetricsListener_HTTPStatusSeriesAppearsAfterRecord`（`feedman_http_status_total`）で
+  6 系列を検証（CounterVec の出力仕様は後述）。
+- 2.1 — `fetcher.go` 200/304 成功時 `RecordFetchSuccess`。
+  `TestFetcher_Fetch_Metrics_Success200` / `TestFetcher_Fetch_Metrics_304Success`。
+- 2.2 — `fetcher.go` SSRF/HTTP/stop/backoff/parse/upsert 失敗時 `RecordFetchFailure`。
+  `TestFetcher_Fetch_Metrics_HTTPFailure` / `...ParseFailure` / `...HTTPStatusRecordedOnBackoff`。
+- 2.3 — `fetcher.go` parse 失敗時 `RecordParseFailure`。`TestFetcher_Fetch_Metrics_ParseFailure`。
+- 2.4 — `fetcher.go` レスポンス受信直後 `RecordHTTPStatus`。
+  `TestFetcher_Fetch_Metrics_Success200`（200）/ `...HTTPStatusRecordedOnBackoff`（500）。
+- 2.5 — `fetcher.go` defer `RecordFetchLatency`。
+  `TestFetcher_Fetch_Metrics_Success200` / `...HTTPFailure`（失敗時も defer 記録）。
+- 2.6 — `upsert.go` BulkUpsert 成功後 `RecordItemsUpserted(inserted+updated)`。
+  `TestUpsertItems_Metrics_RecordsUpsertedCount` / `...NotRecordedOnError` / `...EmptyInputNotRecorded`。
+- 3.1 — `metrics_listener.go` worker 独立 listener。`TestStartWorkerMetricsListener_StartupExposesSeries`。
+- 3.2 — worker registry 共有（`app.go`）。`TestStartWorkerMetricsListener_FetchSuccessReflected`。
+- 3.3 — serve/worker で独立 registry（`app.go`）。`TestStartWorkerMetricsListener_FetchSuccessReflected`。
+- 4.1 — `trusted_cidr.go` 範囲外/未設定/パース不能 403。`TestTrustedCIDRMiddleware` /
+  `TestNewRouter_Metrics_NonNilHandler_OutOfRange_Returns403` / `TestStartWorkerMetricsListener_OutOfRangeForbidden`。
+- 4.2 — `trusted_cidr.go` 範囲内 next。`TestTrustedCIDRMiddleware`（範囲内 200, IPv6 含む）。
+- 4.3 — `trusted_cidr.go` `RemoteAddr` のみで判定・秘匿情報不要。`TestTrustedCIDRMiddleware`。
+- 5.1 — `router.go` `MetricsHandler` nil/非 nil 分岐。
+  `TestNewRouter_Metrics_NilHandler_NotRegistered` / `...NilHandler_ExistingRoutesUnchanged` /
+  `...NonNilHandler_ExistingRoutesUnchanged` + 既存 `internal/handler` 全 green。
+- 5.2 — `app.go` runServe の server timeout（Read/Write/Idle）を変更していないことを diff で確認。
+- 5.3 — `metrics_listener.go` / promhttp 既定。`TestStartWorkerMetricsListener_StartupExposesSeries`（200）。
+- NFR 1.1 — promhttp 空 gather でも 200。`TestStartWorkerMetricsListener_StartupExposesSeries`。
+- NFR 1.2 — option/nil 既定値。`TestNewFetcher_DefaultMetricsIsNopAndNilSafe` /
+  `TestNewItemUpsertService_DefaultMetricsIsNopAndNilSafe` + `go test ./...` 全 green（reviewer 再実行で確認）。
+- NFR 2.1 — `trusted_cidr.go` 空 nets で全拒否。`TestTrustedCIDRMiddleware`（空 CIDR 全拒否）。
+- NFR 2.2 — `trusted_cidr.go` 拒否時 next 未呼び出し。`TestTrustedCIDRMiddleware`（拒否時本文非包含）/
+  `TestNewRouter_..._OutOfRange_Returns403` / `TestStartWorkerMetricsListener_OutOfRangeForbidden`。
+
+reviewer 自身が `go build ./...` / `go test ./...` / `go vet ./...`（tasks.md の verify ブロック
+コマンド）を再実行し、すべて green / clean であることを確認した（NFR 1.2 の既存スイート不退行を含む）。
+
+## Findings
+
+なし
+
+## ROUND=1 reject 理由の解消確認
+
+ROUND=1 の Finding 1〜5（`/metrics` 本体・フェッチ/UPSERT 記録・worker スクレイプ経路・
+CIDR 制限・後方互換）はいずれも AC 未カバーであった。task 2〜6 の追加実装により:
+
+- Finding 1（1.1/1.2/1.3）→ router 条件登録 + worker listener + 全 6 系列登録で解消。
+- Finding 2（2.1〜2.6）→ Fetcher/ItemUpsertService の WithMetrics と各分岐の記録挿入で解消。
+- Finding 3（3.1/3.2/3.3）→ worker 専用 registry + listener、同一プロセス反映テストで解消。
+- Finding 4（4.1〜4.3）→ TrustedCIDRMiddleware の実アクセス制御と単体テストで解消。
+- Finding 5（5.x, NFR）→ router nil 分岐の不変性、serve timeout 不変、起動直後 200、
+  未設定時 403、拒否時本文非包含の各テストで解消。
+
+`feedman_http_status_total` の起動直後非出力（impl-notes.md「確認事項」）は、CounterVec が
+ラベル値記録まで系列を出さない Prometheus テキスト形式の仕様に起因する。Req 1.3 は
+「`/metrics` が全 6 系列を応答に含める」という ubiquitous 要件であり、6 Collector は registry に
+登録済みで、ステータス記録後に 6 系列目が出力されることをテストで実証している。`metrics.go`
+本体不変（Out of Scope）の制約下で観測可能な実装・テストが揃っており、AC 未カバー /
+missing test / boundary 逸脱のいずれにも該当しないため reject 対象としない。
+
+## Summary
+
+ROUND=1 で reject の根拠だった AC 未カバー（Finding 1〜5）は task 2〜6 の是正実装で
+すべて解消され、全 numeric AC / NFR に対応する実装とテストを確認した。reviewer 再実行で
+`go build`/`go test ./...`/`go vet` も green。boundary 逸脱なし、missing test なし。
+
+RESULT: approve

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -7,7 +7,7 @@
   - 6 メソッドが panic せず副作用なく呼べる単体テストを追加
   - _Requirements: 5.1, NFR 1.2_
   - _Boundary: NopCollector_
-- [ ] 1.2 Config に信頼 CIDR とメトリクスポートを追加する (P)
+- [x] 1.2 Config に信頼 CIDR とメトリクスポートを追加する (P)
   - `internal/config/config.go` の `Config` に `TrustedCIDRs []string` / `MetricsPort string` を追加
   - `Load()` で `METRICS_TRUSTED_CIDRS`（カンマ区切り、未設定時は空スライス）と `METRICS_PORT`（既定 9090）を読み込む
   - 未設定時に `TrustedCIDRs` を空のまま保持し、検証はミドルウェアに委譲する（NFR 2.1 は後続タスクで担保）

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -48,7 +48,7 @@
   - _Boundary: ItemUpsertService_
 
 - [ ] 5. serve プロセスへの /metrics 条件登録
-- [ ] 5.1 RouterDeps に MetricsHandler/MetricsMiddleware を追加し /metrics を条件登録する
+- [x] 5.1 RouterDeps に MetricsHandler/MetricsMiddleware を追加し /metrics を条件登録する
   - `internal/handler/router.go` の `RouterDeps` に `MetricsHandler http.Handler`（nil 可）と `MetricsMiddleware func(http.Handler) http.Handler`（nil 可）を追加
   - `MetricsHandler` が非 nil のとき、認証不要グループに `r.With(deps.MetricsMiddleware).Handle("/metrics", deps.MetricsHandler)` を登録
   - `MetricsHandler` が nil の場合は登録せず既存ルーティングを完全に不変に保つ（後方互換）

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -25,7 +25,7 @@
   - _Requirements: 4.1, 4.2, 4.3, NFR 2.1, NFR 2.2_
   - _Boundary: TrustedCIDRMiddleware_
 
-- [ ] 3. フェッチャー層へのメトリクス記録の組み込み
+- [x] 3. フェッチャー層へのメトリクス記録の組み込み
 - [x] 3.1 Fetcher に WithMetrics option とメトリクス記録を追加する
   - `internal/worker/fetch/fetcher.go` の `Fetcher` に `metrics metrics.MetricsCollector` フィールドを追加
   - `FetcherOption` 型と `WithMetrics(c)` を定義し、`NewFetcher(...)` の末尾に `opts ...FetcherOption` を追加（既存 7 引数 call site は不変）

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -66,7 +66,7 @@
   - _Requirements: 1.2, 1.3, 3.1, 3.2, 3.3, 5.3, NFR 1.1_
   - _Boundary: Worker MetricsListener, TrustedCIDRMiddleware_
   - _Depends: 1.1, 2.1_
-- [ ] 6.2 runServe / runWorker で registry・Collector を生成し全レイヤを wiring する
+- [x] 6.2 runServe / runWorker で registry・Collector を生成し全レイヤを wiring する
   - `internal/app/app.go` の `runServe` で serve 専用 `prometheus.NewRegistry()` + `NewCollector` を生成し、CIDR mw と `SetupMetricsRoute` を `RouterDeps` に注入
   - `runWorker` で worker 専用 registry + Collector を生成し、`fetchpkg.NewFetcher` と `item.NewItemUpsertService` に `WithMetrics` で注入、`startWorkerMetricsListener` を ctx 付きで起動
   - serve の既存 server timeout（Read/Write/Idle）は変更しない（Requirement 5.2）

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. NopCollector と設定値（信頼 CIDR / メトリクスポート）の追加
+- [x] 1. NopCollector と設定値（信頼 CIDR / メトリクスポート）の追加
 - [x] 1.1 NopCollector を追加する (P)
   - `internal/metrics/nop.go` に `MetricsCollector` の no-op 実装 `NopCollector` を追加
   - 6 メソッドすべてを空実装。既存 `metrics.go` は変更しない（追加のみ）

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -47,7 +47,7 @@
   - _Requirements: 2.6_
   - _Boundary: ItemUpsertService_
 
-- [ ] 5. serve プロセスへの /metrics 条件登録
+- [x] 5. serve プロセスへの /metrics 条件登録
 - [x] 5.1 RouterDeps に MetricsHandler/MetricsMiddleware を追加し /metrics を条件登録する
   - `internal/handler/router.go` の `RouterDeps` に `MetricsHandler http.Handler`（nil 可）と `MetricsMiddleware func(http.Handler) http.Handler`（nil 可）を追加
   - `MetricsHandler` が非 nil のとき、認証不要グループに `r.With(deps.MetricsMiddleware).Handle("/metrics", deps.MetricsHandler)` を登録

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -36,7 +36,7 @@
   - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5_
   - _Boundary: Fetcher_
 
-- [ ] 4. UPSERT サービス層へのメトリクス記録の組み込み
+- [x] 4. UPSERT サービス層へのメトリクス記録の組み込み
 - [x] 4.1 ItemUpsertService に WithMetrics option とアップサート件数記録を追加する
   - `internal/item/upsert.go` の `ItemUpsertService` に `metrics metrics.MetricsCollector` フィールドを追加
   - `UpsertOption` 型と `WithMetrics(c)` を定義し、`NewItemUpsertService(...)` の末尾に `opts ...UpsertOption` を追加（既存 2 引数 call site は不変）

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -26,7 +26,7 @@
   - _Boundary: TrustedCIDRMiddleware_
 
 - [ ] 3. フェッチャー層へのメトリクス記録の組み込み
-- [ ] 3.1 Fetcher に WithMetrics option とメトリクス記録を追加する
+- [x] 3.1 Fetcher に WithMetrics option とメトリクス記録を追加する
   - `internal/worker/fetch/fetcher.go` の `Fetcher` に `metrics metrics.MetricsCollector` フィールドを追加
   - `FetcherOption` 型と `WithMetrics(c)` を定義し、`NewFetcher(...)` の末尾に `opts ...FetcherOption` を追加（既存 7 引数 call site は不変）
   - option 未指定時は `NopCollector{}` を既定値にする（nil 安全）

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -58,7 +58,7 @@
   - _Depends: 2.1_
 
 - [ ] 6. worker プロセスへの metrics listener と全レイヤ wiring
-- [ ] 6.1 worker 用 metrics listener ヘルパを追加する
+- [x] 6.1 worker 用 metrics listener ヘルパを追加する
   - `internal/app/metrics_listener.go` に `startWorkerMetricsListener(ctx, addr, gatherer, cidrs)` を追加
   - worker registry を gatherer として `metrics.SetupMetricsRoute` を取得し、`NewTrustedCIDRMiddleware` でラップした `http.Server` を goroutine で起動
   - ctx キャンセルで `server.Shutdown` による graceful stop（goroutine リーク防止）、起動失敗はエラーログにとどめ worker 本体を落とさない

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -15,7 +15,7 @@
   - _Boundary: Config_
 
 - [ ] 2. 信頼 CIDR ミドルウェアの実装
-- [ ] 2.1 TrustedCIDRMiddleware を実装する (P)
+- [x] 2.1 TrustedCIDRMiddleware を実装する (P)
   - `internal/middleware/trusted_cidr.go` に `NewTrustedCIDRMiddleware(cidrs []string) func(next http.Handler) http.Handler` を追加（既存ミドルウェアのコンストラクタ関数パターンに準拠）
   - 起動時に `net.ParseCIDR` で `[]*net.IPNet` を構築し、不正な CIDR 文字列はスキップしてログ出力
   - リクエスト時に `r.RemoteAddr` から host を抽出して `net.ParseIP`、いずれかの CIDR に含まれれば next、なければ 403

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -14,7 +14,7 @@
   - _Requirements: 4.1, NFR 2.1_
   - _Boundary: Config_
 
-- [ ] 2. 信頼 CIDR ミドルウェアの実装
+- [x] 2. 信頼 CIDR ミドルウェアの実装
 - [x] 2.1 TrustedCIDRMiddleware を実装する (P)
   - `internal/middleware/trusted_cidr.go` に `NewTrustedCIDRMiddleware(cidrs []string) func(next http.Handler) http.Handler` を追加（既存ミドルウェアのコンストラクタ関数パターンに準拠）
   - 起動時に `net.ParseCIDR` で `[]*net.IPNet` を構築し、不正な CIDR 文字列はスキップしてログ出力

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -1,7 +1,7 @@
 # Implementation Plan
 
 - [ ] 1. NopCollector と設定値（信頼 CIDR / メトリクスポート）の追加
-- [ ] 1.1 NopCollector を追加する (P)
+- [x] 1.1 NopCollector を追加する (P)
   - `internal/metrics/nop.go` に `MetricsCollector` の no-op 実装 `NopCollector` を追加
   - 6 メソッドすべてを空実装。既存 `metrics.go` は変更しない（追加のみ）
   - 6 メソッドが panic せず副作用なく呼べる単体テストを追加

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -57,7 +57,7 @@
   - _Boundary: Router, TrustedCIDRMiddleware_
   - _Depends: 2.1_
 
-- [ ] 6. worker プロセスへの metrics listener と全レイヤ wiring
+- [x] 6. worker プロセスへの metrics listener と全レイヤ wiring
 - [x] 6.1 worker 用 metrics listener ヘルパを追加する
   - `internal/app/metrics_listener.go` に `startWorkerMetricsListener(ctx, addr, gatherer, cidrs)` を追加
   - worker registry を gatherer として `metrics.SetupMetricsRoute` を取得し、`NewTrustedCIDRMiddleware` でラップした `http.Server` を goroutine で起動

--- a/docs/specs/15--collector-metrics/tasks.md
+++ b/docs/specs/15--collector-metrics/tasks.md
@@ -37,7 +37,7 @@
   - _Boundary: Fetcher_
 
 - [ ] 4. UPSERT サービス層へのメトリクス記録の組み込み
-- [ ] 4.1 ItemUpsertService に WithMetrics option とアップサート件数記録を追加する
+- [x] 4.1 ItemUpsertService に WithMetrics option とアップサート件数記録を追加する
   - `internal/item/upsert.go` の `ItemUpsertService` に `metrics metrics.MetricsCollector` フィールドを追加
   - `UpsertOption` 型と `WithMetrics(c)` を定義し、`NewItemUpsertService(...)` の末尾に `opts ...UpsertOption` を追加（既存 2 引数 call site は不変）
   - option 未指定時は `NopCollector{}` を既定値にする

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,6 +11,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/hitoshi/feedman/internal/auth"
 	"github.com/hitoshi/feedman/internal/config"
 	"github.com/hitoshi/feedman/internal/database"
@@ -19,6 +21,7 @@ import (
 	"github.com/hitoshi/feedman/internal/hatebu"
 	"github.com/hitoshi/feedman/internal/item"
 	"github.com/hitoshi/feedman/internal/logger"
+	"github.com/hitoshi/feedman/internal/metrics"
 	"github.com/hitoshi/feedman/internal/middleware"
 	"github.com/hitoshi/feedman/internal/repository"
 	"github.com/hitoshi/feedman/internal/security"
@@ -150,6 +153,12 @@ func runServe(cfg *config.Config) error {
 	// シャットダウン時に Stop() を呼べるよう変数参照を保持する（goroutine リーク防止）。
 	rateLimiter := middleware.NewRateLimiter(rateLimiterCfg)
 
+	// serve 専用の Prometheus registry と Collector を生成する。
+	// serve プロセスにはフェッチ系の記録経路が無いため初期値（0）の公開となるが、
+	// /metrics 自体は信頼 CIDR 制限付きで公開する（Requirement 1.1, 5.1）。
+	serveRegistry := prometheus.NewRegistry()
+	_ = metrics.NewCollector(serveRegistry)
+
 	deps := &handler.RouterDeps{
 		HealthChecker:     db,
 		SessionFinder:     sessionRepo,
@@ -157,6 +166,9 @@ func runServe(cfg *config.Config) error {
 		RateLimiter:       rateLimiter,
 		HSTSEnabled:       cfg.HSTSEnabled,
 		Logger:            slog.Default(),
+
+		MetricsHandler:    metrics.SetupMetricsRoute(serveRegistry),
+		MetricsMiddleware: middleware.NewTrustedCIDRMiddleware(cfg.TrustedCIDRs),
 
 		AuthService: authService,
 		AuthConfig: handler.AuthHandlerConfig{
@@ -243,22 +255,29 @@ func runWorker(cfg *config.Config) error {
 	ssrfGuard := security.NewSSRFGuard()
 	sanitizer := security.NewContentSanitizer()
 
-	// 4. フェッチャーの初期化
-	upsertSvc := item.NewItemUpsertService(itemRepo, sanitizer)
+	// 4. worker 専用の registry と Collector を生成し、各レイヤへ注入する。
+	// フェッチ／UPSERT は worker プロセスで実行されるため、フェッチ系メトリクスは
+	// この registry に蓄積され、後述の metrics listener 経由でスクレイプ可能になる（Requirement 3.1）。
+	workerRegistry := prometheus.NewRegistry()
+	collector := metrics.NewCollector(workerRegistry)
+
+	// 5. フェッチャーの初期化（WithMetrics で Collector を注入）
+	upsertSvc := item.NewItemUpsertService(itemRepo, sanitizer, item.WithMetrics(collector))
 	fetcher := fetchpkg.NewFetcher(
 		feedRepo, subRepo, upsertSvc, ssrfGuard,
 		slog.Default(), cfg.FetchTimeout, cfg.FetchMaxSize,
+		fetchpkg.WithMetrics(collector),
 	)
 
-	// 5. スケジューラの起動
+	// 6. スケジューラの起動
 	scheduler := fetchpkg.NewScheduler(
 		feedRepo, fetcher, slog.Default(), cfg.FetchMaxConcurrent,
 	)
 
-	// 6. クリーンアップジョブの初期化
+	// 7. クリーンアップジョブの初期化
 	cleanupJob := cleanup.NewCleanupJob(db, slog.Default())
 
-	// 7. はてなブックマークバッチジョブの初期化
+	// 8. はてなブックマークバッチジョブの初期化
 	hatebuClient := hatebu.NewClient(
 		&http.Client{Timeout: 10 * time.Second},
 		slog.Default(),
@@ -287,6 +306,11 @@ func runWorker(cfg *config.Config) error {
 		slog.Duration("fetch_interval", cfg.FetchInterval),
 		slog.Int("max_concurrent", cfg.FetchMaxConcurrent),
 	)
+
+	// worker 専用の metrics listener を起動する（信頼 CIDR 制限付き）。
+	// worker は HTTP ルーターを持たないため独立 listener で /metrics を公開し、
+	// ctx キャンセルで graceful stop する（Requirement 1.2, 3.1, 3.2, 3.3）。
+	startWorkerMetricsListener(ctx, ":"+cfg.MetricsPort, workerRegistry, cfg.TrustedCIDRs)
 
 	// はてなブックマークバッチジョブをバックグラウンドで起動
 	go hatebuBatch.Start(ctx)

--- a/internal/app/metrics_listener.go
+++ b/internal/app/metrics_listener.go
@@ -1,0 +1,61 @@
+package app
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/hitoshi/feedman/internal/metrics"
+	"github.com/hitoshi/feedman/internal/middleware"
+)
+
+// startWorkerMetricsListener は worker 用の metrics HTTP listener を新規 goroutine で起動する。
+//
+// gatherer（worker 専用 registry）を SetupMetricsRoute で公開し、NewTrustedCIDRMiddleware(cidrs)
+// で前段に信頼 CIDR 制限を重ねた http.Server を addr で待ち受ける。worker は HTTP ルーターを
+// 持たないため、メトリクス公開専用の軽量 listener を独立して起動する（Requirement 3.1）。
+//
+// ctx がキャンセルされると server.Shutdown による graceful stop を行い goroutine リークを防ぐ。
+// listener の起動失敗（ポート競合等）は worker 本体を落とさずエラーログにとどめる
+// （メトリクス公開の失敗でフェッチ機能全体を止めない）。
+func startWorkerMetricsListener(ctx context.Context, addr string, gatherer prometheus.Gatherer, cidrs []string) {
+	cidrMiddleware := middleware.NewTrustedCIDRMiddleware(cidrs)
+	handler := cidrMiddleware(metrics.SetupMetricsRoute(gatherer))
+
+	server := &http.Server{
+		Addr:         addr,
+		Handler:      handler,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	// ctx キャンセルで graceful shutdown する watcher goroutine。
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			slog.Error("metrics listener のシャットダウンに失敗しました",
+				slog.String("addr", addr),
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
+
+	// listener 本体を別 goroutine で起動する（worker 本体をブロックしない）。
+	go func() {
+		slog.Info("worker metrics listener starting",
+			slog.String("addr", addr),
+		)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("metrics listener の起動に失敗しました",
+				slog.String("addr", addr),
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
+}

--- a/internal/app/metrics_listener_test.go
+++ b/internal/app/metrics_listener_test.go
@@ -1,0 +1,195 @@
+package app
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/hitoshi/feedman/internal/metrics"
+)
+
+// freePort は OS に空きポートを割り当てさせてアドレス文字列（127.0.0.1:NNNN）を返す。
+// 取得後すぐにリスナーを閉じるため、僅かな TOCTOU はあるが flaky になりにくい。
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("空きポートの確保に失敗: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	return addr
+}
+
+// getMetrics は addr の /metrics へ範囲内 IP（loopback）からアクセスし、本文とステータスを返す。
+// 起動直後で listener がまだ準備中の場合に備えて短時間ポーリングする。
+func getMetrics(t *testing.T, addr string) (int, string) {
+	t.Helper()
+	url := "http://" + addr + "/metrics"
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		resp, err := client.Get(url)
+		if err == nil {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return resp.StatusCode, string(body)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("/metrics への接続がタイムアウト: %v", err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// startupSeriesNames は記録なしの起動直後でも /metrics に出力される 5 系列名。
+// feedman_http_status_total はラベル付き CounterVec のため、ラベル値（ステータスコード）が
+// 1 度も記録されるまで Prometheus テキスト出力に現れない。当該系列は
+// TestStartWorkerMetricsListener_HTTPStatusSeriesAppearsAfterRecord で別途検証する。
+var startupSeriesNames = []string{
+	"feedman_fetch_success_total",
+	"feedman_fetch_fail_total",
+	"feedman_parse_fail_total",
+	"feedman_fetch_latency_seconds",
+	"feedman_items_upserted_total",
+}
+
+// TestStartWorkerMetricsListener_StartupExposesSeries は起動直後（未記録）でも
+// /metrics が 200 を返し、ラベルなし 5 系列名を含むことを検証する（Requirement 1.3, 5.3, NFR 1.1）。
+func TestStartWorkerMetricsListener_StartupExposesSeries(t *testing.T) {
+	// Arrange
+	reg := prometheus.NewRegistry()
+	_ = metrics.NewCollector(reg)
+	addr := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Act
+	startWorkerMetricsListener(ctx, addr, reg, []string{"127.0.0.0/8"})
+	status, body := getMetrics(t, addr)
+
+	// Assert
+	if status != http.StatusOK {
+		t.Fatalf("起動直後の /metrics status = %d, want 200", status)
+	}
+	for _, name := range startupSeriesNames {
+		if !strings.Contains(body, name) {
+			t.Errorf("/metrics 応答に系列名 %q が含まれていない", name)
+		}
+	}
+}
+
+// TestStartWorkerMetricsListener_HTTPStatusSeriesAppearsAfterRecord は
+// HTTP ステータスを 1 度記録すると feedman_http_status_total 系列が /metrics に現れることを
+// 検証する（Requirement 1.3 の 6 系列目。CounterVec はラベル値記録後に出力されるため）。
+func TestStartWorkerMetricsListener_HTTPStatusSeriesAppearsAfterRecord(t *testing.T) {
+	// Arrange
+	reg := prometheus.NewRegistry()
+	collector := metrics.NewCollector(reg)
+	addr := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startWorkerMetricsListener(ctx, addr, reg, []string{"127.0.0.0/8"})
+
+	// Act: HTTP ステータス 200 を記録する
+	collector.RecordHTTPStatus(http.StatusOK)
+	status, body := getMetrics(t, addr)
+
+	// Assert
+	if status != http.StatusOK {
+		t.Fatalf("/metrics status = %d, want 200", status)
+	}
+	if !strings.Contains(body, "feedman_http_status_total") {
+		t.Errorf("ステータス記録後の /metrics 応答に feedman_http_status_total が含まれていない。本文:\n%s", body)
+	}
+}
+
+// TestStartWorkerMetricsListener_FetchSuccessReflected はフェッチ成功記録後に
+// /metrics 応答へ feedman_fetch_success_total の増加が反映されることを検証する（Requirement 3.1, 3.2）。
+func TestStartWorkerMetricsListener_FetchSuccessReflected(t *testing.T) {
+	// Arrange
+	reg := prometheus.NewRegistry()
+	collector := metrics.NewCollector(reg)
+	addr := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startWorkerMetricsListener(ctx, addr, reg, []string{"127.0.0.0/8"})
+
+	// Act: フェッチ成功を 1 件記録する
+	collector.RecordFetchSuccess("feed-1")
+	status, body := getMetrics(t, addr)
+
+	// Assert
+	if status != http.StatusOK {
+		t.Fatalf("/metrics status = %d, want 200", status)
+	}
+	if !strings.Contains(body, "feedman_fetch_success_total 1") {
+		t.Errorf("/metrics 応答に feedman_fetch_success_total 1 が反映されていない。本文:\n%s", body)
+	}
+}
+
+// TestStartWorkerMetricsListener_OutOfRangeForbidden は CIDR 範囲外の listener では
+// loopback からのアクセスが 403 になることを検証する（Requirement 4.1, NFR 2.2）。
+func TestStartWorkerMetricsListener_OutOfRangeForbidden(t *testing.T) {
+	// Arrange: loopback を含まない CIDR を設定する
+	reg := prometheus.NewRegistry()
+	_ = metrics.NewCollector(reg)
+	addr := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startWorkerMetricsListener(ctx, addr, reg, []string{"10.0.0.0/8"})
+
+	// Act
+	status, body := getMetrics(t, addr)
+
+	// Assert
+	if status != http.StatusForbidden {
+		t.Errorf("範囲外 listener の /metrics status = %d, want 403", status)
+	}
+	if strings.Contains(body, "feedman_fetch_success_total") {
+		t.Errorf("403 応答にメトリクス本文が含まれている: %q", body)
+	}
+}
+
+// TestStartWorkerMetricsListener_CtxCancelStopsListener は ctx キャンセルで listener が
+// graceful stop し、以降の接続が拒否されることを検証する（goroutine リーク防止）。
+func TestStartWorkerMetricsListener_CtxCancelStopsListener(t *testing.T) {
+	// Arrange
+	reg := prometheus.NewRegistry()
+	_ = metrics.NewCollector(reg)
+	addr := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	startWorkerMetricsListener(ctx, addr, reg, []string{"127.0.0.0/8"})
+
+	// 起動を確認してからキャンセルする
+	if status, _ := getMetrics(t, addr); status != http.StatusOK {
+		t.Fatalf("キャンセル前の /metrics status = %d, want 200", status)
+	}
+
+	// Act
+	cancel()
+
+	// Assert: shutdown 後は接続が確立できなくなる（短時間ポーリングで確認）
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	deadline := time.Now().Add(3 * time.Second)
+	stopped := false
+	for time.Now().Before(deadline) {
+		resp, err := client.Get("http://" + addr + "/metrics")
+		if err != nil {
+			stopped = true
+			break
+		}
+		_ = resp.Body.Close()
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !stopped {
+		t.Error("ctx キャンセル後も listener が応答し続けている（graceful stop されていない）")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,15 @@ type Config struct {
 	// HSTSEnabled は HSTS（Strict-Transport-Security）ヘッダーの出力可否を制御する。
 	// 既定値は false（HSTS 非出力 = 本機能導入前と等価）。
 	HSTSEnabled bool
+
+	// Metrics
+	// TrustedCIDRs は /metrics エンドポイントへのアクセスを許可する信頼ネットワーク範囲（CIDR 表記）。
+	// METRICS_TRUSTED_CIDRS（カンマ区切り）から読み込む。未設定時は空スライス。
+	// 各要素の検証（不正 CIDR の判定）はミドルウェア側に委譲する。
+	TrustedCIDRs []string
+	// MetricsPort は worker プロセスがメトリクスを公開する listener のポート。
+	// METRICS_PORT から読み込む。既定値は "9090"。
+	MetricsPort string
 }
 
 // Load は環境変数からConfigを読み込む。
@@ -120,8 +129,27 @@ func Load() (*Config, error) {
 	cfg.CookieDomain = getEnvString("COOKIE_DOMAIN", "")
 	cfg.CORSAllowedOrigin = getEnvString("CORS_ALLOWED_ORIGIN", "http://localhost:3000")
 	cfg.HSTSEnabled = getEnvBool("HSTS_ENABLED", false)
+	cfg.TrustedCIDRs = parseCommaSeparated(os.Getenv("METRICS_TRUSTED_CIDRS"))
+	cfg.MetricsPort = getEnvString("METRICS_PORT", "9090")
 
 	return cfg, nil
+}
+
+// parseCommaSeparated はカンマ区切りの文字列を要素スライスに分解する。
+// 各要素は前後の空白を除去し、空要素は除外する。
+// 入力が空文字（未設定）の場合は空スライス（nil）を返す。
+func parseCommaSeparated(v string) []string {
+	if strings.TrimSpace(v) == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }
 
 func getEnvString(key, defaultVal string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -167,6 +167,147 @@ func TestLoad_DefaultValues(t *testing.T) {
 	if cfg.HSTSEnabled != false {
 		t.Errorf("HSTSEnabled = %v, want %v (default)", cfg.HSTSEnabled, false)
 	}
+
+	// Metrics defaults: 未設定時 MetricsPort は "9090"、TrustedCIDRs は空。
+	if cfg.MetricsPort != "9090" {
+		t.Errorf("MetricsPort = %q, want %q", cfg.MetricsPort, "9090")
+	}
+	if len(cfg.TrustedCIDRs) != 0 {
+		t.Errorf("TrustedCIDRs = %v, want empty (default)", cfg.TrustedCIDRs)
+	}
+}
+
+// TestLoad_MetricsTrustedCIDRs は METRICS_TRUSTED_CIDRS のカンマ区切りパースを検証する。
+// Requirement 4.1（信頼 CIDR の設定）/ NFR 2.1（未設定時は空のまま保持し検証はミドルウェアに委譲）に対応。
+func TestLoad_MetricsTrustedCIDRs(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want []string
+	}{
+		{
+			name: "単一CIDRのとき1要素のスライスになる",
+			env:  "10.0.0.0/8",
+			want: []string{"10.0.0.0/8"},
+		},
+		{
+			name: "複数CIDRのとき要素ごとに分割される",
+			env:  "10.0.0.0/8,192.168.0.0/16",
+			want: []string{"10.0.0.0/8", "192.168.0.0/16"},
+		},
+		{
+			name: "要素前後に空白があるときトリムされる",
+			env:  " 10.0.0.0/8 , 192.168.0.0/16 ",
+			want: []string{"10.0.0.0/8", "192.168.0.0/16"},
+		},
+		{
+			name: "空要素が含まれるとき除外される",
+			env:  "10.0.0.0/8,,192.168.0.0/16,",
+			want: []string{"10.0.0.0/8", "192.168.0.0/16"},
+		},
+		{
+			name: "不正なCIDR文字列でもパース段階では除外せず保持する",
+			env:  "not-a-cidr,10.0.0.0/8",
+			want: []string{"not-a-cidr", "10.0.0.0/8"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			setRequiredEnvVars(t)
+			t.Setenv("METRICS_TRUSTED_CIDRS", tc.env)
+
+			// Act
+			cfg, err := Load()
+
+			// Assert
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if len(cfg.TrustedCIDRs) != len(tc.want) {
+				t.Fatalf("TrustedCIDRs length = %d (%v), want %d (%v)",
+					len(cfg.TrustedCIDRs), cfg.TrustedCIDRs, len(tc.want), tc.want)
+			}
+			for i, w := range tc.want {
+				if cfg.TrustedCIDRs[i] != w {
+					t.Errorf("TrustedCIDRs[%d] = %q, want %q", i, cfg.TrustedCIDRs[i], w)
+				}
+			}
+		})
+	}
+
+	t.Run("未設定（空文字）のとき空スライスを保持する", func(t *testing.T) {
+		// Arrange
+		setRequiredEnvVars(t)
+		t.Setenv("METRICS_TRUSTED_CIDRS", "")
+
+		// Act
+		cfg, err := Load()
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(cfg.TrustedCIDRs) != 0 {
+			t.Errorf("TrustedCIDRs = %v, want empty", cfg.TrustedCIDRs)
+		}
+	})
+
+	t.Run("空白のみのとき空スライスを保持する", func(t *testing.T) {
+		// Arrange
+		setRequiredEnvVars(t)
+		t.Setenv("METRICS_TRUSTED_CIDRS", "   ")
+
+		// Act
+		cfg, err := Load()
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(cfg.TrustedCIDRs) != 0 {
+			t.Errorf("TrustedCIDRs = %v, want empty", cfg.TrustedCIDRs)
+		}
+	})
+}
+
+// TestLoad_MetricsPort は METRICS_PORT の読み込みと既定値を検証する。
+// Requirement 4.1 に対応。
+func TestLoad_MetricsPort(t *testing.T) {
+	t.Run("METRICS_PORTが設定されているとき値を採用する", func(t *testing.T) {
+		// Arrange
+		setRequiredEnvVars(t)
+		t.Setenv("METRICS_PORT", "9999")
+
+		// Act
+		cfg, err := Load()
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if cfg.MetricsPort != "9999" {
+			t.Errorf("MetricsPort = %q, want %q", cfg.MetricsPort, "9999")
+		}
+	})
+
+	t.Run("METRICS_PORTが未設定のとき既定値9090を採用する", func(t *testing.T) {
+		// Arrange
+		setRequiredEnvVars(t)
+		t.Setenv("METRICS_PORT", "")
+
+		// Act
+		cfg, err := Load()
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if cfg.MetricsPort != "9090" {
+			t.Errorf("MetricsPort = %q, want %q (default)", cfg.MetricsPort, "9090")
+		}
+	})
 }
 
 // TestLoad_HSTSEnabled は HSTS_ENABLED 環境変数の読み込みを検証する。

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -51,6 +51,14 @@ type RouterDeps struct {
 	// nil の場合は slog.Default() にフォールバックする（後方互換）。
 	Logger *slog.Logger
 
+	// メトリクス（任意）
+	// MetricsHandler が非 nil のときのみ認証不要グループに /metrics を登録する。
+	// nil の場合は登録せず、既存ルーティングを完全に不変に保つ（後方互換）。
+	MetricsHandler http.Handler
+	// MetricsMiddleware は /metrics の前段に重ねるミドルウェア（信頼 CIDR 制限など）。
+	// nil の場合は素通し（制限なし）として扱う。MetricsHandler が nil のときは参照しない。
+	MetricsMiddleware func(http.Handler) http.Handler
+
 	// 認証
 	AuthService AuthServiceInterface
 	AuthConfig  AuthHandlerConfig
@@ -136,6 +144,18 @@ func NewRouter(deps *RouterDeps) http.Handler {
 			r.Post("/logout", authHandler.Logout)
 			r.Get("/me", authHandler.Me)
 		})
+
+		// メトリクス公開エンドポイント（任意）。
+		// MetricsHandler が非 nil のときのみ登録し、前段に MetricsMiddleware（信頼 CIDR 制限）を
+		// 重ねる。MetricsHandler が nil の場合は登録せず既存ルーティングを完全に不変に保つ（後方互換）。
+		if deps.MetricsHandler != nil {
+			mw := deps.MetricsMiddleware
+			if mw == nil {
+				// ミドルウェア未指定時は素通しとして扱い、chi の With(nil) panic を避ける。
+				mw = func(next http.Handler) http.Handler { return next }
+			}
+			r.With(mw).Handle("/metrics", deps.MetricsHandler)
+		}
 	})
 
 	// --- 認証が必要なルート ---

--- a/internal/handler/router_metrics_test.go
+++ b/internal/handler/router_metrics_test.go
@@ -1,0 +1,174 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hitoshi/feedman/internal/middleware"
+	"github.com/hitoshi/feedman/internal/model"
+)
+
+// newMetricsTestDeps はメトリクス登録テスト用の最小 RouterDeps を構築する。
+// metricsHandler / metricsMiddleware を任意に注入できる。
+func newMetricsTestDeps(metricsHandler http.Handler, metricsMiddleware func(http.Handler) http.Handler) *RouterDeps {
+	sessionFinder := &mockSessionFinderForRouter{
+		sessions: map[string]*model.Session{
+			"valid-session": {
+				ID:        "valid-session",
+				UserID:    "user-test-1",
+				ExpiresAt: time.Now().Add(1 * time.Hour),
+			},
+		},
+	}
+	return &RouterDeps{
+		SessionFinder:     sessionFinder,
+		CORSAllowedOrigin: "http://localhost:3000",
+		RateLimiter:       middleware.NewRateLimiter(middleware.DefaultRateLimiterConfig()),
+		AuthService: &mockAuthService{
+			getLoginURLFn: func(state string) string {
+				return "https://accounts.google.com?state=" + state
+			},
+			getCurrentUserFn: func(_ context.Context, _ string) (*model.User, error) {
+				return &model.User{ID: "user-test-1", Email: "test@example.com", Name: "Test"}, nil
+			},
+		},
+		AuthConfig:          AuthHandlerConfig{BaseURL: "http://localhost:3000", SessionMaxAge: 86400},
+		FeedService:         &mockFeedService{},
+		SubscriptionDeleter: &mockSubscriptionDeleter{},
+		ItemService:         &mockItemService{},
+		ItemStateService:    &mockItemStateService{},
+		SubscriptionService: &mockSubscriptionService{},
+		UserService:         &mockUserService{},
+		MetricsHandler:      metricsHandler,
+		MetricsMiddleware:   metricsMiddleware,
+	}
+}
+
+// metricsTestBody は /metrics ハンドラが返すテスト用ボディ。
+const metricsTestBody = "feedman_fetch_success_total 0"
+
+// newMetricsTestHandler はメトリクス本文を返すテスト用ハンドラを返す。
+func newMetricsTestHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(metricsTestBody))
+	})
+}
+
+// TestNewRouter_Metrics_NonNilHandler_InRange_Returns200 は MetricsHandler 非 nil かつ
+// CIDR 範囲内のとき /metrics が 200 でメトリクス本文を返すことを検証する（Requirement 1.1）。
+func TestNewRouter_Metrics_NonNilHandler_InRange_Returns200(t *testing.T) {
+	// Arrange
+	mw := middleware.NewTrustedCIDRMiddleware([]string{"127.0.0.0/8"})
+	router := NewRouter(newMetricsTestDeps(newMetricsTestHandler(), mw))
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.RemoteAddr = "127.0.0.1:50000"
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("GET /metrics (範囲内) status = %d, want 200", w.Result().StatusCode)
+	}
+}
+
+// TestNewRouter_Metrics_NonNilHandler_OutOfRange_Returns403 は CIDR 範囲外のとき
+// /metrics が 403 を返しメトリクス本文を含めないことを検証する（Requirement 4.1, 5.1）。
+func TestNewRouter_Metrics_NonNilHandler_OutOfRange_Returns403(t *testing.T) {
+	// Arrange
+	mw := middleware.NewTrustedCIDRMiddleware([]string{"127.0.0.0/8"})
+	router := NewRouter(newMetricsTestDeps(newMetricsTestHandler(), mw))
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.RemoteAddr = "10.0.0.1:50000"
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusForbidden {
+		t.Errorf("GET /metrics (範囲外) status = %d, want 403", w.Result().StatusCode)
+	}
+	if got := w.Body.String(); strings.Contains(got, metricsTestBody) {
+		t.Errorf("403 応答にメトリクス本文が含まれている: %q", got)
+	}
+}
+
+// TestNewRouter_Metrics_NilHandler_NotRegistered は MetricsHandler nil のとき
+// /metrics が登録されず 404 になることを検証する（Requirement 5.1 後方互換）。
+func TestNewRouter_Metrics_NilHandler_NotRegistered(t *testing.T) {
+	// Arrange
+	router := NewRouter(newMetricsTestDeps(nil, nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.RemoteAddr = "127.0.0.1:50000"
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusNotFound {
+		t.Errorf("MetricsHandler nil のとき GET /metrics status = %d, want 404", w.Result().StatusCode)
+	}
+}
+
+// TestNewRouter_Metrics_NilHandler_ExistingRoutesUnchanged は MetricsHandler nil のとき
+// 既存ルート（/health・/auth/*・/api/*）のルーティング挙動が不変であることを検証する（Requirement 5.1）。
+func TestNewRouter_Metrics_NilHandler_ExistingRoutesUnchanged(t *testing.T) {
+	router := NewRouter(newMetricsTestDeps(nil, nil))
+
+	cases := []struct {
+		name       string
+		method     string
+		path       string
+		withCookie bool
+		wantStatus int
+	}{
+		{"health は 200", http.MethodGet, "/health", false, http.StatusOK},
+		{"auth login は 307 リダイレクト", http.MethodGet, "/auth/google/login", false, http.StatusTemporaryRedirect},
+		{"api はセッションなしで 401", http.MethodGet, "/api/subscriptions", false, http.StatusUnauthorized},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			w := httptest.NewRecorder()
+
+			// Act
+			router.ServeHTTP(w, req)
+
+			// Assert
+			if w.Result().StatusCode != tt.wantStatus {
+				t.Errorf("%s %s status = %d, want %d", tt.method, tt.path, w.Result().StatusCode, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// TestNewRouter_Metrics_NonNilHandler_ExistingRoutesUnchanged は MetricsHandler 非 nil でも
+// 既存ルートのルーティング挙動が不変であることを検証する（Requirement 5.1）。
+func TestNewRouter_Metrics_NonNilHandler_ExistingRoutesUnchanged(t *testing.T) {
+	mw := middleware.NewTrustedCIDRMiddleware([]string{"127.0.0.0/8"})
+	router := NewRouter(newMetricsTestDeps(newMetricsTestHandler(), mw))
+
+	// /health は CIDR 制限なしでアクセスできる（/metrics 以外に CIDR mw が漏れていないこと）
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.RemoteAddr = "10.0.0.1:50000" // /metrics では拒否される範囲外 IP
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("MetricsHandler 非 nil 時の GET /health status = %d, want 200（CIDR mw は /metrics のみ）", w.Result().StatusCode)
+	}
+}

--- a/internal/item/upsert.go
+++ b/internal/item/upsert.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hitoshi/feedman/internal/metrics"
 	"github.com/hitoshi/feedman/internal/model"
 	"github.com/hitoshi/feedman/internal/repository"
 	"github.com/hitoshi/feedman/internal/security"
@@ -19,17 +20,37 @@ import (
 type ItemUpsertService struct {
 	itemRepo  repository.ItemRepository
 	sanitizer security.ContentSanitizerService
+	metrics   metrics.MetricsCollector
+}
+
+// UpsertOption は NewItemUpsertService の任意設定を表す functional option。
+type UpsertOption func(*ItemUpsertService)
+
+// WithMetrics は ItemUpsertService にメトリクスコレクタを注入する。
+// 未指定時は metrics.NopCollector{} が既定値として使われ、記録呼び出しは no-op になる。
+func WithMetrics(c metrics.MetricsCollector) UpsertOption {
+	return func(s *ItemUpsertService) {
+		s.metrics = c
+	}
 }
 
 // NewItemUpsertService はItemUpsertServiceの新しいインスタンスを生成する。
+// 既存の 2 引数 call site との後方互換のため、メトリクスコレクタは末尾の可変長
+// functional option（WithMetrics）として受け取る。opts 未指定時は no-op コレクタを既定値とする。
 func NewItemUpsertService(
 	itemRepo repository.ItemRepository,
 	sanitizer security.ContentSanitizerService,
+	opts ...UpsertOption,
 ) *ItemUpsertService {
-	return &ItemUpsertService{
+	s := &ItemUpsertService{
 		itemRepo:  itemRepo,
 		sanitizer: sanitizer,
+		metrics:   metrics.NopCollector{},
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // preparedItem はサニタイズと content_hash 計算を終えた永続化前の中間表現。
@@ -104,6 +125,10 @@ func (s *ItemUpsertService) UpsertItems(
 
 	inserted = len(toCreate)
 	updated = len(toUpdate)
+
+	// BulkUpsert 成功後にアップサート件数（新規 + 更新）を記録する（Requirement 2.6）。
+	// エラー時は上の return で抜けるため記録されない（ロールバック相当）。
+	s.metrics.RecordItemsUpserted(inserted + updated)
 
 	slog.Info("記事UPSERT完了",
 		"feed_id", feedID,

--- a/internal/item/upsert_test.go
+++ b/internal/item/upsert_test.go
@@ -1461,3 +1461,128 @@ func TestUpsertItems_BatchInternalDuplicate_ExistingLastWins(t *testing.T) {
 		t.Errorf("更新対象 id = %q, want %q", repo.lastUpdatedItem.ID, "dup-existing")
 	}
 }
+
+// --- Task 4.1: WithMetrics によるアップサート件数記録のテスト ---
+
+// mockMetricsCollector は metrics.MetricsCollector のテスト用モック。
+// RecordItemsUpserted の呼び出し回数と最後の件数を保持する。
+type mockMetricsCollector struct {
+	itemsUpsertedCalls int
+	lastItemsUpserted  int
+}
+
+func (m *mockMetricsCollector) RecordFetchSuccess(_ string)        {}
+func (m *mockMetricsCollector) RecordFetchFailure(_, _ string)     {}
+func (m *mockMetricsCollector) RecordParseFailure(_ string)        {}
+func (m *mockMetricsCollector) RecordHTTPStatus(_ int)             {}
+func (m *mockMetricsCollector) RecordFetchLatency(_ time.Duration) {}
+func (m *mockMetricsCollector) RecordItemsUpserted(count int) {
+	m.itemsUpsertedCalls++
+	m.lastItemsUpserted = count
+}
+
+// TestUpsertItems_Metrics_RecordsUpsertedCount は UPSERT 成功時に
+// 新規 + 更新の件数が RecordItemsUpserted に加算されることを検証する（Requirement 2.6）。
+func TestUpsertItems_Metrics_RecordsUpsertedCount(t *testing.T) {
+	// Arrange: 既存 1 件（更新対象）+ 新規 1 件 → inserted=1, updated=1
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+	repo.addExistingItem(&model.Item{
+		ID:       "existing-1",
+		FeedID:   "feed-1",
+		GuidOrID: "guid-existing",
+		Title:    "古い",
+	})
+	mc := &mockMetricsCollector{}
+	svc := NewItemUpsertService(repo, sanitizer, WithMetrics(mc))
+
+	parsedItems := []model.ParsedItem{
+		{GuidOrID: "guid-existing", Title: "更新後", Link: "https://example.com/u"},
+		{GuidOrID: "guid-new", Title: "新規", Link: "https://example.com/n"},
+	}
+
+	// Act
+	inserted, updated, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems)
+	if err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+
+	// Assert
+	if inserted != 1 || updated != 1 {
+		t.Fatalf("(inserted, updated) = (%d, %d), want (1, 1)", inserted, updated)
+	}
+	if mc.itemsUpsertedCalls != 1 {
+		t.Errorf("RecordItemsUpserted 呼び出し回数 = %d, want 1", mc.itemsUpsertedCalls)
+	}
+	if mc.lastItemsUpserted != inserted+updated {
+		t.Errorf("記録された件数 = %d, want %d（inserted+updated）", mc.lastItemsUpserted, inserted+updated)
+	}
+}
+
+// TestUpsertItems_Metrics_NotRecordedOnError は BulkUpsert がエラー（ロールバック）の場合に
+// RecordItemsUpserted を呼ばないことを検証する（Requirement 2.6）。
+func TestUpsertItems_Metrics_NotRecordedOnError(t *testing.T) {
+	// Arrange
+	repo := newMockItemRepo()
+	repo.upsertErr = errors.New("bulk upsert failed")
+	sanitizer := &mockSanitizer{}
+	mc := &mockMetricsCollector{}
+	svc := NewItemUpsertService(repo, sanitizer, WithMetrics(mc))
+
+	parsedItems := []model.ParsedItem{
+		{GuidOrID: "guid-1", Title: "記事", Link: "https://example.com/1"},
+	}
+
+	// Act
+	_, _, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems)
+
+	// Assert
+	if err == nil {
+		t.Fatal("BulkUpsert エラー時はエラーを返すべき")
+	}
+	if mc.itemsUpsertedCalls != 0 {
+		t.Errorf("エラー時の RecordItemsUpserted 呼び出し回数 = %d, want 0", mc.itemsUpsertedCalls)
+	}
+}
+
+// TestUpsertItems_Metrics_EmptyInputNotRecorded は空入力（件数 0）のとき
+// 早期 return により RecordItemsUpserted を呼ばないことを検証する。
+func TestUpsertItems_Metrics_EmptyInputNotRecorded(t *testing.T) {
+	// Arrange
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+	mc := &mockMetricsCollector{}
+	svc := NewItemUpsertService(repo, sanitizer, WithMetrics(mc))
+
+	// Act
+	inserted, updated, err := svc.UpsertItems(context.Background(), "feed-1", nil)
+	if err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+
+	// Assert
+	if inserted != 0 || updated != 0 {
+		t.Errorf("(inserted, updated) = (%d, %d), want (0, 0)", inserted, updated)
+	}
+	if mc.itemsUpsertedCalls != 0 {
+		t.Errorf("空入力時の RecordItemsUpserted 呼び出し回数 = %d, want 0", mc.itemsUpsertedCalls)
+	}
+}
+
+// TestNewItemUpsertService_DefaultMetricsIsNopAndNilSafe は WithMetrics を指定しない
+// 既存 2 引数 call site でも no-op コレクタが既定値となり nil panic しないことを検証する。
+func TestNewItemUpsertService_DefaultMetricsIsNopAndNilSafe(t *testing.T) {
+	// Arrange
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	parsedItems := []model.ParsedItem{
+		{GuidOrID: "guid-1", Title: "記事", Link: "https://example.com/1"},
+	}
+
+	// Act + Assert: option 未指定でも記録呼び出しで panic せず正常完了する
+	if _, _, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems); err != nil {
+		t.Fatalf("option 未指定の UpsertItems がエラーを返した: %v", err)
+	}
+}

--- a/internal/metrics/nop.go
+++ b/internal/metrics/nop.go
@@ -1,0 +1,26 @@
+package metrics
+
+import "time"
+
+// NopCollector は MetricsCollector の no-op 実装。
+// Collector が未注入のフェッチャー／サービス層で、nil チェックを書かずに
+// 既定値として安全に利用するために使う（メトリクスを一切記録しない）。
+type NopCollector struct{}
+
+// RecordFetchSuccess は何も記録しない。
+func (NopCollector) RecordFetchSuccess(feedID string) {}
+
+// RecordFetchFailure は何も記録しない。
+func (NopCollector) RecordFetchFailure(feedID, reason string) {}
+
+// RecordParseFailure は何も記録しない。
+func (NopCollector) RecordParseFailure(feedID string) {}
+
+// RecordHTTPStatus は何も記録しない。
+func (NopCollector) RecordHTTPStatus(statusCode int) {}
+
+// RecordFetchLatency は何も記録しない。
+func (NopCollector) RecordFetchLatency(duration time.Duration) {}
+
+// RecordItemsUpserted は何も記録しない。
+func (NopCollector) RecordItemsUpserted(count int) {}

--- a/internal/metrics/nop_test.go
+++ b/internal/metrics/nop_test.go
@@ -1,0 +1,91 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNopCollector_ImplementsMetricsCollector は NopCollector が
+// MetricsCollector インターフェースを満たすことをコンパイル時に検証する。
+// Requirement 5.1（既存挙動の後方互換維持）/ NFR 1.2 に対応。
+func TestNopCollector_ImplementsMetricsCollector(t *testing.T) {
+	// Arrange / Act
+	var c MetricsCollector = NopCollector{}
+
+	// Assert
+	if c == nil {
+		t.Fatal("NopCollector should satisfy MetricsCollector interface")
+	}
+}
+
+// TestNopCollector_MethodsDoNotPanic は NopCollector の 6 メソッドが
+// panic せず副作用なく呼べることを検証する。
+// Collector 未注入時の既定値として nil 安全に振る舞うことを担保する。
+// Requirement 5.1 / NFR 1.2 に対応。
+func TestNopCollector_MethodsDoNotPanic(t *testing.T) {
+	cases := []struct {
+		name string
+		call func(c NopCollector)
+	}{
+		{
+			name: "RecordFetchSuccessを呼んでもpanicしない",
+			call: func(c NopCollector) { c.RecordFetchSuccess("feed-1") },
+		},
+		{
+			name: "RecordFetchFailureを呼んでもpanicしない",
+			call: func(c NopCollector) { c.RecordFetchFailure("feed-1", "timeout") },
+		},
+		{
+			name: "RecordParseFailureを呼んでもpanicしない",
+			call: func(c NopCollector) { c.RecordParseFailure("feed-1") },
+		},
+		{
+			name: "RecordHTTPStatusを呼んでもpanicしない",
+			call: func(c NopCollector) { c.RecordHTTPStatus(200) },
+		},
+		{
+			name: "RecordFetchLatencyを呼んでもpanicしない",
+			call: func(c NopCollector) { c.RecordFetchLatency(150 * time.Millisecond) },
+		},
+		{
+			name: "RecordItemsUpsertedを呼んでもpanicしない",
+			call: func(c NopCollector) { c.RecordItemsUpserted(3) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			c := NopCollector{}
+
+			// Act & Assert: panic しないことを検証する
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("expected no panic, got %v", r)
+				}
+			}()
+			tc.call(c)
+		})
+	}
+}
+
+// TestNopCollector_ZeroValueIsUsable は NopCollector のゼロ値が
+// そのまま利用可能（境界値: 空文字 feedID / 0 件 / ステータス 0）であることを検証する。
+// Requirement 5.1 / NFR 1.2 に対応。
+func TestNopCollector_ZeroValueIsUsable(t *testing.T) {
+	// Arrange
+	var c NopCollector
+
+	// Act & Assert
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("expected no panic with boundary inputs, got %v", r)
+		}
+	}()
+	c.RecordFetchSuccess("")
+	c.RecordFetchFailure("", "")
+	c.RecordParseFailure("")
+	c.RecordHTTPStatus(0)
+	c.RecordFetchLatency(0)
+	c.RecordItemsUpserted(0)
+}

--- a/internal/middleware/trusted_cidr.go
+++ b/internal/middleware/trusted_cidr.go
@@ -1,0 +1,66 @@
+package middleware
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+)
+
+// NewTrustedCIDRMiddleware は信頼 CIDR 範囲内の送信元のみ通過させるミドルウェアを返す。
+//
+// 起動時に cidrs を net.ParseCIDR でパースして []*net.IPNet を構築する。不正な CIDR 文字列は
+// スキップして Warn ログを出力し、有効分のみを判定に採用する。
+//
+// リクエスト時は r.RemoteAddr（host:port 形式）から host を抽出して net.ParseIP し、いずれかの
+// 信頼 CIDR に含まれれば next を呼び、含まれなければ 403 Forbidden を返す。
+//
+// 信頼 CIDR が空（未設定）の場合は全リクエストを 403 で拒否する（安全側 / NFR 2.1）。
+// X-Forwarded-For は信頼せず、判定には r.RemoteAddr のみを用いる（Requirement 4.3）。
+// 拒否時は next を呼ばず http.Error で即終了し、メトリクス本文を一切応答に含めない（NFR 2.2）。
+func NewTrustedCIDRMiddleware(cidrs []string) func(next http.Handler) http.Handler {
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, ipNet, err := net.ParseCIDR(c)
+		if err != nil {
+			slog.Warn("信頼 CIDR のパースに失敗したためスキップします",
+				slog.String("cidr", c),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		nets = append(nets, ipNet)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !isTrustedRemoteAddr(r.RemoteAddr, nets) {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// isTrustedRemoteAddr は remoteAddr（host:port 形式）の IP が nets のいずれかに含まれるかを判定する。
+// パース不能な remoteAddr / IP、および nets が空の場合は false（拒否）を返す（安全側）。
+func isTrustedRemoteAddr(remoteAddr string, nets []*net.IPNet) bool {
+	if len(nets) == 0 {
+		return false
+	}
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		// port を含まない形式の可能性があるため、remoteAddr 全体を IP として試す。
+		host = remoteAddr
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/middleware/trusted_cidr_test.go
+++ b/internal/middleware/trusted_cidr_test.go
@@ -1,0 +1,119 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// metricsBodyMarker は拒否時にメトリクス本文が漏れていないことを確認するための next 側出力。
+const metricsBodyMarker = "feedman_fetch_success_total 1"
+
+func TestTrustedCIDRMiddleware(t *testing.T) {
+	cases := []struct {
+		name       string
+		cidrs      []string
+		remoteAddr string
+		wantStatus int
+		wantNext   bool
+		wantNoBody bool // true の場合、レスポンスボディに metricsBodyMarker が含まれないことを検証
+	}{
+		{
+			name:       "範囲内の送信元のとき200でnextに到達する",
+			cidrs:      []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:54321",
+			wantStatus: http.StatusOK,
+			wantNext:   true,
+		},
+		{
+			name:       "範囲外の送信元のとき403で拒否する",
+			cidrs:      []string{"10.0.0.0/8"},
+			remoteAddr: "192.168.1.1:54321",
+			wantStatus: http.StatusForbidden,
+			wantNext:   false,
+			wantNoBody: true,
+		},
+		{
+			name:       "信頼CIDRが空(未設定)のとき全リクエストを403で拒否する",
+			cidrs:      nil,
+			remoteAddr: "10.1.2.3:54321",
+			wantStatus: http.StatusForbidden,
+			wantNext:   false,
+			wantNoBody: true,
+		},
+		{
+			name:       "不正なCIDRをスキップし有効分のみで判定する(有効範囲内は200)",
+			cidrs:      []string{"not-a-cidr", "10.0.0.0/8"},
+			remoteAddr: "10.5.6.7:1234",
+			wantStatus: http.StatusOK,
+			wantNext:   true,
+		},
+		{
+			name:       "不正なCIDRをスキップし有効分のみで判定する(有効範囲外は403)",
+			cidrs:      []string{"not-a-cidr", "10.0.0.0/8"},
+			remoteAddr: "172.16.0.1:1234",
+			wantStatus: http.StatusForbidden,
+			wantNext:   false,
+			wantNoBody: true,
+		},
+		{
+			name:       "全CIDRが不正のとき有効分ゼロで全拒否する",
+			cidrs:      []string{"bad", "also/bad"},
+			remoteAddr: "10.1.2.3:54321",
+			wantStatus: http.StatusForbidden,
+			wantNext:   false,
+			wantNoBody: true,
+		},
+		{
+			name:       "パース不能なRemoteAddrのとき403で拒否する",
+			cidrs:      []string{"10.0.0.0/8"},
+			remoteAddr: "not-an-address",
+			wantStatus: http.StatusForbidden,
+			wantNext:   false,
+			wantNoBody: true,
+		},
+		{
+			name:       "IPv6範囲内の送信元のとき200でnextに到達する",
+			cidrs:      []string{"::1/128"},
+			remoteAddr: "[::1]:54321",
+			wantStatus: http.StatusOK,
+			wantNext:   true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			mw := NewTrustedCIDRMiddleware(tt.cidrs)
+			nextCalled := false
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+				// next が呼ばれた場合のみメトリクス本文を出力する。
+				_, _ = w.Write([]byte(metricsBodyMarker))
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			req.RemoteAddr = tt.remoteAddr
+			w := httptest.NewRecorder()
+
+			// Act
+			handler.ServeHTTP(w, req)
+
+			// Assert
+			resp := w.Result()
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+			if nextCalled != tt.wantNext {
+				t.Errorf("nextCalled = %v, want %v", nextCalled, tt.wantNext)
+			}
+			if tt.wantNoBody {
+				if strings.Contains(w.Body.String(), metricsBodyMarker) {
+					t.Errorf("拒否時のレスポンスボディにメトリクス本文が含まれている: %q", w.Body.String())
+				}
+			}
+		})
+	}
+}

--- a/internal/worker/fetch/fetcher.go
+++ b/internal/worker/fetch/fetcher.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mmcdole/gofeed"
 
+	"github.com/hitoshi/feedman/internal/metrics"
 	"github.com/hitoshi/feedman/internal/model"
 	"github.com/hitoshi/feedman/internal/repository"
 )
@@ -37,9 +38,23 @@ type Fetcher struct {
 	logger      *slog.Logger
 	timeout     time.Duration
 	maxBodySize int64
+	metrics     metrics.MetricsCollector
+}
+
+// FetcherOption は NewFetcher の任意設定を表す functional option。
+type FetcherOption func(*Fetcher)
+
+// WithMetrics は Fetcher にメトリクスコレクタを注入する。
+// 未指定時は metrics.NopCollector{} が既定値として使われ、記録呼び出しは no-op になる。
+func WithMetrics(c metrics.MetricsCollector) FetcherOption {
+	return func(f *Fetcher) {
+		f.metrics = c
+	}
 }
 
 // NewFetcher はFetcherの新しいインスタンスを生成する。
+// 既存の 7 引数 call site との後方互換のため、メトリクスコレクタは末尾の可変長
+// functional option（WithMetrics）として受け取る。opts 未指定時は no-op コレクタを既定値とする。
 func NewFetcher(
 	feedRepo repository.FeedRepository,
 	subRepo repository.SubscriptionRepository,
@@ -48,8 +63,9 @@ func NewFetcher(
 	logger *slog.Logger,
 	timeout time.Duration,
 	maxBodySize int64,
+	opts ...FetcherOption,
 ) *Fetcher {
-	return &Fetcher{
+	f := &Fetcher{
 		feedRepo:    feedRepo,
 		subRepo:     subRepo,
 		upsertSvc:   upsertSvc,
@@ -57,13 +73,23 @@ func NewFetcher(
 		logger:      logger,
 		timeout:     timeout,
 		maxBodySize: maxBodySize,
+		metrics:     metrics.NopCollector{},
 	}
+	for _, opt := range opts {
+		opt(f)
+	}
+	return f
 }
 
 // Fetch はフィードをフェッチし、結果に応じてフィード状態を更新する。
 // FeedFetcherServiceインターフェースを実装する。
 func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 	start := time.Now()
+
+	// フェッチ完了時に所要時間をレイテンシメトリクスへ記録する（Requirement 2.5）。
+	defer func() {
+		f.metrics.RecordFetchLatency(time.Since(start))
+	}()
 
 	// SSRF検証
 	if err := f.ssrfGuard.ValidateURL(feed.FeedURL); err != nil {
@@ -72,6 +98,7 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 			slog.String("feed_url", feed.FeedURL),
 			slog.String("error", err.Error()),
 		)
+		f.metrics.RecordFetchFailure(feed.ID, "ssrf_validation")
 		ApplyStopFeed(feed, fmt.Sprintf("SSRF検証失敗: %s", err.Error()))
 		if updateErr := f.feedRepo.UpdateFetchState(ctx, feed); updateErr != nil {
 			f.logger.Error("フィード状態の更新に失敗しました",
@@ -109,6 +136,7 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 			slog.String("feed_url", feed.FeedURL),
 			slog.String("error", err.Error()),
 		)
+		f.metrics.RecordFetchFailure(feed.ID, "http_request")
 		ApplyBackoff(feed, fmt.Sprintf("HTTPリクエスト失敗: %s", err.Error()))
 		if updateErr := f.feedRepo.UpdateFetchState(ctx, feed); updateErr != nil {
 			f.logger.Error("フィード状態の更新に失敗しました",
@@ -121,6 +149,9 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 	defer resp.Body.Close()
 
 	duration := time.Since(start)
+
+	// HTTPレスポンスを受信したのでステータスコード別のレスポンス数を記録する（Requirement 2.4）。
+	f.metrics.RecordHTTPStatus(resp.StatusCode)
 
 	// HTTPステータスに基づく処理分岐
 	result := ClassifyHTTPStatus(resp.StatusCode)
@@ -142,6 +173,8 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 			)
 			interval = 60 // デフォルト60分
 		}
+		// 304 は「変更なしで取得成功」として扱い成功数を増加させる（Requirement 2.1）。
+		f.metrics.RecordFetchSuccess(feed.ID)
 		ApplySuccess(feed, interval)
 		return f.feedRepo.UpdateFetchState(ctx, feed)
 
@@ -154,6 +187,7 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 			slog.Int("http_status", resp.StatusCode),
 			slog.String("reason", reason),
 		)
+		f.metrics.RecordFetchFailure(feed.ID, "http_stop")
 		ApplyStopFeed(feed, reason)
 		return f.feedRepo.UpdateFetchState(ctx, feed)
 
@@ -166,6 +200,7 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 			slog.Int("http_status", resp.StatusCode),
 			slog.Int("consecutive_errors", feed.ConsecutiveErrors+1),
 		)
+		f.metrics.RecordFetchFailure(feed.ID, "http_backoff")
 		ApplyBackoff(feed, reason)
 		return f.feedRepo.UpdateFetchState(ctx, feed)
 
@@ -177,6 +212,7 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 			slog.String("feed_id", feed.ID),
 			slog.Int("http_status", resp.StatusCode),
 		)
+		f.metrics.RecordFetchFailure(feed.ID, "http_unexpected")
 		ApplyBackoff(feed, fmt.Sprintf("予期しないHTTPステータス: %d", resp.StatusCode))
 		return f.feedRepo.UpdateFetchState(ctx, feed)
 	}
@@ -188,6 +224,7 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 			slog.String("feed_id", feed.ID),
 			slog.String("error", err.Error()),
 		)
+		f.metrics.RecordFetchFailure(feed.ID, "body_read")
 		ApplyBackoff(feed, fmt.Sprintf("レスポンス読み取り失敗: %s", err.Error()))
 		return f.feedRepo.UpdateFetchState(ctx, feed)
 	}
@@ -209,6 +246,9 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 			slog.String("feed_url", feed.FeedURL),
 			slog.String("error", err.Error()),
 		)
+		// パース失敗はパース失敗数とフェッチ失敗数の両方を記録する（Requirement 2.3, 2.2）。
+		f.metrics.RecordParseFailure(feed.ID)
+		f.metrics.RecordFetchFailure(feed.ID, "parse")
 		ApplyParseFailure(feed, err.Error())
 		if updateErr := f.feedRepo.UpdateFetchState(ctx, feed); updateErr != nil {
 			f.logger.Error("フィード状態の更新に失敗しました",
@@ -237,6 +277,7 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 			slog.String("feed_id", feed.ID),
 			slog.String("error", err.Error()),
 		)
+		f.metrics.RecordFetchFailure(feed.ID, "upsert")
 		ApplyParseFailure(feed, fmt.Sprintf("記事UPSERT失敗: %s", err.Error()))
 		if updateErr := f.feedRepo.UpdateFetchState(ctx, feed); updateErr != nil {
 			f.logger.Error("フィード状態の更新に失敗しました",
@@ -265,8 +306,12 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 			slog.String("feed_id", feed.ID),
 			slog.String("error", updateErr.Error()),
 		)
+		f.metrics.RecordFetchFailure(feed.ID, "update_state")
 		return updateErr
 	}
+
+	// 200 で UPSERT・状態更新まで成功したのでフェッチ成功数を増加させる（Requirement 2.1）。
+	f.metrics.RecordFetchSuccess(feed.ID)
 
 	f.logger.Info("フィードフェッチが完了しました",
 		slog.String("feed_id", feed.ID),

--- a/internal/worker/fetch/fetcher_test.go
+++ b/internal/worker/fetch/fetcher_test.go
@@ -76,6 +76,42 @@ func (m *mockUpsertService) UpsertItems(_ context.Context, _ string, items []mod
 	return m.insertCount, m.updateCount, m.err
 }
 
+// mockMetricsCollector は metrics.MetricsCollector のテスト用モック。
+// 各記録メソッドの呼び出し回数と最後に渡された値を保持する。
+type mockMetricsCollector struct {
+	fetchSuccess  int
+	fetchFailure  int
+	parseFailure  int
+	httpStatus    int
+	fetchLatency  int
+	itemsUpserted int
+
+	lastStatusCode    int
+	lastItemsUpserted int
+	lastLatency       time.Duration
+}
+
+func (m *mockMetricsCollector) RecordFetchSuccess(_ string) { m.fetchSuccess++ }
+
+func (m *mockMetricsCollector) RecordFetchFailure(_, _ string) { m.fetchFailure++ }
+
+func (m *mockMetricsCollector) RecordParseFailure(_ string) { m.parseFailure++ }
+
+func (m *mockMetricsCollector) RecordHTTPStatus(statusCode int) {
+	m.httpStatus++
+	m.lastStatusCode = statusCode
+}
+
+func (m *mockMetricsCollector) RecordFetchLatency(duration time.Duration) {
+	m.fetchLatency++
+	m.lastLatency = duration
+}
+
+func (m *mockMetricsCollector) RecordItemsUpserted(count int) {
+	m.itemsUpserted++
+	m.lastItemsUpserted = count
+}
+
 // mockSSRFGuard はSSRFGuardServiceのテスト用モック。
 type mockSSRFGuard struct {
 	validateErr error
@@ -782,5 +818,217 @@ func TestFetcher_Fetch_UpdatesFeedTitle(t *testing.T) {
 
 	if feed.Title != "Updated Feed Title" {
 		t.Errorf("Feed.Title = %q, want %q", feed.Title, "Updated Feed Title")
+	}
+}
+
+// --- Task 3.1: WithMetrics によるメトリクス記録のテスト ---
+
+func TestFetcher_Fetch_Metrics_Success200(t *testing.T) {
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <item><title>A</title><guid>g1</guid></item>
+  </channel>
+</rss>`)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	mc := &mockMetricsCollector{}
+	f := NewFetcher(
+		&mockFeedRepo{updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil }},
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{insertCount: 1},
+		&mockSSRFGuard{},
+		newTestLogger(&buf),
+		10*time.Second,
+		5*1024*1024,
+		WithMetrics(mc),
+	)
+	feed := &model.Feed{ID: "feed-1", FeedURL: server.URL, FetchStatus: model.FetchStatusActive}
+
+	// Act
+	if err := f.Fetch(context.Background(), feed); err != nil {
+		t.Fatalf("Fetch() がエラーを返した: %v", err)
+	}
+
+	// Assert: 200 成功時は成功数・HTTP ステータス・レイテンシが各 1 回記録される
+	if mc.fetchSuccess != 1 {
+		t.Errorf("RecordFetchSuccess 呼び出し回数 = %d, want 1", mc.fetchSuccess)
+	}
+	if mc.fetchFailure != 0 {
+		t.Errorf("RecordFetchFailure 呼び出し回数 = %d, want 0", mc.fetchFailure)
+	}
+	if mc.httpStatus != 1 || mc.lastStatusCode != http.StatusOK {
+		t.Errorf("RecordHTTPStatus = (count %d, code %d), want (1, 200)", mc.httpStatus, mc.lastStatusCode)
+	}
+	if mc.fetchLatency != 1 {
+		t.Errorf("RecordFetchLatency 呼び出し回数 = %d, want 1", mc.fetchLatency)
+	}
+}
+
+func TestFetcher_Fetch_Metrics_304Success(t *testing.T) {
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	mc := &mockMetricsCollector{}
+	f := NewFetcher(
+		&mockFeedRepo{updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil }},
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{},
+		&mockSSRFGuard{},
+		newTestLogger(&buf),
+		10*time.Second,
+		5*1024*1024,
+		WithMetrics(mc),
+	)
+	feed := &model.Feed{ID: "feed-1", FeedURL: server.URL, ETag: `"abc"`}
+
+	// Act
+	_ = f.Fetch(context.Background(), feed)
+
+	// Assert: 304 は成功（変更なし）として成功数に計上される
+	if mc.fetchSuccess != 1 {
+		t.Errorf("304 時の RecordFetchSuccess 呼び出し回数 = %d, want 1", mc.fetchSuccess)
+	}
+	if mc.lastStatusCode != http.StatusNotModified {
+		t.Errorf("RecordHTTPStatus のステータス = %d, want 304", mc.lastStatusCode)
+	}
+}
+
+func TestFetcher_Fetch_Metrics_HTTPFailure(t *testing.T) {
+	// Arrange: SSRFGuard が ValidateURL を成功させた上で、到達不能なアドレスへ client.Do を失敗させる
+	var buf bytes.Buffer
+	mc := &mockMetricsCollector{}
+	f := NewFetcher(
+		&mockFeedRepo{updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil }},
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{},
+		&mockSSRFGuard{},
+		newTestLogger(&buf),
+		1*time.Second,
+		5*1024*1024,
+		WithMetrics(mc),
+	)
+	// 予約済みドキュメント用ドメインで名前解決に失敗させる
+	feed := &model.Feed{ID: "feed-1", FeedURL: "http://nonexistent.invalid/feed.xml", FetchStatus: model.FetchStatusActive}
+
+	// Act
+	_ = f.Fetch(context.Background(), feed)
+
+	// Assert: HTTP リクエスト失敗で失敗数が記録され、成功数は 0
+	if mc.fetchFailure != 1 {
+		t.Errorf("RecordFetchFailure 呼び出し回数 = %d, want 1", mc.fetchFailure)
+	}
+	if mc.fetchSuccess != 0 {
+		t.Errorf("RecordFetchSuccess 呼び出し回数 = %d, want 0", mc.fetchSuccess)
+	}
+	// レイテンシは defer で常に記録される
+	if mc.fetchLatency != 1 {
+		t.Errorf("RecordFetchLatency 呼び出し回数 = %d, want 1", mc.fetchLatency)
+	}
+}
+
+func TestFetcher_Fetch_Metrics_ParseFailure(t *testing.T) {
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, `not valid XML at all!!!`)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	mc := &mockMetricsCollector{}
+	f := NewFetcher(
+		&mockFeedRepo{updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil }},
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{},
+		&mockSSRFGuard{},
+		newTestLogger(&buf),
+		10*time.Second,
+		5*1024*1024,
+		WithMetrics(mc),
+	)
+	feed := &model.Feed{ID: "feed-1", FeedURL: server.URL, FetchStatus: model.FetchStatusActive}
+
+	// Act
+	_ = f.Fetch(context.Background(), feed)
+
+	// Assert: パース失敗はパース失敗数とフェッチ失敗数の両方を記録する
+	if mc.parseFailure != 1 {
+		t.Errorf("RecordParseFailure 呼び出し回数 = %d, want 1", mc.parseFailure)
+	}
+	if mc.fetchFailure != 1 {
+		t.Errorf("RecordFetchFailure 呼び出し回数 = %d, want 1", mc.fetchFailure)
+	}
+	if mc.fetchSuccess != 0 {
+		t.Errorf("RecordFetchSuccess 呼び出し回数 = %d, want 0", mc.fetchSuccess)
+	}
+}
+
+func TestFetcher_Fetch_Metrics_HTTPStatusRecordedOnBackoff(t *testing.T) {
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	mc := &mockMetricsCollector{}
+	f := NewFetcher(
+		&mockFeedRepo{updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil }},
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{},
+		&mockSSRFGuard{},
+		newTestLogger(&buf),
+		10*time.Second,
+		5*1024*1024,
+		WithMetrics(mc),
+	)
+	feed := &model.Feed{ID: "feed-1", FeedURL: server.URL, FetchStatus: model.FetchStatusActive}
+
+	// Act
+	_ = f.Fetch(context.Background(), feed)
+
+	// Assert: 500 はバックオフ失敗として失敗数を記録し、HTTP ステータスも記録される
+	if mc.lastStatusCode != http.StatusInternalServerError {
+		t.Errorf("RecordHTTPStatus のステータス = %d, want 500", mc.lastStatusCode)
+	}
+	if mc.fetchFailure != 1 {
+		t.Errorf("RecordFetchFailure 呼び出し回数 = %d, want 1", mc.fetchFailure)
+	}
+}
+
+func TestNewFetcher_DefaultMetricsIsNopAndNilSafe(t *testing.T) {
+	// Arrange: WithMetrics を指定しない（既存 7 引数 call site 相当）
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, `<?xml version="1.0"?><rss version="2.0"><channel><title>T</title></channel></rss>`)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	f := NewFetcher(
+		&mockFeedRepo{updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil }},
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{},
+		&mockSSRFGuard{},
+		newTestLogger(&buf),
+		10*time.Second,
+		5*1024*1024,
+	)
+	feed := &model.Feed{ID: "feed-1", FeedURL: server.URL, FetchStatus: model.FetchStatusActive}
+
+	// Act + Assert: option 未指定でも nil 参照で panic せず正常完了する
+	if err := f.Fetch(context.Background(), feed); err != nil {
+		t.Fatalf("option 未指定の Fetch() がエラーを返した: %v", err)
 	}
 }


### PR DESCRIPTION
## 概要

Feedman にはメトリクス収集 Collector と `/metrics` エンドポイントの実装が既に存在していたが、
起動エントリから一切参照されていなかった（デッドコード状態）。本 PR では:

- フィードフェッチ処理と記事 UPSERT 処理への Collector 組み込み
- Prometheus テキスト形式で応答する `/metrics` エンドポイントのルーター登録
- 信頼 CIDR によるアクセス制限（CIDR 範囲外は 403）
- フェッチを行う worker プロセス専用の独立 metrics listener 起動

を実施し、6 種のフィード取得メトリクスを本番環境で観測可能にした。

## 対応 Issue

Closes #15

## 関連 PR

- 設計 PR: #79（merged）

## 実装内容

- (Req 1.1 / Task 5.1) `internal/handler/router.go` — RouterDeps に `MetricsHandler`/`MetricsMiddleware` を追加し、nil 判定で `/metrics` を条件登録
- (Req 1.2 / Task 6.2) `internal/app/app.go` — `runServe`/`runWorker` で registry・Collector 生成と全レイヤ wiring。worker では metrics listener を起動
- (Req 1.3) `internal/metrics/nop.go` — `MetricsCollector` interface の no-op 実装 `NopCollector` を追加（既定値として安全に使える value receiver 実装）
- (Req 2.1〜2.6 / Task 3.1) `internal/worker/fetch/fetcher.go` — `WithMetrics` option でフェッチ成功・失敗・パース失敗・HTTP ステータス・レイテンシを各分岐で記録
- (Req 2.6 / Task 4.1) `internal/item/upsert.go` — `WithMetrics` option で UPSERT 完了時に挿入＋更新件数を加算
- (Req 3.1〜3.3 / Task 6.1) `internal/app/metrics_listener.go` — worker プロセス専用の独立 HTTP listener（ctx キャンセルで graceful stop）
- (Req 4.1〜4.3 / Task 2.1) `internal/middleware/trusted_cidr.go` — 送信元 IP アドレスのみで判定する CIDR アクセス制限ミドルウェア
- (Req 5.1〜5.3 / NFR 1.2) `internal/config/config.go` — `TrustedCIDRs`/`MetricsPort` フィールド追加。既存エンドポイントのルーティング・タイムアウト設定は不変維持

## 受入基準チェック

- [x] Req 1.1: When 信頼 CIDR 内からアクセスしたとき, the Metrics Endpoint shall Prometheus テキスト公開形式で応答する ← `TestNewRouter_Metrics_NonNilHandler_InRange_Returns200` / `TestStartWorkerMetricsListener_StartupExposesSeries`
- [x] Req 1.2: When 起動完了したとき, the Metrics Endpoint shall 即スクレイプ可能になる ← `TestStartWorkerMetricsListener_StartupExposesSeries`（起動直後 200）
- [x] Req 1.3: The Metrics Endpoint shall 全 6 種のメトリクス系列を応答に含める ← `TestStartWorkerMetricsListener_StartupExposesSeries`（5 系列）+ `TestStartWorkerMetricsListener_HTTPStatusSeriesAppearsAfterRecord`（6 系列目）
- [x] Req 2.1〜2.6: フェッチ成功・失敗・パース失敗・HTTP ステータス・レイテンシ・UPSERT 件数の各記録 ← `TestFetcher_Fetch_Metrics_*` / `TestUpsertItems_Metrics_*`
- [x] Req 3.1〜3.3: worker 独立 registry + listener でフェッチ系メトリクスのスクレイプ経路保証 ← `TestStartWorkerMetricsListener_FetchSuccessReflected`
- [x] Req 4.1〜4.3: 信頼 CIDR によるアクセス制限（範囲外 403・範囲内 200・IP のみ判定） ← `TestTrustedCIDRMiddleware` / `TestNewRouter_Metrics_NonNilHandler_OutOfRange_Returns403` / `TestStartWorkerMetricsListener_OutOfRangeForbidden`
- [x] Req 5.1〜5.3 / NFR 1.1〜2.2: 既存ルーティング・タイムアウト不変、起動直後 200、未設定時 403、拒否時本文非包含 ← 各 `router_metrics_test.go` / `trusted_cidr_test.go` テスト

## テスト結果

```
Reviewer が go build ./... / go test ./... / go vet ./... を再実行し、
すべて green / clean であることを確認（review-notes.md 参照）
```

詳細: `docs/specs/15--collector-metrics/review-notes.md`

## 実装上の判断

- `feedman_http_status_total` はラベル付き `CounterVec` であるため、Prometheus テキスト形式仕様上、
  ラベル値が 1 度も記録されるまで出力されない。このため起動直後は 5 系列のみが現れ、HTTP ステータス
  記録後に 6 系列目が出現する。`metrics.go` 本体は「Out of Scope」として変更していない（詳細は impl-notes.md「確認事項」参照）。
- `RouterDeps.MetricsMiddleware` が nil のケースは chi の `With(nil)` が panic するため、
  素通しラッパにフォールバックして安全側に倒している（実運用では常に CIDR mw を渡すため通常は通らない経路）。
- `NewFetcher`/`NewItemUpsertService` は functional options 方式で末尾引数を追加。既存の呼び出しサイト（50+ ヶ所）はコンパイル・挙動とも不変（NFR 1.2）。

詳細: `docs/specs/15--collector-metrics/impl-notes.md`

## 確認事項 / レビュワーへの依頼

- base=develop 検証 OK: --base develop 指定 / baseRefName: develop / 一致確認済み
- Reviewer レビュー結果参照: `docs/specs/15--collector-metrics/review-notes.md`（RESULT: approve）
- `feedman_http_status_total` の起動直後非出力については、Req 1.3 の厳密充足を要する場合は `metrics.go` の初期化を許容する設計変更（別 Issue）が必要であり、その判断を human レビュワーに委ねる（impl-notes.md「確認事項」参照）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #15 のコメントを参照してください。
