### PR TITLE
feat(#18): favicon 取得の非同期化で WriteTimeout 超過を回避

### DIFF
--- a/docs/specs/18-registerfeed-favicon-writetimeout/impl-notes.md
+++ b/docs/specs/18-registerfeed-favicon-writetimeout/impl-notes.md
@@ -1,0 +1,95 @@
+# 実装ノート: Issue #18 RegisterFeed の同期 favicon 取得が WriteTimeout を超過するリスクを解消する
+
+## 実装方針（確定済み Option A: favicon 取得の非同期化）
+
+`FeedService.RegisterFeed` は購読作成完了後、favicon 取得の完了を待たずに `(feed, sub, nil)` を
+即時返すように変更した。favicon 取得は購読作成後に独立した goroutine で非同期実行する。
+
+- favicon 取得はリクエストスコープの `ctx` から `context.WithoutCancel(ctx)` で切り離した
+  **独立 context** で実行する。これによりリクエスト ctx のキャンセル/タイムアウトに
+  引きずられず、レスポンス送出後のリクエストスコープ完了で取得が中断されない（要件 3.3）。
+- goroutine リーク防止のため、独立 context に `context.WithTimeout` で
+  **上限時間 `backgroundFaviconTimeout = 30 * time.Second`** を付与し、完了/打ち切り時に
+  `defer cancel()` でリソースを解放する（要件 4.1, 4.2, 4.3）。
+- favicon 取得失敗・未検出・タイムアウト時は現行どおり null 保持（DB 更新せず、`slog` ログ
+  出力のみ）。挙動を弱めていない（要件 2.3, 2.4, 2.5 / NFR 2）。
+- WriteTimeout の延長（Option B）は採用していない。`internal/app/app.go` の HTTP サーバー
+  設定（WriteTimeout 15s）は変更していない。
+
+## 主要な変更点
+
+### `internal/feed/service.go`
+
+- `backgroundFaviconTimeout` 定数（30 秒）を追加（要件 4.1）。
+- `FeedService` に `faviconWG sync.WaitGroup` フィールドを追加。バックグラウンド goroutine の
+  完了を追跡する。本番フローでは `Wait` を呼ばないため本番挙動には影響せず、テストから
+  非同期完了を決定論的に待つための補助。
+- `RegisterFeed` の手順 5 を同期呼び出しから `startFaviconFetch`（非同期起動）に変更。
+  シグネチャ・戻り値 `(*model.Feed, *model.Subscription, error)` は不変（後方互換 / 要件 5）。
+- `startFaviconFetch(ctx, feedID, siteURL)` を新設。`context.WithoutCancel` で独立 context を
+  生成し、`faviconWG.Add(1)` → goroutine 内で `context.WithTimeout` を付与して
+  `fetchAndSaveFavicon` を呼ぶ。
+- `fetchAndSaveFavicon` の引数を `*model.Feed` から `feedID, siteURL string` に変更。
+  **返却済みの `feed` ポインタへの書き戻し（`feed.FaviconData = ...` / `feed.FaviconMime = ...`）を
+  廃止**し、取得結果は DB の `UpdateFavicon` にのみ反映する。これにより返却済みポインタへの
+  並行書き込み（データ競合）を回避（`go test -race` clean）。
+- `faviconTargetURL(feed)` ヘルパーを追加（SiteURL 空時は FeedURL フォールバック。従来ロジックを抽出）。
+- `waitFaviconFetch()` をテスト容易性のための補助メソッドとして追加（本番未使用）。
+
+### `internal/feed/service_test.go`
+
+- `mockFeedRepo` に `mu sync.Mutex` と `getFaviconCall()` ヘルパーを追加し、
+  `UpdateFavicon` の `faviconCall` 記録をロックで保護（バックグラウンド goroutine からの
+  書き込みとテストの読み出しの競合回避）。`UpdateFavicon` 内の返却済み feed ポインタへの
+  書き戻しは本番に合わせて廃止。
+- 既存 `TestFeedService_RegisterFeed_FaviconSavedOnSuccess` / `_FaviconFetchFailure` /
+  `_Integration_WithHTTPServer` は非同期化に伴い `svc.waitFaviconFetch()` で完了を待ってから
+  assert するよう調整（assert 内容自体は維持・強化。緩和していない）。
+
+### `internal/feed/service_async_test.go`（新規）
+
+新規 AC 向けテストを集約。`controllableFaviconFetcher`（block チャネル / context 観測付き）と
+`deadlineObservingFetcher` を用意。
+
+## テスト観点と AC トレーサビリティ
+
+| Requirement / AC | テスト |
+|---|---|
+| 1.1, 1.2, 1.3（favicon 完了を待たず即時返却・応答時間に加算しない） | `TestRegisterFeed_ReturnsBeforeFaviconCompletes`（favicon を block したまま RegisterFeed が 2 秒以内に返り、応答時間が 1 秒未満であることを検証） |
+| 1.4 / NFR 1.1（WriteTimeout 15s 未満で返す） | `TestRegisterFeed_ReturnsBeforeFaviconCompletes`（即時返却を担保。15s の WriteTimeout に対し応答は favicon 取得時間と無関係） |
+| 2.1, 2.4（取得失敗でも登録成功・null 保持） | `TestRegisterFeed_SucceedsWhenFaviconFetchErrors` / 既存 `TestFeedService_RegisterFeed_FaviconFetchFailure` |
+| 2.2（タイムアウト時も登録成功） | `TestRegisterFeed_ReturnsBeforeFaviconCompletes`（取得が長時間でも登録は成功）+ `TestStartFaviconFetch_AppliesTimeoutDeadline`（タイムアウト機構の存在）|
+| 2.3（未検出時 null 保持） | `TestRegisterFeed_SucceedsWhenFaviconNotFound`（data==nil 境界値） |
+| 2.5 / NFR 2.1（失敗/未検出/タイムアウトのログ記録） | `fetchAndSaveFavicon` 内の `slog.Warn`/`slog.Info`（feedID/siteURL 付き）。テスト実行ログで出力を確認 |
+| 3.1, 3.2（成功時に保存・後続で参照可能） | `TestRegisterFeed_FaviconSavedAsynchronously` / 既存 `TestFeedService_RegisterFeed_FaviconSavedOnSuccess` |
+| 3.3（リクエストスコープ完了で中断しない） | `TestRegisterFeed_FaviconContinuesAfterRequestCtxCanceled`（リクエスト ctx キャンセル後も独立 context で取得完了・保存。呼び出し時 ctx が未キャンセルであることも検証） |
+| 4.1（上限時間 30 秒以内） | `TestBackgroundFaviconTimeout_IsBounded`（定数 ≤ 30s）/ `TestStartFaviconFetch_AppliesTimeoutDeadline`（context にデッドライン設定） |
+| 4.2（上限到達で打ち切り） | `TestStartFaviconFetch_AppliesTimeoutDeadline`（WithTimeout context を fetcher に渡している＝上限到達で ctx がキャンセルされる機構を担保） |
+| 4.3（完了/打ち切りでリソース解放） | `defer cancel()` による解放。`go test -race` 全 green（goroutine リーク・競合なし） |
+| 5.1, 5.3（レスポンス形式・既存エラー応答維持） | 既存 handler テスト（`internal/handler/feed_handler_test.go`）全 green。`RegisterFeed` シグネチャ不変 |
+| 5.2（201 Created 維持） | 既存 `TestFeedHandler_RegisterFeed_Success` 等（ハンドラー層未変更で維持） |
+| NFR 3.1（レスポンス形式 feed/subscription 同一） | `RegisterFeed` 戻り値・handler 層未変更。既存テストで担保 |
+
+## 品質ゲート結果
+
+- `go build ./...`: OK
+- `go vet ./...`: OK
+- `gofmt -l`（変更ファイル）: 差分なし（clean）
+- `go test ./... -race`: 全パッケージ PASS
+
+## 確認事項（レビュワー判断ポイント）
+
+- **データ競合回避の設計**: 返却済み `feed` ポインタへの favicon 書き戻しを廃止した。
+  これにより登録レスポンスには favicon バイナリが含まれない（従来も登録レスポンスは
+  feed/subscription のみで、favicon バイナリは別経路の想定 / 要件 NFR 3.1 と整合）。
+  favicon は DB の `UpdateFavicon` 経由でのみ反映され、後続のフィード取得操作（`GetFeed` 等）で
+  参照可能（要件 3.2）。
+- **テスト補助メソッド `waitFaviconFetch()` / `faviconWG`**: 本番フローでは `Wait` を呼ばず
+  挙動に影響しない。非同期完了を決定論的に検証するための最小限の機構であり、本番挙動を
+  弱めるものではない（テスト規約「実装ではなくテスト側を弱める」には該当しない）。
+- **`mockFeedRepo.UpdateFavicon` の書き戻し廃止**: 本番 `fetchAndSaveFavicon` が返却済み
+  ポインタへ書き戻さなくなったため、モックも同様に共有ポインタへの書き込みを廃止し
+  `faviconCall` 記録のみとした（`-race` clean のため）。既存テストの assert は維持。
+- requirements.md との矛盾は検出されなかった。
+
+STATUS: complete

--- a/docs/specs/18-registerfeed-favicon-writetimeout/requirements.md
+++ b/docs/specs/18-registerfeed-favicon-writetimeout/requirements.md
@@ -1,0 +1,93 @@
+# Requirements Document
+
+## Introduction
+
+フィード登録処理（`FeedService.RegisterFeed`）は、フィード検出（最大 10 秒）と favicon 取得（最大 5 秒）を
+同期実行している。両者が同時に遅延すると合計処理時間が HTTP サーバーの WriteTimeout（15 秒）を超過し、
+購読登録自体は成功しているのにクライアントへはタイムアウトエラーとして見える不整合が起こり得る。
+本要件は、人間が確定した方針（favicon 取得の非同期化＝Option A）に基づき、登録レスポンスを WriteTimeout
+内で安定して返しつつ、favicon の取得遅延・失敗が登録結果に波及しないことを定義する。
+favicon 取得失敗時に null として扱う現行のフォールバック挙動と、登録 API のレスポンス形式は維持する。
+
+## Requirements
+
+### Requirement 1: 登録レスポンスのタイムアウト安全性
+
+**Objective:** As a フィードを登録するユーザー, I want 登録レスポンスが WriteTimeout 内に必ず返ること, so that 登録が成功したのにタイムアウトエラーに見える不整合を経験しない
+
+#### Acceptance Criteria
+
+1. When ユーザーがフィード登録を要求し favicon 取得が遅延または完了していない状態のとき, the Feed Service shall favicon 取得の完了を待たずに登録レスポンスを返す
+2. When フィード検出が上限時間（10 秒）近くまで要した後に登録処理を継続するとき, the Feed Service shall favicon 取得時間を登録レスポンスの応答時間に加算しない
+3. While favicon 取得がバックグラウンドで継続している状態のとき, the Feed Service shall ユーザーへの登録レスポンス送出をブロックしない
+4. The Feed Service shall 登録レスポンスを WriteTimeout（15 秒）未満で返す
+
+### Requirement 2: favicon 取得失敗・遅延時の登録成功維持
+
+**Objective:** As a フィードを登録するユーザー, I want favicon が取得できなくても登録自体は成功扱いになること, so that favicon の有無に関わらずフィードを購読できる
+
+#### Acceptance Criteria
+
+1. If favicon 取得が失敗したとき, the Feed Service shall 登録を成功として扱い成功レスポンスを返す
+2. If favicon 取得が遅延しタイムアウトしたとき, the Feed Service shall 登録を成功として扱い成功レスポンスを返す
+3. If favicon が見つからないとき, the Feed Service shall 当該フィードの favicon を null として保持する
+4. If favicon 取得が失敗したとき, the Feed Service shall 当該フィードの favicon を null として保持する
+5. When favicon 取得が失敗または遅延したとき, the Feed Service shall 失敗事由を運用者が追跡できるログとして記録する
+
+### Requirement 3: favicon 取得成功時の保存
+
+**Objective:** As a フィードを登録するユーザー, I want favicon が取得できた場合は最終的にフィードへ反映されること, so that 後続の表示で favicon を確認できる
+
+#### Acceptance Criteria
+
+1. When favicon 取得がバックグラウンドで成功したとき, the Feed Service shall 取得した favicon を当該フィードに保存する
+2. When favicon の保存が完了したとき, the Feed Service shall 後続のフィード取得操作で当該 favicon を参照可能にする
+3. While 登録レスポンス送出後に favicon 取得が継続している状態のとき, the Feed Service shall 当該登録要求のリクエストスコープ完了によって favicon 取得を中断しない
+
+### Requirement 4: バックグラウンド処理の有界性
+
+**Objective:** As a システム運用者, I want バックグラウンドの favicon 取得が無制限に滞留しないこと, so that リソースリークや滞留処理の蓄積を避けられる
+
+#### Acceptance Criteria
+
+1. While favicon 取得がバックグラウンドで継続している状態のとき, the Feed Service shall 取得処理に上限時間（30 秒以内）を設ける
+2. When favicon 取得が上限時間に達したとき, the Feed Service shall 当該取得処理を打ち切る
+3. When favicon 取得処理が完了または打ち切られたとき, the Feed Service shall 当該処理に割り当てたバックグラウンドリソースを解放する
+
+### Requirement 5: 後方互換の維持
+
+**Objective:** As a 登録 API の利用者, I want 既存のレスポンス形式と挙動が変わらないこと, so that 既存クライアントが影響を受けない
+
+#### Acceptance Criteria
+
+1. When フィード登録が成功したとき, the Feed Service shall フィード情報と購読情報を含む既存のレスポンス形式で結果を返す
+2. The Feed Service shall 登録成功時の HTTP ステータスを現行（201 Created）から変更しない
+3. When 購読上限超過・重複購読・無効 URL・フィード未検出などフィード検出までに発生する既存のエラー条件が成立したとき, the Feed Service shall 現行と同一のエラー応答を返す
+
+## Non-Functional Requirements
+
+### NFR 1: 応答時間
+
+1. The Feed Service shall フィード登録レスポンスを WriteTimeout（15 秒）未満で返す
+2. While favicon 取得がバックグラウンドで継続している状態のとき, the Feed Service shall 登録レスポンスの応答時間に favicon 取得時間を含めない
+
+### NFR 2: 可観測性
+
+1. When favicon 取得が失敗・未検出・タイムアウトのいずれかになったとき, the Feed Service shall 対象フィードを特定できる情報を含むログを記録する
+
+### NFR 3: 互換性
+
+1. The Feed Service shall 登録 API のレスポンス形式（feed / subscription）を本変更前と同一に保つ
+
+## Out of Scope
+
+- フィード検出（パース・URL 正規化）ロジックの変更
+- favicon の画像最適化・キャッシュ戦略
+- WriteTimeout の延長（Option B は不採用）
+- favicon 取得の非同期化に伴う UI 側の遅延反映表示（後追い表示）の追加
+- 既存のフィード検出タイムアウト（10 秒）・favicon 取得タイムアウト（5 秒）値そのものの調整
+
+## Open Questions
+
+- なし（実装方針は Issue コメントで Option A（非同期化）に確定済み。バックグラウンド取得の上限時間は
+  目安 30 秒以内とし、具体値・実装手段は design.md の領分とする）

--- a/docs/specs/18-registerfeed-favicon-writetimeout/review-notes.md
+++ b/docs/specs/18-registerfeed-favicon-writetimeout/review-notes.md
@@ -1,0 +1,44 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T18:42:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-18-impl-registerfeed-favicon-writetimeout
+- HEAD commit: 02cc6c6088664d7b0227fa102d68e37cb48c4e1e
+- Compared to: develop..HEAD
+
+注: 本 Issue は design-less impl（`tasks.md` / `design.md` 不在）。`_Boundary:_` アノテーションが
+存在しないため、boundary 判定は変更が要件の対象コンポーネント（Feed Service 層）に閉じているかで
+確認した。CLAUDE.md の Feature Flag Protocol 採否は `opt-out` のため flag 観点は適用しない。
+
+## Verified Requirements
+
+- 1.1 — `internal/feed/service.go:141` で `startFaviconFetch` 起動後すぐ `return feed, sub, nil`。`TestRegisterFeed_ReturnsBeforeFaviconCompletes`（favicon を block したまま即時返却を検証）
+- 1.2 — 同上。favicon 取得時間を応答に加算しない。`TestRegisterFeed_ReturnsBeforeFaviconCompletes`（応答 1 秒未満を assert）
+- 1.3 — favicon は独立 goroutine 実行。レスポンス送出をブロックしない。`TestRegisterFeed_ReturnsBeforeFaviconCompletes`
+- 1.4 / NFR 1.1, 1.2 — 即時返却により WriteTimeout(15s) と無関係。`TestRegisterFeed_ReturnsBeforeFaviconCompletes`
+- 2.1, 2.4 — 取得エラー時も登録成功・null 保持（DB 更新せず）。`TestRegisterFeed_SucceedsWhenFaviconFetchErrors` / 既存 `TestFeedService_RegisterFeed_FaviconFetchFailure`
+- 2.2 — タイムアウト時も登録成功。`backgroundFaviconTimeout` 機構 + 即時返却（`TestRegisterFeed_ReturnsBeforeFaviconCompletes` / `TestStartFaviconFetch_AppliesTimeoutDeadline`）
+- 2.3 — 未検出（data==nil）時 null 保持。`TestRegisterFeed_SucceedsWhenFaviconNotFound`
+- 2.5 / NFR 2.1 — `internal/feed/service.go:259-270` の `fetchAndSaveFavicon` 内 `slog.Warn`/`slog.Info`（feedID/siteURL 付き）。テスト実行ログで出力確認
+- 3.1, 3.2 — 成功時 `UpdateFavicon` 経由で DB 保存（後続 `GetFeed` で参照可）。`TestRegisterFeed_FaviconSavedAsynchronously` / 既存 `TestFeedService_RegisterFeed_FaviconSavedOnSuccess`
+- 3.3 — `context.WithoutCancel(ctx)` で独立 context 化（`service.go:157`）。`TestRegisterFeed_FaviconContinuesAfterRequestCtxCanceled`（リクエスト ctx キャンセル後も完了・保存、呼び出し時 ctx 未キャンセルを検証）
+- 4.1 — `backgroundFaviconTimeout = 30 * time.Second`（`service.go:23`）。`TestBackgroundFaviconTimeout_IsBounded`（≤30s）/ `TestStartFaviconFetch_AppliesTimeoutDeadline`（context デッドライン設定）
+- 4.2 — `context.WithTimeout` で fetcher に渡す ctx にデッドライン付与（上限到達で ctx キャンセル）。`TestStartFaviconFetch_AppliesTimeoutDeadline`
+- 4.3 — `defer cancel()`（`service.go:165`）でリソース解放。`go test ./internal/feed/... -race` clean（goroutine リーク・競合なし）
+- 5.1, 5.3 / NFR 3.1 — `RegisterFeed` シグネチャ・戻り値不変、handler 層（`internal/handler/`）未変更。レスポンス形式 feed/subscription 維持
+- 5.2 — handler 層未変更により 201 Created 維持。既存 handler テストで担保
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric requirement ID（1.x / 2.x / 3.x / 4.x / 5.x / NFR）について、Feed Service 層の非同期化実装と
+対応テストでカバレッジを確認した。変更は `internal/feed/service.go` および同パッケージのテストに閉じており、
+handler 層・WriteTimeout 設定は不変で後方互換を保つ。`go test ./internal/feed/... -race -count=1` 全 PASS を
+独立に再実行して確認した。
+
+RESULT: approve

--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -19,6 +20,11 @@ const maxSubscriptionsPerUser = 100
 // defaultFetchIntervalMinutes は新規購読のデフォルトフェッチ間隔（分）。
 const defaultFetchIntervalMinutes = 60
 
+// backgroundFaviconTimeout はバックグラウンドでの favicon 取得処理に課す上限時間。
+// リクエストスコープから切り離した独立 context にこのタイムアウトを付与することで、
+// goroutine が無制限に滞留するのを防ぐ（要件 4: バックグラウンド処理の有界性）。
+const backgroundFaviconTimeout = 30 * time.Second
+
 // Detector はフィード検出のインターフェース。
 // テスタビリティのためFeedDetectorを抽象化する。
 type Detector interface {
@@ -27,11 +33,17 @@ type Detector interface {
 
 // FeedService はフィード登録・管理のサービス層。
 // 検出 → フィード保存 → 購読作成 → favicon取得のフローを統括する。
+// favicon 取得は購読作成完了後に独立した goroutine で非同期実行され、
+// 登録レスポンスの応答時間に影響しない（要件 1: タイムアウト安全性）。
 type FeedService struct {
 	feedRepo       repository.FeedRepository
 	subRepo        repository.SubscriptionRepository
 	detector       Detector
 	faviconFetcher FaviconFetcherService
+
+	// faviconWG はバックグラウンドの favicon 取得 goroutine の完了を追跡する。
+	// テストから非同期完了を待つために用いる（本番では Wait を呼ばないため挙動に影響しない）。
+	faviconWG sync.WaitGroup
 }
 
 // NewFeedService はFeedServiceの新しいインスタンスを生成する。
@@ -121,10 +133,55 @@ func (s *FeedService) RegisterFeed(ctx context.Context, userID string, inputURL 
 		return nil, nil, fmt.Errorf("購読の作成に失敗しました: %w", err)
 	}
 
-	// 5. favicon取得（非同期ではなく同期で実行。取得失敗時はnullとして保存）
-	s.fetchAndSaveFavicon(ctx, feed)
+	// 5. favicon取得（非同期）。
+	// リクエストスコープの ctx から切り離した独立 context で実行し、
+	// 取得完了を待たずに登録レスポンスを返す（要件 1）。
+	// ctx のキャンセル/タイムアウトに引きずられないこと（要件 3.3）、
+	// かつ上限時間を付与して goroutine リークを防ぐこと（要件 4）。
+	s.startFaviconFetch(ctx, feed.ID, faviconTargetURL(feed))
 
 	return feed, sub, nil
+}
+
+// startFaviconFetch はリクエストスコープから切り離した独立 context で
+// favicon 取得を非同期実行する goroutine を起動する。
+// 独立 context には backgroundFaviconTimeout の上限時間を付与し、
+// goroutine の完了を faviconWG で追跡する。
+func (s *FeedService) startFaviconFetch(ctx context.Context, feedID, siteURL string) {
+	if s.faviconFetcher == nil {
+		return
+	}
+
+	// リクエスト ctx の値（トレース情報等）は引き継ぎつつ、
+	// キャンセル/デッドラインの伝播を断ち切る独立 context を生成する。
+	bgCtx := context.WithoutCancel(ctx)
+
+	s.faviconWG.Add(1)
+	go func() {
+		defer s.faviconWG.Done()
+
+		// 上限時間を付与し、処理完了または打ち切り時に必ずリソースを解放する（要件 4.3）。
+		timeoutCtx, cancel := context.WithTimeout(bgCtx, backgroundFaviconTimeout)
+		defer cancel()
+
+		s.fetchAndSaveFavicon(timeoutCtx, feedID, siteURL)
+	}()
+}
+
+// waitFaviconFetch は進行中のバックグラウンド favicon 取得 goroutine の完了を待つ。
+// 本番フローでは呼ばれず、非同期完了を決定論的に検証したいテストからのみ利用する
+// （テスト容易性のための補助であり、本番挙動には影響しない）。
+func (s *FeedService) waitFaviconFetch() {
+	s.faviconWG.Wait()
+}
+
+// faviconTargetURL は favicon 取得の対象となるサイト URL を決定する。
+// SiteURL が空の場合は FeedURL をフォールバックとして用いる。
+func faviconTargetURL(feed *model.Feed) string {
+	if feed.SiteURL != "" {
+		return feed.SiteURL
+	}
+	return feed.FeedURL
 }
 
 // GetFeed はフィード情報を取得する。
@@ -182,38 +239,32 @@ func (s *FeedService) UpdateFeedURL(ctx context.Context, userID, feedID, newURL 
 }
 
 // fetchAndSaveFavicon はフィードのfaviconを取得して保存する。
-// 取得失敗時はログ出力のみで、エラーを返さない。
-func (s *FeedService) fetchAndSaveFavicon(ctx context.Context, feed *model.Feed) {
+// 取得失敗・未検出・タイムアウト時はログ出力のみで、エラーを返さず favicon を null のまま保持する。
+// 返却済みの feed ポインタへの並行書き込みを避けるため、引数は feedID / siteURL のみとし、
+// 取得結果はローカル変数経由で DB（UpdateFavicon）にのみ反映する。
+func (s *FeedService) fetchAndSaveFavicon(ctx context.Context, feedID, siteURL string) {
 	if s.faviconFetcher == nil {
 		return
 	}
 
-	// サイトURLからfaviconを取得
-	siteURL := feed.SiteURL
-	if siteURL == "" {
-		siteURL = feed.FeedURL
-	}
-
 	data, mimeType, err := s.faviconFetcher.FetchFaviconForSite(ctx, siteURL)
 	if err != nil {
-		slog.Warn("favicon取得エラー", "feedID", feed.ID, "siteURL", siteURL, "error", err)
+		slog.Warn("favicon取得エラー", "feedID", feedID, "siteURL", siteURL, "error", err)
 		return
 	}
 
 	if data == nil {
-		slog.Info("favicon未検出（nullとして保存）", "feedID", feed.ID, "siteURL", siteURL)
+		slog.Info("favicon未検出（nullとして保存）", "feedID", feedID, "siteURL", siteURL)
 		return
 	}
 
 	// faviconをDB保存
-	if err := s.feedRepo.UpdateFavicon(ctx, feed.ID, data, mimeType); err != nil {
-		slog.Warn("favicon保存エラー", "feedID", feed.ID, "error", err)
+	if err := s.feedRepo.UpdateFavicon(ctx, feedID, data, mimeType); err != nil {
+		slog.Warn("favicon保存エラー", "feedID", feedID, "error", err)
 		return
 	}
 
-	feed.FaviconData = data
-	feed.FaviconMime = mimeType
-	slog.Info("favicon保存完了", "feedID", feed.ID, "mimeType", mimeType, "size", len(data))
+	slog.Info("favicon保存完了", "feedID", feedID, "mimeType", mimeType, "size", len(data))
 }
 
 // extractSiteURL はフィードURLまたは入力URLからサイトURLを抽出する。

--- a/internal/feed/service_async_test.go
+++ b/internal/feed/service_async_test.go
@@ -1,0 +1,328 @@
+package feed
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- 非同期 favicon 取得テスト用の制御可能なモック ---
+
+// controllableFaviconFetcher はテストから取得の遅延・成否・呼び出し時の context を
+// 観測できる FaviconFetcherService モック。
+type controllableFaviconFetcher struct {
+	mu sync.Mutex
+
+	// block が non-nil の場合、FetchFaviconForSite はこのチャネルが閉じられるまでブロックする。
+	block chan struct{}
+
+	// 返却値
+	data []byte
+	mime string
+	err  error
+
+	// 観測用
+	called      bool
+	ctxCanceled bool // 呼び出し時点で渡された ctx が既にキャンセル済みだったか
+}
+
+func (c *controllableFaviconFetcher) FetchFavicon(ctx context.Context, _ string) ([]byte, string, error) {
+	return c.FetchFaviconForSite(ctx, "")
+}
+
+func (c *controllableFaviconFetcher) FetchFaviconForSite(ctx context.Context, _ string) ([]byte, string, error) {
+	c.mu.Lock()
+	c.called = true
+	c.ctxCanceled = ctx.Err() != nil
+	block := c.block
+	c.mu.Unlock()
+
+	if block != nil {
+		<-block
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.data, c.mime, c.err
+}
+
+func (c *controllableFaviconFetcher) wasCalled() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.called
+}
+
+func (c *controllableFaviconFetcher) ctxWasCanceledOnCall() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.ctxCanceled
+}
+
+// newRegisterTestService は新規フィード登録テスト用の FeedService を生成する。
+func newRegisterTestService(fetcher FaviconFetcherService) (*FeedService, *mockFeedRepo) {
+	feedRepo := newMockFeedRepo()
+	subRepo := newMockSubRepo()
+	detector := &mockDetector{feedURL: "https://example.com/feed.xml"}
+	return NewFeedService(feedRepo, subRepo, detector, fetcher), feedRepo
+}
+
+// --- Requirement 1: 登録レスポンスのタイムアウト安全性 ---
+
+// TestRegisterFeed_ReturnsBeforeFaviconCompletes は favicon 取得が遅延・未完了でも
+// RegisterFeed が完了を待たずに即座に返ることを検証する（AC 1.1, 1.2, 1.3）。
+func TestRegisterFeed_ReturnsBeforeFaviconCompletes(t *testing.T) {
+	// Arrange: favicon 取得を明示的にブロックする
+	fetcher := &controllableFaviconFetcher{
+		block: make(chan struct{}),
+		data:  []byte{0x89, 0x50, 0x4E, 0x47},
+		mime:  "image/png",
+	}
+	svc, _ := newRegisterTestService(fetcher)
+
+	// Act: favicon 取得がブロック中でも RegisterFeed は短時間で返るはず
+	done := make(chan struct{})
+	var feed interface{}
+	var regErr error
+	start := time.Now()
+	go func() {
+		f, _, err := svc.RegisterFeed(context.Background(), "user-1", "https://example.com")
+		feed, regErr = f, err
+		close(done)
+	}()
+
+	// Assert: favicon 取得をブロックしたまま、RegisterFeed が完了することを確認
+	select {
+	case <-done:
+		// 期待どおり即時に返った
+	case <-time.After(2 * time.Second):
+		close(fetcher.block) // goroutine を解放してリークを防ぐ
+		svc.waitFaviconFetch()
+		t.Fatal("RegisterFeed が favicon 取得の完了を待ってブロックしている")
+	}
+
+	if regErr != nil {
+		close(fetcher.block)
+		svc.waitFaviconFetch()
+		t.Fatalf("RegisterFeed returned error: %v", regErr)
+	}
+	if feed == nil {
+		close(fetcher.block)
+		svc.waitFaviconFetch()
+		t.Fatal("expected non-nil feed")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("RegisterFeed の応答時間が favicon 取得に依存している: %v", elapsed)
+	}
+
+	// クリーンアップ: ブロックを解放しバックグラウンド goroutine を回収する
+	close(fetcher.block)
+	svc.waitFaviconFetch()
+}
+
+// --- Requirement 3: favicon 取得成功時の保存 ---
+
+// TestRegisterFeed_FaviconSavedAsynchronously は favicon 取得がバックグラウンドで成功したとき、
+// 最終的に UpdateFavicon が呼ばれ favicon が保存されることを検証する（AC 3.1, 3.2）。
+func TestRegisterFeed_FaviconSavedAsynchronously(t *testing.T) {
+	// Arrange
+	fetcher := &controllableFaviconFetcher{
+		data: []byte{0x89, 0x50, 0x4E, 0x47},
+		mime: "image/png",
+	}
+	svc, feedRepo := newRegisterTestService(fetcher)
+
+	// Act
+	feed, _, err := svc.RegisterFeed(context.Background(), "user-1", "https://example.com")
+	if err != nil {
+		t.Fatalf("RegisterFeed returned error: %v", err)
+	}
+	svc.waitFaviconFetch()
+
+	// Assert: 非同期完了後に favicon が保存されている
+	gotFeedID, gotData, gotMime := feedRepo.getFaviconCall()
+	if gotFeedID != feed.ID {
+		t.Errorf("UpdateFavicon の feedID = %q, want %q", gotFeedID, feed.ID)
+	}
+	if gotMime != "image/png" {
+		t.Errorf("favicon mime = %q, want %q", gotMime, "image/png")
+	}
+	if len(gotData) == 0 {
+		t.Error("favicon データが保存されていない")
+	}
+}
+
+// --- Requirement 2: favicon 取得失敗・遅延時の登録成功維持 ---
+
+// TestRegisterFeed_SucceedsWhenFaviconFetchErrors は favicon 取得がエラーを返しても
+// RegisterFeed が成功し、favicon が保存されない（null 保持）ことを検証する（AC 2.1, 2.4）。
+func TestRegisterFeed_SucceedsWhenFaviconFetchErrors(t *testing.T) {
+	// Arrange: favicon 取得がエラーを返す
+	fetcher := &controllableFaviconFetcher{
+		err: errors.New("favicon 取得失敗"),
+	}
+	svc, feedRepo := newRegisterTestService(fetcher)
+
+	// Act
+	feed, _, err := svc.RegisterFeed(context.Background(), "user-1", "https://example.com")
+
+	// Assert: 登録は成功
+	if err != nil {
+		t.Fatalf("favicon 取得エラーでも RegisterFeed は成功すべき: %v", err)
+	}
+	if feed == nil {
+		t.Fatal("expected non-nil feed")
+	}
+	svc.waitFaviconFetch()
+
+	// favicon は保存されない（null 保持）
+	if gotFeedID, _, _ := feedRepo.getFaviconCall(); gotFeedID != "" {
+		t.Errorf("favicon 取得失敗時は UpdateFavicon が呼ばれるべきでない。feedID = %q", gotFeedID)
+	}
+}
+
+// TestRegisterFeed_SucceedsWhenFaviconNotFound は favicon が見つからない（data == nil）場合でも
+// 登録が成功し、favicon が null 保持されることを検証する（AC 2.3, 境界値: 空入力）。
+func TestRegisterFeed_SucceedsWhenFaviconNotFound(t *testing.T) {
+	// Arrange: favicon 未検出（data == nil, err == nil）
+	fetcher := &controllableFaviconFetcher{
+		data: nil,
+		mime: "",
+		err:  nil,
+	}
+	svc, feedRepo := newRegisterTestService(fetcher)
+
+	// Act
+	feed, _, err := svc.RegisterFeed(context.Background(), "user-1", "https://example.com")
+	if err != nil {
+		t.Fatalf("favicon 未検出でも RegisterFeed は成功すべき: %v", err)
+	}
+	if feed == nil {
+		t.Fatal("expected non-nil feed")
+	}
+	svc.waitFaviconFetch()
+
+	// Assert: favicon は保存されない（null 保持）
+	if gotFeedID, _, _ := feedRepo.getFaviconCall(); gotFeedID != "" {
+		t.Errorf("favicon 未検出時は UpdateFavicon が呼ばれるべきでない。feedID = %q", gotFeedID)
+	}
+}
+
+// --- Requirement 3.3 / 境界値: リクエスト ctx キャンセル時も独立 context で継続 ---
+
+// TestRegisterFeed_FaviconContinuesAfterRequestCtxCanceled はリクエストスコープの ctx が
+// キャンセル/タイムアウトされても、独立 context で favicon 取得が中断されず継続することを
+// 検証する（AC 3.3、境界値）。
+func TestRegisterFeed_FaviconContinuesAfterRequestCtxCanceled(t *testing.T) {
+	// Arrange: favicon 取得をブロックし、その間にリクエスト ctx をキャンセルする
+	fetcher := &controllableFaviconFetcher{
+		block: make(chan struct{}),
+		data:  []byte{0x89, 0x50, 0x4E, 0x47},
+		mime:  "image/png",
+	}
+	svc, feedRepo := newRegisterTestService(fetcher)
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+
+	// Act: 登録（favicon は非同期で起動される）
+	feed, _, err := svc.RegisterFeed(reqCtx, "user-1", "https://example.com")
+	if err != nil {
+		close(fetcher.block)
+		svc.waitFaviconFetch()
+		t.Fatalf("RegisterFeed returned error: %v", err)
+	}
+
+	// favicon 取得 goroutine が起動して呼び出しに入るまで待つ
+	deadline := time.After(2 * time.Second)
+	for !fetcher.wasCalled() {
+		select {
+		case <-deadline:
+			close(fetcher.block)
+			svc.waitFaviconFetch()
+			t.Fatal("favicon 取得が起動されていない")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	// リクエストスコープの ctx をキャンセル（レスポンス送出後のリクエスト完了を模す）
+	cancel()
+
+	// 取得処理を完了させる
+	close(fetcher.block)
+	svc.waitFaviconFetch()
+
+	// Assert: リクエスト ctx のキャンセルに引きずられず、独立 context で取得が完了し保存された
+	if fetcher.ctxWasCanceledOnCall() {
+		t.Error("favicon 取得に渡された context が呼び出し時点で既にキャンセルされている（独立 context になっていない）")
+	}
+	gotFeedID, _, _ := feedRepo.getFaviconCall()
+	if gotFeedID != feed.ID {
+		t.Errorf("リクエスト ctx キャンセル後も favicon は保存されるべき。UpdateFavicon feedID = %q, want %q", gotFeedID, feed.ID)
+	}
+}
+
+// --- Requirement 4: バックグラウンド処理の有界性 ---
+
+// TestBackgroundFaviconTimeout_IsBounded はバックグラウンド favicon 取得に上限時間
+// （30 秒以内）が設定されていることを検証する（AC 4.1）。
+func TestBackgroundFaviconTimeout_IsBounded(t *testing.T) {
+	if backgroundFaviconTimeout <= 0 {
+		t.Fatalf("backgroundFaviconTimeout は正の上限時間であるべき: %v", backgroundFaviconTimeout)
+	}
+	if backgroundFaviconTimeout > 30*time.Second {
+		t.Errorf("backgroundFaviconTimeout は 30 秒以内であるべき: %v", backgroundFaviconTimeout)
+	}
+}
+
+// TestStartFaviconFetch_AppliesTimeoutDeadline は startFaviconFetch が favicon fetcher へ
+// 渡す context にデッドライン（上限時間）が設定されていることを検証する（AC 4.1, 4.2）。
+func TestStartFaviconFetch_AppliesTimeoutDeadline(t *testing.T) {
+	// Arrange: 呼び出し時の context のデッドラインを観測するフェッチャー
+	observed := &deadlineObservingFetcher{}
+	feedRepo := newMockFeedRepo()
+	subRepo := newMockSubRepo()
+	detector := &mockDetector{feedURL: "https://example.com/feed.xml"}
+	svc := NewFeedService(feedRepo, subRepo, detector, observed)
+
+	// Act
+	_, _, err := svc.RegisterFeed(context.Background(), "user-1", "https://example.com")
+	if err != nil {
+		t.Fatalf("RegisterFeed returned error: %v", err)
+	}
+	svc.waitFaviconFetch()
+
+	// Assert: 渡された context にデッドラインが設定されている（無制限ではない）
+	deadline, hasDeadline := observed.deadline()
+	if !hasDeadline {
+		t.Fatal("favicon 取得の context に上限時間（デッドライン）が設定されていない")
+	}
+	if remaining := time.Until(deadline); remaining > backgroundFaviconTimeout+time.Second {
+		t.Errorf("デッドラインが上限時間より大幅に先: 残り %v", remaining)
+	}
+}
+
+// deadlineObservingFetcher は呼び出し時の context のデッドラインを観測する FaviconFetcherService モック。
+type deadlineObservingFetcher struct {
+	mu          sync.Mutex
+	dl          time.Time
+	hasDeadline bool
+}
+
+func (d *deadlineObservingFetcher) FetchFavicon(ctx context.Context, _ string) ([]byte, string, error) {
+	return d.FetchFaviconForSite(ctx, "")
+}
+
+func (d *deadlineObservingFetcher) FetchFaviconForSite(ctx context.Context, _ string) ([]byte, string, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.dl, d.hasDeadline = ctx.Deadline()
+	return nil, "", nil
+}
+
+func (d *deadlineObservingFetcher) deadline() (time.Time, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.dl, d.hasDeadline
+}

--- a/internal/feed/service_test.go
+++ b/internal/feed/service_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/hitoshi/feedman/internal/model"
@@ -19,11 +20,20 @@ type mockFeedRepo struct {
 	feedByURL   map[string]*model.Feed
 	createCalls int
 	updateCalls int
+	// mu は faviconCall への並行アクセス（バックグラウンドgoroutineからの書き込み）を保護する。
+	mu          sync.Mutex
 	faviconCall struct {
 		feedID      string
 		faviconData []byte
 		faviconMime string
 	}
+}
+
+// getFaviconCall は faviconCall をロック越しに読み出すテスト用ヘルパー。
+func (m *mockFeedRepo) getFaviconCall() (feedID string, data []byte, mime string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.faviconCall.feedID, m.faviconCall.faviconData, m.faviconCall.faviconMime
 }
 
 func newMockFeedRepo() *mockFeedRepo {
@@ -64,13 +74,16 @@ func (m *mockFeedRepo) Update(_ context.Context, feed *model.Feed) error {
 }
 
 func (m *mockFeedRepo) UpdateFavicon(_ context.Context, feedID string, data []byte, mime string) error {
+	// favicon取得はバックグラウンドgoroutineから呼ばれるため、faviconCall への記録は
+	// mu で保護する（テストは svc.waitFaviconFetch() 後にロック越しで参照する）。
+	// 返却済み feed ポインタ（m.feeds[feedID]）への書き戻しは行わない。本番の
+	// fetchAndSaveFavicon が返却済みポインタへ書き戻さなくなったため、それに合わせて
+	// 共有ポインタへの並行書き込み（データ競合）を避ける。
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.faviconCall.feedID = feedID
 	m.faviconCall.faviconData = data
 	m.faviconCall.faviconMime = mime
-	if f, ok := m.feeds[feedID]; ok {
-		f.FaviconData = data
-		f.FaviconMime = mime
-	}
 	return nil
 }
 
@@ -364,9 +377,17 @@ func TestFeedService_RegisterFeed_FaviconFetchFailure(t *testing.T) {
 	if feed == nil {
 		t.Fatal("expected non-nil feed")
 	}
+
+	// favicon取得はバックグラウンドで非同期に実行されるため、完了を待ってから検証する。
+	svc.waitFaviconFetch()
+
 	// favicon取得失敗時はnullとして保存される
 	if feed.FaviconData != nil {
 		t.Error("favicon取得失敗時はfavicon_dataがnilであるべき")
+	}
+	// DB（UpdateFavicon）が呼ばれていないこと（null保持）。
+	if gotFeedID, _, _ := feedRepo.getFaviconCall(); gotFeedID != "" {
+		t.Errorf("favicon未取得時はUpdateFaviconが呼ばれるべきでない。feedID = %q", gotFeedID)
 	}
 }
 
@@ -387,12 +408,16 @@ func TestFeedService_RegisterFeed_FaviconSavedOnSuccess(t *testing.T) {
 		t.Fatalf("RegisterFeed returned error: %v", err)
 	}
 
+	// favicon取得はバックグラウンドで非同期に実行されるため、完了を待ってから検証する。
+	svc.waitFaviconFetch()
+
 	// faviconデータが保存されていることを確認
-	if feedRepo.faviconCall.feedID != feed.ID {
-		t.Errorf("UpdateFaviconのfeedID = %q, want %q", feedRepo.faviconCall.feedID, feed.ID)
+	gotFeedID, _, gotMime := feedRepo.getFaviconCall()
+	if gotFeedID != feed.ID {
+		t.Errorf("UpdateFaviconのfeedID = %q, want %q", gotFeedID, feed.ID)
 	}
-	if feedRepo.faviconCall.faviconMime != "image/png" {
-		t.Errorf("faviconMime = %q, want %q", feedRepo.faviconCall.faviconMime, "image/png")
+	if gotMime != "image/png" {
+		t.Errorf("faviconMime = %q, want %q", gotMime, "image/png")
 	}
 }
 
@@ -642,6 +667,10 @@ func TestFeedService_RegisterFeed_Integration_WithHTTPServer(t *testing.T) {
 	if feed.FeedURL != server.URL+"/feed.xml" {
 		t.Errorf("feed.FeedURL = %q, want %q", feed.FeedURL, server.URL+"/feed.xml")
 	}
+
+	// バックグラウンドの favicon 取得 goroutine がテストサーバーを参照し続けないよう、
+	// 完了を待ってからテストを終える（defer server.Close() より前に完了させる）。
+	svc.waitFaviconFetch()
 }
 
 // feedDetectorAdapter はFeedDetectorをDetectorインターフェースに適合させるアダプター。
@@ -710,4 +739,3 @@ func TestFeedService_RegisterFeed_SubscriptionLimitExact100(t *testing.T) {
 		t.Errorf("エラーコード = %q, want %q", apiErr.Code, model.ErrCodeSubscriptionLimit)
 	}
 }
-


### PR DESCRIPTION
## 概要

フィード登録処理（`FeedService.RegisterFeed`）が favicon 取得を同期実行していたため、フィード検出（最大 10 秒）と favicon 取得（最大 5 秒）が同時に遅延すると合計処理時間が HTTP サーバーの WriteTimeout（15 秒）を超過し、登録自体は成功しているのにクライアントへはタイムアウトエラーとして返る不整合が起きていた。

本 PR では favicon 取得を購読作成完了後に独立した goroutine で非同期実行するよう変更し、WriteTimeout 内に登録レスポンスを安定して返せるようにした。favicon 取得の失敗・遅延が登録結果に波及しない設計を維持しつつ、登録 API のレスポンス形式・ステータスコードは変更していない。

バックグラウンド goroutine の上限時間として `backgroundFaviconTimeout = 30 * time.Second` を設定し、リクエストスコープのキャンセル伝播から切り離した `context.WithoutCancel` + `context.WithTimeout` の組み合わせでリソースリークを防いでいる。

## 対応 Issue

Closes #18

## 関連 PR

なし（design-less impl のため設計 PR は作成していない）

## 実装内容

- (Req 1.1〜1.4 / NFR 1) `RegisterFeed` が `startFaviconFetch` 起動後すぐ `return feed, sub, nil` を返すよう変更し、favicon 取得時間を応答時間に加算しない
- (Req 3.3 / Req 4.1〜4.3) `context.WithoutCancel(ctx)` で独立 context を生成し、上限 30 秒の `context.WithTimeout` を付与した goroutine で favicon 取得を実行。`defer cancel()` でリソース解放
- (Req 2.1〜2.5 / NFR 2) 取得失敗・未検出・タイムアウト時は null 保持（DB 更新せず）し、`slog.Warn`/`slog.Info` で feedID/siteURL 付きログを記録
- (Req 3.1〜3.2) 取得成功時は `UpdateFavicon` 経由で DB に保存し、後続の `GetFeed` で参照可能
- (Req 5) `RegisterFeed` シグネチャ・戻り値不変。handler 層・WriteTimeout 設定は変更しない

## 受入基準チェック

- [x] Req 1.1: When favicon 取得が遅延、the Feed Service shall favicon 完了を待たずに登録レスポンスを返す ← `TestRegisterFeed_ReturnsBeforeFaviconCompletes`
- [x] Req 1.2: favicon 取得時間を応答時間に加算しない ← `TestRegisterFeed_ReturnsBeforeFaviconCompletes`（応答 1 秒未満）
- [x] Req 1.3: While favicon 取得継続中、レスポンス送出をブロックしない ← `TestRegisterFeed_ReturnsBeforeFaviconCompletes`
- [x] Req 2.1, 2.4: If favicon 取得失敗、登録成功・null 保持 ← `TestRegisterFeed_SucceedsWhenFaviconFetchErrors` / 既存 `TestFeedService_RegisterFeed_FaviconFetchFailure`
- [x] Req 2.3: If favicon 未検出、null 保持 ← `TestRegisterFeed_SucceedsWhenFaviconNotFound`
- [x] Req 3.1, 3.2: When favicon 取得成功、DB 保存・後続参照可能 ← `TestRegisterFeed_FaviconSavedAsynchronously`
- [x] Req 3.3: リクエストスコープ完了で中断しない ← `TestRegisterFeed_FaviconContinuesAfterRequestCtxCanceled`
- [x] Req 4.1, 4.2: 上限時間 30 秒以内・到達で打ち切り ← `TestBackgroundFaviconTimeout_IsBounded` / `TestStartFaviconFetch_AppliesTimeoutDeadline`
- [x] Req 4.3: 完了/打ち切りでリソース解放 ← `defer cancel()` / `go test -race` clean
- [x] Req 5.1〜5.3 / NFR 3: レスポンス形式・ステータス・既存エラー応答維持 ← handler 層未変更・既存テスト全 PASS

## テスト結果

```
ok  	github.com/hitoshi/feedman/internal/feed	1.045s
```

`go test ./internal/feed/... -race -count=1` 全 PASS。`go build ./...` / `go vet ./...` / `gofmt -l`（変更ファイル）いずれも clean。

## 実装上の判断

- **返却済み `feed` ポインタへの favicon 書き戻しを廃止**: バックグラウンド goroutine からの並行書き込みによるデータ競合（`-race` 検出）を回避するため、`fetchAndSaveFavicon` 内での `feed.FaviconData = ...` 書き戻しを廃止した。favicon は DB の `UpdateFavicon` 経由でのみ反映される（要件 NFR 3.1 と整合）。
- **`faviconWG sync.WaitGroup` をテスト補助として追加**: 本番フローでは `Wait` を呼ばないため本番挙動に影響しない。非同期完了を決定論的にアサートするための最小限の機構（禁止事項「テストを通すためにテスト側を弱める」には該当しない）。

## 確認事項 / レビュワーへの依頼

- base ブランチ検証: `--base develop` 指定 / baseRefName: develop / OK（PR 作成後に検証済み）
- Reviewer の詳細な判定結果（全 numeric requirement ID のカバレッジ確認）は `docs/specs/18-registerfeed-favicon-writetimeout/review-notes.md` を参照
- requirements.md との矛盾は検出されなかった（impl-notes.md に記載）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #18 のコメントを参照してください。
