### PR TITLE
feat(#47): handler / feed / subscription の単体試験カバレッジを改善

### DIFF
--- a/docs/specs/47--handler-feed-subscription/impl-notes.md
+++ b/docs/specs/47--handler-feed-subscription/impl-notes.md
@@ -1,0 +1,108 @@
+# 実装ノート（Issue #47: 単体試験カバレッジの細部改善）
+
+## 概要
+
+`internal/handler` / `internal/feed` / `internal/subscription` の未カバー分岐に対して
+ユニットテストを **追加** した。実装コード（非テストファイル）は一切変更していない
+（NFR 1.1: テストファイルの追加・拡張のみで完結）。
+
+本 Issue は design-less impl（design.md / tasks.md なし）であり、`requirements.md` を
+入力として実装した。
+
+## 追加したテストと対応 AC
+
+### 要件 1: handler のエラーステータスマッピング default 分岐（`internal/handler/feed_handler_test.go`）
+
+| テスト関数 | 対応 AC | 観点 |
+|---|---|---|
+| `TestMapAPIErrorToHTTPStatus_KnownCodes` | 1.2 | 既知エラーコード 14 種が個別の HTTP ステータスへマッピングされる正常系（table-driven） |
+| `TestMapAPIErrorToHTTPStatus_UnknownCode_ReturnsInternalServerError` | 1.1 | 未マップコードが default 分岐で HTTP 500 にフォールバック |
+| `TestMapAPIErrorToHTTPStatus_EmptyCode_ReturnsInternalServerError` | 1.1 | 空コード（境界値）も default 分岐で HTTP 500 にフォールバック |
+
+`mapAPIErrorToHTTPStatus` は private 関数のため、同一パッケージ内テストから直接呼び出して
+検証した（HTTP リクエスト全体を経由せずマッピング表の単体ロジックを直接固定）。要件 1.2 の
+「既知の正常系と default 経路を区別して検証する」を、別テスト関数として明確に分離した。
+
+### 要件 2: feed パッケージの SSRF ガード有効/無効経路
+
+#### detector（`internal/feed/detector_test.go`）
+
+| テスト関数 | 対応 AC | 観点 |
+|---|---|---|
+| `TestNewFeedDetector_SSRFGuardEnabled_UsesSafeClient` | 2.1 | ガード有効時に `NewSafeClient`（SSRF 対策付きクライアント）経路が選択される |
+| `TestNewFeedDetector_SSRFGuardDisabled_UsesPlainClient` | 2.2 | ガード無効(nil)時に素のクライアント（既定 `detectorTimeout`）経路が選択される |
+
+#### favicon（`internal/feed/favicon_test.go`）
+
+| テスト関数 | 対応 AC | 観点 |
+|---|---|---|
+| `TestNewFaviconFetcher_SSRFGuardEnabled_UsesSafeClient` | 2.3 | ガード有効時に `NewSafeClient` 経路が選択される |
+| `TestNewFaviconFetcher_SSRFGuardDisabled_UsesPlainClient` | 2.4 | ガード無効(nil)時に素のクライアント（既定 `faviconTimeout`）経路が選択される |
+
+SSRF 有効/無効の分岐本体は `newDetectorHTTPClient` / `newFaviconHTTPClient` の
+`if ssrfGuard != nil { ... NewSafeClient ... } else { ... 素クライアント ... }` にある。
+分岐を観察可能にするため、有効経路は既存 `mockSSRFGuard` の `newSafeClientCalls()` が
+1 回呼ばれることで確認し、無効経路は生成クライアントの `Timeout` が定数（SSRF 対策なし
+クライアントに設定される既定値）と一致することで確認した。いずれも `httptest` でテスト用
+HTTP サーバを立て、実際の取得まで通して経路が観測可能な形にした（Issue 本文の推奨方針に準拠）。
+
+### 要件 3: subscription の購読解除 nil 分岐とエラー経路（`internal/subscription/service_test.go`）
+
+| テスト関数 | 対応 AC | 観点 |
+|---|---|---|
+| `TestService_Unsubscribe_NilItemStateRepo_SkipsItemStateDelete` | 3.1 | `itemStateRepo == nil` のとき記事状態削除をスキップし購読削除が成功 |
+| `TestService_Unsubscribe_ItemStateDeleteError_PropagatesError` | 3.2 | `DeleteByUserAndFeed` がエラーを返すとエラーが伝播し、購読削除は実行されない |
+
+### 要件 4: subscription のフェッチ再開における状態前提違反経路（`internal/subscription/service_test.go`）
+
+| テスト関数 | 対応 AC | 観点 |
+|---|---|---|
+| `TestService_ResumeFetch_NotStopped_ReturnsFeedNotStoppedAndDoesNotUpdate` | 4.1 | 停止中でない（active）feed に対し `FEED_NOT_STOPPED` 専用エラーを返し、`UpdateFetchState` を呼ばない |
+
+既存の `TestService_ResumeFetch_NotStopped_ReturnsError` は `err != nil` のみを確認していた
+ため、AC 4.1 が要求する「専用エラーであること」「状態が更新されないこと」を明示的に検証する
+テストを **別関数として追加**した（既存テストは変更していない）。
+
+## AC とテストの対応（網羅確認）
+
+| AC | 担保テスト |
+|---|---|
+| 1.1 | `TestMapAPIErrorToHTTPStatus_UnknownCode_ReturnsInternalServerError`, `TestMapAPIErrorToHTTPStatus_EmptyCode_ReturnsInternalServerError` |
+| 1.2 | `TestMapAPIErrorToHTTPStatus_KnownCodes`（正常系）+ 上記 default 系（区別して検証） |
+| 2.1 | `TestNewFeedDetector_SSRFGuardEnabled_UsesSafeClient` |
+| 2.2 | `TestNewFeedDetector_SSRFGuardDisabled_UsesPlainClient` |
+| 2.3 | `TestNewFaviconFetcher_SSRFGuardEnabled_UsesSafeClient` |
+| 2.4 | `TestNewFaviconFetcher_SSRFGuardDisabled_UsesPlainClient` |
+| 3.1 | `TestService_Unsubscribe_NilItemStateRepo_SkipsItemStateDelete` |
+| 3.2 | `TestService_Unsubscribe_ItemStateDeleteError_PropagatesError` |
+| 4.1 | `TestService_ResumeFetch_NotStopped_ReturnsFeedNotStoppedAndDoesNotUpdate` |
+| NFR 1.1 | 実装コード（非テストファイル）は未変更。テストファイルのみ追加 |
+| NFR 1.2 | `go test ./...` 全パッケージ成功（既存テストへの影響なし） |
+| NFR 2.1 | 追加テストはすべて期待挙動が読み取れる関数名 + Arrange/Act/Assert 構造 |
+| NFR 2.2 | HTTP 経路はモック SSRF ガード + `httptest`、nil 分岐・純粋ロジックは実物のまま検証 |
+
+## 検証結果
+
+- `go test ./...`: 全パッケージ ok（`internal/handler` / `internal/feed` / `internal/subscription` 含む）
+- `go test -race ./internal/handler/ ./internal/feed/ ./internal/subscription/`: ok（データ競合なし）
+- `go vet ./...`: 警告なし
+- `gofmt -l`（追加・編集ファイル）:
+  - `internal/feed/detector_test.go` / `internal/feed/favicon_test.go` / `internal/subscription/service_test.go`: クリーン
+  - `internal/handler/feed_handler_test.go`: 後述「確認事項」参照
+
+## 確認事項
+
+- `internal/handler/feed_handler_test.go` は **本変更以前から** `gofmt -l` で
+  リストされる既存の整形差分（92〜103 行付近・828 行付近のインデント）を持っている。
+  `git show main:internal/handler/feed_handler_test.go` でも同じく検出されるため、本仕様の
+  追加コードに起因するものではない。本仕様は「テスト追加のみ・既存挙動不変」が目的であり、
+  当該既存行の整形差分修正は無関係なノイズ変更となるため **本 PR では触れていない**
+  （追加した私のコード範囲は gofmt クリーン）。必要であれば別 Issue での整形修正を提案する。
+- 要件 2 の SSRF 無効経路の観測手段として、`NewSafeClient` 非経由であることを「クライアントの
+  `Timeout` が既定値と一致する」ことで間接的に確認している。`mockSSRFGuard.NewSafeClient` も
+  `&http.Client{Timeout: timeout}` を返すため Timeout 値だけでは両経路を完全には判別できないが、
+  無効経路では `guard` 自体が nil で `newSafeClientCalls()` を観測できないため、有効経路側で
+  `newSafeClientCalls() == 1` を確認することで「無効時は NewSafeClient を経由しない」ことを
+  相補的に担保している。実装挙動を変えない制約下での最大限の観測方法と判断した。
+
+STATUS: complete

--- a/docs/specs/47--handler-feed-subscription/requirements.md
+++ b/docs/specs/47--handler-feed-subscription/requirements.md
@@ -1,0 +1,73 @@
+# Requirements Document
+
+## Introduction
+
+Feedman の `internal/handler` / `internal/feed` / `internal/subscription` には、低優先度ながら
+ユニットテストで明示的に検証されていない分岐が残存している。これらは主にエラー経路・nil 分岐・
+SSRF ガードの有効/無効切替・状態前提違反のケースであり、未検証のまま実装が変更されると静かに
+リグレッションが入り込む余地がある。本仕様は、実装挙動を一切変更せず、これら指定分岐に対する
+ユニットテストを追加して回帰防止網を補強することを目的とする。SSRF 対策（要件 12）の有効/無効
+両経路は、本仕様で明示的に検証対象とする。
+
+## Requirements
+
+### Requirement 1: handler のエラーステータスマッピング default 分岐の検証
+
+**Objective:** As a 開発者, I want `mapAPIErrorToHTTPStatus` の未マップエラーコードに対する default 挙動がテストで固定されること, so that マッピング表の改変時に未知コードのフォールバックが静かに壊れないことを保証できる
+
+#### Acceptance Criteria
+
+1. When 未マップの APIError コードを `mapAPIErrorToHTTPStatus` 相当の経路に渡したとき, the Handler テストスイート shall HTTP 500（Internal Server Error）が返ることを検証する
+2. The Handler テストスイート shall 既知のエラーコードが個別に対応する HTTP ステータスへマッピングされる正常系と、未知コードの default 経路（500）の両方を区別して検証する
+
+### Requirement 2: feed パッケージの SSRF ガード有効/無効経路の検証
+
+**Objective:** As a 開発者, I want フィード検出と favicon 取得の HTTP クライアント生成が SSRF ガードの有効時と無効時の両経路でテストされること, so that 要件 12（SSRF 対策）のガード分岐が将来の変更で意図せず無効化されないことを保証できる
+
+#### Acceptance Criteria
+
+1. Where SSRF ガードが有効化されたとき, the FeedDetector テスト shall SSRF 対策付き HTTP クライアントが選択される経路を検証する
+2. Where SSRF ガードが無効（未設定）であるとき, the FeedDetector テスト shall SSRF 対策なしの HTTP クライアントが選択される経路を検証する
+3. Where SSRF ガードが有効化されたとき, the FaviconFetcher テスト shall SSRF 対策付き HTTP クライアントが選択される経路を検証する
+4. Where SSRF ガードが無効（未設定）であるとき, the FaviconFetcher テスト shall SSRF 対策なしの HTTP クライアントが選択される経路を検証する
+
+### Requirement 3: subscription の購読解除 nil 分岐とエラー経路の検証
+
+**Objective:** As a 開発者, I want 購読解除処理の itemStateRepo nil 分岐と記事状態削除エラー経路がテストされること, so that 依存リポジトリ未設定時の安全動作と削除失敗時のエラー伝播が回帰しないことを保証できる
+
+#### Acceptance Criteria
+
+1. Where 記事状態リポジトリが未設定（nil）であるとき, the Subscription Service テスト shall 購読解除が記事状態削除をスキップしたうえで正常に完了する経路を検証する
+2. If 記事状態リポジトリの削除処理がエラーを返したとき, the Subscription Service テスト shall 購読解除がエラーを呼び出し元へ伝播することを検証する
+
+### Requirement 4: subscription のフェッチ再開における状態前提違反経路の検証
+
+**Objective:** As a 開発者, I want 停止中ではないフィードに対するフェッチ再開呼び出しがテストされること, so that 状態前提の検証ロジックが回帰した際に検出できる
+
+#### Acceptance Criteria
+
+1. If 停止中ではないフィードに対してフェッチ再開が呼び出されたとき, the Subscription Service テスト shall 状態前提違反として専用エラーが返り、フィード状態が更新されないことを検証する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性（実装挙動の不変性）
+
+1. The 本仕様の変更 shall `internal/handler` / `internal/feed` / `internal/subscription` の実装コードの挙動を変更せず、テストファイルの追加・拡張のみで完結する
+2. While 既存テストスイートが実行されている間, the 追加テスト shall 既存テストの結果に影響を与えず、`go test ./...` 全体が成功する状態を維持する
+
+### NFR 2: テストの観点充足
+
+1. The 追加テスト shall 各検証対象につき期待挙動が読み取れる名前と Arrange / Act / Assert 構造を持つ
+2. The 追加テスト shall 外部副作用（HTTP / DB）が必要な分岐ではモック実装を用い、検証対象の純粋ロジック・nil 分岐は実物のまま検証する
+
+## Out of Scope
+
+- `subscription.Service.UpdateSettings` のユニットテスト（#45 で別途対応）
+- 実装コードの挙動変更・リファクタリング（本仕様はテスト追加のみが目的）
+- カバレッジ率を KPI として目標値化すること（目的は指定分岐の回帰防止であり、率の達成ではない）
+- 結合テスト・E2E テストの追加（本仕様はユニットテスト層に限定する）
+- 上記以外のパッケージ・分岐のカバレッジ補完
+
+## Open Questions
+
+- なし（Issue 本文に検証対象分岐が列挙済みで、既存コメントに人間の追加判断はない）

--- a/docs/specs/47--handler-feed-subscription/review-notes.md
+++ b/docs/specs/47--handler-feed-subscription/review-notes.md
@@ -1,0 +1,41 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-47-impl--handler-feed-subscription
+- HEAD commit: 2b50ffb76a192bf55a064bd07a785c8f11bbf3ba
+- Compared to: develop..HEAD
+
+本 Issue は design-less impl（design.md / tasks.md なし）。requirements.md の numeric ID と
+実装コード・追加テストを突き合わせて判定した。CLAUDE.md の Feature Flag Protocol は opt-out の
+ため flag 観点は適用しない。diff は test ファイル 4 本（internal/handler / internal/feed ×2 /
+internal/subscription）と spec markdown 2 本のみで、実装コード（非テスト）の変更は 0 件。
+
+## Verified Requirements
+
+- 1.1 — `internal/handler/feed_handler_test.go`: `TestMapAPIErrorToHTTPStatus_UnknownCode_ReturnsInternalServerError` / `TestMapAPIErrorToHTTPStatus_EmptyCode_ReturnsInternalServerError` が未マップ/空コードの default 分岐で HTTP 500 を検証（実装 feed_handler.go:291 default 分岐に対応）
+- 1.2 — 同ファイル `TestMapAPIErrorToHTTPStatus_KnownCodes` が既知 14 コードの個別マッピングを table-driven で検証し、default 系（1.1）と別関数で区別
+- 2.1 — `internal/feed/detector_test.go`: `TestNewFeedDetector_SSRFGuardEnabled_UsesSafeClient` がガード有効時 `NewSafeClient` 1 回呼出を検証（detector.go:71-72 の `ssrfGuard != nil` 分岐に対応）
+- 2.2 — 同ファイル `TestNewFeedDetector_SSRFGuardDisabled_UsesPlainClient` がガード nil 時に素クライアント（`detectorTimeout`）が選択される経路を検証
+- 2.3 — `internal/feed/favicon_test.go`: `TestNewFaviconFetcher_SSRFGuardEnabled_UsesSafeClient` がガード有効時 `NewSafeClient` 1 回呼出を検証（favicon.go:53-54 分岐に対応）
+- 2.4 — 同ファイル `TestNewFaviconFetcher_SSRFGuardDisabled_UsesPlainClient` がガード nil 時に素クライアント（`faviconTimeout`）が選択される経路を検証
+- 3.1 — `internal/subscription/service_test.go`: `TestService_Unsubscribe_NilItemStateRepo_SkipsItemStateDelete` が itemStateRepo=nil 時に記事状態削除をスキップし購読削除が成功することを検証（service.go:166 の nil ガードに対応）
+- 3.2 — 同ファイル `TestService_Unsubscribe_ItemStateDeleteError_PropagatesError` が DeleteByUserAndFeed のエラーを `errors.Is` で wrap 伝播確認し、後続の購読 Delete が呼ばれないことも検証（service.go:167-169）
+- 4.1 — 同ファイル `TestService_ResumeFetch_NotStopped_ReturnsFeedNotStoppedAndDoesNotUpdate` が active フィードに対し `FEED_NOT_STOPPED` 専用エラー（*model.APIError）を返し UpdateFetchState を呼ばないことを検証（service.go:202-203）
+- NFR 1.1 — diff stat 上、実装コード（非テストファイル）の変更は 0 件。テストファイルと spec markdown のみ
+- NFR 1.2 — `go test ./internal/handler/ ./internal/feed/ ./internal/subscription/` 全 ok（reviewer 再実行で green 確認）。追加 9 関数すべて -v で PASS を確認
+- NFR 2.1 — 追加テストはいずれも期待挙動が読み取れる関数名 + Arrange/Act/Assert コメント構造
+- NFR 2.2 — HTTP 経路は httptest + mockSSRFGuard、nil 分岐・純粋ロジックは実物で検証
+
+## Findings
+
+なし
+
+## Summary
+
+requirements.md の全 numeric AC（1.1, 1.2, 2.1〜2.4, 3.1, 3.2, 4.1）に対応する追加テストが存在し、
+いずれも実装の該当分岐と整合して PASS。実装コード変更なしで NFR 1.1 を満たし、boundary 逸脱なし。
+
+RESULT: approve

--- a/internal/feed/detector_test.go
+++ b/internal/feed/detector_test.go
@@ -693,6 +693,64 @@ func TestFeedDetector_Concurrent_NoDataRace(t *testing.T) {
 	// Assert: 競合が無いことは -race フラグが検出する。ここでは到達のみ確認。
 }
 
+// --- SSRF ガード有効/無効の HTTP クライアント生成経路のテスト（要件 2） ---
+
+// TestNewFeedDetector_SSRFGuardEnabled_UsesSafeClient はSSRFガードが有効化されたとき、
+// HTTPクライアント生成が SSRF 対策付きクライアント（guard.NewSafeClient）を選択する経路を
+// 検証する（要件 2.1）。実際の HTTP 取得まで通して経路が観測可能であることを確認する。
+func TestNewFeedDetector_SSRFGuardEnabled_UsesSafeClient(t *testing.T) {
+	// Arrange: フィードを返すテスト用サーバとSSRFガード（有効）を用意する。
+	rssXML := `<?xml version="1.0"?><rss version="2.0"><channel><title>Test</title></channel></rss>`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, rssXML)
+	}))
+	defer server.Close()
+
+	guard := &mockSSRFGuard{}
+
+	// Act: ガード有効でDetectorを生成する（生成時に NewSafeClient 経路を通る）。
+	d := NewFeedDetector(guard)
+	_, err := d.DetectFeedURL(context.Background(), server.URL+"/feed.xml")
+
+	// Assert: SSRF 対策付きクライアント生成（NewSafeClient）が選択され、検出も成功している。
+	if err != nil {
+		t.Fatalf("DetectFeedURL returned error: %v", err)
+	}
+	if got := guard.newSafeClientCalls(); got != 1 {
+		t.Errorf("SSRFガード有効時は NewSafeClient が1回呼ばれるべき。結果: %d 回", got)
+	}
+}
+
+// TestNewFeedDetector_SSRFGuardDisabled_UsesPlainClient はSSRFガードが無効（nil）であるとき、
+// HTTPクライアント生成が SSRF 対策なしの素のクライアント（NewSafeClient 非経由・既定タイムアウト）を
+// 選択する経路を検証する（要件 2.2）。
+func TestNewFeedDetector_SSRFGuardDisabled_UsesPlainClient(t *testing.T) {
+	// Arrange: フィードを返すテスト用サーバを用意する（ガードは nil）。
+	rssXML := `<?xml version="1.0"?><rss version="2.0"><channel><title>Test</title></channel></rss>`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, rssXML)
+	}))
+	defer server.Close()
+
+	// Act: ガード無効（nil）でDetectorを生成する（素のクライアント経路を通る）。
+	d := NewFeedDetector(nil)
+	client := d.getHTTPClient()
+	_, err := d.DetectFeedURL(context.Background(), server.URL+"/feed.xml")
+
+	// Assert: 素のクライアント（既定タイムアウト）が選択され、検出も成功している。
+	if err != nil {
+		t.Fatalf("DetectFeedURL returned error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("SSRFガード無効時もHTTPクライアントは生成されるべき")
+	}
+	if client.Timeout != detectorTimeout {
+		t.Errorf("素のクライアントは detectorTimeout(%v) を持つべき。結果: %v", detectorTimeout, client.Timeout)
+	}
+}
+
 // --- mockSSRFGuard ---
 
 // mockSSRFGuard はテスト用のSSRFGuardモック。

--- a/internal/feed/favicon_test.go
+++ b/internal/feed/favicon_test.go
@@ -360,6 +360,70 @@ func TestFaviconFetcher_Concurrent_NoDataRace(t *testing.T) {
 	// Assert: 競合が無いことは -race フラグが検出する。
 }
 
+// --- SSRF ガード有効/無効の HTTP クライアント生成経路のテスト（要件 2） ---
+
+// TestNewFaviconFetcher_SSRFGuardEnabled_UsesSafeClient はSSRFガードが有効化されたとき、
+// favicon取得のHTTPクライアント生成が SSRF 対策付きクライアント（guard.NewSafeClient）を
+// 選択する経路を検証する（要件 2.3）。実際の取得まで通して経路が観測可能であることを確認する。
+func TestNewFaviconFetcher_SSRFGuardEnabled_UsesSafeClient(t *testing.T) {
+	// Arrange: favicon を返すテスト用サーバとSSRFガード（有効）を用意する。
+	pngData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(pngData)
+	}))
+	defer server.Close()
+
+	guard := &mockSSRFGuard{}
+
+	// Act: ガード有効でFetcherを生成する（生成時に NewSafeClient 経路を通る）。
+	f := NewFaviconFetcher(guard)
+	data, _, err := f.FetchFavicon(context.Background(), server.URL+"/favicon.ico")
+
+	// Assert: SSRF 対策付きクライアント生成（NewSafeClient）が選択され、取得も成功している。
+	if err != nil {
+		t.Fatalf("FetchFavicon returned error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty favicon data")
+	}
+	if got := guard.newSafeClientCalls(); got != 1 {
+		t.Errorf("SSRFガード有効時は NewSafeClient が1回呼ばれるべき。結果: %d 回", got)
+	}
+}
+
+// TestNewFaviconFetcher_SSRFGuardDisabled_UsesPlainClient はSSRFガードが無効（nil）であるとき、
+// favicon取得のHTTPクライアント生成が SSRF 対策なしの素のクライアント（NewSafeClient 非経由・
+// 既定タイムアウト）を選択する経路を検証する（要件 2.4）。
+func TestNewFaviconFetcher_SSRFGuardDisabled_UsesPlainClient(t *testing.T) {
+	// Arrange: favicon を返すテスト用サーバを用意する（ガードは nil）。
+	pngData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(pngData)
+	}))
+	defer server.Close()
+
+	// Act: ガード無効（nil）でFetcherを生成する（素のクライアント経路を通る）。
+	f := NewFaviconFetcher(nil)
+	client := f.getHTTPClient()
+	data, _, err := f.FetchFavicon(context.Background(), server.URL+"/favicon.ico")
+
+	// Assert: 素のクライアント（既定タイムアウト）が選択され、取得も成功している。
+	if err != nil {
+		t.Fatalf("FetchFavicon returned error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty favicon data")
+	}
+	if client == nil {
+		t.Fatal("SSRFガード無効時もHTTPクライアントは生成されるべき")
+	}
+	if client.Timeout != faviconTimeout {
+		t.Errorf("素のクライアントは faviconTimeout(%v) を持つべき。結果: %v", faviconTimeout, client.Timeout)
+	}
+}
+
 // mockSSRFGuardForFavicon は既にdetector_test.goで定義されているmockSSRFGuardを使用する。
 // ここではdetector_test.goのモックが同パッケージ内で利用可能。
 

--- a/internal/handler/feed_handler_test.go
+++ b/internal/handler/feed_handler_test.go
@@ -928,6 +928,79 @@ func TestSetupFeedRoutes_DeleteEndpoint(t *testing.T) {
 	}
 }
 
+// --- mapAPIErrorToHTTPStatus（エラーコード→HTTPステータスマッピング）のテスト ---
+
+// TestMapAPIErrorToHTTPStatus_KnownCodes は既知のエラーコードがそれぞれ対応する
+// HTTPステータスへマッピングされる正常系を検証する（要件 1.2）。
+func TestMapAPIErrorToHTTPStatus_KnownCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		code       string
+		wantStatus int
+	}{
+		{"FEED_NOT_DETECTED のとき 422", model.ErrCodeFeedNotDetected, http.StatusUnprocessableEntity},
+		{"INVALID_URL のとき 400", model.ErrCodeInvalidURL, http.StatusBadRequest},
+		{"SSRF_BLOCKED のとき 403", model.ErrCodeSSRFBlocked, http.StatusForbidden},
+		{"FETCH_FAILED のとき 502", model.ErrCodeFetchFailed, http.StatusBadGateway},
+		{"PARSE_FAILED のとき 422", model.ErrCodeParseFailed, http.StatusUnprocessableEntity},
+		{"SUBSCRIPTION_LIMIT のとき 409", model.ErrCodeSubscriptionLimit, http.StatusConflict},
+		{"DUPLICATE_SUBSCRIPTION のとき 409", "DUPLICATE_SUBSCRIPTION", http.StatusConflict},
+		{"FEED_NOT_FOUND のとき 404", "FEED_NOT_FOUND", http.StatusNotFound},
+		{"SUBSCRIPTION_NOT_FOUND のとき 404", model.ErrCodeSubscriptionNotFound, http.StatusNotFound},
+		{"ITEM_NOT_FOUND のとき 404", model.ErrCodeItemNotFound, http.StatusNotFound},
+		{"INVALID_FILTER のとき 400", model.ErrCodeInvalidFilter, http.StatusBadRequest},
+		{"INVALID_FETCH_INTERVAL のとき 400", model.ErrCodeInvalidFetchInterval, http.StatusBadRequest},
+		{"FEED_NOT_STOPPED のとき 409", model.ErrCodeFeedNotStopped, http.StatusConflict},
+		{"USER_NOT_FOUND のとき 404", model.ErrCodeUserNotFound, http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			apiErr := &model.APIError{Code: tt.code}
+
+			// Act
+			got := mapAPIErrorToHTTPStatus(apiErr)
+
+			// Assert
+			if got != tt.wantStatus {
+				t.Errorf("mapAPIErrorToHTTPStatus(code=%q) = %d, want %d", tt.code, got, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// TestMapAPIErrorToHTTPStatus_UnknownCode_ReturnsInternalServerError は未マップの
+// エラーコードが default 分岐で HTTP 500（Internal Server Error）にフォールバックする
+// ことを検証する（要件 1.1）。
+func TestMapAPIErrorToHTTPStatus_UnknownCode_ReturnsInternalServerError(t *testing.T) {
+	// Arrange: マッピング表に存在しない未知のエラーコード。
+	apiErr := &model.APIError{Code: "SOME_UNMAPPED_ERROR_CODE"}
+
+	// Act
+	got := mapAPIErrorToHTTPStatus(apiErr)
+
+	// Assert
+	if got != http.StatusInternalServerError {
+		t.Errorf("未知コードの default 分岐 = %d, want %d", got, http.StatusInternalServerError)
+	}
+}
+
+// TestMapAPIErrorToHTTPStatus_EmptyCode_ReturnsInternalServerError は空のエラーコード
+// （境界値）も default 分岐で 500 にフォールバックすることを検証する（要件 1.1）。
+func TestMapAPIErrorToHTTPStatus_EmptyCode_ReturnsInternalServerError(t *testing.T) {
+	// Arrange: 空文字コードはどの case にも一致しない。
+	apiErr := &model.APIError{Code: ""}
+
+	// Act
+	got := mapAPIErrorToHTTPStatus(apiErr)
+
+	// Assert
+	if got != http.StatusInternalServerError {
+		t.Errorf("空コードの default 分岐 = %d, want %d", got, http.StatusInternalServerError)
+	}
+}
+
 func TestSetupFeedRoutes_UnknownRoute_Returns404Or405(t *testing.T) {
 	router := SetupFeedRoutes(&mockFeedService{}, &mockSubscriptionDeleter{}, nil)
 

--- a/internal/subscription/service_test.go
+++ b/internal/subscription/service_test.go
@@ -359,6 +359,121 @@ func TestService_ResumeFetch_NotStopped_ReturnsError(t *testing.T) {
 	}
 }
 
+// TestService_Unsubscribe_NilItemStateRepo_SkipsItemStateDelete は
+// 記事状態リポジトリが未設定（nil）のとき、記事状態削除をスキップしたうえで
+// 購読削除が正常に完了することを検証する（要件 3.1）。
+func TestService_Unsubscribe_NilItemStateRepo_SkipsItemStateDelete(t *testing.T) {
+	// Arrange: itemStateRepo を nil で生成する。
+	deleteCalled := false
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return &model.Subscription{ID: "sub-1", UserID: "user-1", FeedID: "feed-1"}, nil
+		},
+		deleteFn: func(ctx context.Context, id string) error {
+			deleteCalled = true
+			return nil
+		},
+	}
+
+	svc := NewService(subRepo, nil, nil)
+
+	// Act
+	err := svc.Unsubscribe(context.Background(), "user-1", "sub-1")
+
+	// Assert: nil 分岐でも購読削除が呼ばれ、エラーなく完了する。
+	if err != nil {
+		t.Fatalf("Unsubscribe returned error: %v", err)
+	}
+	if !deleteCalled {
+		t.Error("expected subscription Delete to be called even when itemStateRepo is nil")
+	}
+}
+
+// TestService_Unsubscribe_ItemStateDeleteError_PropagatesError は
+// 記事状態リポジトリの削除（DeleteByUserAndFeed）がエラーを返したとき、
+// 購読解除がそのエラーを呼び出し元へ伝播し、購読削除を行わないことを検証する（要件 3.2）。
+func TestService_Unsubscribe_ItemStateDeleteError_PropagatesError(t *testing.T) {
+	// Arrange: DeleteByUserAndFeed がエラーを返す。
+	sentinelErr := errors.New("delete item states failed")
+	deleteCalled := false
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return &model.Subscription{ID: "sub-1", UserID: "user-1", FeedID: "feed-1"}, nil
+		},
+		deleteFn: func(ctx context.Context, id string) error {
+			deleteCalled = true
+			return nil
+		},
+	}
+	itemStateRepo := &mockItemStateRepo{
+		deleteByUserAndFeedFn: func(ctx context.Context, userID, feedID string) error {
+			return sentinelErr
+		},
+	}
+
+	svc := NewService(subRepo, itemStateRepo, nil)
+
+	// Act
+	err := svc.Unsubscribe(context.Background(), "user-1", "sub-1")
+
+	// Assert: エラーが wrap されて伝播し、購読削除は実行されない。
+	if err == nil {
+		t.Fatal("expected error from item state delete, got nil")
+	}
+	if !errors.Is(err, sentinelErr) {
+		t.Errorf("expected wrapped error to match sentinel, got %v", err)
+	}
+	if deleteCalled {
+		t.Error("subscription Delete should not be called when item state delete fails")
+	}
+}
+
+// TestService_ResumeFetch_NotStopped_ReturnsFeedNotStoppedAndDoesNotUpdate は
+// 停止中ではない（active）フィードに対してフェッチ再開が呼ばれたとき、
+// 状態前提違反として FEED_NOT_STOPPED 専用エラーを返し、フィード状態を更新しないことを
+// 検証する（要件 4.1）。
+func TestService_ResumeFetch_NotStopped_ReturnsFeedNotStoppedAndDoesNotUpdate(t *testing.T) {
+	// Arrange: フィードは active 状態（停止中ではない）。
+	updateCalled := false
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return &model.Subscription{ID: "sub-1", UserID: "user-1", FeedID: "feed-1"}, nil
+		},
+	}
+	feedRepo := &mockFeedRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Feed, error) {
+			return &model.Feed{ID: "feed-1", FetchStatus: model.FetchStatusActive}, nil
+		},
+		updateFetchStateFn: func(ctx context.Context, feed *model.Feed) error {
+			updateCalled = true
+			return nil
+		},
+	}
+
+	svc := NewService(subRepo, nil, feedRepo)
+
+	// Act
+	result, err := svc.ResumeFetch(context.Background(), "user-1", "sub-1")
+
+	// Assert: 専用エラー（FEED_NOT_STOPPED）が返り、状態更新は呼ばれない。
+	if err == nil {
+		t.Fatal("expected error for non-stopped feed, got nil")
+	}
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("error type = %T, want *model.APIError", err)
+	}
+	if apiErr.Code != model.ErrCodeFeedNotStopped {
+		t.Errorf("error code = %q, want %q", apiErr.Code, model.ErrCodeFeedNotStopped)
+	}
+	if updateCalled {
+		t.Error("UpdateFetchState should not be called when feed is not stopped")
+	}
+	if result != nil {
+		t.Errorf("expected nil result, got %+v", result)
+	}
+}
+
 // TestService_UpdateSettings_Success は有効間隔・所有者一致・全依存成功時に
 // 更新後の購読情報を返し UpdateFetchInterval が呼ばれることを検証する（要件 1.1）。
 func TestService_UpdateSettings_Success(t *testing.T) {


### PR DESCRIPTION
## 概要

`internal/handler` / `internal/feed` / `internal/subscription` パッケージに残存していた
未カバー分岐（エラー経路・nil 分岐・SSRF ガード有効/無効切替・状態前提違反）に対して
ユニットテストを追加し、回帰防止網を補強した。

実装コード（非テストファイル）は一切変更せず、テストファイルの追加・拡張のみで完結している
（NFR 1.1）。追加テスト 9 関数すべて `go test ./...` で PASS。

## 対応 Issue

Closes #47

## 関連 PR

- 設計 PR: なし（design-less impl。本 Issue は design.md / tasks.md を経由せず requirements.md のみを入力として実装）

## 実装内容

- (Req 1.1 / 1.2) `internal/handler/feed_handler_test.go` に `mapAPIErrorToHTTPStatus` の default 分岐（HTTP 500 フォールバック）と既知コードのマッピング正常系を追加
- (Req 2.1 / 2.2) `internal/feed/detector_test.go` に SSRF ガード有効/無効の両経路でクライアント生成を検証するテストを追加
- (Req 2.3 / 2.4) `internal/feed/favicon_test.go` に SSRF ガード有効/無効の両経路でクライアント生成を検証するテストを追加
- (Req 3.1 / 3.2) `internal/subscription/service_test.go` に `itemStateRepo == nil` 時のスキップ経路と削除エラーの伝播経路を追加
- (Req 4.1) `internal/subscription/service_test.go` に停止中でないフィードへのフェッチ再開呼び出しで専用エラーを返す経路を追加

## 受入基準チェック

- [x] Req 1.1: 未マップ APIError コードで HTTP 500 が返る ← `TestMapAPIErrorToHTTPStatus_UnknownCode_ReturnsInternalServerError`, `TestMapAPIErrorToHTTPStatus_EmptyCode_ReturnsInternalServerError`
- [x] Req 1.2: 既知コードの正常系と default 経路を別関数で区別 ← `TestMapAPIErrorToHTTPStatus_KnownCodes`
- [x] Req 2.1: SSRF 有効時に `NewSafeClient` 経路が選択される（detector） ← `TestNewFeedDetector_SSRFGuardEnabled_UsesSafeClient`
- [x] Req 2.2: SSRF 無効時に素クライアント経路が選択される（detector） ← `TestNewFeedDetector_SSRFGuardDisabled_UsesPlainClient`
- [x] Req 2.3: SSRF 有効時に `NewSafeClient` 経路が選択される（favicon） ← `TestNewFaviconFetcher_SSRFGuardEnabled_UsesSafeClient`
- [x] Req 2.4: SSRF 無効時に素クライアント経路が選択される（favicon） ← `TestNewFaviconFetcher_SSRFGuardDisabled_UsesPlainClient`
- [x] Req 3.1: `itemStateRepo == nil` 時に削除スキップして正常完了 ← `TestService_Unsubscribe_NilItemStateRepo_SkipsItemStateDelete`
- [x] Req 3.2: 削除エラーが呼び出し元へ伝播する ← `TestService_Unsubscribe_ItemStateDeleteError_PropagatesError`
- [x] Req 4.1: 停止中でないフィードへの再開で専用エラーが返り状態更新なし ← `TestService_ResumeFetch_NotStopped_ReturnsFeedNotStoppedAndDoesNotUpdate`

## テスト結果

```
ok  	github.com/hitoshiichikawa/feedman/internal/handler   0.032s
ok  	github.com/hitoshiichikawa/feedman/internal/feed      0.045s
ok  	github.com/hitoshiichikawa/feedman/internal/subscription  0.021s
```

`go test ./...` 全パッケージ PASS（既存テストへの影響なし）。
`go test -race ./internal/handler/ ./internal/feed/ ./internal/subscription/` でデータ競合なし。

## 実装上の判断

詳細は `impl-notes.md` を参照。主な判断点:

- `mapAPIErrorToHTTPStatus` は private 関数のため、同一パッケージ内テストから直接呼び出して検証
- SSRF 無効経路は `NewSafeClient` が呼ばれないことを、有効経路側で `newSafeClientCalls() == 1` を確認することで相補的に担保（nil の guard に対してメソッド呼出を観測できないため）
- 既存テスト関数は変更せず、新しい検証観点を別関数として追加

## 確認事項 / レビュワーへの依頼

- base ブランチ検証: `--base develop` 指定 / baseRefName: develop / OK
- Reviewer 判定詳細: `docs/specs/47--handler-feed-subscription/review-notes.md` を参照（RESULT: approve）
- `internal/handler/feed_handler_test.go` は本変更以前から `gofmt -l` で検出される既存の整形差分が存在する。本 PR は追加コード範囲のみ gofmt クリーンであり、既存行の整形は本スコープ外（impl-notes.md 参照）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #47 のコメントを参照してください。
