### PR TITLE
feat(#96): docker-compose.yml の api healthcheck を Compose 仕様準拠の形式に修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
         max-size: "10m"
         max-file: "14"
     healthcheck:
-      test: ["/feedman", "healthcheck"]
+      test: ["CMD", "/feedman", "healthcheck"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docs/specs/96-docker-compose-yml-api-healthcheck-compo/impl-notes.md
+++ b/docs/specs/96-docker-compose-yml-api-healthcheck-compo/impl-notes.md
@@ -1,0 +1,80 @@
+# 実装ノート（Issue #96）
+
+## 概要
+
+`docker-compose.yml` の `api` サービスの healthcheck がリスト形式 `test: ["/feedman", "healthcheck"]`
+で記述されており、Compose 仕様（リスト形式 `healthcheck.test` の先頭要素は `CMD` / `CMD-SHELL` /
+`NONE` のいずれか）に違反していたため、スタックが起動できない不具合を修正した。
+
+## 修正内容
+
+`docker-compose.yml` の `api` サービスの healthcheck.test に `CMD` を前置した（1 行のみの修正）。
+
+```yaml
+# 修正前（Compose 仕様違反）
+healthcheck:
+  test: ["/feedman", "healthcheck"]
+  interval: 10s
+  timeout: 5s
+  retries: 3
+
+# 修正後（Compose 仕様準拠）
+healthcheck:
+  test: ["CMD", "/feedman", "healthcheck"]
+  interval: 10s
+  timeout: 5s
+  retries: 3
+```
+
+- `interval` / `timeout` / `retries` は変更していない（Req 2.1〜2.3）。
+- `db` サービスの healthcheck（`["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-feedman}"]`）は
+  既に Compose 仕様準拠のため変更していない（Req 3.2）。
+- `web` / `worker` は healthcheck 未定義のため対象外。
+- サービス構成（api / web / worker / db）・ネットワーク（internal / external）・`depends_on` は
+  本修正前と同一（NFR 1）。
+
+## 検証結果
+
+本環境では `docker` / `docker compose` が利用可能だったため、実コマンドで検証した。
+
+- 環境: Docker version 29.4.3 / Docker Compose version v5.1.3
+- 実行コマンド: `SESSION_SECRET=dummy POSTGRES_PASSWORD=dummy docker compose -f docker-compose.yml config`
+  - 終了コード: `RC=0`（正常終了。Req 1.3）
+  - `healthcheck.test must start either by "CMD", "CMD-SHELL" or "NONE"` エラーは出力されなかった
+  - stderr は `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` 未設定の warning のみで、healthcheck とは無関係
+- `docker compose config` の解決結果（healthcheck 抜粋）:
+  - api: `test: [CMD, /feedman, healthcheck]` / `interval: 10s` / `timeout: 5s` / `retries: 3`（Req 1.1, 1.2, 2.x）
+  - db: `test: [CMD-SHELL, pg_isready -U feedman]` / `interval: 5s` / `timeout: 5s` / `retries: 5`（未変更 / Req 3.2）
+- Req 3.1（同種違反の不在確認）: リスト形式 `healthcheck.test` を持つサービスは api / db の 2 件のみで、
+  それぞれ先頭要素が `CMD` / `CMD-SHELL` であることを `config` 解決結果および元 YAML の grep で確認した。
+  CMD/CMD-SHELL/NONE 前置のないリスト形式 healthcheck は残存しない。
+
+> Req 1.4（`docker compose up` でのスタック起動）は、イメージビルド・外部依存・OAuth クレデンシャル等の
+> 実行時前提が必要で本検証環境では完結しないため、healthcheck 記法の妥当性を担保する
+> `docker compose config`（rc=0 / 記法エラー無し）で代替検証とした。記法起因の起動失敗が解消された
+> ことは config レベルで確認済み。
+
+## 受入基準とテスト/検証の対応
+
+| Req ID | 内容 | 担保方法 |
+|---|---|---|
+| 1.1 | healthcheck.test 先頭が CMD/CMD-SHELL/NONE | `config` 解決結果で `test: [CMD, ...]` を確認 |
+| 1.2 | コンテナ内で `/feedman healthcheck` 実行を保持 | `config` 解決結果で `[CMD, /feedman, healthcheck]` を確認 |
+| 1.3 | `config` が記法エラーなく正常終了 | `RC=0`・該当エラー無しを確認 |
+| 1.4 | `up` で記法起因エラーなく起動 | `config` rc=0 で代替検証（上記注記参照） |
+| 2.1 | interval = 10s | `config` 解決結果で確認 |
+| 2.2 | timeout = 5s | `config` 解決結果で確認 |
+| 2.3 | retries = 3 | `config` 解決結果で確認 |
+| 3.1 | 全リスト形式 healthcheck が CMD/CMD-SHELL/NONE 前置 | grep + `config` 解決結果（api / db のみ）で確認 |
+| 3.2 | db の healthcheck 定義を変更しない | 差分が api の 1 行のみであることと db 解決結果が従来どおりであることを確認 |
+| NFR 1 | サービス構成・ネットワーク・depends_on を同一に保つ | 差分が healthcheck.test 1 行のみで他要素に変更なし |
+
+## 確認事項
+
+- なし（修正は api healthcheck.test の 1 行のみで、requirements.md の Out of Scope と整合している）
+
+## 残課題 / 派生タスク
+
+- なし
+
+STATUS: complete

--- a/docs/specs/96-docker-compose-yml-api-healthcheck-compo/requirements.md
+++ b/docs/specs/96-docker-compose-yml-api-healthcheck-compo/requirements.md
@@ -1,0 +1,55 @@
+# Requirements Document
+
+## Introduction
+
+`docker-compose.yml` の `api` サービスの healthcheck がリスト形式 `test: ["/feedman", "healthcheck"]` で記述されており、Compose 仕様に違反している。Compose 仕様ではリスト形式の `healthcheck.test` は先頭要素が `CMD` / `CMD-SHELL` / `NONE` のいずれかでなければならず、現状のままでは `docker compose config` / `docker compose up` が `healthcheck.test must start either by "CMD", "CMD-SHELL" or "NONE"` エラーで失敗し、スタックを起動できない。本要件は当該違反を解消し、Compose によるスタック起動を回復させることを目的とする。なお `db` サービスの healthcheck は既に Compose 仕様準拠（`["CMD-SHELL", ...]`）であり修正対象外である。
+
+## Requirements
+
+### Requirement 1: api サービス healthcheck の Compose 仕様準拠化
+
+**Objective:** As a 運用者, I want api サービスの healthcheck 定義を Compose 仕様準拠の形式にしたい, so that スタックを `docker compose` で正常に起動できる
+
+#### Acceptance Criteria
+
+1. The api サービスの healthcheck.test shall リスト形式の先頭要素が `CMD` / `CMD-SHELL` / `NONE` のいずれかである Compose 仕様準拠の形式である
+2. The api サービスの healthcheck shall コンテナ内で `/feedman healthcheck` を実行する内容を保持する
+3. When healthcheck 定義を修正した状態で `docker compose -f docker-compose.yml config` を実行したとき, the docker compose shall `healthcheck.test must start either by "CMD", "CMD-SHELL" or "NONE"` エラーを出さずに正常終了する
+4. When healthcheck 定義を修正した状態で `docker compose up` を実行したとき, the docker compose shall healthcheck 記法に起因するエラーなしでスタックを起動する
+
+### Requirement 2: 既存 healthcheck パラメータの維持
+
+**Objective:** As a 運用者, I want healthcheck の検査周期・タイムアウト・リトライ回数を従来どおり維持したい, so that ヘルスチェックの挙動が本修正前と等価に保たれる
+
+#### Acceptance Criteria
+
+1. The api サービスの healthcheck shall interval を `10s` に維持する
+2. The api サービスの healthcheck shall timeout を `5s` に維持する
+3. The api サービスの healthcheck shall retries を `3` に維持する
+
+### Requirement 3: 同種違反の不在確認
+
+**Objective:** As a 運用者, I want docker-compose.yml 全体で CMD 前置のないリスト形式 healthcheck が残っていないことを確認したい, so that 同種の Compose 仕様違反による起動失敗が再発しないことを保証できる
+
+#### Acceptance Criteria
+
+1. The docker-compose.yml shall リスト形式 `healthcheck.test` を持つすべてのサービスについて先頭要素が `CMD` / `CMD-SHELL` / `NONE` のいずれかである
+2. While db サービスの healthcheck が既に Compose 仕様準拠である状態で, the 修正作業 shall db サービスの healthcheck 定義を変更しない
+
+## Non-Functional Requirements
+
+### NFR 1: 互換性
+
+1. The 修正後の docker-compose.yml shall api / web / worker / db の 4 サービス構成・ネットワーク設計・依存関係（depends_on）を本修正前と同一に保つ
+
+## Out of Scope
+
+- `db` / `web` / `worker` サービスの healthcheck・設定変更（`db` は既に仕様準拠、`web` / `worker` は healthcheck 未定義）
+- healthcheck の検査内容（`/feedman healthcheck` サブコマンドそのもの）の挙動変更
+- interval / timeout / retries の値そのものの見直し（現行値を維持する）
+- override ファイル（未 commit）や他環境向け compose ファイルの追加・修正
+- `/feedman healthcheck` サブコマンドの実装変更
+
+## Open Questions
+
+- なし

--- a/docs/specs/96-docker-compose-yml-api-healthcheck-compo/review-notes.md
+++ b/docs/specs/96-docker-compose-yml-api-healthcheck-compo/review-notes.md
@@ -1,0 +1,40 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-96-impl-docker-compose-yml-api-healthcheck-compo
+- HEAD commit: ed7115a31fd46710f140c2606684ca7f31b24b84
+- Compared to: develop..HEAD
+
+本 Issue は design モードを経由しない design-less impl（`tasks.md` / `design.md` 不在）。
+`_Boundary:_` アノテーションが存在しないため boundary 逸脱判定は対象外（N/A）。
+Feature Flag Protocol は `opt-out` のため flag 観点の確認は行わない。
+変更は docker-compose YAML（インフラ設定）であり Go / TS アプリコードではないため、
+単体テスト層は適用されない。検証は `docker compose config` による記法妥当性確認で担保される。
+
+## Verified Requirements
+
+- 1.1 — docker-compose.yml:77 `test: ["CMD", "/feedman", "healthcheck"]`（先頭要素が `CMD`）。impl-notes.md の `config` 解決結果 `test: [CMD, /feedman, healthcheck]` で裏取り
+- 1.2 — docker-compose.yml:77 でコンテナ内 `/feedman healthcheck` 実行を保持
+- 1.3 — impl-notes.md「検証結果」: `docker compose -f docker-compose.yml config` を RC=0 で実行、`healthcheck.test must start...` エラー無しを確認
+- 1.4 — config レベル（rc=0 / 記法エラー無し）で代替検証。`up` の実行時前提（イメージビルド / OAuth クレデンシャル）が本環境で完結しない旨を impl-notes.md に明記。記法起因の起動失敗解消は config で担保
+- 2.1 — docker-compose.yml:78 `interval: 10s`（未変更、差分外）
+- 2.2 — docker-compose.yml:79 `timeout: 5s`（未変更、差分外）
+- 2.3 — docker-compose.yml:80 `retries: 3`（未変更、差分外）
+- 3.1 — リスト形式 `test: [` を持つサービスは api（CMD）/ db（CMD-SHELL）の 2 件のみ。grep で先頭要素が共に CMD/CMD-SHELL であることを確認。CMD 前置のないリスト形式 healthcheck は残存しない
+- 3.2 — db healthcheck（docker-compose.yml:149 `["CMD-SHELL", "pg_isready ..."]`）は差分に含まれず未変更
+- NFR 1 — `git diff develop..HEAD -- docker-compose.yml` は healthcheck.test の 1 行のみ。api / web / worker / db のサービス構成・ネットワーク・depends_on に変更なし
+
+## Findings
+
+なし
+
+## Summary
+
+api healthcheck.test に `CMD` を前置する 1 行修正で、全 numeric AC（1.x / 2.x / 3.x / NFR 1）が
+実装または config 検証で担保されている。db healthcheck・サービス構成は未変更で Out of Scope と整合。
+インフラ設定変更のため単体テスト層は適用されず、`docker compose config` 検証が AC 1.3/1.4 を担保する。
+
+RESULT: approve


### PR DESCRIPTION
## 概要

`docker-compose.yml` の `api` サービスの healthcheck がリスト形式 `test: ["/feedman", "healthcheck"]` で記述されており、Compose 仕様（リスト形式 `healthcheck.test` の先頭要素は `CMD` / `CMD-SHELL` / `NONE` のいずれか）に違反していた。この違反により `docker compose config` / `docker compose up` が `healthcheck.test must start either by "CMD", "CMD-SHELL" or "NONE"` エラーで失敗し、スタックを起動できない状態だった。

本 PR は `api` サービスの healthcheck.test に `CMD` を前置する 1 行修正で当該 Compose 仕様違反を解消し、スタック起動を回復させる。`interval` / `timeout` / `retries` の値・サービス構成・ネットワーク設計・`depends_on` は変更しない。

## 対応 Issue

Closes #96

## 関連 PR

- 設計 PR: なし（design-less impl）

## 実装内容

- (Req 1.1 / Req 1.2 / Req 1.3) `docker-compose.yml` の api サービス healthcheck.test を `["/feedman", "healthcheck"]` から `["CMD", "/feedman", "healthcheck"]` に修正し、Compose 仕様準拠の形式にした
- (Req 2.1 / 2.2 / 2.3) `interval: 10s` / `timeout: 5s` / `retries: 3` は変更なし
- (Req 3.1 / 3.2) `db` サービスの healthcheck（既に `CMD-SHELL` 前置で Compose 仕様準拠）は変更なし。リスト形式 `test:` を持つ全サービス（api / db）で先頭要素が CMD/CMD-SHELL であることを確認
- (NFR 1) api / web / worker / db のサービス構成・ネットワーク・`depends_on` は変更なし

## 受入基準チェック

- [x] Req 1.1: healthcheck.test の先頭要素が `CMD` / `CMD-SHELL` / `NONE` のいずれかである ← `docker compose config` の解決結果 `test: [CMD, /feedman, healthcheck]` で確認
- [x] Req 1.2: コンテナ内で `/feedman healthcheck` を実行する内容を保持する ← 同上 `[CMD, /feedman, healthcheck]`
- [x] Req 1.3: `docker compose -f docker-compose.yml config` が記法エラーなく正常終了する ← RC=0 / `healthcheck.test must start...` エラー無しを確認
- [x] Req 1.4: `docker compose up` で記法起因エラーなく起動する ← `config` RC=0 で代替検証（イメージビルド・OAuth クレデンシャル等の実行時前提が検証環境で完結しないため）
- [x] Req 2.1 / 2.2 / 2.3: interval=10s / timeout=5s / retries=3 を維持 ← 差分に含まれず未変更
- [x] Req 3.1: リスト形式 healthcheck を持つ全サービスで先頭が CMD/CMD-SHELL/NONE ← api（CMD）/ db（CMD-SHELL）の 2 件のみ、grep と `config` 解決結果で確認
- [x] Req 3.2: db サービスの healthcheck 定義を変更しない ← 差分は api の 1 行のみ
- [x] NFR 1: サービス構成・ネットワーク・`depends_on` を同一に保つ ← `git diff develop..HEAD -- docker-compose.yml` は healthcheck.test の 1 行のみ

## テスト結果

```
変更対象は docker-compose YAML（インフラ設定）であり Go / TypeScript アプリコードではないため、
単体テスト層は適用されない。

検証コマンド（impl-notes.md より）:
  SESSION_SECRET=dummy POSTGRES_PASSWORD=dummy docker compose -f docker-compose.yml config
  → RC=0 / healthcheck.test must start... エラー無し / stderr は OAuth 環境変数未設定 warning のみ

config 解決結果（healthcheck 抜粋）:
  api: test: [CMD, /feedman, healthcheck] / interval: 10s / timeout: 5s / retries: 3
  db:  test: [CMD-SHELL, pg_isready -U feedman] / interval: 5s / timeout: 5s / retries: 5（未変更）
```

## 実装上の判断

- Req 1.4（`docker compose up`）の検証はイメージビルド・外部依存・OAuth クレデンシャル等の実行時前提が必要で本環境では完結しないため、`docker compose config`（RC=0 / 記法エラー無し）で代替検証とした。記法起因の起動失敗が解消されたことは config レベルで確認済み
- `db` サービスは既に `CMD-SHELL` 前置で Compose 仕様準拠のため変更対象外とした（requirements.md Out of Scope と整合）

## 確認事項 / レビュワーへの依頼

- Reviewer（Reviewer Round 1）による独立レビューで全 AC が担保されていることが確認済み（RESULT: approve）。詳細は `docs/specs/96-docker-compose-yml-api-healthcheck-compo/review-notes.md` を参照
- base: develop / baseRefName: develop / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #96 のコメントを参照してください。
