### PR TITLE
feat(#97): web standalone server に HOSTNAME=0.0.0.0 を組み込み公開ポート到達性を確保

### DIFF
--- a/docs/specs/97-web-next-js-standalone-hostname/impl-notes.md
+++ b/docs/specs/97-web-next-js-standalone-hostname/impl-notes.md
@@ -1,0 +1,101 @@
+# 実装ノート: Issue #97 web（Next.js standalone）の全 interface bind
+
+## 変更概要
+
+Next.js standalone server（`.next/standalone/server.js`）は起動時に `process.env.HOSTNAME`
+が指すアドレスへ bind する。Docker は既定でコンテナ ID を `HOSTNAME` に自動設定するため、
+`internal` / `external` の 2 ネットワークに所属し複数 IP を持つ web コンテナは、コンテナ ID
+が解決する IP に bind し、公開ポート（NAT 先 IP）と bind 先が食い違って接続拒否になっていた。
+
+本変更では requirements.md の **Requirement 2.1（image 自己完結性）** を採用し、
+`web/Dockerfile` の runner ステージに以下の `ENV` を追加した。
+
+- `ENV HOSTNAME=0.0.0.0` — Docker 既定のコンテナ ID 由来 `HOSTNAME` を image 側で上書きし、
+  全 interface（全 IP）へ bind させる。外部 environment 無しでも到達可能（Req 2.1）。
+- `ENV PORT=3000` — 待ち受けポートを image に明示する（`EXPOSE 3000` と整合）。
+
+配置は runner ステージ既存の `ENV NODE_ENV=production` 直後にまとめた。
+
+### Docker env 優先順位による上書き可能性（Req 2.2 / 2.3）
+
+Dockerfile の `ENV` は、`docker-compose.yml` の `environment` / `docker run -e` で同名の
+環境変数が与えられた場合にそれらが優先される（Docker の env 解決順）。したがって:
+
+- `HOSTNAME` を外部から指定すれば bind アドレスを上書きできる（Req 2.2）。
+- `PORT` を外部から指定すれば待ち受けポートを変更できる（Req 2.3）。
+
+### compose 側の扱い（Out of Scope と整合）
+
+`docker-compose.yml` の web サービスには bind アドレス／ポートの environment を追加していない。
+Issue 方針および requirements.md「image の自己完結性」を正とし、設定箇所を Dockerfile に一本化した。
+これは Out of Scope の「web の待ち受けポート番号そのものの既定値変更（既定 `3000` を維持）」とも整合する
+（`PORT=3000` は既定値の明示であり既定値の変更ではない）。
+
+`web` 以外（api / worker / db）のコンテナ構成・起動挙動は一切変更していない（NFR 1.2 / Out of Scope）。
+
+## テスト方針
+
+本変更は Dockerfile の `ENV` 追加であり、`docker build` + `run` + `curl 200` のフル E2E は
+CI / unit テスト環境では実行できない。代わりに **回帰を機械的にロックする近傍テスト**を追加した。
+
+- 追加テスト: `web/dockerfile-hostname.test.ts`（Vitest / BDD スタイル）
+- `web/Dockerfile` を読み込み、**最後の `FROM ... AS runner` 行以降（= runner ステージ本体）**を
+  切り出して、以下を assert する:
+  - runner ステージに `ENV HOSTNAME=0.0.0.0` が存在すること（Req 2.1 = 全 interface bind の image 組み込み）
+  - runner ステージに `ENV PORT=3000` が存在すること（Req 2.3 の待ち受けポート明示）
+  - ビルドステージ（deps / builder）には `ENV HOSTNAME` / `ENV PORT` を設定しないこと
+    （runner ステージ限定の上書きであることを保証し、誤検出を防ぐ）
+- Red → Green: ENV 未追加の状態で 2 件の assertion が失敗することを確認してから Dockerfile を修正して通した。
+
+### 受入基準とテストの対応
+
+| Requirement ID | 担保方法 |
+|---|---|
+| 1.1（全 interface 待ち受け） | `dockerfile-hostname.test.ts`「runner ステージに ENV HOSTNAME=0.0.0.0」で image 設定を回帰ガード。実 bind は手動 / staging 検証で担保 |
+| 1.2（起動ログに `http://0.0.0.0:3000`） | 手動 / staging 検証で担保（unit 検証不能。Next.js standalone server が出力） |
+| 1.3（公開ポート経由 `/` で HTTP 200） | 手動 / staging 検証で担保（unit 検証不能） |
+| 1.4（応答 HTML に `<title>Feedman - RSS リーダー</title>`） | 手動 / staging 検証で担保（unit 検証不能） |
+| 1.5（ホスト側ポート変更後も到達可能） | 手動 / staging 検証で担保（compose `${WEB_PORT}` マッピングは既存。本変更非対象） |
+| 2.1（外部 env 無しでも全 interface bind = image 自己完結） | `dockerfile-hostname.test.ts`「ENV HOSTNAME=0.0.0.0」で回帰ガード |
+| 2.2（外部 env 指定時は優先） | Docker の env 優先順位で担保（仕様）。手動 / staging で `HOSTNAME` 上書き確認 |
+| 2.3（待ち受けポート変更可能） | `dockerfile-hostname.test.ts`「ENV PORT=3000」で既定明示を回帰ガード。上書きは Docker env 優先順位（仕様） |
+| 3.1（`API_INTERNAL_URL` 未設定で fail-fast） | 既存 `web/src/lib/rewrites.test.ts` の `resolveApiInternalUrl` テスト群（未設定 / 空 / 空白で throw）で担保。本変更は entrypoint の fail-fast を変更しないため既存挙動を保持 |
+| 3.2（有効時は起動継続し全 interface bind） | 手動 / staging 検証で担保（unit 検証不能）+ ENV HOSTNAME 回帰ガード |
+| 3.3（公開ポート未マッピング網からの到達可否を従来どおり維持） | compose のネットワーク分離（`internal` / `external`）を非変更とすることで担保（Out of Scope） |
+| NFR 1.1（変更前後で `/` の 200 応答・HTML 同一） | 手動 / staging 検証で担保。bind 範囲拡大のみで応答内容は不変 |
+| NFR 1.2（api / worker / db を変更しない） | `web/Dockerfile` のみ変更。他コンポーネント未変更で担保 |
+| NFR 2.1（待ち受けアドレスを起動ログに出力） | 手動 / staging 検証で担保（Next.js standalone server が Network 行を出力） |
+
+## 手動 / staging 検証で担保する AC
+
+`docker build` + `curl` を要する以下の AC は unit 環境で検証不能なため、手動 / staging 検証で担保する:
+
+- Req 1.2 / 1.3 / 1.4 / 1.5、Req 2.2、Req 3.2、NFR 1.1、NFR 2.1
+- Issue にて staging で `HOSTNAME=0.0.0.0` 付与 → 公開ポート経由 `/` で 200 を確認済みである旨が示されている。
+  本実装はその設定を image 側 `ENV` に恒久化したものである。
+
+## 確認事項（レビュワー判断ポイント）
+
+- **設定箇所の一本化**: requirements.md Open Questions は最終的な設定箇所（Dockerfile / compose の
+  双方か片方か）を design.md の領分としているが、本 Issue は design なし impl のため、Issue 方針
+  「image の自己完結性のため Dockerfile への追加が望ましい」に従い **Dockerfile に一本化**した。
+  compose 側に environment を重複追加していない。この判断で問題ないか確認されたい。
+- **`ENV PORT=3000` の追加是非**: Issue 方針で `EXPOSE 3000` と整合する待ち受けポート明示として
+  追加した。Out of Scope の「既定ポート番号の変更」には当たらない（既定値の明示であり変更ではない）が、
+  スコープ判断の確認をお願いしたい。
+- **テスト方式**: 本変更は Dockerfile の宣言的設定であり、フル E2E は CI で実行できないため、
+  Dockerfile を文字列解析する回帰ガードテストで担保している。実 bind 挙動は手動 / staging 検証に依存する。
+
+## 補足（実行環境メモ）
+
+- 当 worktree のローカル node は v22.11.0 で、vite 7 / vitest 4 の ESM ローダ要件
+  （Node 22.12+）をわずかに下回るため、`npm test` / `npm run lint` を
+  `NODE_OPTIONS=--experimental-require-module` 付きで実行した（テスト結果には影響しない）。
+  CI 環境では Node バージョンが要件を満たす想定。
+
+## 検証結果
+
+- `npm test`（= `vitest run`）: 26 ファイル / 187 テスト すべて green（新規 `dockerfile-hostname.test.ts` の 4 件を含む）
+- `npm run lint`（ESLint）: 0 errors（warning 6 件はすべて本変更非対象の既存ファイル。新規テストファイルは warning なし）
+
+STATUS: complete

--- a/docs/specs/97-web-next-js-standalone-hostname/requirements.md
+++ b/docs/specs/97-web-next-js-standalone-hostname/requirements.md
@@ -1,0 +1,91 @@
+# Requirements Document
+
+## Introduction
+
+web コンポーネント（Next.js standalone server）は、起動時に `process.env.HOSTNAME` が指す
+アドレスへ bind する。Docker は既定でコンテナ ID を `HOSTNAME` に自動設定するため、現状の
+web コンテナはコンテナ ID が解決する IP に bind し、公開ポート（NAT 先 IP）と bind 先が
+食い違って接続拒否となる。web サービスは `internal` / `external` の 2 ネットワークに所属し
+複数 IP を持つため、この食い違いが顕在化している。本要件は、web イメージが全 interface に
+bind し、公開ポート経由でブラウザ／HTTP から到達できる状態を、image 自己完結的に担保する
+ことを目的とする。
+
+## Requirements
+
+### Requirement 1: 全 interface への bind による公開ポート到達性
+
+**Objective:** As a Feedman を構築・運用する運用者, I want web コンテナが公開ポート経由で
+HTTP 到達可能であること, so that ブラウザから Feedman の UI にアクセスできる
+
+#### Acceptance Criteria
+
+1. When web コンテナがデフォルト構成で起動されたとき, the Web Container shall すべての
+   ネットワーク interface（全 IP）からの受付が可能な状態で待ち受ける
+2. When web コンテナが起動を完了したとき, the Web Container shall 起動ログの Network 行に
+   全 interface への待ち受けを示すアドレス（`http://0.0.0.0:3000`）を出力する
+3. When 公開ポート経由で web コンテナのルートパス（`/`）に HTTP GET を送信したとき, the
+   Web Container shall HTTP ステータス `200` を返す
+4. When 公開ポート経由で web コンテナのルートパス（`/`）に HTTP GET を送信したとき, the
+   Web Container shall 応答 HTML に `<title>Feedman - RSS リーダー</title>` を含める
+5. The Web Container shall 公開ポートのホスト側ポート番号が既定値（`3000`）から変更された
+   場合でも、変更後のホスト側ポート経由で到達可能である
+
+### Requirement 2: image 自己完結性と上書き可能性
+
+**Objective:** As a Feedman を構築・運用する運用者, I want bind アドレスの設定が image 内に
+組み込まれていること, so that 追加の environment 指定なしでもコンテナが到達可能になる
+
+#### Acceptance Criteria
+
+1. When web イメージから生成したコンテナを、外部から bind アドレスを指示する environment を
+   一切付与せず起動したとき, the Web Container shall 全 interface へ bind した状態になる
+2. Where 外部からコンテナ起動時に bind アドレスを指示する environment が付与されているとき,
+   the Web Container shall 外部から指定された bind アドレスを優先して適用する
+3. The Web Container shall 待ち受けポートが既定値から変更可能であり、変更後のポートで
+   待ち受ける
+
+### Requirement 3: 異常系・既存挙動の保持
+
+**Objective:** As a Feedman を構築・運用する運用者, I want 本変更が既存の起動時検証や
+セキュリティ前提を壊さないこと, so that 誤設定の検出やネットワーク分離が従来どおり機能する
+
+#### Acceptance Criteria
+
+1. If web コンテナ起動時に内部 API 接続先設定（`API_INTERNAL_URL`）が未設定または空である
+   とき, the Web Container shall bind アドレス設定の有無に関わらず非ゼロ終了で fail-fast する
+2. While 内部 API 接続先設定が有効であるとき, the Web Container shall 起動を継続し全
+   interface へ bind したうえで待ち受ける
+3. If 公開ポートにマッピングされていないネットワーク（外部から到達不可な内部ネットワーク）
+   からのみアクセスされたとき, the Web Container shall 当該経路の到達可否を従来の
+   ネットワーク分離方針どおりに維持する
+
+## Non-Functional Requirements
+
+### NFR 1: 互換性
+
+1. The Web Container shall 本変更の前後で、公開ポート経由のルートパス `/` への HTTP GET に
+   対して同一の HTTP ステータス（`200`）応答内容（`<title>Feedman - RSS リーダー</title>`
+   を含む HTML）を返し、UI の表示挙動を変えない
+2. The Web Container shall web 以外のコンポーネント（api / worker / db）の起動・通信挙動を
+   変更しない
+
+### NFR 2: 可観測性
+
+1. When web コンテナが起動を完了したとき, the Web Container shall 待ち受けアドレスを起動
+   ログに出力し、運用者が bind 先を 1 行のログで確認できるようにする
+
+## Out of Scope
+
+- api / worker / db コンテナの bind 設定や起動挙動の変更
+- web の待ち受けポート番号そのものの既定値変更（既定 `3000` を維持する）
+- リバースプロキシ・TLS 終端・ロードバランサ等、コンテナ外のネットワーク構成の導入
+- ネットワーク設計（`internal` / `external` の 2 ネットワーク所属）の見直し
+- Next.js のアップグレードや standalone 出力方式そのものの変更
+
+## Open Questions
+
+- 恒久対応として bind アドレス設定を image 側（Dockerfile の `ENV`）に組み込むか、compose 側
+  の environment で与えるかは、Issue 本文で「image の自己完結性のため Dockerfile への追加が
+  望ましい（compose 側 environment でも可）」と方針が示されている。本要件は image 自己完結性
+  を Requirement 2.1 として採用するが、最終的な設定箇所（Dockerfile / compose の双方に置くか
+  片方のみか）の確定は design.md の領分とする。

--- a/docs/specs/97-web-next-js-standalone-hostname/review-notes.md
+++ b/docs/specs/97-web-next-js-standalone-hostname/review-notes.md
@@ -1,0 +1,61 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-97-impl-web-next-js-standalone-hostname
+- HEAD commit: 7a2e4fd4e697270bf5c4c393d5be5617308bd4f5
+- Compared to: develop..HEAD
+
+差分は `web/Dockerfile`（runner ステージへの `ENV HOSTNAME=0.0.0.0` / `ENV PORT=3000` 追加）と
+新規 `web/dockerfile-hostname.test.ts`（回帰ガード）、および spec ドキュメント
+（`requirements.md` / `impl-notes.md`）のみ。design なし impl のため `tasks.md` は不在で
+`_Boundary:_` アノテーションは存在しない。Feature Flag Protocol は CLAUDE.md にて `opt-out`
+宣言のため flag 観点は適用しない（通常の 3 カテゴリ判定のみ）。
+
+## Verified Requirements
+
+- 1.1 — `web/Dockerfile:38` `ENV HOSTNAME=0.0.0.0` で全 interface bind を image に組み込み。
+  `dockerfile-hostname.test.ts`「runner ステージに ENV HOSTNAME=0.0.0.0」で回帰ガード
+- 1.2 — 起動ログ Network 行 `http://0.0.0.0:3000` は HOSTNAME bind の結果 Next.js standalone
+  server が出力する。unit 検証不能、impl-notes.md で手動 / staging 検証へ紐付け済み
+- 1.3 — 公開ポート経由 `/` で HTTP 200。HOSTNAME=0.0.0.0 bind により到達可能。unit 検証不能、
+  impl-notes.md で手動 / staging 検証へ紐付け済み（Issue 本文でも staging 確認済みと明記）
+- 1.4 — 応答 HTML の `<title>Feedman - RSS リーダー</title>`。bind 範囲拡大のみで応答内容不変。
+  unit 検証不能、impl-notes.md で手動 / staging 検証へ紐付け済み
+- 1.5 — ホスト側ポート変更後の到達性は既存 compose `${WEB_PORT}` マッピングで担保（本変更非対象）。
+  impl-notes.md で紐付け済み
+- 2.1 — 外部 env 無しでも全 interface bind（image 自己完結）。`ENV HOSTNAME=0.0.0.0` +
+  `dockerfile-hostname.test.ts` で回帰ガード
+- 2.2 — 外部 env 指定時の優先は Docker の env 解決順（`docker-compose.yml` の environment /
+  `docker run -e` が `ENV` を上書き）で担保。impl-notes.md に明記
+- 2.3 — `web/Dockerfile:40` `ENV PORT=3000` で待ち受けポート明示。
+  `dockerfile-hostname.test.ts`「runner ステージに ENV PORT=3000」で回帰ガード。上書きは env 優先順
+- 3.1 — `API_INTERNAL_URL` 未設定 / 空 / 空白での fail-fast は既存
+  `web/src/lib/rewrites.test.ts` の `resolveApiInternalUrl` テスト群（rewrites.test.ts:75/83/91、
+  いずれも throw を assert）で担保。本変更は entrypoint の fail-fast を変更しないため既存挙動保持
+- 3.2 — 有効時は起動継続し全 interface bind。HOSTNAME bind + entrypoint 通過で担保。unit 検証
+  不能分は手動 / staging 検証へ紐付け済み
+- 3.3 — 公開ポート未マッピング網からの到達可否はネットワーク分離（`internal` / `external`）を
+  非変更とすることで従来どおり維持。`web/Dockerfile` のみ変更で担保（Out of Scope）
+- NFR 1.1 — 変更前後で `/` の 200 応答・HTML 同一。bind 範囲拡大のみで応答内容不変。手動 /
+  staging 検証へ紐付け済み
+- NFR 1.2 — api / worker / db の起動・通信挙動を変更しない。`web/Dockerfile` のみ変更で担保
+- NFR 2.1 — 待ち受けアドレスを起動ログに出力。Next.js standalone server の Network 行出力で担保。
+  unit 検証不能、手動 / staging 検証へ紐付け済み
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric ID（Req 1.1〜1.5 / 2.1〜2.3 / 3.1〜3.3 / NFR 1.1〜2.1）に対し、観測可能な image 設定
+（`ENV HOSTNAME=0.0.0.0` / `ENV PORT=3000`）と回帰テスト、もしくは既存テスト・手動 staging 検証への
+明示的な紐付けが impl-notes.md に揃っている。新規 image 設定には `dockerfile-hostname.test.ts` の
+回帰テストが追加され、Req 3.1 の fail-fast は既存 `rewrites.test.ts` でカバー済み（紐付け明記）。
+変更は `web/Dockerfile` と近傍テストのみで Out of Scope への侵食はなく、Feature Flag Protocol は
+opt-out のため flag 観点は適用外。AC 未カバー / missing test / boundary 逸脱のいずれも検出されない。
+
+RESULT: approve

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -30,6 +30,15 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
+# Next.js standalone server（server.js）は process.env.HOSTNAME へ bind する。
+# Docker は既定でコンテナ ID を HOSTNAME に設定するため、image 側で 0.0.0.0 に
+# 上書きして全 interface へ bind させる（外部 environment 無しでも公開ポート経由で
+# 到達可能にする image 自己完結性）。compose / docker run -e の HOSTNAME 指定が
+# あれば Docker の env 優先順位でこの ENV を上書きできる。
+ENV HOSTNAME=0.0.0.0
+# 待ち受けポートを明示する（EXPOSE 3000 と整合）。environment で上書き可能。
+ENV PORT=3000
+
 # Next.js のスタンドアロン出力を利用（node ユーザーで所有）
 COPY --from=builder --chown=node:node /app/.next/standalone ./
 COPY --from=builder --chown=node:node /app/.next/static ./.next/static

--- a/web/dockerfile-hostname.test.ts
+++ b/web/dockerfile-hostname.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * web/Dockerfile の runner ステージに、Next.js standalone server を全 interface へ
+ * bind させるための `ENV HOSTNAME=0.0.0.0` と待ち受けポートを明示する
+ * `ENV PORT=3000` が組み込まれていることを検証する回帰ガード。
+ *
+ * Next.js standalone server（.next/standalone/server.js）は `process.env.HOSTNAME` の
+ * 値に bind するため、Docker が既定でコンテナ ID を設定する `HOSTNAME` を image 側で
+ * `0.0.0.0` に上書きする必要がある（Issue #97 / Req 2.1: image 自己完結性）。
+ *
+ * docker build + curl のフル E2E は unit 環境で実行できないため、本テストは
+ * Dockerfile の runner ステージに当該 ENV が存在することを機械的にロックする。
+ */
+
+// vitest は cwd = web/ で実行されるため、Dockerfile は web/ 直下に存在する。
+const dockerfilePath = path.resolve(process.cwd(), "Dockerfile");
+
+/**
+ * Dockerfile から最後の `FROM ... AS runner` 行以降（= runner ステージ本体）を
+ * 切り出して返す。ビルドステージ等の誤検出を避けるため、runner ステージのみを対象にする。
+ */
+function extractRunnerStage(dockerfile: string): string {
+  const lines = dockerfile.split("\n");
+  const runnerStartIndex = lines.findLastIndex((line) =>
+    /^\s*FROM\s+.+\s+AS\s+runner\s*$/i.test(line),
+  );
+
+  if (runnerStartIndex === -1) {
+    throw new Error("runner ステージ（FROM ... AS runner）が Dockerfile に見つからない");
+  }
+
+  return lines.slice(runnerStartIndex).join("\n");
+}
+
+describe("web/Dockerfile runner ステージ", () => {
+  const dockerfile = readFileSync(dockerfilePath, "utf-8");
+  const runnerStage = extractRunnerStage(dockerfile);
+
+  it("runner ステージ（FROM ... AS runner）が存在するとき切り出せること", () => {
+    // Arrange / Act は describe スコープで実施済み
+
+    // Assert
+    expect(runnerStage).toMatch(/^\s*FROM\s+.+\s+AS\s+runner/i);
+  });
+
+  it("runner ステージに ENV HOSTNAME=0.0.0.0 が設定されているとき全 interface bind を image 自己完結で担保できること", () => {
+    // Arrange / Act は describe スコープで実施済み
+
+    // Assert
+    expect(runnerStage).toMatch(/^\s*ENV\s+HOSTNAME=0\.0\.0\.0\s*$/m);
+  });
+
+  it("runner ステージに ENV PORT=3000 が設定されているとき待ち受けポートが image に明示されていること", () => {
+    // Arrange / Act は describe スコープで実施済み
+
+    // Assert
+    expect(runnerStage).toMatch(/^\s*ENV\s+PORT=3000\s*$/m);
+  });
+
+  it("ビルドステージ（deps / builder）には HOSTNAME/PORT を設定しないこと（runner ステージ限定の上書き）", () => {
+    // Arrange
+    const lines = dockerfile.split("\n");
+    const runnerStartIndex = lines.findLastIndex((line) =>
+      /^\s*FROM\s+.+\s+AS\s+runner\s*$/i.test(line),
+    );
+    const beforeRunner = lines.slice(0, runnerStartIndex).join("\n");
+
+    // Act / Assert
+    expect(beforeRunner).not.toMatch(/^\s*ENV\s+HOSTNAME=/m);
+    expect(beforeRunner).not.toMatch(/^\s*ENV\s+PORT=/m);
+  });
+});


### PR DESCRIPTION
## 概要

web コンポーネント（Next.js standalone server）は起動時に `process.env.HOSTNAME` が指すアドレスへ
bind する。Docker は既定でコンテナ ID を `HOSTNAME` に自動設定するため、`internal` / `external`
の 2 ネットワークに所属し複数 IP を持つ web コンテナでは、コンテナ ID が解決する IP に bind し、
公開ポート（NAT 先 IP）と bind 先が食い違って接続拒否となっていた。

本 PR では `web/Dockerfile` の runner ステージに `ENV HOSTNAME=0.0.0.0` を追加し、image の
自己完結性を維持したまま全 interface への bind を恒久化する。`ENV PORT=3000` も同時に追加し、
`EXPOSE 3000` との整合を明示している。いずれも外部からの environment 指定で上書き可能。

## 対応 Issue

Closes #97

## 関連 PR

- 設計 PR: なし（design なし impl）

## 実装内容

- (Req 2.1 / 1.1) `web/Dockerfile` runner ステージに `ENV HOSTNAME=0.0.0.0` を追加し、外部 env 無しでも全 interface への bind を保証
- (Req 2.3) `web/Dockerfile` runner ステージに `ENV PORT=3000` を追加し、待ち受けポートの image 組み込み明示
- (Req 2.2 / 2.3) Docker env 優先順位により、外部からの environment 指定で bind アドレス・ポートを上書き可能
- テスト: `web/dockerfile-hostname.test.ts` を新規追加し、runner ステージへの ENV 設定を回帰ガード

## 受入基準チェック

- [x] Req 1.1: When web コンテナがデフォルト構成で起動されたとき、全 interface からの待ち受けが可能 ← `dockerfile-hostname.test.ts`「runner ステージに ENV HOSTNAME=0.0.0.0」
- [x] Req 2.1: When 外部 env 無しで起動したとき、全 interface bind ← `dockerfile-hostname.test.ts`「ENV HOSTNAME=0.0.0.0」
- [x] Req 2.3: The Web Container shall 待ち受けポートが変更可能 ← `dockerfile-hostname.test.ts`「runner ステージに ENV PORT=3000」
- [x] Req 3.1: If API_INTERNAL_URL 未設定のとき fail-fast ← 既存 `rewrites.test.ts`（resolveApiInternalUrl テスト群）
- [x] NFR 1.2: api / worker / db の起動・通信挙動を変更しない ← `web/Dockerfile` のみ変更
- [x] Req 1.2 / 1.3 / 1.4: 起動ログ・HTTP 200・HTML title ← 手動 / staging 検証で担保（unit 検証不能。Issue 本文で staging 確認済み）

## テスト結果

```
npm test（vitest run）: 26 ファイル / 187 テスト すべて green
  新規 web/dockerfile-hostname.test.ts の 4 件を含む
npm run lint（ESLint）: 0 errors
  warning 6 件はすべて本変更非対象の既存ファイル
```

## 実装上の判断

- **設定箇所の一本化**: Issue 方針「image の自己完結性のため Dockerfile への追加が望ましい」に従い、
  `web/Dockerfile` のみに設定を集約。`docker-compose.yml` への重複 environment 追加は行わない。
- **`ENV PORT=3000` の追加**: `EXPOSE 3000` との整合を明示する目的で追加。Out of Scope の
  「既定ポート番号の変更」には当たらず（既定値の明示）。
- **テスト方式**: Dockerfile の宣言的設定変更のため、フル E2E は CI で実行不能。
  `dockerfile-hostname.test.ts` で Dockerfile の文字列解析による回帰ガードを採用。

## 確認事項 / レビュワーへの依頼

- Reviewer の判定詳細は [`docs/specs/97-web-next-js-standalone-hostname/review-notes.md`](docs/specs/97-web-next-js-standalone-hostname/review-notes.md) を参照（RESULT: approve）
- base ブランチ検証: --base develop 指定 / baseRefName: develop / OK
- **設定箇所の一本化**（Dockerfile のみ / compose 未変更）の判断が問題ないか確認をお願いしたい
- **`ENV PORT=3000` の追加是非**: Out of Scope 境界（既定値変更ではなく明示）の判断確認をお願いしたい
- **テスト方式**: Dockerfile 文字列解析による回帰ガードで実 bind の代替とする方針の妥当性確認をお願いしたい

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #97 のコメントを参照してください。
