### PR TITLE
feat(#52): CI にコンテナイメージ脆弱性スキャン（Trivy）を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,10 @@ jobs:
     name: Container Image Vulnerability Scan (Trivy)
     runs-on: ubuntu-latest
     # NFR 2.2 / Req 4: 既存ジョブに依存せず独立して実行する（needs を付けない）。
-    # 脆弱性検出でもジョブを fail させないため continue-on-error を併用する（Req 3.1 / 3.3）。
+    # Req 3.1 / 3.3: 警告のみ（PR を一切ブロックしない）とするため、ジョブ全体に
+    # continue-on-error を付与する。これにより docker build 失敗を含め trivy ジョブが
+    # CI を fail させない。後段の trivy-action は exit-code: '0' を併用し二重に担保する。
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,66 @@ jobs:
 
       - name: Run npm audit (fail on high or above)
         run: npm audit --audit-level=high
+
+  trivy:
+    name: Container Image Vulnerability Scan (Trivy)
+    runs-on: ubuntu-latest
+    # NFR 2.2 / Req 4: 既存ジョブに依存せず独立して実行する（needs を付けない）。
+    # 脆弱性検出でもジョブを fail させないため continue-on-error を併用する（Req 3.1 / 3.3）。
+    steps:
+      - uses: actions/checkout@v4
+
+      # Req 1.3 の主目的（ベースイメージ・OS パッケージ由来の CVE 検出）を満たすため、
+      # config スキャンではなくイメージビルド後の image スキャンを採用する。
+      # config スキャンでは distroless-debian12 / node:20-alpine の OS パッケージ CVE を
+      # 検出できないため。
+      - name: Build api/worker image (root Dockerfile)
+        run: docker build -t feedman-api:scan -f Dockerfile .
+
+      - name: Build web image (web/Dockerfile)
+        run: docker build -t feedman-web:scan -f web/Dockerfile web
+
+      # Req 1.1 / 1.3 / NFR 3.1: ルート Dockerfile 由来イメージをスキャンし、
+      # CRITICAL/HIGH を table 形式で出力して可視化する。
+      # Req 3.1 / 3.3: exit-code: '0' により脆弱性検出でもジョブを fail させない。
+      - name: Scan api/worker image (warning only)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: image
+          image-ref: feedman-api:scan
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: '0'
+          ignore-unfixed: false
+          output: trivy-api.txt
+
+      # Req 1.2 / 1.3 / NFR 3.1: web/Dockerfile 由来イメージをスキャンする。
+      - name: Scan web image (warning only)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: image
+          image-ref: feedman-web:scan
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: '0'
+          ignore-unfixed: false
+          output: trivy-web.txt
+
+      # Req 3.2 / NFR 3.1: 検出結果（重大度・件数）をジョブサマリーとして残し、
+      # CI 上で参照可能にする。stdout の table 出力（CI ログ）と合わせて二重に可視化する。
+      - name: Publish scan results to job summary
+        if: always()
+        run: |
+          {
+            echo '## Trivy Container Image Scan (CRITICAL / HIGH)'
+            echo ''
+            echo '### api/worker image (root Dockerfile)'
+            echo '```'
+            cat trivy-api.txt 2>/dev/null || echo 'スキャン結果なし（trivy-api.txt 未生成）'
+            echo '```'
+            echo ''
+            echo '### web image (web/Dockerfile)'
+            echo '```'
+            cat trivy-web.txt 2>/dev/null || echo 'スキャン結果なし（trivy-web.txt 未生成）'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       # CRITICAL/HIGH を table 形式で出力して可視化する。
       # Req 3.1 / 3.3: exit-code: '0' により脆弱性検出でもジョブを fail させない。
       - name: Scan api/worker image (warning only)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: image
           image-ref: feedman-api:scan
@@ -155,7 +155,7 @@ jobs:
 
       # Req 1.2 / 1.3 / NFR 3.1: web/Dockerfile 由来イメージをスキャンする。
       - name: Scan web image (warning only)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: image
           image-ref: feedman-web:scan

--- a/docs/specs/52-ci-trivy/impl-notes.md
+++ b/docs/specs/52-ci-trivy/impl-notes.md
@@ -1,0 +1,139 @@
+# 実装ノート: Issue #52 CI にコンテナイメージ脆弱性スキャン（Trivy）を追加
+
+## 実装サマリー
+
+`.github/workflows/ci.yml` に新規 job `trivy`（job 名表示: `Container Image Vulnerability
+Scan (Trivy)`）を追加した。既存ジョブ（backend / go-vet / govulncheck / frontend /
+frontend-lint / frontend-audit）には一切手を加えず、独立した新規 job として並列実行される。
+
+job のステップ構成:
+
+1. `actions/checkout@v4` でソースを取得（既存ジョブのピン留め流儀に合わせて `@v4`）
+2. `docker build` でルート `Dockerfile`（api/worker 用）を `feedman-api:scan` としてビルド
+3. `docker build` で `web/Dockerfile`（web 用）を `feedman-web:scan` としてビルド
+4. `aquasecurity/trivy-action@0.28.0` で `feedman-api:scan` を image スキャン（CRITICAL/HIGH）
+5. 同アクションで `feedman-web:scan` を image スキャン（CRITICAL/HIGH）
+6. スキャン結果（table 形式テキスト）を GitHub Step Summary に出力
+
+### 警告のみ（CI を fail させない）にした方法
+
+- trivy-action の `exit-code: '0'` を指定し、CRITICAL/HIGH を検出しても Trivy が非ゼロ
+  exit code を返さないようにした（Req 3.1 / 3.3）。
+- 念のための二重防御として、job レベルのコメントに記載のとおり `exit-code: '0'` を主たる
+  手段とし、検出時もステップが成功扱いになるようにした。`output:` でファイル出力した結果を
+  後続ステップ（`if: always()`）が job summary に出すため、スキャン結果は必ず可視化される。
+
+## スキャン方式の選択理由（config / image / fs）
+
+**採用: image スキャン（イメージビルド後にビルド済みイメージをスキャン）**
+
+要件の主目的（Req 1.3）は「ベースイメージ・OS パッケージ由来の CRITICAL/HIGH CVE 検出」で
+ある。本リポジトリのスキャン対象は以下:
+
+- ルート `Dockerfile`: 実行ステージが `gcr.io/distroless/static-debian12:nonroot`
+  （Debian 12 ベースの OS パッケージを含む）
+- `web/Dockerfile`: 実行ステージが `node:20-alpine`（Alpine OS パッケージ + Node ランタイム）
+
+3 方式のトレードオフ:
+
+| 方式 | OS パッケージ CVE 検出 | 実行時間 | 判断 |
+|---|---|---|---|
+| config スキャン（Dockerfile） | **不可**（Dockerfile の記述ミスのみ検出） | 速い | Req 1.3 を満たせない |
+| fs スキャン（リポジトリ FS） | 不可（ビルド前のソース/lockfile のみ。ベースイメージ層を見ない） | 速い | Req 1.3 を満たせない |
+| image スキャン（ビルド済みイメージ） | **可**（ベースイメージ層・OS パッケージを解析） | ビルド分の時間増 | **採用** |
+
+config / fs スキャンでは distroless-debian12 や node:20-alpine の OS パッケージ層に含まれる
+CVE を検出できないため、Req 1.3 を満たすには image スキャンが必須と判断した。実行時間は
+`docker build`（マルチステージビルド）分が増えるが、両イメージとも軽量（distroless /
+alpine ベース）であり、NFR 1.1 の目安（1 ジョブ 5 分以内）に収まる見込み。万一実行時間が
+許容範囲を超える場合は、NFR 1.2 のとおりスキャンモードの軽量化や実行頻度の調整
+（schedule 化等）で抑制できる構成余地を残している。
+
+## アクションのバージョンピン留め
+
+- `aquasecurity/trivy-action@0.28.0` を採用。既存 ci.yml の他アクション
+  （`actions/checkout@v4` / `actions/setup-go@v5` / `actions/setup-node@v4`）はメジャー版
+  タグでピン留めしているが、trivy-action は `vMAJOR` 形式のタグを提供していないため、
+  公式が推奨する semver リリースタグ（`0.28.0`）でピン留めした。これは「リリースタグで
+  バージョンを固定する」という既存流儀と整合する。
+
+## 各 AC と実装の対応（トレーサビリティ）
+
+| AC | 実装箇所 / 担保内容 |
+|---|---|
+| Req 1.1（ルート Dockerfile スキャン） | `feedman-api:scan` を image スキャンするステップ |
+| Req 1.2（web/Dockerfile スキャン） | `feedman-web:scan` を image スキャンするステップ |
+| Req 1.3（CRITICAL/HIGH OS CVE を検出結果に含める） | image スキャン採用 + `severity: CRITICAL,HIGH`。OS パッケージ層を解析できる方式を選択 |
+| Req 1.4（重大脆弱性なしなら正常終了） | `exit-code: '0'` により常に正常終了。脆弱性なしの場合も当然 job 成功 |
+| Req 2.1（PR トリガーで起動） | 既存 `on: pull_request: branches: [main, develop]` をそのまま利用。trivy job も同トリガーで起動 |
+| Req 2.2（push でも整合起動） | 既存 `on: push: branches: [main, develop]` をそのまま利用。トリガー定義は無変更 |
+| Req 2.3（CI チェック一覧に表示） | `jobs.trivy` として独立 job 定義。GitHub の checks に名前 `Container Image Vulnerability Scan (Trivy)` で表示される |
+| Req 3.1（検出でも fail させない） | `exit-code: '0'` で Trivy が非ゼロ exit しない |
+| Req 3.2（結果を CI 上で参照可能に残す） | `output:` でファイル出力し、`Publish scan results to job summary` ステップで Step Summary に table を掲載。加えて CI ログにも table 出力が残る |
+| Req 3.3（マージをブロックしない） | job が常に成功扱いになるため required check でもブロックしない |
+| Req 4.1（既存各 job を従来どおり実行） | 既存 job 定義を一切変更せず、trivy を新規追加のみ（diff で確認済み） |
+| Req 4.2（検出が既存 job 成否を変えない） | trivy は独立 job で `needs` 無し。他 job の成否に影響しない |
+| Req 4.3（依存脆弱性スキャンとスコープ非重複） | trivy は Dockerfile/コンテナイメージ（ベースイメージ・OS パッケージ）が対象。govulncheck（Go 依存）/ npm audit（npm 依存）とスコープが重複しない |
+| NFR 1.1（実行時間） | 軽量ベースイメージ（distroless / alpine）のため目安 5 分以内に収まる見込み |
+| NFR 1.2（軽量化・頻度調整の選択肢） | image スキャン + severity 絞り込みで抑制可能。将来 schedule 化や fs/config 併用の余地あり |
+| NFR 2.1（既存 job 成否判定ロジック不変） | 既存 job は無変更（diff で確認済み） |
+| NFR 2.2（独立実行） | `needs` 無しで独立 job として実行 |
+| NFR 3.1（重大度・件数を CI 上で確認可能） | `severity: CRITICAL,HIGH` の table 出力を CI ログ + Step Summary の双方に残す |
+
+## 検証手順と結果
+
+1. **YAML 構文検証**
+
+   ```sh
+   python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')"
+   ```
+
+   結果: `YAML OK`（構文妥当）
+
+2. **actionlint によるワークフロー lint**
+
+   `which actionlint` では未インストールだったため、
+   `go install github.com/rhysd/actionlint/cmd/actionlint@latest`（v1.7.12 / Go 1.25.10）で
+   インストールし、以下を実行:
+
+   ```sh
+   "$(go env GOPATH)/bin/actionlint" .github/workflows/ci.yml
+   ```
+
+   結果: exit code 0（指摘なし）
+
+3. **既存ジョブ非影響の diff 確認**
+
+   ```sh
+   git diff HEAD -- .github/workflows/ci.yml
+   ```
+
+   結果: 追加分は `trivy` job のみ。既存 job（backend / go-vet / govulncheck / frontend /
+   frontend-lint / frontend-audit）および `on:` トリガー定義に変更なし。
+
+   注記: `git diff main` では go-vet / govulncheck / frontend-lint / frontend-audit /
+   develop トリガー等の差分も出るが、これらは本ブランチの base（直近マージ済みの
+   #87/#88/#89）に既に含まれる変更で、`main` がそれらより手前にあることに起因する。
+   本 Issue で実際に加えた変更は `git diff HEAD` のとおり trivy job 追加のみ。
+
+   Trivy が実際に脆弱性を検出する/しないの実挙動はランナー上での docker build + スキャン
+   実行が必要なため、ローカルでは検証していない（docker / trivy バイナリ未配置のローカル
+   環境のため）。ワークフロー定義としての妥当性は YAML 検証 + actionlint で担保している。
+
+## 確認事項
+
+- なし。検出時挙動「警告のみ」・実行タイミング「PR トリガー」はいずれも requirements.md で
+  確定済みであり、実装は確定方針に沿っている。スキャン方式（image スキャン）は設計裁量と
+  して Req 1.3 を満たす観点から選択した（上記「スキャン方式の選択理由」参照）。
+
+## 受入基準カバレッジの補足（テスト観点）
+
+本変更は GitHub Actions ワークフロー YAML であり、アプリケーションコードのような単体テストは
+存在しない。AC の担保は以下の検証で代替する:
+
+- YAML 構文検証（全 AC の前提となるワークフロー妥当性）
+- actionlint（ステップ定義・アクション参照の妥当性）
+- diff 確認（Req 4 / NFR 2 の既存ジョブ非影響）
+- requirements.md の各 AC とワークフロー定義の対応（上記トレーサビリティ表）
+
+STATUS: complete

--- a/docs/specs/52-ci-trivy/impl-notes.md
+++ b/docs/specs/52-ci-trivy/impl-notes.md
@@ -17,11 +17,27 @@ job のステップ構成:
 
 ### 警告のみ（CI を fail させない）にした方法
 
-- trivy-action の `exit-code: '0'` を指定し、CRITICAL/HIGH を検出しても Trivy が非ゼロ
-  exit code を返さないようにした（Req 3.1 / 3.3）。
-- 念のための二重防御として、job レベルのコメントに記載のとおり `exit-code: '0'` を主たる
-  手段とし、検出時もステップが成功扱いになるようにした。`output:` でファイル出力した結果を
-  後続ステップ（`if: always()`）が job summary に出すため、スキャン結果は必ず可視化される。
+- trivy job 全体に **ジョブレベルの `continue-on-error: true`**（`runs-on` と同じインデント
+  階層）を付与し、`docker build` ステップを含むいずれのステップが fail しても trivy job が
+  PR の CI を fail させないようにした（Req 3.1 / 3.3 / NFR 2.2 独立実行）。
+- 加えて二重の保険として、trivy-action の `exit-code: '0'` を指定し、CRITICAL/HIGH を検出
+  しても Trivy スキャンステップが非ゼロ exit code を返さないようにしている（Req 3.1 / 3.3）。
+- `output:` でファイル出力した結果を後続ステップ（`if: always()`）が job summary に出すため、
+  スキャン結果は必ず可視化される。
+
+#### 追記: `continue-on-error` の整合修正（コメントと実装の不一致是正）
+
+初版では「continue-on-error を併用する」とコメントに記載しながら、実際には job/step の
+いずれにも `continue-on-error` を付与しておらず、`exit-code: '0'` だけで Trivy スキャン
+ステップの fail を回避していた。この構成では前段の `docker build` ステップが無保護で、
+ビルド失敗時に trivy job 全体が fail し得る（コメント記述と実態が食い違う）状態だった。
+
+確定方針「警告のみ（trivy ジョブが PR を一切ブロックしない）」（Req 3.1 / 3.3 / NFR 2.2
+独立実行）に合わせ、`trivy` ジョブ全体にジョブレベルの `continue-on-error: true` を付与
+してコメントと実装を一致させた。これにより docker build 失敗を含め trivy ジョブが PR の
+CI を fail させなくなり、既存の `exit-code: '0'`（Trivy スキャンステップの警告のみ）は
+二重の保険としてそのまま残している。本修正は他ジョブ・既存定義・requirements.md には一切
+変更を加えていない（diff で確認済み）。
 
 ## スキャン方式の選択理由（config / image / fs）
 
@@ -68,16 +84,16 @@ alpine ベース）であり、NFR 1.1 の目安（1 ジョブ 5 分以内）に
 | Req 2.1（PR トリガーで起動） | 既存 `on: pull_request: branches: [main, develop]` をそのまま利用。trivy job も同トリガーで起動 |
 | Req 2.2（push でも整合起動） | 既存 `on: push: branches: [main, develop]` をそのまま利用。トリガー定義は無変更 |
 | Req 2.3（CI チェック一覧に表示） | `jobs.trivy` として独立 job 定義。GitHub の checks に名前 `Container Image Vulnerability Scan (Trivy)` で表示される |
-| Req 3.1（検出でも fail させない） | `exit-code: '0'` で Trivy が非ゼロ exit しない |
+| Req 3.1（検出でも fail させない） | ジョブレベル `continue-on-error: true` で trivy job 全体が fail を伝播しない。加えて `exit-code: '0'` で Trivy スキャンステップが非ゼロ exit しない（二重担保） |
 | Req 3.2（結果を CI 上で参照可能に残す） | `output:` でファイル出力し、`Publish scan results to job summary` ステップで Step Summary に table を掲載。加えて CI ログにも table 出力が残る |
-| Req 3.3（マージをブロックしない） | job が常に成功扱いになるため required check でもブロックしない |
+| Req 3.3（マージをブロックしない） | ジョブレベル `continue-on-error: true` により docker build 失敗を含め job が常に成功扱いになるため、required check でもブロックしない |
 | Req 4.1（既存各 job を従来どおり実行） | 既存 job 定義を一切変更せず、trivy を新規追加のみ（diff で確認済み） |
 | Req 4.2（検出が既存 job 成否を変えない） | trivy は独立 job で `needs` 無し。他 job の成否に影響しない |
 | Req 4.3（依存脆弱性スキャンとスコープ非重複） | trivy は Dockerfile/コンテナイメージ（ベースイメージ・OS パッケージ）が対象。govulncheck（Go 依存）/ npm audit（npm 依存）とスコープが重複しない |
 | NFR 1.1（実行時間） | 軽量ベースイメージ（distroless / alpine）のため目安 5 分以内に収まる見込み |
 | NFR 1.2（軽量化・頻度調整の選択肢） | image スキャン + severity 絞り込みで抑制可能。将来 schedule 化や fs/config 併用の余地あり |
 | NFR 2.1（既存 job 成否判定ロジック不変） | 既存 job は無変更（diff で確認済み） |
-| NFR 2.2（独立実行） | `needs` 無しで独立 job として実行 |
+| NFR 2.2（独立実行） | `needs` 無しで独立 job として実行。さらにジョブレベル `continue-on-error: true` により trivy job の成否が他 job・CI 全体の結果に影響しない |
 | NFR 3.1（重大度・件数を CI 上で確認可能） | `severity: CRITICAL,HIGH` の table 出力を CI ログ + Step Summary の双方に残す |
 
 ## 検証手順と結果

--- a/docs/specs/52-ci-trivy/requirements.md
+++ b/docs/specs/52-ci-trivy/requirements.md
@@ -1,0 +1,84 @@
+# Requirements Document
+
+## Introduction
+
+Feedman の CI（`.github/workflows/ci.yml`）には Go 依存（`govulncheck`）と
+フロントエンド依存（`npm audit`）の脆弱性スキャンは存在するが、Dockerfile や
+コンテナイメージ（ベースイメージ・OS パッケージ）由来の既知脆弱性を検知する仕組みが無い。
+そのため `distroless` や `node:20-alpine` などのベースイメージ・OS パッケージに既知 CVE が
+混入しても CI では検知されず見過ごされる。本要件では、ルート `Dockerfile`（api/worker）と
+`web/Dockerfile`（web）を対象に Trivy による脆弱性スキャンジョブを CI へ追加し、PR 上で
+スキャン結果を可視化する。検出時の挙動は「警告のみ（CI を fail させない）」、実行タイミングは
+「PR トリガー」とすることが人間判断により確定済みである。
+
+## Requirements
+
+### Requirement 1: Trivy 脆弱性スキャンの CI 実行
+
+**Objective:** As a Feedman のメンテナ, I want Dockerfile / コンテナイメージの脆弱性スキャンが CI で自動実行されること, so that ベースイメージや OS パッケージ由来の既知脆弱性を PR の段階で把握できる
+
+#### Acceptance Criteria
+
+1. The CI ワークフロー shall ルート `Dockerfile` を対象とする Trivy 脆弱性スキャンを実行する
+2. The CI ワークフロー shall `web/Dockerfile` を対象とする Trivy 脆弱性スキャンを実行する
+3. When スキャン対象に既知の CRITICAL または HIGH の脆弱性が含まれるとき, the CI ワークフロー shall 当該脆弱性を検出結果に含める
+4. While スキャン対象に既知の重大脆弱性が存在しないとき, the CI ワークフロー shall スキャンジョブを正常終了として完了する
+
+### Requirement 2: スキャン実行タイミング（PR トリガー）
+
+**Objective:** As a Feedman のメンテナ, I want スキャンが PR の CI チェックに組み込まれること, so that マージ前に脆弱性の有無を PR 上で確認できる
+
+#### Acceptance Criteria
+
+1. When `main` または `develop` を対象ブランチとする pull_request イベントが発生したとき, the CI ワークフロー shall Trivy スキャンジョブを起動する
+2. When `main` または `develop` への push イベントが発生したとき, the CI ワークフロー shall 既存ジョブと整合する形でワークフローを起動する
+3. The Trivy スキャンジョブ shall PR の CI チェック一覧に表示されるジョブとして実行される
+
+### Requirement 3: 検出時の挙動（警告のみ・PR をブロックしない）
+
+**Objective:** As a Feedman のメンテナ, I want 脆弱性検出時に CI を fail させず結果を残すだけにすること, so that 段階導入の初期段階で開発フローを止めずに脆弱性を可視化できる
+
+#### Acceptance Criteria
+
+1. If スキャンで CRITICAL または HIGH の脆弱性が検出されたとき, the Trivy スキャンジョブ shall ジョブを失敗（fail）させずに正常終了する
+2. When スキャンが完了したとき, the Trivy スキャンジョブ shall 検出結果を CI 上で参照可能な形（アノテーションまたはジョブサマリー）として残す
+3. If スキャンで脆弱性が検出されたとき, the Trivy スキャンジョブ shall その検出によって PR のマージをブロックしない
+
+### Requirement 4: 既存 CI ジョブへの非影響
+
+**Objective:** As a Feedman のメンテナ, I want Trivy ジョブ追加が既存ジョブの結果に影響しないこと, so that 既存の Backend / Frontend / 依存脆弱性スキャンの判定が変わらない
+
+#### Acceptance Criteria
+
+1. The CI ワークフロー shall 既存の backend / go-vet / govulncheck / frontend / frontend-lint / frontend-audit 各ジョブを従来どおり実行する
+2. When Trivy スキャンジョブが脆弱性を検出したとき, the CI ワークフロー shall 既存の各ジョブの成否判定を変化させない
+3. The Trivy スキャンジョブ shall 既存の依存脆弱性スキャン（govulncheck / npm audit）が対象とするスコープと重複しない対象（Dockerfile / コンテナイメージ）を扱う
+
+## Non-Functional Requirements
+
+### NFR 1: 実行コスト・性能
+
+1. The Trivy スキャンジョブ shall pull_request での CI 実行時間が既存ジョブの最長実行時間を大幅に超えない範囲で完了する（目安として 1 ジョブあたり 5 分以内）
+2. Where スキャン所要時間が pull_request 実行の許容範囲を超える場合, the スキャン構成 shall 軽量なスキャンモードまたは実行頻度の調整で実行時間を抑制できる選択肢を持つ
+
+### NFR 2: 後方互換性
+
+1. The CI ワークフロー shall 本変更導入前から存在する全ジョブの成否判定ロジックを変更しない
+2. The Trivy スキャンジョブ shall 既存ジョブの実行可否や成否に依存せず独立して実行される
+
+### NFR 3: 可観測性
+
+1. When Trivy スキャンジョブが完了したとき, the スキャンジョブ shall メンテナが検出された脆弱性の重大度（CRITICAL / HIGH 等）と件数を CI 上で確認できる出力を残す
+
+## Out of Scope
+
+- Go の静的解析・依存脆弱性スキャン（`go vet` / `govulncheck`。別 Issue / 既存ジョブ）
+- フロントエンドの静的解析・依存脆弱性スキャン（ESLint / `npm audit`。別 Issue / 既存ジョブ）
+- 検出された脆弱性の自動修復・ベースイメージの自動更新
+- CRITICAL のみを対象とした PR ブロック（fail-on-critical）への段階移行（将来 Issue で別途検討）
+- 定期実行（schedule トリガー）を本 Issue の主トリガーとすること（PR トリガーが確定方針。schedule は NFR 1.2 の選択肢にとどめ、本 Issue では追加要件としない）
+- Dockerfile / コンテナイメージ以外のスキャン対象（IaC / シークレットスキャン等）
+
+## Open Questions
+
+- なし（検出時挙動「警告のみ」・実行タイミング「PR トリガー」はいずれも Issue コメントで人間判断により確定済み）

--- a/docs/specs/52-ci-trivy/review-notes.md
+++ b/docs/specs/52-ci-trivy/review-notes.md
@@ -1,0 +1,43 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-52-impl-ci-trivy
+- HEAD commit: 3be283a32f5500736fdc3e544c9d1313dab24cb5
+- Compared to: develop..HEAD
+- 変更ファイル: `.github/workflows/ci.yml`（trivy job 追加のみ）+ spec docs（requirements.md / impl-notes.md）
+- Feature Flag Protocol: CLAUDE.md `**採否**: opt-out` のため flag 観点は適用せず、通常の 3 カテゴリ判定のみ実施
+- 本 Issue は design-less impl（`design.md` / `tasks.md` 不在）。`_Boundary:_` アノテーションが無いため、boundary 判定は requirements の Out of Scope と変更ファイルの妥当性で確認した
+
+## Verified Requirements
+
+- 1.1 — `.github/workflows/ci.yml` の trivy job「Build api/worker image」（`docker build -t feedman-api:scan -f Dockerfile .`）+「Scan api/worker image」（`aquasecurity/trivy-action@0.28.0`, scan-type: image, image-ref: feedman-api:scan）。ルート Dockerfile を image スキャン
+- 1.2 — 同 job「Build web image」（`docker build -t feedman-web:scan -f web/Dockerfile web`）+「Scan web image」。`web/Dockerfile` を image スキャン
+- 1.3 — 両スキャンステップに `severity: CRITICAL,HIGH`。image スキャン採用によりベースイメージ（distroless-debian12 / node:20-alpine）の OS パッケージ層 CVE を検出対象に含める
+- 1.4 — `exit-code: '0'` により脆弱性無し時も job 正常終了
+- 2.1 — 既存 `on.pull_request.branches: [main, develop]` をそのまま利用し trivy job も同トリガーで起動（無変更）
+- 2.2 — 既存 `on.push.branches: [main, develop]` 無変更。トリガー定義に変更なし
+- 2.3 — 独立 job `trivy`（name: `Container Image Vulnerability Scan (Trivy)`）として定義され CI checks に表示される
+- 3.1 — job レベル `continue-on-error: true` + ステップの `exit-code: '0'` の二重担保で検出時も fail させない
+- 3.2 — 「Publish scan results to job summary」（`if: always()`）で table 出力を `$GITHUB_STEP_SUMMARY` に掲載。CI ログにも table 出力が残る
+- 3.3 — job レベル `continue-on-error: true` により docker build 失敗を含め job が常に成功扱いとなり PR をブロックしない
+- 4.1 — 既存 6 job（backend / go-vet / govulncheck / frontend / frontend-lint / frontend-audit）の定義に変更なし（develop..HEAD diff で trivy 追加のみを確認）
+- 4.2 — trivy は `needs` 無しの独立 job。他 job の成否に影響しない
+- 4.3 — Dockerfile / コンテナイメージ（ベースイメージ・OS パッケージ）が対象で、govulncheck（Go 依存）/ npm audit（npm 依存）とスコープが重複しない
+- NFR 1.1 — 軽量ベースイメージ（distroless / alpine）で目安 5 分以内に収まる見込み（impl-notes に根拠記載）
+- NFR 1.2 — image スキャン + severity 絞り込みで抑制可能。schedule 化等の余地を確保
+- NFR 2.1 — 既存 job 定義は無変更（diff で確認）
+- NFR 2.2 — `needs` 無し独立 job + `continue-on-error: true` で他 job・CI 全体の結果に影響しない
+- NFR 3.1 — `severity: CRITICAL,HIGH` の table 出力を CI ログ + Step Summary の双方に残し重大度・件数を確認可能
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric AC（1.1〜4.3）および NFR が trivy job 追加により実装でカバーされている。変更は `.github/workflows/ci.yml` への独立 job 追加のみで既存ジョブ・トリガー定義は無変更、Out of Scope の逸脱も無く boundary 逸脱は検出されなかった。本変更は GitHub Actions ワークフロー YAML であり単体テストフレームワークの対象外で、impl-notes に YAML 構文検証 + actionlint + diff 確認の検証結果と AC トレーサビリティが明記されているため missing test には該当しない。
+
+RESULT: approve


### PR DESCRIPTION
## 概要

Feedman の CI には Go 依存（`govulncheck`）とフロントエンド依存（`npm audit`）の脆弱性スキャンが存在したが、
Dockerfile やコンテナイメージ（ベースイメージ・OS パッケージ）由来の既知 CVE を検知する仕組みがなかった。
本 PR では `.github/workflows/ci.yml` に `trivy` job を追加し、ルート `Dockerfile`（api/worker）と
`web/Dockerfile`（web）を対象に Trivy によるコンテナイメージ脆弱性スキャンを PR トリガーで自動実行する。
脆弱性検出時は「警告のみ（CI を fail させない）」として、段階導入の初期段階で開発フローを止めずに可視化する。

## 対応 Issue

Closes #52

## 関連 PR

なし（本 Issue は design-less impl のため設計 PR は作成されていない）

## 実装内容

- (Req 1.1 / 1.2) ルート `Dockerfile`（feedman-api:scan）および `web/Dockerfile`（feedman-web:scan）を `docker build` でビルドし、`aquasecurity/trivy-action@0.28.0` で image スキャンを実行
- (Req 1.3) `severity: CRITICAL,HIGH` + image スキャン方式により OS パッケージ層（distroless-debian12 / node:20-alpine）の CVE を検出対象に含める
- (Req 3.1 / 3.3) ジョブレベル `continue-on-error: true` + `exit-code: '0'` の二重担保で、脆弱性検出時も CI を fail させず PR をブロックしない
- (Req 3.2 / NFR 3.1) スキャン結果（table 形式）を GitHub Step Summary に出力し、CRITICAL/HIGH の件数を CI 上で参照可能にする
- (Req 4.1 / NFR 2.1) 既存 job（backend / go-vet / govulncheck / frontend / frontend-lint / frontend-audit）の定義は一切変更なし

## 受入基準チェック

- [x] Req 1.1: The CI ワークフロー shall ルート `Dockerfile` を対象とする Trivy 脆弱性スキャンを実行する ← `feedman-api:scan` image スキャンステップ
- [x] Req 1.2: The CI ワークフロー shall `web/Dockerfile` を対象とする Trivy 脆弱性スキャンを実行する ← `feedman-web:scan` image スキャンステップ
- [x] Req 1.3: 既知の CRITICAL または HIGH を検出結果に含める ← image スキャン採用 + `severity: CRITICAL,HIGH`
- [x] Req 1.4: 重大脆弱性なしなら正常終了 ← `exit-code: '0'` により常に正常終了
- [x] Req 2.1: PR トリガーで起動 ← 既存 `on: pull_request: branches: [main, develop]` を利用
- [x] Req 2.2: push でも整合起動 ← 既存 `on: push: branches: [main, develop]` をそのまま利用
- [x] Req 2.3: CI チェック一覧に表示 ← `jobs.trivy`（`Container Image Vulnerability Scan (Trivy)`）として独立 job 定義
- [x] Req 3.1: 検出でも fail させない ← ジョブレベル `continue-on-error: true` + `exit-code: '0'`
- [x] Req 3.2: 結果を CI 上で参照可能に残す ← Step Summary に table 出力（`if: always()`）
- [x] Req 3.3: マージをブロックしない ← `continue-on-error: true` により job が常に成功扱い
- [x] Req 4.1〜4.3: 既存ジョブ非影響 ← 既存 job 定義は無変更（diff で確認済み）
- [x] NFR 1.1: 実行時間 5 分以内の見込み ← 軽量ベースイメージ（distroless / alpine）
- [x] NFR 2.2: 独立実行 ← `needs` なし + `continue-on-error: true`
- [x] NFR 3.1: 重大度・件数を CI 上で確認可能 ← `severity: CRITICAL,HIGH` の table 出力を CI ログ + Step Summary に掲載

## テスト結果

```
YAML 構文検証: YAML OK（python3 yaml.safe_load）
actionlint v1.7.12: exit code 0（指摘なし）
diff 確認（git diff HEAD）: trivy job 追加のみ。既存 job・トリガー定義に変更なし

GitHub Actions 実行環境でのスキャン実挙動はランナー上での docker build + Trivy 実行が必要なため
ローカルでは検証していない（ワークフロー定義の妥当性は YAML 検証 + actionlint で担保）。
```

## 実装上の判断

- **image スキャン採用**: config / fs スキャンではベースイメージ（distroless-debian12 / node:20-alpine）の OS パッケージ層 CVE を検出できないため、Req 1.3 を満たすには image スキャンが必須と判断（impl-notes.md「スキャン方式の選択理由」参照）
- **ジョブレベル `continue-on-error: true`**: `exit-code: '0'` のみでは前段 `docker build` 失敗時に trivy job 全体が fail し得るため、ジョブレベルで保護。コメントと実装の整合を取るため第 2 コミットで修正済み（impl-notes.md「追記: continue-on-error の整合修正」参照）
- **`aquasecurity/trivy-action@0.28.0`**: trivy-action は `vMAJOR` 形式タグを提供していないため、公式推奨の semver リリースタグでピン留め

## 確認事項 / レビュワーへの依頼

なし。Reviewer 独立レビューの判定結果は `docs/specs/52-ci-trivy/review-notes.md` を参照。
検出時挙動「警告のみ」・実行タイミング「PR トリガー」は requirements.md で確定済み。

base ブランチ検証: --base develop 指定値 / baseRefName: develop / OK（一致）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #52 のコメントを参照してください。