### PR TITLE
feat(#28): FeedDetector / FaviconFetcher の HTTP クライアントを再利用してコネクションプールを共有する

### DIFF
--- a/docs/specs/28-feeddetector-faviconfetcher-http/impl-notes.md
+++ b/docs/specs/28-feeddetector-faviconfetcher-http/impl-notes.md
@@ -1,0 +1,134 @@
+# 実装ノート: Issue #28 FeedDetector / FaviconFetcher の HTTP クライアント再利用
+
+## 実装サマリ
+
+`FeedDetector` / `FaviconFetcher` はリクエストごとに `getHTTPClient()` 内で新しい
+`*http.Client` を生成していたため、クライアント単位で独立したコネクションプールが割り当てられ、
+TCP/TLS コネクションが再利用されていなかった。本変更では各構造体に再利用用の HTTP クライアントを
+保持するフィールド `httpClient *http.Client` を追加し、コンストラクタ
+（`NewFeedDetector` / `NewFaviconFetcher`）で **一度だけ** 生成して格納する形に変更した。
+`getHTTPClient()` は生成済みインスタンスをそのまま返すだけになり、リクエスト間でコネクション
+プールが共有される。
+
+### 変更内容
+
+- `internal/feed/detector.go`
+  - `FeedDetector` に `httpClient *http.Client` フィールドを追加
+  - タイムアウト・最大サイズをマジックナンバーから定数化（`detectorTimeout = 10 * time.Second` /
+    `detectorMaxResponseSize = 5 * 1024 * 1024`。**値は従来と完全に同一**で、`DetectFeedURL` 内の
+    インライン `maxBodySize` も同一定数を参照するよう統一）
+  - `newDetectorHTTPClient(ssrfGuard)` ヘルパを追加し、コンストラクタから呼んでクライアントを 1 回生成
+  - `getHTTPClient()` は `d.httpClient` を返すだけに変更（生成ロジックを排除）
+- `internal/feed/favicon.go`
+  - `FaviconFetcher` に `httpClient *http.Client` フィールドを追加
+  - `newFaviconHTTPClient(ssrfGuard)` ヘルパを追加し、コンストラクタから呼んでクライアントを 1 回生成
+    （タイムアウト `faviconTimeout` / 最大サイズ `maxFaviconSize` の **既存定数をそのまま使用**）
+  - `getHTTPClient()` は `f.httpClient` を返すだけに変更
+
+公開シグネチャ（`NewFeedDetector(SSRFValidator)` / `NewFaviconFetcher(SSRFValidator)`、
+各公開メソッドの引数・戻り値型、`SSRFValidator` インターフェース）はいずれも変更していない（NFR 1）。
+
+### 各 AC への対応
+
+| AC | 対応内容 |
+|---|---|
+| 1.1 / 1.2 / 1.3 | コンストラクタで 1 回生成したクライアントを再利用。リクエスト都度の生成を排除しコネクションプールを共有 |
+| 2.1 / 2.2 | 検出ロジック自体は不変。同一インスタンスから複数回検出しても検出結果・未検出エラーが従来と同一 |
+| 3.1 / 3.2 / 3.3 | favicon 側も同様にコンストラクタで 1 回生成・再利用 |
+| 4.1 / 4.2 | favicon 取得ロジックは不変。成功時データ・MIME、失敗時 nil・空 MIME・エラーなしが従来と同一 |
+| 5.1〜5.5 | `ValidateURL` による事前検証はリクエスト都度実行され（再利用クライアントとは独立）、SSRF ガード経由クライアント（`NewSafeClient`）も DNS 解決後の IP 検証を含めて防御ロジックを温存。本変更ではガードの防御ロジック自体には一切触れていない |
+| 6.1 / 6.2 | タイムアウト・サイズ上限の値は定数化のみで数値は不変（detector: 10s / 5MB、favicon: 5s / 2MB） |
+
+## 並行安全性の担保方法（NFR 2.1）
+
+クライアントを **コンストラクタで即時 1 回生成してフィールドに格納** する方式を採用した。
+生成後 `httpClient` フィールドは書き換えられず read-only な参照となるため、複数 goroutine が
+同一インスタンスの `getHTTPClient()` / `DetectFeedURL` / `FetchFavicon` を同時に呼んでも、
+フィールドへの並行書き込みが発生せずデータ競合は起こらない（`sync.Once` による遅延初期化も
+選択肢だったが、コンストラクタで `ssrfGuard` を受け取り即時生成する方が単純で並行安全なため
+こちらを採用）。
+
+`*http.Client` 自体は標準ライブラリの仕様として複数 goroutine からの並行利用が安全である。
+
+`go test -race ./internal/feed/...` で 10 goroutine からの同時アクセステスト
+（`TestFeedDetector_Concurrent_NoDataRace` / `TestFaviconFetcher_Concurrent_NoDataRace`）を
+含めて green を確認済み（production code に race なし）。
+
+> 補足: 並行テスト追加に伴い、テスト用 `mockSSRFGuard` の呼び出し回数カウンタを `atomic.Int64`
+> 化した（mock 自身が race を起こさないようにするためで、production code とは無関係）。
+
+## 追加・変更したテストと検証結果
+
+### detector_test.go（追加）
+
+- `TestFeedDetector_GetHTTPClient_ReusesSameInstanceWithGuard`（AC 1.1, 1.2, 5.1）: SSRF ガード有効時、
+  同一インスタンスの `getHTTPClient()` が同一ポインタを返し `NewSafeClient` 呼び出しが 1 回以下
+- `TestFeedDetector_GetHTTPClient_ReusesSameInstanceWithoutGuard`（AC 1.1, 1.2）: ガード無効(nil)でも同一クライアント
+- `TestFeedDetector_DetectFeedURL_NoAdditionalClientPerRequest`（AC 1.2, 2.1, 3）: 3 回検出で結果一致 + クライアント追加生成なし
+- `TestFeedDetector_DetectFeedURL_NotDetectedResultStable`（AC 2.2）: 未検出エラーの安定性（異常系）
+- `TestFeedDetector_SSRFBlocked_StableAfterReuse`（AC 5.1, 5.3）: 再利用後も SSRF ブロック維持 + ValidateURL が各回呼ばれる（異常系）
+- `TestFeedDetector_GetHTTPClient_TimeoutPreserved`（AC 6.1）: タイムアウト 10 秒の維持（境界値）
+- `TestFeedDetector_Concurrent_NoDataRace`（NFR 2.1）: 10 goroutine 同時実行で race なし
+
+### favicon_test.go（追加）
+
+- `TestFaviconFetcher_GetHTTPClient_ReusesSameInstanceWithGuard`（AC 3.1, 3.2, 5.2）
+- `TestFaviconFetcher_GetHTTPClient_ReusesSameInstanceWithoutGuard`（AC 3.1, 3.2）
+- `TestFaviconFetcher_FetchFavicon_NoAdditionalClientPerRequest`（AC 3.2, 4.1, 3）: 3 回取得で結果一致 + 追加生成なし
+- `TestFaviconFetcher_FetchFavicon_FailureResultStable`（AC 4.2）: 取得失敗(404)時の nil・空 MIME・エラーなしの安定性（異常系）
+- `TestFaviconFetcher_SSRFBlocked_StableAfterReuse`（AC 5.2, 5.4）: 再利用後も SSRF ブロック維持（異常系）
+- `TestFaviconFetcher_GetHTTPClient_TimeoutPreserved`（AC 6.2）: タイムアウト 5 秒の維持（境界値）
+- `TestFaviconFetcher_Concurrent_NoDataRace`（NFR 2.1）: 10 goroutine 同時実行で race なし
+
+### 既存テストの扱い
+
+- 既存テストは一切弱体化・コメントアウトしていない。`mockSSRFGuard` にカウンタフィールドと
+  read メソッドを追加したのみ（既存の `NewSafeClient` / `ValidateURL` の戻り値・挙動は不変）
+- `DetectFeedURL` 内のインライン `maxBodySize` 定数を `detectorMaxResponseSize` 参照に統一したが
+  値は `5 * 1024 * 1024` で同一（AC 6.1 維持）
+
+### 検証結果
+
+- `gofmt -l`（変更 4 ファイル）: 差分なし（clean）
+- `go vet ./internal/feed/...`: 警告なし
+- `go test -race ./internal/feed/...`: **PASS**（feed パッケージ 73 テスト全 pass / 0 fail）
+- `go build ./...`: 成功
+- `go test ./...`: 全パッケージ **PASS**（fail なし）
+
+## 受入基準とテストの対応（全 numeric ID）
+
+| AC ID | 担保テスト |
+|---|---|
+| 1.1 | `TestFeedDetector_GetHTTPClient_ReusesSameInstanceWithGuard` / `..._WithoutGuard` |
+| 1.2 | `TestFeedDetector_GetHTTPClient_ReusesSameInstanceWithGuard` / `TestFeedDetector_DetectFeedURL_NoAdditionalClientPerRequest` |
+| 1.3 | `TestFeedDetector_DetectFeedURL_NoAdditionalClientPerRequest`（クライアント再利用＝プール共有を呼び出し回数で担保） |
+| 2.1 | `TestFeedDetector_DetectFeedURL_NoAdditionalClientPerRequest`（複数回検出で結果一致）+ 既存 `TestDetectFeedURL_*` |
+| 2.2 | `TestFeedDetector_DetectFeedURL_NotDetectedResultStable` + 既存 `TestDetectFeedURL_HTMLNoFeedLink` |
+| 3.1 | `TestFaviconFetcher_GetHTTPClient_ReusesSameInstanceWithGuard` / `..._WithoutGuard` |
+| 3.2 | `TestFaviconFetcher_GetHTTPClient_ReusesSameInstanceWithGuard` / `TestFaviconFetcher_FetchFavicon_NoAdditionalClientPerRequest` |
+| 3.3 | `TestFaviconFetcher_FetchFavicon_NoAdditionalClientPerRequest` |
+| 4.1 | `TestFaviconFetcher_FetchFavicon_NoAdditionalClientPerRequest`（複数回取得で結果一致）+ 既存 `TestFaviconFetcher_FetchFavicon_Success` |
+| 4.2 | `TestFaviconFetcher_FetchFavicon_FailureResultStable` + 既存 `TestFaviconFetcher_FetchFavicon_404` |
+| 5.1 | `TestFeedDetector_SSRFBlocked_StableAfterReuse`（ガード有効 + 再利用） |
+| 5.2 | `TestFaviconFetcher_SSRFBlocked_StableAfterReuse` |
+| 5.3 | `TestFeedDetector_SSRFBlocked_StableAfterReuse` + 既存 `TestDetectFeedURL_SSRFBlocked` |
+| 5.4 | `TestFaviconFetcher_SSRFBlocked_StableAfterReuse` + 既存 `TestFaviconFetcher_FetchFavicon_SSRFBlocked` |
+| 5.5 | `TestFeedDetector_SSRFBlocked_StableAfterReuse` / `TestFaviconFetcher_SSRFBlocked_StableAfterReuse`（ValidateURL がリクエスト都度呼ばれること、および `NewSafeClient` 経由クライアント再利用で防御ロジックが温存されることを担保。DNS リバインディング対策を含む DNS 解決後の IP 検証はガード実装（`internal/security`、本 Issue 対象外）が担い、本変更はそれを呼び出すパスを変えていない） |
+| 6.1 | `TestFeedDetector_GetHTTPClient_TimeoutPreserved` |
+| 6.2 | `TestFaviconFetcher_GetHTTPClient_TimeoutPreserved` |
+| NFR 1.1 / 1.2 | 公開シグネチャ無変更（`go build ./...` / 既存全テスト pass で担保。`var _ FaviconFetcherService = (*FaviconFetcher)(nil)` のコンパイル時チェックも維持） |
+| NFR 2.1 | `TestFeedDetector_Concurrent_NoDataRace` / `TestFaviconFetcher_Concurrent_NoDataRace`（`-race` 実行） |
+
+## 確認事項
+
+- AC 5.5 の「DNS 解決後の IP 検証（DNS リバインディング対策を含む SSRF 検証）」は、SSRF ガード
+  （`NewSafeClient` が返すクライアントのトランスポート / dialer）が担う実装で、`internal/security`
+  配下にあり本 Issue のスコープ外（Out of Scope の「SSRF ガードの防御ロジック自体の変更」）。
+  本変更ではガード経由クライアントを再利用するだけで、その内部のフック（DNS 解決後検証）は
+  一切変更していないため、再利用後も同一に適用される。`mockSSRFGuard` は単純な
+  `&http.Client{Timeout: ...}` を返すため DNS リバインディング検証の実挙動はモックでは再現
+  できないが、これは本 Issue 導入前のテストでも同じであり退行ではない（実防御の検証は
+  `internal/security` 側テストの責務）。
+- 上記以外に requirements.md と実装の矛盾は検出されなかった。requirements.md は書き換えていない。
+
+STATUS: complete

--- a/docs/specs/28-feeddetector-faviconfetcher-http/requirements.md
+++ b/docs/specs/28-feeddetector-faviconfetcher-http/requirements.md
@@ -1,0 +1,94 @@
+# Requirements Document
+
+## Introduction
+
+`FeedDetector` と `FaviconFetcher` は HTTP リクエストのたびに新しい HTTP クライアントを生成しており、
+クライアント単位で独立したコネクションプールが割り当てられるため、TCP/TLS コネクションが再利用されず
+リクエスト都度にハンドシェイクが発生している。フィード検出・favicon 取得を多数行う場面ではこの
+コネクション確立コストが無駄に積み上がる。本要件は、各コンポーネントが HTTP クライアントを再利用して
+コネクションプールを共有しつつ、フィード検出・favicon 取得の外部から見た挙動（検出結果・取得結果・
+SSRF 防止・タイムアウト・サイズ上限）を一切変えないことを定義するリファクタ要件である。
+
+## Requirements
+
+### Requirement 1: FeedDetector の HTTP クライアント再利用
+
+**Objective:** As a Feedman の運用者, I want FeedDetector が HTTP クライアントを再利用してコネクションプールを共有すること, so that 多数のフィード検出時に無駄な TCP/TLS ハンドシェイクが発生せず確立コストを削減できる
+
+#### Acceptance Criteria
+
+1. While 同一の FeedDetector インスタンスが複数回のフィード検出に使われている, the FeedDetector shall リクエスト間で同一の HTTP クライアントを使い回す
+2. When 同一の FeedDetector インスタンスで連続して複数回のリクエストを実行したとき, the FeedDetector shall リクエストごとに新しい HTTP クライアントを追加生成しない
+3. The FeedDetector shall フィード検出ごとに新規コネクションを確立せず再利用可能なコネクションプールを共有する
+
+### Requirement 2: FeedDetector の検出結果不変性
+
+**Objective:** As a フィードを登録するユーザー, I want クライアント再利用後もフィード検出結果が従来と同一であること, so that リファクタによって検出の振る舞いが退行しない
+
+#### Acceptance Criteria
+
+1. When 同一の FeedDetector インスタンスから同一の入力 URL に対して複数回フィード検出を実行したとき, the FeedDetector shall 各回で本変更前と同一の検出結果（検出された feed URL もしくは未検出エラー）を返す
+2. If 入力 URL からフィードが検出できないとき, the FeedDetector shall 本変更前と同一の未検出エラーを返す
+
+### Requirement 3: FaviconFetcher の HTTP クライアント再利用
+
+**Objective:** As a Feedman の運用者, I want FaviconFetcher が HTTP クライアントを再利用してコネクションプールを共有すること, so that 多数の favicon 取得時に無駄な TCP/TLS ハンドシェイクが発生せず確立コストを削減できる
+
+#### Acceptance Criteria
+
+1. While 同一の FaviconFetcher インスタンスが複数回の favicon 取得に使われている, the FaviconFetcher shall リクエスト間で同一の HTTP クライアントを使い回す
+2. When 同一の FaviconFetcher インスタンスで連続して複数回のリクエストを実行したとき, the FaviconFetcher shall リクエストごとに新しい HTTP クライアントを追加生成しない
+3. The FaviconFetcher shall favicon 取得ごとに新規コネクションを確立せず再利用可能なコネクションプールを共有する
+
+### Requirement 4: FaviconFetcher の取得結果不変性
+
+**Objective:** As a フィードを購読するユーザー, I want クライアント再利用後も favicon 取得結果が従来と同一であること, so that リファクタによって favicon 取得の振る舞いが退行しない
+
+#### Acceptance Criteria
+
+1. When 同一の FaviconFetcher インスタンスから複数回 favicon を取得したとき, the FaviconFetcher shall 各回で本変更前と同一の取得結果（取得データと MIME タイプ、もしくは取得失敗時の nil データと空 MIME）を返す
+2. If favicon の取得に失敗したとき, the FaviconFetcher shall 本変更前と同一の挙動（nil データ・空 MIME・エラーなし）を返す
+
+### Requirement 5: SSRF 防止の非退行
+
+**Objective:** As a セキュリティ責任者, I want クライアント再利用後も SSRF 防止が退行しないこと, so that 内部 IP や禁止先への到達がこれまでどおりブロックされる
+
+#### Acceptance Criteria
+
+1. Where SSRF ガードが有効になっている, the FeedDetector shall SSRF 防止挙動を維持したまま HTTP クライアントを再利用する
+2. Where SSRF ガードが有効になっている, the FaviconFetcher shall SSRF 防止挙動を維持したまま HTTP クライアントを再利用する
+3. If SSRF ガード有効時に内部 IP・ループバック・リンクローカル・禁止スキーム等の禁止先への到達が試みられたとき, the FeedDetector shall 本変更前と同一にその到達をブロックする
+4. If SSRF ガード有効時に内部 IP・ループバック・リンクローカル・禁止スキーム等の禁止先への到達が試みられたとき, the FaviconFetcher shall 本変更前と同一にその到達をブロックする
+5. While 再利用される HTTP クライアントがリクエストを処理している, the FeedDetector and FaviconFetcher shall DNS 解決後の IP 検証（DNS リバインディング対策を含む SSRF 検証）を本変更前と同一に適用する
+
+### Requirement 6: 既存設定値の維持
+
+**Objective:** As a Feedman の運用者, I want タイムアウトや最大レスポンスサイズ等の既存設定値が維持されること, so that 再利用化によってリクエストの制限挙動が変わらない
+
+#### Acceptance Criteria
+
+1. The FeedDetector shall 本変更前と同一のタイムアウト値・最大レスポンスサイズ上限で HTTP リクエストを処理する
+2. The FaviconFetcher shall 本変更前と同一のタイムアウト値・最大 favicon サイズ上限で HTTP リクエストを処理する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The FeedDetector shall 本変更前と同一の公開メソッドシグネチャ・戻り値の型を維持する
+2. The FaviconFetcher shall 本変更前と同一の公開メソッドシグネチャ・戻り値の型を維持する
+
+### NFR 2: 並行安全性
+
+1. While 複数の goroutine が同一インスタンスを介して同時にリクエストを実行している, the FeedDetector and FaviconFetcher shall データ競合を発生させずに再利用される HTTP クライアントへ安全にアクセスする
+
+## Out of Scope
+
+- SSRF ガード（`NewSafeClient`）の防御ロジック自体の変更
+- タイムアウト値・最大レスポンスサイズ・最大 favicon サイズ等のチューニング・値変更
+- HTTP/2 やプロキシ対応などの新機能追加
+- フィード検出・favicon 取得のアルゴリズムや判定ロジックの変更
+- `internal/worker/fetch` 等、本 Issue の対象外コンポーネントの HTTP クライアント生成箇所の変更
+
+## Open Questions
+
+- なし

--- a/docs/specs/28-feeddetector-faviconfetcher-http/review-notes.md
+++ b/docs/specs/28-feeddetector-faviconfetcher-http/review-notes.md
@@ -1,0 +1,41 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-28-impl-feeddetector-faviconfetcher-http
+- HEAD commit: 9cffcd4556b1552c4af9e2c09e8cdd5b2d991406
+- Compared to: develop..HEAD
+
+## Verified Requirements
+
+- 1.1 — `FeedDetector.httpClient` をコンストラクタで 1 回生成し `getHTTPClient()` がそれを返す（detector.go）。`TestFeedDetector_GetHTTPClient_ReusesSameInstanceWithGuard` / `..._WithoutGuard`
+- 1.2 — リクエスト都度の生成ロジックを排除（旧 `getHTTPClient` 内の生成削除）。`TestFeedDetector_DetectFeedURL_NoAdditionalClientPerRequest`（NewSafeClient 呼び出し ≤1 回を検証）
+- 1.3 — クライアント再利用＝コネクションプール共有。同上テストで担保
+- 2.1 — 検出ロジック不変。3 回検出で結果一致を検証（`TestFeedDetector_DetectFeedURL_NoAdditionalClientPerRequest`）+ 既存 `TestDetectFeedURL_*`
+- 2.2 — 未検出エラー安定性。`TestFeedDetector_DetectFeedURL_NotDetectedResultStable`（異常系）
+- 3.1 — `FaviconFetcher.httpClient` をコンストラクタで 1 回生成（favicon.go）。`TestFaviconFetcher_GetHTTPClient_ReusesSameInstanceWithGuard` / `..._WithoutGuard`
+- 3.2 — favicon 側もリクエスト都度生成を排除。`TestFaviconFetcher_FetchFavicon_NoAdditionalClientPerRequest`
+- 3.3 — 再利用によるプール共有。同上テスト
+- 4.1 — 取得ロジック不変。3 回取得でデータ長・MIME 一致を検証（同上）+ 既存 `TestFaviconFetcher_FetchFavicon_Success`
+- 4.2 — 取得失敗(404)時 nil・空 MIME・エラーなしの安定性。`TestFaviconFetcher_FetchFavicon_FailureResultStable`（異常系）
+- 5.1 — SSRF ガード有効時のクライアント再利用後もブロック維持。`TestFeedDetector_SSRFBlocked_StableAfterReuse`
+- 5.2 — 同上（favicon）。`TestFaviconFetcher_SSRFBlocked_StableAfterReuse`
+- 5.3 — 禁止先ブロックの非退行。同上 + 既存 `TestDetectFeedURL_SSRFBlocked`
+- 5.4 — 同上（favicon）+ 既存 `TestFaviconFetcher_FetchFavicon_SSRFBlocked`
+- 5.5 — `ValidateURL` がリクエスト都度呼ばれることを検証（detector.go:312 / favicon.go:68 のパス不変）。DNS 解決後 IP 検証は `internal/security`（Out of Scope）が担い、本変更は呼び出しパス・`NewSafeClient` 経由クライアントを変更していない
+- 6.1 — `detectorTimeout=10s` / `detectorMaxResponseSize=5MB`（定数化のみ、値不変。インライン `maxBodySize` も同定数に統一）。`TestFeedDetector_GetHTTPClient_TimeoutPreserved`
+- 6.2 — `faviconTimeout=5s` / `maxFaviconSize=2MB`（既存定数をそのまま使用）。`TestFaviconFetcher_GetHTTPClient_TimeoutPreserved`
+- NFR 1.1 / 1.2 — 公開シグネチャ（`NewFeedDetector` / `NewFaviconFetcher` / 各メソッド・`SSRFValidator` IF）無変更。`go build ./...` 成功 + 既存全テスト pass
+- NFR 2.1 — クライアントをコンストラクタで即時生成し read-only フィールドとして保持。`TestFeedDetector_Concurrent_NoDataRace` / `TestFaviconFetcher_Concurrent_NoDataRace`（`go test -race` で PASS を確認）
+
+## Findings
+
+なし
+
+## Summary
+
+本 Issue は design-less impl（tasks.md / design.md 不在）のため AC カバレッジは requirements.md と既存コードの突き合わせで判定した。変更は in-scope の `internal/feed`（detector.go / favicon.go と各テスト）のみで Out of Scope の `internal/worker/fetch` / `internal/security` には触れていない（boundary 逸脱なし）。全 numeric AC（1.1〜6.2 / NFR 1.1, 1.2, 2.1）に対応する実装と正常系・異常系・境界値・並行のテストが追加され、`go test -race ./internal/feed/...` および `go build ./...` の green を確認した。Feature Flag Protocol は opt-out のため flag 観点は適用外。
+
+RESULT: approve

--- a/internal/feed/detector.go
+++ b/internal/feed/detector.go
@@ -40,16 +40,38 @@ type SSRFValidator interface {
 	NewSafeClient(timeout time.Duration, maxResponseSize int64) *http.Client
 }
 
+// detectorTimeout はフィード検出のHTTPタイムアウト。
+const detectorTimeout = 10 * time.Second
+
+// detectorMaxResponseSize はフィード検出時に読み込むレスポンスの最大サイズ（5MB）。
+const detectorMaxResponseSize = 5 * 1024 * 1024
+
 // FeedDetector はフィード自動検出機能を提供する。
 type FeedDetector struct {
 	ssrfGuard SSRFValidator
+	// httpClient はリクエスト間で再利用するHTTPクライアント。
+	// コンストラクタで一度だけ生成し、生成後は read-only なフィールド参照となるため、
+	// 複数 goroutine からの同時アクセスでもデータ競合は発生しない（NFR 2.1）。
+	httpClient *http.Client
 }
 
 // NewFeedDetector はFeedDetectorの新しいインスタンスを生成する。
+// HTTPクライアントはここで一度だけ生成し、以降のリクエストで使い回す
+// （コネクションプールを共有して無駄な TCP/TLS ハンドシェイクを抑制する）。
 func NewFeedDetector(ssrfGuard SSRFValidator) *FeedDetector {
 	return &FeedDetector{
-		ssrfGuard: ssrfGuard,
+		ssrfGuard:  ssrfGuard,
+		httpClient: newDetectorHTTPClient(ssrfGuard),
 	}
+}
+
+// newDetectorHTTPClient はフィード検出用のHTTPクライアントを生成する。
+// SSRFGuardが設定されている場合はSSRF防止付きクライアントを返す。
+func newDetectorHTTPClient(ssrfGuard SSRFValidator) *http.Client {
+	if ssrfGuard != nil {
+		return ssrfGuard.NewSafeClient(detectorTimeout, detectorMaxResponseSize)
+	}
+	return &http.Client{Timeout: detectorTimeout}
 }
 
 // feedContentTypes はフィードとして認識するContent-Typeのリスト。
@@ -308,8 +330,7 @@ func (d *FeedDetector) DetectFeedURL(ctx context.Context, inputURL string) (stri
 	defer resp.Body.Close()
 
 	// レスポンスボディを読み込み（最大5MB）
-	const maxBodySize = 5 * 1024 * 1024
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodySize))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, detectorMaxResponseSize))
 	if err != nil {
 		return "", model.NewFetchFailedError(fmt.Sprintf("レスポンスの読み取りに失敗: %v", err))
 	}
@@ -343,11 +364,8 @@ func (d *FeedDetector) DetectFeedURL(ctx context.Context, inputURL string) (stri
 	return best.URL, nil
 }
 
-// getHTTPClient はHTTPクライアントを取得する。
-// SSRFGuardが設定されている場合はSSRF防止付きクライアントを返す。
+// getHTTPClient はコンストラクタで生成済みの再利用HTTPクライアントを返す。
+// リクエストごとに新しいクライアントを生成せず、コネクションプールを共有する。
 func (d *FeedDetector) getHTTPClient() *http.Client {
-	if d.ssrfGuard != nil {
-		return d.ssrfGuard.NewSafeClient(10*time.Second, 5*1024*1024)
-	}
-	return &http.Client{Timeout: 10 * time.Second}
+	return d.httpClient
 }

--- a/internal/feed/detector_test.go
+++ b/internal/feed/detector_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -514,20 +516,214 @@ func TestDetectFeedURL_HTMLWithMultipleFeedLinks_PrioritySelection(t *testing.T)
 	}
 }
 
+// --- HTTP クライアント再利用のテスト（Requirement 1 / 5 / 6） ---
+
+// TestFeedDetector_GetHTTPClient_ReusesSameInstanceWithGuard はSSRFガード有効時に
+// 同一インスタンスでgetHTTPClientを複数回呼んでも同一クライアントを使い回し、
+// NewSafeClientの追加生成が発生しないことをテストする（AC 1.1, 1.2, 5.1）。
+func TestFeedDetector_GetHTTPClient_ReusesSameInstanceWithGuard(t *testing.T) {
+	// Arrange
+	guard := &mockSSRFGuard{}
+	d := NewFeedDetector(guard)
+
+	// Act
+	c1 := d.getHTTPClient()
+	c2 := d.getHTTPClient()
+	c3 := d.getHTTPClient()
+
+	// Assert
+	if c1 != c2 || c2 != c3 {
+		t.Error("同一インスタンスのgetHTTPClientは同一のHTTPクライアントを返すべき")
+	}
+	if guard.newSafeClientCalls() > 1 {
+		t.Errorf("NewSafeClientの呼び出しは1回までであるべき。結果: %d 回", guard.newSafeClientCalls())
+	}
+}
+
+// TestFeedDetector_GetHTTPClient_ReusesSameInstanceWithoutGuard はSSRFガード無効時(nil)に
+// 同一インスタンスでgetHTTPClientを複数回呼んでも同一クライアントを使い回すことをテストする（AC 1.1, 1.2）。
+func TestFeedDetector_GetHTTPClient_ReusesSameInstanceWithoutGuard(t *testing.T) {
+	// Arrange
+	d := NewFeedDetector(nil)
+
+	// Act
+	c1 := d.getHTTPClient()
+	c2 := d.getHTTPClient()
+
+	// Assert
+	if c1 != c2 {
+		t.Error("SSRFガード無効時も同一インスタンスのgetHTTPClientは同一クライアントを返すべき")
+	}
+	if c1 == nil {
+		t.Fatal("getHTTPClientはnilを返すべきではない")
+	}
+}
+
+// TestFeedDetector_DetectFeedURL_NoAdditionalClientPerRequest は同一インスタンスから
+// 複数回フィード検出しても新しいHTTPクライアントが追加生成されないことをテストする（AC 1.2, 2.1, 3）。
+func TestFeedDetector_DetectFeedURL_NoAdditionalClientPerRequest(t *testing.T) {
+	// Arrange
+	rssXML := `<?xml version="1.0"?><rss version="2.0"><channel><title>Test</title></channel></rss>`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, rssXML)
+	}))
+	defer server.Close()
+
+	guard := &mockSSRFGuard{}
+	d := NewFeedDetector(guard)
+
+	// Act: 同一インスタンスから3回検出
+	var results []string
+	for i := 0; i < 3; i++ {
+		feedURL, err := d.DetectFeedURL(context.Background(), server.URL+"/feed.xml")
+		if err != nil {
+			t.Fatalf("DetectFeedURL returned error on iteration %d: %v", i, err)
+		}
+		results = append(results, feedURL)
+	}
+
+	// Assert: 結果が全回一致（AC 2.1）かつクライアント追加生成なし（AC 1.2）
+	for i, got := range results {
+		if got != server.URL+"/feed.xml" {
+			t.Errorf("iteration %d: 期待URL: %s/feed.xml, 結果: %s", i, server.URL, got)
+		}
+	}
+	if guard.newSafeClientCalls() > 1 {
+		t.Errorf("複数回検出してもNewSafeClientは1回までであるべき。結果: %d 回", guard.newSafeClientCalls())
+	}
+}
+
+// TestFeedDetector_DetectFeedURL_NotDetectedResultStable は同一インスタンスから
+// 未検出URLを複数回検出しても各回で同一の未検出エラーを返すことをテストする（AC 2.2）。
+func TestFeedDetector_DetectFeedURL_NotDetectedResultStable(t *testing.T) {
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><head><title>No Feed</title></head><body></body></html>`)
+	}))
+	defer server.Close()
+
+	guard := &mockSSRFGuard{}
+	d := NewFeedDetector(guard)
+
+	// Act & Assert: 2回連続で同一の未検出エラー
+	for i := 0; i < 2; i++ {
+		_, err := d.DetectFeedURL(context.Background(), server.URL+"/")
+		if err == nil {
+			t.Fatalf("iteration %d: フィード未検出時はエラーを返すべき", i)
+		}
+		apiErr, ok := err.(*model.APIError)
+		if !ok {
+			t.Fatalf("iteration %d: APIError型が期待されるが、%T が返された", i, err)
+		}
+		if apiErr.Code != model.ErrCodeFeedNotDetected {
+			t.Errorf("iteration %d: 期待エラーコード: %s, 結果: %s", i, model.ErrCodeFeedNotDetected, apiErr.Code)
+		}
+	}
+}
+
+// TestFeedDetector_SSRFBlocked_StableAfterReuse はクライアント再利用後もSSRFブロックが
+// 維持され、複数回試行で各回ともValidateURL経由でブロックされることをテストする（AC 5.1, 5.3）。
+func TestFeedDetector_SSRFBlocked_StableAfterReuse(t *testing.T) {
+	// Arrange
+	guard := &mockSSRFGuard{blockAll: true}
+	d := NewFeedDetector(guard)
+
+	// Act & Assert: 2回連続でブロックされる
+	for i := 0; i < 2; i++ {
+		_, err := d.DetectFeedURL(context.Background(), "http://192.168.1.1/feed.xml")
+		if err == nil {
+			t.Fatalf("iteration %d: SSRFブロック対象URLはエラーを返すべき", i)
+		}
+		apiErr, ok := err.(*model.APIError)
+		if !ok {
+			t.Fatalf("iteration %d: APIError型が期待されるが、%T が返された", i, err)
+		}
+		if apiErr.Code != model.ErrCodeSSRFBlocked {
+			t.Errorf("iteration %d: 期待エラーコード: %s, 結果: %s", i, model.ErrCodeSSRFBlocked, apiErr.Code)
+		}
+	}
+	// 各リクエストでValidateURLが呼ばれている（DNS解決前の事前検証が維持されている）
+	if guard.validateURLCalls() != 2 {
+		t.Errorf("ValidateURLは各リクエストで呼ばれるべき。期待: 2回, 結果: %d 回", guard.validateURLCalls())
+	}
+}
+
+// TestFeedDetector_GetHTTPClient_TimeoutPreserved は再利用クライアントが既存の
+// タイムアウト値(10秒)を維持していることをテストする（AC 6.1）。
+func TestFeedDetector_GetHTTPClient_TimeoutPreserved(t *testing.T) {
+	// Arrange
+	d := NewFeedDetector(nil)
+
+	// Act
+	client := d.getHTTPClient()
+
+	// Assert
+	if client.Timeout != 10*time.Second {
+		t.Errorf("FeedDetectorのタイムアウトは10秒であるべき。結果: %v", client.Timeout)
+	}
+}
+
+// TestFeedDetector_Concurrent_NoDataRace は複数goroutineから同一インスタンスを
+// 同時利用してもデータ競合が発生しないことをテストする（NFR 2.1。-race と併用）。
+func TestFeedDetector_Concurrent_NoDataRace(t *testing.T) {
+	// Arrange
+	rssXML := `<?xml version="1.0"?><rss version="2.0"><channel><title>Test</title></channel></rss>`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, rssXML)
+	}))
+	defer server.Close()
+
+	guard := &mockSSRFGuard{}
+	d := NewFeedDetector(guard)
+
+	// Act: 10 goroutineから同時検出
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = d.DetectFeedURL(context.Background(), server.URL+"/feed.xml")
+		}()
+	}
+	wg.Wait()
+
+	// Assert: 競合が無いことは -race フラグが検出する。ここでは到達のみ確認。
+}
+
 // --- mockSSRFGuard ---
 
 // mockSSRFGuard はテスト用のSSRFGuardモック。
+// 並行テスト（NFR 2.1）でも自身が race を起こさないよう、呼び出し回数は atomic で記録する。
 type mockSSRFGuard struct {
 	blockAll bool
+	// newSafeClientCallCount は NewSafeClient が呼ばれた回数（クライアント再利用の検証用）。
+	newSafeClientCallCount atomic.Int64
+	// validateURLCallCount は ValidateURL が呼ばれた回数（SSRF 非退行の検証用）。
+	validateURLCallCount atomic.Int64
 }
 
 func (m *mockSSRFGuard) NewSafeClient(timeout time.Duration, maxResponseSize int64) *http.Client {
+	m.newSafeClientCallCount.Add(1)
 	return &http.Client{Timeout: timeout}
 }
 
 func (m *mockSSRFGuard) ValidateURL(rawURL string) error {
+	m.validateURLCallCount.Add(1)
 	if m.blockAll {
 		return fmt.Errorf("blocked by SSRF guard")
 	}
 	return nil
+}
+
+// newSafeClientCalls は NewSafeClient の呼び出し回数を返す。
+func (m *mockSSRFGuard) newSafeClientCalls() int64 {
+	return m.newSafeClientCallCount.Load()
+}
+
+// validateURLCalls は ValidateURL の呼び出し回数を返す。
+func (m *mockSSRFGuard) validateURLCalls() int64 {
+	return m.validateURLCallCount.Load()
 }

--- a/internal/feed/favicon.go
+++ b/internal/feed/favicon.go
@@ -31,13 +31,29 @@ type FaviconFetcherService interface {
 // FaviconFetcher はfavicon取得機能の実装。
 type FaviconFetcher struct {
 	ssrfGuard SSRFValidator
+	// httpClient はリクエスト間で再利用するHTTPクライアント。
+	// コンストラクタで一度だけ生成し、生成後は read-only なフィールド参照となるため、
+	// 複数 goroutine からの同時アクセスでもデータ競合は発生しない（NFR 2.1）。
+	httpClient *http.Client
 }
 
 // NewFaviconFetcher はFaviconFetcherの新しいインスタンスを生成する。
+// HTTPクライアントはここで一度だけ生成し、以降のリクエストで使い回す
+// （コネクションプールを共有して無駄な TCP/TLS ハンドシェイクを抑制する）。
 func NewFaviconFetcher(ssrfGuard SSRFValidator) *FaviconFetcher {
 	return &FaviconFetcher{
-		ssrfGuard: ssrfGuard,
+		ssrfGuard:  ssrfGuard,
+		httpClient: newFaviconHTTPClient(ssrfGuard),
 	}
+}
+
+// newFaviconHTTPClient はfavicon取得用のHTTPクライアントを生成する。
+// SSRFGuardが設定されている場合はSSRF防止付きクライアントを返す。
+func newFaviconHTTPClient(ssrfGuard SSRFValidator) *http.Client {
+	if ssrfGuard != nil {
+		return ssrfGuard.NewSafeClient(faviconTimeout, maxFaviconSize)
+	}
+	return &http.Client{Timeout: faviconTimeout}
 }
 
 // FetchFavicon は指定URLからfaviconを取得する。
@@ -114,12 +130,10 @@ func (f *FaviconFetcher) FetchFaviconForSite(ctx context.Context, siteURL string
 	return f.FetchFavicon(ctx, faviconURL)
 }
 
-// getHTTPClient はHTTPクライアントを取得する。
+// getHTTPClient はコンストラクタで生成済みの再利用HTTPクライアントを返す。
+// リクエストごとに新しいクライアントを生成せず、コネクションプールを共有する。
 func (f *FaviconFetcher) getHTTPClient() *http.Client {
-	if f.ssrfGuard != nil {
-		return f.ssrfGuard.NewSafeClient(faviconTimeout, maxFaviconSize)
-	}
-	return &http.Client{Timeout: faviconTimeout}
+	return f.httpClient
 }
 
 // guessDefaultFaviconURL はサイトURLからデフォルトのfavicon URLを推測する。

--- a/internal/feed/favicon_test.go
+++ b/internal/feed/favicon_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 )
@@ -183,6 +184,180 @@ func TestFaviconFetcher_FetchFavicon_LargeResponse(t *testing.T) {
 	if data != nil {
 		t.Error("expected nil favicon data for large response")
 	}
+}
+
+// --- HTTP クライアント再利用のテスト（Requirement 3 / 4 / 5 / 6） ---
+
+// TestFaviconFetcher_GetHTTPClient_ReusesSameInstanceWithGuard はSSRFガード有効時に
+// 同一インスタンスでgetHTTPClientを複数回呼んでも同一クライアントを使い回し、
+// NewSafeClientの追加生成が発生しないことをテストする（AC 3.1, 3.2, 5.2）。
+func TestFaviconFetcher_GetHTTPClient_ReusesSameInstanceWithGuard(t *testing.T) {
+	// Arrange
+	guard := &mockSSRFGuard{}
+	f := NewFaviconFetcher(guard)
+
+	// Act
+	c1 := f.getHTTPClient()
+	c2 := f.getHTTPClient()
+	c3 := f.getHTTPClient()
+
+	// Assert
+	if c1 != c2 || c2 != c3 {
+		t.Error("同一インスタンスのgetHTTPClientは同一のHTTPクライアントを返すべき")
+	}
+	if guard.newSafeClientCalls() > 1 {
+		t.Errorf("NewSafeClientの呼び出しは1回までであるべき。結果: %d 回", guard.newSafeClientCalls())
+	}
+}
+
+// TestFaviconFetcher_GetHTTPClient_ReusesSameInstanceWithoutGuard はSSRFガード無効時(nil)に
+// 同一インスタンスでgetHTTPClientを複数回呼んでも同一クライアントを使い回すことをテストする（AC 3.1, 3.2）。
+func TestFaviconFetcher_GetHTTPClient_ReusesSameInstanceWithoutGuard(t *testing.T) {
+	// Arrange
+	f := NewFaviconFetcher(nil)
+
+	// Act
+	c1 := f.getHTTPClient()
+	c2 := f.getHTTPClient()
+
+	// Assert
+	if c1 != c2 {
+		t.Error("SSRFガード無効時も同一インスタンスのgetHTTPClientは同一クライアントを返すべき")
+	}
+	if c1 == nil {
+		t.Fatal("getHTTPClientはnilを返すべきではない")
+	}
+}
+
+// TestFaviconFetcher_FetchFavicon_NoAdditionalClientPerRequest は同一インスタンスから
+// 複数回favicon取得しても新しいHTTPクライアントが追加生成されず、結果が一致することをテストする（AC 3.2, 4.1, 3）。
+func TestFaviconFetcher_FetchFavicon_NoAdditionalClientPerRequest(t *testing.T) {
+	// Arrange
+	pngData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(pngData)
+	}))
+	defer server.Close()
+
+	guard := &mockSSRFGuard{}
+	f := NewFaviconFetcher(guard)
+
+	// Act: 同一インスタンスから3回取得
+	for i := 0; i < 3; i++ {
+		data, mimeType, err := f.FetchFavicon(context.Background(), server.URL+"/favicon.ico")
+		if err != nil {
+			t.Fatalf("iteration %d: FetchFavicon returned error: %v", i, err)
+		}
+		// Assert: 各回で結果が一致（AC 4.1）
+		if len(data) != len(pngData) {
+			t.Errorf("iteration %d: 期待データ長 %d, 結果 %d", i, len(pngData), len(data))
+		}
+		if mimeType != "image/png" {
+			t.Errorf("iteration %d: 期待MIME image/png, 結果 %q", i, mimeType)
+		}
+	}
+
+	// Assert: クライアント追加生成なし（AC 3.2）
+	if guard.newSafeClientCalls() > 1 {
+		t.Errorf("複数回取得してもNewSafeClientは1回までであるべき。結果: %d 回", guard.newSafeClientCalls())
+	}
+}
+
+// TestFaviconFetcher_FetchFavicon_FailureResultStable は同一インスタンスから
+// 取得失敗(404)を複数回試行しても各回で同一の挙動(nil・空MIME・エラーなし)を返すことをテストする（AC 4.2）。
+func TestFaviconFetcher_FetchFavicon_FailureResultStable(t *testing.T) {
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	guard := &mockSSRFGuard{}
+	f := NewFaviconFetcher(guard)
+
+	// Act & Assert: 2回連続で同一の失敗挙動
+	for i := 0; i < 2; i++ {
+		data, mimeType, err := f.FetchFavicon(context.Background(), server.URL+"/favicon.ico")
+		if err != nil {
+			t.Fatalf("iteration %d: 取得失敗時はエラーを返すべきでない: %v", i, err)
+		}
+		if data != nil {
+			t.Errorf("iteration %d: 取得失敗時はnilデータであるべき", i)
+		}
+		if mimeType != "" {
+			t.Errorf("iteration %d: 取得失敗時は空MIMEであるべき。結果: %q", i, mimeType)
+		}
+	}
+}
+
+// TestFaviconFetcher_SSRFBlocked_StableAfterReuse はクライアント再利用後もSSRFブロックが
+// 維持され、複数回試行で各回ともValidateURL経由でブロックされることをテストする（AC 5.2, 5.4）。
+func TestFaviconFetcher_SSRFBlocked_StableAfterReuse(t *testing.T) {
+	// Arrange
+	guard := &mockSSRFGuard{blockAll: true}
+	f := NewFaviconFetcher(guard)
+
+	// Act & Assert: 2回連続でブロック（nil・空MIME・エラーなし）
+	for i := 0; i < 2; i++ {
+		data, mimeType, err := f.FetchFavicon(context.Background(), "http://192.168.1.1/favicon.ico")
+		if err != nil {
+			t.Fatalf("iteration %d: SSRFブロック時はエラーを返すべきでない: %v", i, err)
+		}
+		if data != nil {
+			t.Errorf("iteration %d: SSRFブロック時はnilデータであるべき", i)
+		}
+		if mimeType != "" {
+			t.Errorf("iteration %d: SSRFブロック時は空MIMEであるべき。結果: %q", i, mimeType)
+		}
+	}
+	// 各リクエストでValidateURLが呼ばれている
+	if guard.validateURLCalls() != 2 {
+		t.Errorf("ValidateURLは各リクエストで呼ばれるべき。期待: 2回, 結果: %d 回", guard.validateURLCalls())
+	}
+}
+
+// TestFaviconFetcher_GetHTTPClient_TimeoutPreserved は再利用クライアントが既存の
+// タイムアウト値(faviconTimeout=5秒)を維持していることをテストする（AC 6.2）。
+func TestFaviconFetcher_GetHTTPClient_TimeoutPreserved(t *testing.T) {
+	// Arrange
+	f := NewFaviconFetcher(nil)
+
+	// Act
+	client := f.getHTTPClient()
+
+	// Assert
+	if client.Timeout != faviconTimeout {
+		t.Errorf("FaviconFetcherのタイムアウトはfaviconTimeout(%v)であるべき。結果: %v", faviconTimeout, client.Timeout)
+	}
+}
+
+// TestFaviconFetcher_Concurrent_NoDataRace は複数goroutineから同一インスタンスを
+// 同時利用してもデータ競合が発生しないことをテストする（NFR 2.1。-race と併用）。
+func TestFaviconFetcher_Concurrent_NoDataRace(t *testing.T) {
+	// Arrange
+	pngData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(pngData)
+	}))
+	defer server.Close()
+
+	guard := &mockSSRFGuard{}
+	f := NewFaviconFetcher(guard)
+
+	// Act: 10 goroutineから同時取得
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, _ = f.FetchFavicon(context.Background(), server.URL+"/favicon.ico")
+		}()
+	}
+	wg.Wait()
+
+	// Assert: 競合が無いことは -race フラグが検出する。
 }
 
 // mockSSRFGuardForFavicon は既にdetector_test.goで定義されているmockSSRFGuardを使用する。


### PR DESCRIPTION
## 概要

`FeedDetector` と `FaviconFetcher` はリクエストのたびに新しい HTTP クライアントを生成しており、
クライアント単位で独立したコネクションプールが割り当てられ TCP/TLS コネクションが再利用されていなかった。
本 PR では各構造体にコンストラクタで一度だけ生成した `*http.Client` を保持させ、リクエスト間でコネクションプールを共有するリファクタを実装した。
外部から見た挙動（検出結果・取得結果・SSRF 防止・タイムアウト・サイズ上限）は一切変更していない。

## 対応 Issue

Closes #28

## 関連 PR

なし（設計 PR は走っていない design-less impl）

## 実装内容

- (Req 1 / AC 1.1〜1.3) `FeedDetector` に `httpClient *http.Client` フィールドを追加し、`NewFeedDetector` コンストラクタで 1 回のみ生成（`internal/feed/detector.go`）
- (Req 3 / AC 3.1〜3.3) `FaviconFetcher` に同様の `httpClient *http.Client` フィールドを追加し、`NewFaviconFetcher` コンストラクタで 1 回のみ生成（`internal/feed/favicon.go`）
- (Req 2 / Req 4) 検出・取得ロジック自体は不変。再利用後も同一の結果・エラーを返す
- (Req 5) SSRF ガード（`NewSafeClient` / `ValidateURL`）の呼び出しパスは変更せず、防御ロジックは温存
- (Req 6) タイムアウト・サイズ上限の値は定数化のみで数値は不変（detector: 10s / 5MB、favicon: 5s / 2MB）
- (NFR 1) 公開シグネチャ（`NewFeedDetector` / `NewFaviconFetcher` / 各メソッド・`SSRFValidator` IF）は無変更
- (NFR 2) クライアントをコンストラクタで即時生成し read-only フィールドとして保持することでデータ競合を回避

## 受入基準チェック

- [x] AC 1.1: While 同一の FeedDetector インスタンスが複数回使われている, the FeedDetector shall 同一クライアントを使い回す ← `TestFeedDetector_GetHTTPClient_ReusesSameInstanceWithGuard` / `..._WithoutGuard`
- [x] AC 1.2: When 連続して複数回リクエストを実行したとき, the FeedDetector shall リクエストごとに新しいクライアントを追加生成しない ← `TestFeedDetector_DetectFeedURL_NoAdditionalClientPerRequest`
- [x] AC 1.3: The FeedDetector shall 再利用可能なコネクションプールを共有する ← 同上
- [x] AC 2.1: When 同一インスタンスから複数回検出したとき, the FeedDetector shall 各回で同一の検出結果を返す ← `TestFeedDetector_DetectFeedURL_NoAdditionalClientPerRequest`
- [x] AC 2.2: If 入力 URL からフィードが検出できないとき, the FeedDetector shall 同一の未検出エラーを返す ← `TestFeedDetector_DetectFeedURL_NotDetectedResultStable`
- [x] AC 3.1〜3.3: FaviconFetcher の再利用・プール共有 ← `TestFaviconFetcher_GetHTTPClient_Reuses*` / `TestFaviconFetcher_FetchFavicon_NoAdditionalClientPerRequest`
- [x] AC 4.1: When 複数回 favicon 取得したとき, the FaviconFetcher shall 同一結果を返す ← `TestFaviconFetcher_FetchFavicon_NoAdditionalClientPerRequest`
- [x] AC 4.2: If favicon 取得に失敗したとき, the FaviconFetcher shall nil データ・空 MIME・エラーなしを返す ← `TestFaviconFetcher_FetchFavicon_FailureResultStable`
- [x] AC 5.1〜5.5: SSRF 防止の非退行 ← `TestFeedDetector_SSRFBlocked_StableAfterReuse` / `TestFaviconFetcher_SSRFBlocked_StableAfterReuse`
- [x] AC 6.1: The FeedDetector shall 同一タイムアウト値・最大サイズで処理する ← `TestFeedDetector_GetHTTPClient_TimeoutPreserved`
- [x] AC 6.2: The FaviconFetcher shall 同一タイムアウト値・最大サイズで処理する ← `TestFaviconFetcher_GetHTTPClient_TimeoutPreserved`
- [x] NFR 1.1 / 1.2: 公開シグネチャ無変更 ← `go build ./...` 成功 + 既存全テスト pass
- [x] NFR 2.1: While 複数 goroutine が同時リクエスト, the FeedDetector and FaviconFetcher shall データ競合なく安全にアクセスする ← `TestFeedDetector_Concurrent_NoDataRace` / `TestFaviconFetcher_Concurrent_NoDataRace`（`-race`）

## テスト結果

```
go test -race ./internal/feed/...
PASS
全 73 テスト pass / 0 fail（feed パッケージ）

go build ./...
成功（ビルドエラーなし）

go test ./...
全パッケージ PASS（fail なし）

gofmt -l（変更 4 ファイル）: 差分なし（clean）
go vet ./internal/feed/...: 警告なし
```

## 実装上の判断

- HTTP クライアントはコンストラクタで即時 1 回生成してフィールドに格納する方式を採用。生成後は書き換えられず read-only な参照となるため `sync.Once` による遅延初期化より単純で並行安全（`impl-notes.md` 参照）
- `DetectFeedURL` 内のインライン `maxBodySize` を `detectorMaxResponseSize` 定数に統一（値は `5 * 1024 * 1024` で同一）
- 並行テストの `mockSSRFGuard` 呼び出し回数カウンタを `atomic.Int64` 化（mock 自身のレース防止のみ。production code とは無関係）

## 確認事項 / レビュワーへの依頼

- AC 5.5 の「DNS 解決後の IP 検証（DNS リバインディング対策）」は `internal/security` 配下のガード実装が担い、本 Issue のスコープ外。`mockSSRFGuard` ではその実挙動を再現できないが、本変更前のテストも同様であり退行ではない（詳細は `docs/specs/28-feeddetector-faviconfetcher-http/impl-notes.md` 参照）
- Reviewer（round=1）は全 AC を approve 判定済み。review-notes.md の RESULT: approve を確認すること
- base=develop を検証済み（`--base develop` 指定 / `baseRefName` = develop / 一致）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #28 のコメントを参照してください。
