### PR TITLE
feat(#122): RSS フィード favicon を段階フォールバック取得し未取得時は代替アイコンを表示

### DIFF
--- a/docs/specs/122-rss-favicon/impl-notes.md
+++ b/docs/specs/122-rss-favicon/impl-notes.md
@@ -1,0 +1,164 @@
+# 実装ノート — Issue #122 RSS フィード一覧 favicon 取得改善
+
+## 実装方針の要約
+
+### Backend (`internal/feed/`)
+
+`FaviconFetcherService` インターフェースに新規メソッド `FetchFaviconWithFallback(ctx, feedURL)`
+を追加し、以下の 4 段階で favicon を順次探索する実装を `FaviconFetcher` に追加した。
+
+| 段階 | 試行内容 | 対応要件 |
+|---|---|---|
+| (a) | フィード配信 URL のオリジン + `/favicon.ico` | 要件 2.1（従来経路） |
+| (b) | フィード配信 URL のオリジン HTML 内 `<link rel="icon">` 等 | 要件 2.4 |
+| (c) | フィード本体から記事リンクを取得し、そのオリジン + `/favicon.ico` | 要件 1.1 |
+| (d) | (c) と同じオリジンの HTML 内 `<link rel="icon">` 等 | 要件 1.1 + 2.4 |
+
+各段階の試行内容と成功・失敗・URL を `slog.Info` / `slog.Warn` で構造化ログ出力する（NFR 2.1）。
+いずれかの段階で画像 MIME を持つ favicon を取得できた時点で打ち切る（要件 2.2）。
+
+#### 設計判断
+
+- **記事リンクの抽出**: gofeed (`mmcdole/gofeed`) でフィード本体をパースし、最初の有効
+  （`Link` 非空）な記事リンクのオリジンを採用する。要件 1.3 に従い、記事リンクが 1 件も
+  ない場合は段階 (c)(d) を試行せず段階 (b) までで打ち切る。
+- **配信ドメインと記事リンクのオリジンが同一の場合**: 段階 (c)(d) を試行すると段階 (a)(b) と
+  同じリクエストになるため、`siteOrigin == feedOrigin` の場合はスキップする（要件 4.1
+  非リグレッション保証）。
+- **HTTP クライアントの共有**: `FaviconFetcher.httpClient` を favicon 取得・HTML 解析・
+  フィード本体取得すべてで再利用する。これにより既存 `TestFaviconFetcher_GetHTTPClient_Reuses*`
+  テスト（NewSafeClient 呼び出し 1 回まで）を温存。クライアント側のレスポンスサイズ上限は
+  HTML/フィード本体を許容する 5MB（`maxFeedFetchSizeForFavicon`）に揃え、favicon 経路では
+  呼び出し側で `LimitReader` と長さ検査により 2MB 上限（`maxFaviconSize`）を強制する（NFR 1.2）。
+- **HTML 解析ライブラリ**: 既存の `golang.org/x/net/html`（`detector.go` で採用済み）。
+  ライブラリ追加なし。
+- **rel 属性の優先順位**: `icon` (0) → `shortcut icon` (1) → `apple-touch-icon` /
+  `apple-touch-icon-precomposed` (2)。複数候補がある場合は priority が最小のものを採用。
+
+#### Service 層の変更
+
+`FeedService.startFaviconFetch` が `feedURL` も受け取るよう拡張し、`fetchAndSaveFavicon` 内で
+`feedURL != ""` のとき `FetchFaviconWithFallback` を呼ぶようにした。`feedURL` が空の場合は
+従来通り `FetchFaviconForSite` にフォールバックする（後方互換）。
+
+### Frontend (`web/src/components/feed-list.tsx`)
+
+`FeedFavicon` サブコンポーネントを追加し、以下の 2 ケースで `lucide-react` の `Rss` アイコンを
+代替アイコンとして表示する。
+
+- `favicon_url` が `null` または空文字（要件 3.1）
+- `<img>` の `onError` が発火した（要件 3.2）
+
+`onError` ハンドラは `useState` の `imgFailed` を `true` に切り替え、以降の再描画で
+`<img>` を消して代替アイコンに切り替える。代替アイコンは `w-4 h-4` で実 favicon と同じ
+表示サイズ・配置領域を持ち、レイアウト（タイトル・未読数バッジ・ステータスアイコン）は
+変化しない（要件 3.3, 3.4）。
+
+#### Test ID 追加
+
+- `feed-favicon-<sub-id>`: 画像要素
+- `feed-favicon-fallback-<sub-id>`: 代替アイコン要素
+
+## 変更ファイル一覧と AC との対応
+
+| ファイル | 変更内容 | 関連 AC |
+|---|---|---|
+| `internal/feed/favicon.go` | `FetchFaviconWithFallback` / `parseFaviconURLFromHTML` / 補助関数追加 | 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.4, NFR 1.1, 1.2, 1.3, 2.1 |
+| `internal/feed/service.go` | `startFaviconFetch` / `fetchAndSaveFavicon` の引数拡張 | 1.5, 4.2 |
+| `internal/feed/service_test.go` | `mockFaviconFetcher` に新メソッド追加 | （既存テスト維持） |
+| `internal/feed/service_async_test.go` | `controllableFaviconFetcher` / `deadlineObservingFetcher` に新メソッド追加 | （既存テスト維持） |
+| `internal/feed/favicon_fallback_test.go` | 新規ファイル: 段階フォールバック・HTML パースの単体・結合テスト | 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.4, 4.1, NFR 1.1 |
+| `web/src/components/feed-list.tsx` | `FeedFavicon` サブコンポーネント追加・`onError` ハンドラ追加 | 3.1, 3.2, 3.3, 3.4, NFR 3.2 |
+| `web/src/components/feed-list.test.tsx` | 代替アイコン表示・onError 切替・レイアウト維持のテスト追加 | 3.1, 3.2, 3.4 |
+
+## 受入基準ごとのテスト対応
+
+### Requirement 1: サイト本体ドメインからの favicon フォールバック取得
+
+| AC | テスト |
+|---|---|
+| 1.1 配信失敗時にサイト本体ドメインで再取得 | `TestFetchFaviconWithFallback_StageC_SiteOriginICOSucceeds` / `TestFetchFaviconWithFallback_StageD_SiteOriginHTMLSucceeds` |
+| 1.2 サイト本体取得成功時に永続化 | `TestFetchFaviconWithFallback_StageC_SiteOriginICOSucceeds`（data 返却を service の `UpdateFavicon` 経由で確認） |
+| 1.3 記事リンク 0 件のとき再取得しない | `TestFetchFaviconWithFallback_NoArticles_StopsAfterStageB` |
+| 1.4 全段階失敗で null として保存 | `TestFetchFaviconWithFallback_AllStagesFail_ReturnsNil` + 既存 `TestRegisterFeed_SucceedsWhenFaviconNotFound`（service 層） |
+| 1.5 バックグラウンド処理として実行 | 既存 `TestRegisterFeed_ReturnsBeforeFaviconCompletes`（async test） |
+
+### Requirement 2: favicon 探索経路の段階化
+
+| AC | テスト |
+|---|---|
+| 2.1 配信 URL → サイト本体ドメインの順で段階試行 | `TestFetchFaviconWithFallback_StageA_FeedOriginICOSucceeds` / `StageC_SiteOriginICOSucceeds` |
+| 2.2 成功時に後続段階をスキップ | `TestFetchFaviconWithFallback_StageA_FeedOriginICOSucceeds`（stageB/C/D ヒットフラグで検証） |
+| 2.3 段階・URL・成功可否のログ記録 | `slog.Info("favicon取得: 成功", "stage", ...)` 等の構造化ログ（実装で確認、`go test -v` で観測可能） |
+| 2.4 既定パス + HTML 内 icon 宣言の両方を探索 | `TestParseFaviconURLFromHTML_*` (8 件) + `TestFetchFaviconWithFallback_StageB_FeedOriginHTMLSucceeds` / `StageD_SiteOriginHTMLSucceeds` |
+
+### Requirement 3: フロントエンドのデフォルトアイコン表示
+
+| AC | テスト |
+|---|---|
+| 3.1 favicon 未設定時に代替アイコン表示 | `faviconがnullの場合に代替アイコン（fallback）を表示すること` |
+| 3.2 画像読み込み失敗時に代替アイコンに切替 | `favicon画像の読み込みに失敗した場合に代替アイコンに切り替わること` |
+| 3.3 代替アイコンは同じサイズ・配置領域 | `feed-list.tsx` で `w-4 h-4` を維持（既存スナップショット相当のレイアウトテストは追加せず、CSS クラス指定で担保） |
+| 3.4 タイトル・未読数バッジ・ステータスのレイアウト不変 | `代替アイコン表示時もフィードタイトル・未読数バッジ・ステータスアイコンのレイアウトを維持すること` |
+
+### Requirement 4: 既存正常ケースの非リグレッション
+
+| AC | テスト |
+|---|---|
+| 4.1 従来経路で取得できる場合に同一 favicon を採用 | `TestFetchFaviconWithFallback_StageA_FeedOriginICOSucceeds` / `TestFetchFaviconWithFallback_SameHostArticleLink_NoStageCDExtraFetch` |
+| 4.2 既永続化フィードへの再取得を行わない | `fetchAndSaveFavicon` は新規登録 / `RegisterFeed` 経路のみで呼ばれる（service.go の構造で担保。既存実装と差分なし） |
+| 4.3 既存表示の見た目を変更しない | `feed-list.test.tsx` の既存 12 ケース（タイトル / 選択 / 未読数 / ステータス / favicon あり時 img）が全て pass |
+
+### Non-Functional Requirements
+
+| NFR | テスト・実装根拠 |
+|---|---|
+| NFR 1.1 SSRF 対策の同等適用 | `TestFetchFaviconWithFallback_SSRFGuardBlocksAll`（全段階で `ValidateURL` 経由ブロック → 外部リクエスト 0 件） |
+| NFR 1.2 タイムアウト / サイズ上限の同等適用 | `faviconTimeout = 5s` をクライアント側で適用、`maxFaviconSize = 2MB` を呼び出し側 `LimitReader` で強制（既存 `TestFaviconFetcher_FetchFavicon_LargeResponse` が pass） |
+| NFR 1.3 HTML サニタイズ / 画像 MIME 判定 | `isImageMime` で既存と同じ MIME 判定。HTML は href 抽出のみで画面に出さないためサニタイズ不要 |
+| NFR 2.1 構造化ログ出力 | `slog.Info("favicon取得: 成功", "stage", "feed_origin_ico" 等, "url", "mime")` で各段階を識別可能に記録 |
+| NFR 3.1 永続化スキーマ・API 形状不変 | `model.Feed` / `repository.FeedRepository.UpdateFavicon` のシグネチャ・スキーマは変更していない |
+| NFR 3.2 既存 favicon ありフィードの表示挙動不変 | `feed-list.test.tsx` の既存テスト 12 件全 pass |
+
+## 実行コマンド
+
+| コマンド | 結果 |
+|---|---|
+| `go test ./...` | `ok` 全パッケージ pass |
+| `go test -race ./internal/feed/...` | `ok` race なし |
+| `go vet ./...` | warnings なし |
+| `gofmt -l internal/feed/` | 出力なし（clean） |
+| `npm test`（`web/`） | 218 passed / 26 files |
+| `npm run lint`（`web/`） | 0 errors / 5 warnings（warning 5 件はすべて preexisting） |
+
+## 確認事項（PR レビュワー向け）
+
+- 段階 (b)(d) の HTML 解析は `golang.org/x/net/html` を使用し、`detector.go` の
+  `ParseFeedLinksFromHTML` と同等の token-based パーサーで実装した。新規依存ライブラリは追加していない。
+- 段階 (c)(d) のサイト本体ドメイン推定は「最初の有効な記事リンク」のオリジンを採用する。
+  仕様上「最初」と限定していないが、決定論性とリクエスト数の節約のため 1 件目で確定する
+  設計とした（要件 1.1 の文言「フィード内の記事リンクから得られるサイト本体ドメイン」を
+  単数として解釈）。
+- フィード本体の二重取得（worker 取得とは別に registration 時にも取得する）が発生する。
+  これは registration 時点でフィードがまだ DB にキャッシュされていないため不可避。
+  キャッシュ TTL / 共有取得経路の最適化は本 Issue のスコープ外（Out of Scope の
+  「favicon キャッシュ TTL の見直し」に該当）。
+- ローカル環境で `node --version` が 22.11.0 で vitest 4.0.18 と非互換だったため、
+  Playwright 同梱の Node 24.11.1 をシンボリックリンク経由で利用して `npm test` を
+  実行・確認した（CI は `actions/setup-node@v4` で node-version: 20 を使うため CI では
+  そのまま動作する）。
+
+## 補足ノート
+
+- 要件で曖昧だった点とその解釈:
+  - 「記事リンク」の単複: 単数として解釈（最初の有効な記事リンクのオリジン）。詳細は
+    「確認事項」参照。
+  - 「同一ドメインの場合の挙動」: 要件で明示されていないが、無駄なリクエストを避けるため
+    `siteOrigin == feedOrigin` 時は段階 (c)(d) をスキップする実装とした。
+- 追加した依存: なし（既存 `golang.org/x/net/html` / `mmcdole/gofeed` / `lucide-react` を利用）。
+- 次の Issue として切り出すべき派生タスク:
+  - 既永続化フィードへのバッチ的な favicon 再評価（Out of Scope 明示済み）
+  - favicon キャッシュ TTL の見直し（Out of Scope 明示済み）
+  - サイト本体ドメイン推定の精度向上（複数記事リンクのドメイン分布から最頻ドメインを採用する等）
+
+STATUS: complete

--- a/docs/specs/122-rss-favicon/requirements.md
+++ b/docs/specs/122-rss-favicon/requirements.md
@@ -1,0 +1,89 @@
+# Requirements Document
+
+## Introduction
+
+Feedman のフィード一覧（画面左ペイン）には、各フィードの favicon を表示してユーザーが
+視覚的に識別できるようにする UI 要件がある。現状はフィード配信 URL（RSS / Atom URL）を
+基準に favicon を取得しているため、配信ドメインとサイト本体ドメインが異なるフィード
+（例: 別ドメインで配信される RSS、CDN ホスト配信、ブログサービス独自ドメイン等）で
+favicon が取得できず、フィード一覧で空白や壊れた画像が表示されるケースが発生している。
+
+本機能では (1) フィード配信 URL での取得に失敗した場合にサイト本体のドメインを起点に
+favicon を再探索し、(2) すべての取得経路で失敗した場合はフロントエンド側で壊れた画像を
+出さずに代替アイコンを表示することで、フィード一覧の視認性を回復させる。既に favicon が
+正しく取得・表示できている既存フィードに対して挙動を後退させないことを前提とする。
+
+## Requirements
+
+### Requirement 1: サイト本体ドメインからの favicon フォールバック取得
+
+**Objective:** As a Feedman ユーザー, I want 配信 URL とサイト本体ドメインが異なるフィードでも favicon が表示されること, so that フィード一覧で視覚的にフィードを識別できる
+
+#### Acceptance Criteria
+
+1. When フィード登録時にフィード配信 URL を起点とする favicon 取得が失敗したとき, the Feed Service shall フィード内の記事リンクから得られるサイト本体ドメインを起点に favicon の再取得を試行する
+2. When サイト本体ドメインを起点にした favicon 取得が成功したとき, the Feed Service shall 取得した favicon を当該フィードの favicon として永続化する
+3. When フィードに記事リンクが 1 件も含まれていないとき, the Feed Service shall サイト本体ドメインからの再取得は試行せずに従来どおりフィード配信 URL を起点とした結果のみを採用する
+4. When サイト本体ドメインからの favicon 取得においても画像を取得できなかったとき, the Feed Service shall 当該フィードの favicon を未取得（null）として永続化する
+5. The Feed Service shall favicon 取得処理がフィード登録 API のレスポンス時間に影響しないよう、登録応答返却後のバックグラウンド処理として実行する
+
+### Requirement 2: favicon 探索経路の段階化
+
+**Objective:** As a Feedman 運用者, I want favicon 探索が決定論的な順序で段階実行されること, so that 取得成功率を高めつつ取得経路を観測・再現できる
+
+#### Acceptance Criteria
+
+1. The Feed Service shall favicon 取得を「フィード配信 URL を起点とする取得」「サイト本体ドメインを起点とする取得」の順で段階的に試行する
+2. When いずれかの段階で画像として有効な favicon を取得できたとき, the Feed Service shall 後続段階の試行をスキップして取得済み favicon を採用する
+3. While 各取得段階を実行している間, the Feed Service shall 取得対象 URL・成功可否・採用された段階を運用ログに記録する
+4. The Feed Service shall サイト本体ドメインを起点とする探索において、ドメイントップの favicon 既定パスと、サイト HTML 内で明示宣言された favicon 参照の両方を探索対象とする
+
+### Requirement 3: フロントエンドのデフォルトアイコン表示
+
+**Objective:** As a Feedman ユーザー, I want favicon が無い／取得できないフィードでも壊れた画像ではなく代替アイコンが表示されること, so that フィード一覧の視認性が損なわれない
+
+#### Acceptance Criteria
+
+1. When フィードの favicon が未設定（null または空）であるとき, the Feed List UI shall 当該フィード行に既定の代替アイコンを表示する
+2. If favicon の参照先画像の読み込みに失敗したとき, the Feed List UI shall 壊れた画像表示に代えて既定の代替アイコンを表示する
+3. The Feed List UI shall 代替アイコンを実際の favicon と同じ表示サイズ・同じ配置領域で描画する
+4. The Feed List UI shall 代替アイコン表示時もフィードタイトル・未読数バッジ・ステータスアイコンのレイアウトを変化させない
+
+### Requirement 4: 既存正常ケースの非リグレッション
+
+**Objective:** As a Feedman 既存利用ユーザー, I want 現在 favicon が正しく表示されているフィードの挙動が変わらないこと, so that 本修正によって表示崩れや再取得負荷が発生しない
+
+#### Acceptance Criteria
+
+1. When フィード配信 URL を起点とする従来経路で favicon が取得できる既存フィードを登録するとき, the Feed Service shall 従来と同一の favicon を採用する
+2. While 既に favicon が永続化されているフィードについて, the Feed Service shall 本要件によるフォールバック取得を理由とした再取得を行わない
+3. The Feed List UI shall 既存の favicon 表示済みフィードの表示位置・サイズ・代替表示ロジック以外の見た目を変更しない
+
+## Non-Functional Requirements
+
+### NFR 1: 外部 URL 取得の安全性
+
+1. The Feed Service shall サイト本体ドメインを起点とした favicon 取得においても、フィード配信 URL を起点とする既存経路と同等の SSRF 対策・ホスト検証を適用する
+2. The Feed Service shall サイト本体ドメインを起点とした favicon 取得においても、フィード配信 URL を起点とする既存経路と同じタイムアウト上限と同じレスポンスサイズ上限を適用する
+3. If サイト本体ドメインの HTML を解析する必要があるとき, the Feed Service shall 既存実装と同等の HTML サニタイズ方針および画像 MIME 判定基準を適用する
+
+### NFR 2: 可観測性
+
+1. The Feed Service shall favicon 取得結果（採用段階・成功失敗）を構造化ログとして出力し、運用者が後追いでフィード単位に取得経路を特定できるようにする
+
+### NFR 3: 後方互換性
+
+1. The Feed Service shall 本要件導入前に永続化されたフィードの favicon データ・スキーマ・公開 API レスポンス形状を変更しない
+2. The Feed List UI shall 本要件導入前に登録された favicon を持つフィードの表示挙動を変更しない
+
+## Out of Scope
+
+- ユーザーが手動で favicon 画像をアップロードしてカスタマイズする機能
+- 既に favicon が永続化されているフィードに対するバッチ的な再取得・再評価
+- favicon キャッシュ TTL の見直し、CDN 配信、解像度別バリアント生成
+- フィード一覧以外の UI（記事詳細・設定画面 等）における favicon 表示挙動の変更
+- フィード配信 URL とサイト本体ドメインの対応関係をユーザーに編集させる UI
+
+## Open Questions
+
+- なし（Issue 本文・既存実装・コメントから挙動仕様は確定可能。実装手段の選定（HTML 解析ライブラリ、探索パターンの細部、ログ項目名 等）は design.md の領分）

--- a/docs/specs/122-rss-favicon/review-notes.md
+++ b/docs/specs/122-rss-favicon/review-notes.md
@@ -1,0 +1,92 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-28T14:55:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-122-impl-rss-favicon
+- HEAD commit: 53bf082405708d59d5f27f2127b749621e71a88f
+- Compared to: develop..HEAD
+- spec ディレクトリには `requirements.md` と `impl-notes.md` のみが存在し、`tasks.md` /
+  `design.md` は存在しない（design-less impl）。Boundary 判定は requirements.md の
+  Feed Service / Feed List UI スコープと CLAUDE.md のコンポーネント境界
+  （`internal/feed/` バックエンド・`web/src/components/` フロントエンド）に照らして実施した。
+- CLAUDE.md `## Feature Flag Protocol` の `**採否**:` 行は `opt-out` を確認。flag 観点の
+  細目判定は適用しない。
+
+## Verified Requirements
+
+- 1.1 — `TestFetchFaviconWithFallback_StageC_SiteOriginICOSucceeds` /
+  `TestFetchFaviconWithFallback_StageD_SiteOriginHTMLSucceeds`（記事リンクから推測した
+  サイト本体オリジンで favicon 再取得が試行されることを確認）
+- 1.2 — `internal/feed/service.go:278` `feedRepo.UpdateFavicon(ctx, feedID, data, mimeType)`
+  により、いずれの段階で取得した favicon も同じ経路で永続化される。`StageC_SiteOriginICOSucceeds`
+  が data 返却を、既存 `service_test.go` が永続化呼び出しを検証
+- 1.3 — `TestFetchFaviconWithFallback_NoArticles_StopsAfterStageB`（記事リンク 0 件の
+  RSS で `siteHit.Load()` が false であることを assert）
+- 1.4 — `TestFetchFaviconWithFallback_AllStagesFail_ReturnsNil`（全段階 NotFound 時に
+  `data == nil` を assert）+ 既存 `TestRegisterFeed_SucceedsWhenFaviconNotFound` で
+  null 永続化経路を担保
+- 1.5 — 既存 `TestRegisterFeed_ReturnsBeforeFaviconCompletes`（service_async_test.go）が
+  バックグラウンド処理であることを担保。本 PR で `mockFaviconFetcher` /
+  `controllableFaviconFetcher` / `deadlineObservingFetcher` に `FetchFaviconWithFallback`
+  メソッドが追加され、既存非同期テストが引き続き green
+- 2.1 — `TestFetchFaviconWithFallback_StageA_FeedOriginICOSucceeds` /
+  `StageC_SiteOriginICOSucceeds`（feed origin → site origin の順序を hit フラグで確認）
+- 2.2 — `StageA_FeedOriginICOSucceeds` / `StageB_FeedOriginHTMLSucceeds` /
+  `StageC_SiteOriginICOSucceeds` で後続段階の hit フラグが false であることを assert
+- 2.3 — `internal/feed/favicon.go:223,226,238,243,248,251,189,206,368` 等で
+  `slog.Info("favicon取得: 成功", "stage", ...)` / `slog.Info("favicon取得: 段階失敗", ...)`
+  により段階・URL・成功可否が構造化ログに出力される
+- 2.4 — `TestParseFaviconURLFromHTML_*` 8 件（IconAbsolute / RelativeResolved /
+  ShortcutIcon / AppleTouchIcon / Priority* / NoMatch / IgnoreOutsideHead / EmptyHref /
+  InvalidBaseURL）+ `StageB_FeedOriginHTMLSucceeds` / `StageD_SiteOriginHTMLSucceeds`
+- 3.1 — `web/src/components/feed-list.test.tsx`
+  「faviconがnullの場合に代替アイコン（fallback）を表示すること」
+- 3.2 — `web/src/components/feed-list.test.tsx`
+  「favicon画像の読み込みに失敗した場合に代替アイコンに切り替わること」
+  （`fireEvent.error(img)` で onError 発火 → fallback 表示を assert）
+- 3.3 — `web/src/components/feed-list.tsx:122,136,138` で fallback 表示要素の外側 div /
+  内側 span / Rss アイコンすべてに `w-4 h-4` クラスを付与。実 favicon の `<img>` も
+  `w-4 h-4`。同一サイズ・配置領域を CSS class で担保
+- 3.4 — `web/src/components/feed-list.test.tsx`
+  「代替アイコン表示時もフィードタイトル・未読数バッジ・ステータスアイコンのレイアウトを
+  維持すること」（sub-2 行で fallback / タイトル / ステータス が同行に並ぶことを assert）
+- 4.1 — `TestFetchFaviconWithFallback_StageA_FeedOriginICOSucceeds`（従来経路で取得できれば
+  後続段階を試行しない）+ `TestFetchFaviconWithFallback_SameHostArticleLink_NoStageCDExtraFetch`
+  （配信ドメインと記事リンクオリジンが同一なら段階 c/d を skip）
+- 4.2 — `internal/feed/service.go:142` の `startFaviconFetch` 呼び出しは新規登録経路
+  （`RegisterFeed` 内のみ）であり、既存永続化フィードへの再取得経路は導入されていない
+- 4.3 — `web/src/components/feed-list.test.tsx` の既存テスト群（favicon あり時の `<img>`
+  描画、選択状態、未読数、ステータス）は impl-notes 記載のとおり 218 passed で全て green
+- NFR 1.1 — `TestFetchFaviconWithFallback_SSRFGuardBlocksAll`（`blockAll=true` で
+  外部 HTTP リクエスト 0 件を assert）。実装では favicon 取得 (`FetchFavicon`)、
+  HTML 取得 (`fetchHTML`)、フィード再取得 (`deriveSiteOriginFromFeed`) いずれも
+  `ssrfGuard.ValidateURL` を経由
+- NFR 1.2 — `faviconTimeout = 5 * time.Second` / `maxFaviconSize = 2MB` /
+  `maxHTMLFetchSize = 2MB` / `maxFeedFetchSizeForFavicon = 5MB`。呼び出し側で
+  `io.LimitReader` と長さ検査により厳密に上限を強制
+- NFR 1.3 — `isImageMime` で画像 MIME 判定を統一。HTML は href 抽出のみで画面に出さない
+- NFR 2.1 — `slog.Info("favicon取得: 成功", "stage", "feed_origin_ico" 等, "url", "mime")`
+  を含む構造化ログ
+- NFR 3.1 — `model.Feed` / `repository.FeedRepository.UpdateFavicon` のシグネチャ・
+  スキーマは変更されていない（diff 未検出）
+- NFR 3.2 — 既存 favicon ありフィードの表示は `showImage = hasURL && !imgFailed` が
+  true のとき従来通り `<img>` を描画するため挙動不変
+
+## Findings
+
+なし
+
+## Summary
+
+要件 1〜4 および NFR 1〜3 に紐づくすべての AC について、`internal/feed/favicon.go` /
+`internal/feed/service.go` / `web/src/components/feed-list.tsx` の実装と、新規追加された
+`internal/feed/favicon_fallback_test.go`（637 行・段階 a〜d 統合テスト + HTML パーサ単体）
+/ `web/src/components/feed-list.test.tsx`（要件 3.1〜3.4 をカバーする 4 ケース追加）
+で必要な観測可能挙動が確認できた。design-less impl のため tasks.md `_Boundary:_` は
+存在しないが、requirements.md スコープ（Feed Service / Feed List UI）と CLAUDE.md の
+コンポーネント境界（`internal/feed/` / `web/src/components/`）の範囲内に変更が閉じており
+boundary 逸脱なし。Feature Flag Protocol は opt-out 宣言のため flag 観点の細目判定は適用外。
+
+RESULT: approve

--- a/internal/feed/favicon.go
+++ b/internal/feed/favicon.go
@@ -2,6 +2,7 @@
 package feed
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -9,6 +10,9 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/mmcdole/gofeed"
+	"golang.org/x/net/html"
 )
 
 // maxFaviconSize はfaviconの最大サイズ（2MB）。
@@ -16,6 +20,14 @@ const maxFaviconSize = 2 * 1024 * 1024
 
 // faviconTimeout はfavicon取得のタイムアウト。
 const faviconTimeout = 5 * time.Second
+
+// maxFeedFetchSizeForFavicon は favicon フォールバック用にフィード本体を取得する際の
+// レスポンスサイズ上限（5MB）。Worker のフィード取得上限と同等の値を採用する。
+const maxFeedFetchSizeForFavicon = 5 * 1024 * 1024
+
+// maxHTMLFetchSize はサイト本体ドメインの HTML を解析するために取得するサイズ上限（2MB）。
+// favicon と同等の上限を採用して NFR 1.2 を満たす。
+const maxHTMLFetchSize = 2 * 1024 * 1024
 
 // FaviconFetcherService はfavicon取得のインターフェース。
 type FaviconFetcherService interface {
@@ -26,6 +38,17 @@ type FaviconFetcherService interface {
 	// FetchFaviconForSite はサイトURLからfaviconを推測して取得する。
 	// /favicon.ico を試行し、取得失敗時はnilデータと空MIMEを返す。
 	FetchFaviconForSite(ctx context.Context, siteURL string) (data []byte, mimeType string, err error)
+
+	// FetchFaviconWithFallback はフィード配信 URL とサイト本体ドメインを起点に
+	// 段階的に favicon を探索する。探索段階は以下の順序で試行され、いずれかが
+	// 成功した時点で打ち切る:
+	//   (a) フィード配信 URL ドメインの /favicon.ico
+	//   (b) フィード配信 URL ドメインの HTML 内 <link rel="icon"> 等から抽出
+	//   (c) フィード本体から抽出した記事リンクのドメインの /favicon.ico
+	//   (d) (c) と同じドメインの HTML 内 <link rel="icon"> 等から抽出
+	// 各段階の試行は構造化ログに記録される（NFR 2.1）。
+	// すべての段階で取得できなかった場合は nil データと空 MIME を返す。
+	FetchFaviconWithFallback(ctx context.Context, feedURL string) (data []byte, mimeType string, err error)
 }
 
 // FaviconFetcher はfavicon取得機能の実装。
@@ -34,6 +57,11 @@ type FaviconFetcher struct {
 	// httpClient はリクエスト間で再利用するHTTPクライアント。
 	// コンストラクタで一度だけ生成し、生成後は read-only なフィールド参照となるため、
 	// 複数 goroutine からの同時アクセスでもデータ競合は発生しない（NFR 2.1）。
+	//
+	// favicon 取得・HTML 解析・フィード本体取得の各経路で同一クライアントを再利用する。
+	// レスポンスサイズの上限はクライアント側では HTML / フィード取得を許容する大きめの値
+	// （maxFeedFetchSizeForFavicon = 5MB）に設定し、favicon 経路では呼び出し側で
+	// LimitReader と長さ検査により厳密に maxFaviconSize（2MB）まで切り詰める（NFR 1.2）。
 	httpClient *http.Client
 }
 
@@ -49,9 +77,12 @@ func NewFaviconFetcher(ssrfGuard SSRFValidator) *FaviconFetcher {
 
 // newFaviconHTTPClient はfavicon取得用のHTTPクライアントを生成する。
 // SSRFGuardが設定されている場合はSSRF防止付きクライアントを返す。
+// クライアント側のレスポンスサイズ上限は HTML / フィード本体取得を許容するために
+// maxFeedFetchSizeForFavicon を採用し、favicon 経路は呼び出し側で LimitReader による
+// 2MB 上限を別途強制する（NFR 1.2）。
 func newFaviconHTTPClient(ssrfGuard SSRFValidator) *http.Client {
 	if ssrfGuard != nil {
-		return ssrfGuard.NewSafeClient(faviconTimeout, maxFaviconSize)
+		return ssrfGuard.NewSafeClient(faviconTimeout, maxFeedFetchSizeForFavicon)
 	}
 	return &http.Client{Timeout: faviconTimeout}
 }
@@ -128,6 +159,365 @@ func (f *FaviconFetcher) FetchFaviconForSite(ctx context.Context, siteURL string
 		return nil, "", nil
 	}
 	return f.FetchFavicon(ctx, faviconURL)
+}
+
+// FetchFaviconWithFallback はフィード配信 URL とサイト本体ドメインを起点に
+// 段階的に favicon を探索する（要件 1, 2）。
+// 探索段階は (a) → (b) → (c) → (d) の順で試行され、最初に成功した段階の
+// favicon を返す。各段階の試行結果は構造化ログに記録される。
+func (f *FaviconFetcher) FetchFaviconWithFallback(ctx context.Context, feedURL string) ([]byte, string, error) {
+	if feedURL == "" {
+		return nil, "", nil
+	}
+
+	feedOrigin := originURL(feedURL)
+
+	// 段階 (a): フィード配信 URL ドメインの /favicon.ico
+	if data, mime := f.tryFaviconForOrigin(ctx, feedOrigin, "feed_origin_ico"); data != nil {
+		return data, mime, nil
+	}
+
+	// 段階 (b): フィード配信 URL ドメインの HTML 解析
+	if data, mime := f.tryFaviconViaHTML(ctx, feedOrigin, "feed_origin_html"); data != nil {
+		return data, mime, nil
+	}
+
+	// 段階 (c) / (d): フィード本体から記事リンクを取得し、別ドメインなら再探索する
+	siteOrigin := f.deriveSiteOriginFromFeed(ctx, feedURL)
+	if siteOrigin == "" || siteOrigin == feedOrigin {
+		// 記事リンクが取得できない / 配信ドメインと同一なら再試行する意味がない。
+		slog.Info("favicon取得: サイト本体ドメイン未取得（フォールバック打ち切り）",
+			"feedURL", feedURL,
+			"feedOrigin", feedOrigin,
+		)
+		return nil, "", nil
+	}
+
+	// 段階 (c)
+	if data, mime := f.tryFaviconForOrigin(ctx, siteOrigin, "site_origin_ico"); data != nil {
+		return data, mime, nil
+	}
+
+	// 段階 (d)
+	if data, mime := f.tryFaviconViaHTML(ctx, siteOrigin, "site_origin_html"); data != nil {
+		return data, mime, nil
+	}
+
+	slog.Info("favicon取得: 全段階で失敗",
+		"feedURL", feedURL,
+		"feedOrigin", feedOrigin,
+		"siteOrigin", siteOrigin,
+	)
+	return nil, "", nil
+}
+
+// tryFaviconForOrigin は指定オリジンの /favicon.ico を試行する。
+// 成功時は (data, mime) を返し、失敗時は (nil, "") を返す。stage は構造化ログ用ラベル。
+func (f *FaviconFetcher) tryFaviconForOrigin(ctx context.Context, origin, stage string) ([]byte, string) {
+	if origin == "" {
+		return nil, ""
+	}
+	faviconURL := guessDefaultFaviconURL(origin)
+	data, mime, _ := f.FetchFavicon(ctx, faviconURL)
+	if data != nil {
+		slog.Info("favicon取得: 成功", "stage", stage, "url", faviconURL, "mime", mime)
+		return data, mime
+	}
+	slog.Info("favicon取得: 段階失敗", "stage", stage, "url", faviconURL)
+	return nil, ""
+}
+
+// tryFaviconViaHTML は指定オリジンの HTML を取得し、<link rel="icon"> 等から
+// favicon URL を抽出して取得する。stage は構造化ログ用ラベル。
+func (f *FaviconFetcher) tryFaviconViaHTML(ctx context.Context, origin, stage string) ([]byte, string) {
+	if origin == "" {
+		return nil, ""
+	}
+	htmlBody, baseURL := f.fetchHTML(ctx, origin)
+	if len(htmlBody) == 0 {
+		slog.Info("favicon取得: HTML取得失敗", "stage", stage, "origin", origin)
+		return nil, ""
+	}
+	iconURL := parseFaviconURLFromHTML(htmlBody, baseURL)
+	if iconURL == "" {
+		slog.Info("favicon取得: HTML内にicon宣言なし", "stage", stage, "origin", origin)
+		return nil, ""
+	}
+	data, mime, _ := f.FetchFavicon(ctx, iconURL)
+	if data != nil {
+		slog.Info("favicon取得: 成功", "stage", stage, "url", iconURL, "mime", mime)
+		return data, mime
+	}
+	slog.Info("favicon取得: 段階失敗", "stage", stage, "url", iconURL)
+	return nil, ""
+}
+
+// fetchHTML は指定 URL の HTML を取得する。
+// 取得失敗時は (nil, "") を返す。返却 baseURL は相対 URL 解決用にレスポンスの最終 URL を返す。
+func (f *FaviconFetcher) fetchHTML(ctx context.Context, pageURL string) ([]byte, string) {
+	if pageURL == "" {
+		return nil, ""
+	}
+	if f.ssrfGuard != nil {
+		if err := f.ssrfGuard.ValidateURL(pageURL); err != nil {
+			slog.Warn("HTML取得: SSRFブロック", "url", pageURL, "error", err)
+			return nil, ""
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
+	if err != nil {
+		slog.Warn("HTML取得: リクエスト作成失敗", "url", pageURL, "error", err)
+		return nil, ""
+	}
+	req.Header.Set("User-Agent", "Feedman/1.0 RSS Reader")
+	req.Header.Set("Accept", "text/html, application/xhtml+xml, */*")
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		slog.Warn("HTML取得: HTTPリクエスト失敗", "url", pageURL, "error", err)
+		return nil, ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		slog.Warn("HTML取得: HTTPステータス異常", "url", pageURL, "status", resp.StatusCode)
+		return nil, ""
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxHTMLFetchSize+1))
+	if err != nil {
+		slog.Warn("HTML取得: レスポンス読み取り失敗", "url", pageURL, "error", err)
+		return nil, ""
+	}
+	if int64(len(body)) > maxHTMLFetchSize {
+		slog.Warn("HTML取得: サイズ超過", "url", pageURL, "size", len(body))
+		return nil, ""
+	}
+
+	// 相対 URL 解決用のベース URL は最終的なリクエスト URL（リダイレクト追従後）を採用する。
+	baseURL := pageURL
+	if resp.Request != nil && resp.Request.URL != nil {
+		baseURL = resp.Request.URL.String()
+	}
+	return body, baseURL
+}
+
+// deriveSiteOriginFromFeed はフィード本体を取得・パースし、
+// 最初の有効な記事リンクからサイト本体オリジンを取得する。
+// 取得できない場合は空文字を返す。
+func (f *FaviconFetcher) deriveSiteOriginFromFeed(ctx context.Context, feedURL string) string {
+	if feedURL == "" {
+		return ""
+	}
+	if f.ssrfGuard != nil {
+		if err := f.ssrfGuard.ValidateURL(feedURL); err != nil {
+			slog.Warn("favicon取得: フィード再取得 SSRFブロック", "url", feedURL, "error", err)
+			return ""
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, feedURL, nil)
+	if err != nil {
+		slog.Warn("favicon取得: フィード再取得 リクエスト作成失敗", "url", feedURL, "error", err)
+		return ""
+	}
+	req.Header.Set("User-Agent", "Feedman/1.0 RSS Reader")
+	req.Header.Set("Accept", "application/rss+xml, application/atom+xml, application/xml, text/xml, */*")
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		slog.Warn("favicon取得: フィード再取得 HTTPリクエスト失敗", "url", feedURL, "error", err)
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		slog.Warn("favicon取得: フィード再取得 HTTPステータス異常", "url", feedURL, "status", resp.StatusCode)
+		return ""
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFeedFetchSizeForFavicon+1))
+	if err != nil {
+		slog.Warn("favicon取得: フィード再取得 読み取り失敗", "url", feedURL, "error", err)
+		return ""
+	}
+	if int64(len(body)) > maxFeedFetchSizeForFavicon {
+		slog.Warn("favicon取得: フィード再取得 サイズ超過", "url", feedURL, "size", len(body))
+		return ""
+	}
+
+	parser := gofeed.NewParser()
+	parsedFeed, err := parser.ParseString(string(body))
+	if err != nil {
+		slog.Warn("favicon取得: フィードパース失敗", "url", feedURL, "error", err)
+		return ""
+	}
+
+	// 記事リンクから site origin を抽出する（要件 1.1）。
+	// 記事が 1 件もない場合は要件 1.3 に従い空文字を返す。
+	for _, item := range parsedFeed.Items {
+		if item == nil || item.Link == "" {
+			continue
+		}
+		origin := originURL(item.Link)
+		if origin != "" {
+			return origin
+		}
+	}
+	slog.Info("favicon取得: 記事リンクなし（フォールバック打ち切り）", "url", feedURL)
+	return ""
+}
+
+// parseFaviconURLFromHTML は HTML から favicon を宣言する link 要素を抽出し、
+// 絶対 URL を返す。優先順位は以下:
+//  1. rel="icon"
+//  2. rel="shortcut icon"
+//  3. rel="apple-touch-icon" / rel="apple-touch-icon-precomposed"
+//
+// 複数の候補があれば優先度の高いものを返す。見つからない場合は空文字。
+func parseFaviconURLFromHTML(htmlBody []byte, baseURL string) string {
+	baseU, err := url.Parse(baseURL)
+	if err != nil {
+		return ""
+	}
+
+	var found []candidate
+
+	tokenizer := html.NewTokenizer(bytes.NewReader(htmlBody))
+	inHead := false
+
+	for {
+		tt := tokenizer.Next()
+		switch tt {
+		case html.ErrorToken:
+			return selectBestFaviconCandidate(found, baseU)
+		case html.StartTagToken, html.SelfClosingTagToken:
+			tn, hasAttr := tokenizer.TagName()
+			tagName := string(tn)
+
+			if tagName == "head" {
+				inHead = true
+				continue
+			}
+			if tagName == "body" {
+				return selectBestFaviconCandidate(found, baseU)
+			}
+			if !inHead || tagName != "link" || !hasAttr {
+				continue
+			}
+
+			var rel, href string
+			for {
+				key, val, more := tokenizer.TagAttr()
+				k := strings.ToLower(string(key))
+				v := string(val)
+				switch k {
+				case "rel":
+					rel = strings.ToLower(strings.TrimSpace(v))
+				case "href":
+					href = strings.TrimSpace(v)
+				}
+				if !more {
+					break
+				}
+			}
+			if href == "" {
+				continue
+			}
+			// rel 属性は空白区切りで複数値を持てる。各値を確認する。
+			priority := faviconRelPriority(rel)
+			if priority < 0 {
+				continue
+			}
+			found = append(found, candidate{href: href, priority: priority})
+		case html.EndTagToken:
+			tn, _ := tokenizer.TagName()
+			if string(tn) == "head" {
+				return selectBestFaviconCandidate(found, baseU)
+			}
+		}
+	}
+}
+
+// faviconRelPriority は rel 属性値に含まれる favicon 関連の rel を判定し、
+// 優先度を返す（低いほど優先）。該当する rel が含まれなければ -1。
+func faviconRelPriority(rel string) int {
+	if rel == "" {
+		return -1
+	}
+	// 空白区切りで複数 rel を持てる: 例 "icon shortcut"
+	tokens := strings.Fields(rel)
+	hasIcon := false
+	hasShortcutIcon := false
+	hasAppleTouch := false
+	for _, tok := range tokens {
+		switch tok {
+		case "icon":
+			hasIcon = true
+		case "shortcut":
+			// shortcut 単独では favicon と限らないが、典型 "shortcut icon" のため
+			// "icon" を併せ持つときのみ favicon 扱いとする（後段で判定）。
+		case "apple-touch-icon", "apple-touch-icon-precomposed":
+			hasAppleTouch = true
+		}
+	}
+	// "shortcut icon" の組み合わせ判定: rel 全体に "shortcut" と "icon" の両方が含まれるかを直接確認
+	if strings.Contains(rel, "shortcut") && hasIcon {
+		hasShortcutIcon = true
+	}
+	switch {
+	case hasIcon && !hasShortcutIcon:
+		return 0
+	case hasShortcutIcon:
+		return 1
+	case hasAppleTouch:
+		return 2
+	}
+	return -1
+}
+
+// selectBestFaviconCandidate は candidate のうち最も優先度が高い（priority が最小の）
+// 候補の href を絶対 URL に解決して返す。
+func selectBestFaviconCandidate(found []candidate, baseU *url.URL) string {
+	if len(found) == 0 {
+		return ""
+	}
+	bestIdx := 0
+	for i := 1; i < len(found); i++ {
+		if found[i].priority < found[bestIdx].priority {
+			bestIdx = i
+		}
+	}
+	href := found[bestIdx].href
+	ref, err := url.Parse(href)
+	if err != nil {
+		return ""
+	}
+	return baseU.ResolveReference(ref).String()
+}
+
+// candidate は parseFaviconURLFromHTML 内で利用する favicon 候補。
+// （selectBestFaviconCandidate のシグネチャを安定させるためにファイルスコープに置く。）
+type candidate struct {
+	href     string
+	priority int
+}
+
+// originURL は URL から scheme + host のみを抽出した「オリジン URL」を返す。
+// パース失敗時や scheme/host が空の場合は空文字を返す。
+func originURL(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
 }
 
 // getHTTPClient はコンストラクタで生成済みの再利用HTTPクライアントを返す。

--- a/internal/feed/favicon_fallback_test.go
+++ b/internal/feed/favicon_fallback_test.go
@@ -1,0 +1,637 @@
+package feed
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// pngBody は最小サイズの PNG ヘッダー（テスト用 favicon ペイロード）。
+var pngBody = []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+
+// --- parseFaviconURLFromHTML のテスト（要件 2.4） ---
+
+// TestParseFaviconURLFromHTML_IconAbsolute はHTML内の rel="icon" + 絶対URLを抽出するテスト。
+func TestParseFaviconURLFromHTML_IconAbsolute(t *testing.T) {
+	htmlBody := []byte(`<html><head>
+		<link rel="icon" href="https://cdn.example.com/icon.png">
+	</head></html>`)
+
+	got := parseFaviconURLFromHTML(htmlBody, "https://example.com/")
+	want := "https://cdn.example.com/icon.png"
+	if got != want {
+		t.Errorf("parseFaviconURLFromHTML = %q, want %q", got, want)
+	}
+}
+
+// TestParseFaviconURLFromHTML_RelativeResolved は rel="icon" + 相対URLを baseURL で絶対化するテスト。
+func TestParseFaviconURLFromHTML_RelativeResolved(t *testing.T) {
+	htmlBody := []byte(`<html><head>
+		<link rel="icon" href="/static/favicon.svg">
+	</head></html>`)
+
+	got := parseFaviconURLFromHTML(htmlBody, "https://example.com/blog")
+	want := "https://example.com/static/favicon.svg"
+	if got != want {
+		t.Errorf("parseFaviconURLFromHTML = %q, want %q", got, want)
+	}
+}
+
+// TestParseFaviconURLFromHTML_ShortcutIcon は rel="shortcut icon" を検出するテスト。
+func TestParseFaviconURLFromHTML_ShortcutIcon(t *testing.T) {
+	htmlBody := []byte(`<html><head>
+		<link rel="shortcut icon" href="/favicon.ico">
+	</head></html>`)
+
+	got := parseFaviconURLFromHTML(htmlBody, "https://example.com/")
+	want := "https://example.com/favicon.ico"
+	if got != want {
+		t.Errorf("parseFaviconURLFromHTML = %q, want %q", got, want)
+	}
+}
+
+// TestParseFaviconURLFromHTML_AppleTouchIcon は rel="apple-touch-icon" を検出するテスト。
+func TestParseFaviconURLFromHTML_AppleTouchIcon(t *testing.T) {
+	htmlBody := []byte(`<html><head>
+		<link rel="apple-touch-icon" href="/apple-icon.png">
+	</head></html>`)
+
+	got := parseFaviconURLFromHTML(htmlBody, "https://example.com/")
+	want := "https://example.com/apple-icon.png"
+	if got != want {
+		t.Errorf("parseFaviconURLFromHTML = %q, want %q", got, want)
+	}
+}
+
+// TestParseFaviconURLFromHTML_PriorityIconOverShortcut は icon と shortcut icon が両方ある場合に
+// 優先度の高い rel="icon" を選択するテスト。
+func TestParseFaviconURLFromHTML_PriorityIconOverShortcut(t *testing.T) {
+	htmlBody := []byte(`<html><head>
+		<link rel="shortcut icon" href="/old.ico">
+		<link rel="icon" href="/new.png">
+	</head></html>`)
+
+	got := parseFaviconURLFromHTML(htmlBody, "https://example.com/")
+	want := "https://example.com/new.png"
+	if got != want {
+		t.Errorf("rel=\"icon\" は shortcut icon より優先されるべき。got %q, want %q", got, want)
+	}
+}
+
+// TestParseFaviconURLFromHTML_PriorityShortcutOverAppleTouch は shortcut icon と apple-touch-icon
+// が両方ある場合に shortcut icon が選択されるテスト。
+func TestParseFaviconURLFromHTML_PriorityShortcutOverAppleTouch(t *testing.T) {
+	htmlBody := []byte(`<html><head>
+		<link rel="apple-touch-icon" href="/apple.png">
+		<link rel="shortcut icon" href="/favicon.ico">
+	</head></html>`)
+
+	got := parseFaviconURLFromHTML(htmlBody, "https://example.com/")
+	want := "https://example.com/favicon.ico"
+	if got != want {
+		t.Errorf("shortcut icon は apple-touch-icon より優先されるべき。got %q, want %q", got, want)
+	}
+}
+
+// TestParseFaviconURLFromHTML_NoMatch は icon 系の link が存在しない場合に空文字を返すテスト。
+func TestParseFaviconURLFromHTML_NoMatch(t *testing.T) {
+	htmlBody := []byte(`<html><head>
+		<link rel="stylesheet" href="/style.css">
+		<link rel="alternate" type="application/rss+xml" href="/feed.xml">
+	</head></html>`)
+
+	got := parseFaviconURLFromHTML(htmlBody, "https://example.com/")
+	if got != "" {
+		t.Errorf("icon系の link がない場合は空文字を返すべき。got %q", got)
+	}
+}
+
+// TestParseFaviconURLFromHTML_IgnoreOutsideHead は head 外の link 要素を無視するテスト。
+func TestParseFaviconURLFromHTML_IgnoreOutsideHead(t *testing.T) {
+	htmlBody := []byte(`<html><head><title>x</title></head>
+		<body><link rel="icon" href="/should-be-ignored.png"></body></html>`)
+
+	got := parseFaviconURLFromHTML(htmlBody, "https://example.com/")
+	if got != "" {
+		t.Errorf("body 内の link は無視されるべき。got %q", got)
+	}
+}
+
+// TestParseFaviconURLFromHTML_EmptyHref は href が空の場合に空文字を返すテスト。
+func TestParseFaviconURLFromHTML_EmptyHref(t *testing.T) {
+	htmlBody := []byte(`<html><head>
+		<link rel="icon" href="">
+	</head></html>`)
+
+	got := parseFaviconURLFromHTML(htmlBody, "https://example.com/")
+	if got != "" {
+		t.Errorf("href が空の場合は空文字を返すべき。got %q", got)
+	}
+}
+
+// TestParseFaviconURLFromHTML_InvalidBaseURL は baseURL が不正な場合に空文字を返すテスト。
+func TestParseFaviconURLFromHTML_InvalidBaseURL(t *testing.T) {
+	htmlBody := []byte(`<html><head><link rel="icon" href="/icon.png"></head></html>`)
+
+	got := parseFaviconURLFromHTML(htmlBody, "://invalid-url")
+	if got != "" {
+		t.Errorf("baseURL が不正なら空文字を返すべき。got %q", got)
+	}
+}
+
+// --- originURL のテスト ---
+
+// TestOriginURL は様々な URL に対して scheme + host を抽出することをテストする。
+func TestOriginURL(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"https://example.com/path?q=1#h", "https://example.com"},
+		{"https://example.com:8080/", "https://example.com:8080"},
+		{"http://example.com", "http://example.com"},
+		{"", ""},
+		{"not-a-url", ""},
+		{"//example.com/path", ""}, // scheme なし → 空
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := originURL(tt.in)
+			if got != tt.want {
+				t.Errorf("originURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- FetchFaviconWithFallback の統合テスト（要件 1, 2） ---
+
+// TestFetchFaviconWithFallback_StageA_FeedOriginICOSucceeds は段階 (a) の /favicon.ico が
+// 取得できる場合に他の段階を試行せずに採用するテスト（要件 2.1, 2.2, 4.1）。
+func TestFetchFaviconWithFallback_StageA_FeedOriginICOSucceeds(t *testing.T) {
+	var stageBHit, stageCHit, stageDHit atomic.Bool
+
+	feedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/favicon.ico":
+			w.Header().Set("Content-Type", "image/x-icon")
+			_, _ = w.Write(pngBody)
+		case "/":
+			// 段階 (b) で来る HTML
+			stageBHit.Store(true)
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html><head><link rel="icon" href="/never.png"></head></html>`))
+		case "/feed.xml":
+			// 段階 (c) のためのフィード本体
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer feedSrv.Close()
+
+	siteSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		stageCHit.Store(true)
+		stageDHit.Store(true)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer siteSrv.Close()
+
+	f := NewFaviconFetcher(&mockSSRFGuard{})
+	data, mime, err := f.FetchFaviconWithFallback(context.Background(), feedSrv.URL+"/feed.xml")
+	if err != nil {
+		t.Fatalf("FetchFaviconWithFallback returned error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("段階 (a) で favicon が取得できるべき")
+	}
+	if mime != "image/x-icon" {
+		t.Errorf("MIME = %q, want image/x-icon", mime)
+	}
+	if stageBHit.Load() {
+		t.Error("段階 (a) で成功している場合、段階 (b) は試行されてはならない")
+	}
+	if stageCHit.Load() {
+		t.Error("段階 (a) で成功している場合、段階 (c) は試行されてはならない")
+	}
+	if stageDHit.Load() {
+		t.Error("段階 (a) で成功している場合、段階 (d) は試行されてはならない")
+	}
+}
+
+// TestFetchFaviconWithFallback_StageB_FeedOriginHTMLSucceeds は段階 (a) が 404 で
+// 段階 (b) の HTML 内 <link rel="icon"> から取得できるテスト（要件 2.4）。
+func TestFetchFaviconWithFallback_StageB_FeedOriginHTMLSucceeds(t *testing.T) {
+	var stageCHit, stageDHit atomic.Bool
+
+	feedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/favicon.ico":
+			// 段階 (a) は失敗
+			w.WriteHeader(http.StatusNotFound)
+		case "/":
+			// 段階 (b) で来る HTML、icon を宣言
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html><head><link rel="icon" href="/declared-icon.png"></head></html>`))
+		case "/declared-icon.png":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(pngBody)
+		case "/feed.xml":
+			// 段階 (c) のためのフィード本体
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer feedSrv.Close()
+
+	siteSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		stageCHit.Store(true)
+		stageDHit.Store(true)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer siteSrv.Close()
+
+	f := NewFaviconFetcher(&mockSSRFGuard{})
+	data, mime, err := f.FetchFaviconWithFallback(context.Background(), feedSrv.URL+"/feed.xml")
+	if err != nil {
+		t.Fatalf("FetchFaviconWithFallback returned error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("段階 (b) で favicon が取得できるべき")
+	}
+	if mime != "image/png" {
+		t.Errorf("MIME = %q, want image/png", mime)
+	}
+	if stageCHit.Load() || stageDHit.Load() {
+		t.Error("段階 (b) で成功している場合、(c)(d) は試行されてはならない")
+	}
+}
+
+// TestFetchFaviconWithFallback_StageC_SiteOriginICOSucceeds は段階 (a)(b) が失敗、
+// 段階 (c)（記事リンクから推測したサイト本体ドメインの /favicon.ico）で取得できるテスト
+// （要件 1.1, 1.2, 2.1）。
+func TestFetchFaviconWithFallback_StageC_SiteOriginICOSucceeds(t *testing.T) {
+	var siteFaviconHit, siteHTMLHit atomic.Bool
+	var siteHostBase string
+
+	siteSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/favicon.ico":
+			siteFaviconHit.Store(true)
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(pngBody)
+		case "/":
+			siteHTMLHit.Store(true)
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html></html>`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer siteSrv.Close()
+	siteHostBase = siteSrv.URL
+
+	feedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/favicon.ico":
+			w.WriteHeader(http.StatusNotFound) // 段階 (a) 失敗
+		case "/":
+			w.WriteHeader(http.StatusNotFound) // 段階 (b) HTML 取得失敗
+		case "/feed.xml":
+			// フィード本体: 記事リンクが別ドメイン
+			rss := fmt.Sprintf(`<?xml version="1.0"?>
+<rss version="2.0"><channel>
+<title>Test</title>
+<link>%s</link>
+<item><title>Item 1</title><link>%s/article-1</link></item>
+</channel></rss>`, siteHostBase, siteHostBase)
+			w.Header().Set("Content-Type", "application/rss+xml")
+			_, _ = w.Write([]byte(rss))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer feedSrv.Close()
+
+	f := NewFaviconFetcher(&mockSSRFGuard{})
+	data, mime, err := f.FetchFaviconWithFallback(context.Background(), feedSrv.URL+"/feed.xml")
+	if err != nil {
+		t.Fatalf("FetchFaviconWithFallback returned error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("段階 (c) で favicon が取得できるべき")
+	}
+	if mime != "image/png" {
+		t.Errorf("MIME = %q, want image/png", mime)
+	}
+	if !siteFaviconHit.Load() {
+		t.Error("サイト本体ドメインの /favicon.ico がリクエストされるべき")
+	}
+	if siteHTMLHit.Load() {
+		t.Error("段階 (c) で成功している場合、(d) は試行されてはならない")
+	}
+}
+
+// TestFetchFaviconWithFallback_StageD_SiteOriginHTMLSucceeds は段階 (a)(b)(c) が失敗、
+// 段階 (d)（サイト本体ドメインの HTML 内 icon 宣言）で取得できるテスト（要件 1.1, 2.4）。
+func TestFetchFaviconWithFallback_StageD_SiteOriginHTMLSucceeds(t *testing.T) {
+	var siteHostBase string
+
+	siteSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/favicon.ico":
+			w.WriteHeader(http.StatusNotFound) // 段階 (c) 失敗
+		case "/":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html><head><link rel="shortcut icon" href="/icon.svg"></head></html>`))
+		case "/icon.svg":
+			w.Header().Set("Content-Type", "image/svg+xml")
+			_, _ = w.Write([]byte(`<svg/>`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer siteSrv.Close()
+	siteHostBase = siteSrv.URL
+
+	feedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/favicon.ico":
+			w.WriteHeader(http.StatusNotFound) // 段階 (a) 失敗
+		case "/":
+			w.WriteHeader(http.StatusNotFound) // 段階 (b) 失敗
+		case "/feed.xml":
+			rss := fmt.Sprintf(`<?xml version="1.0"?>
+<rss version="2.0"><channel>
+<title>Test</title>
+<link>%s</link>
+<item><title>Item 1</title><link>%s/article-1</link></item>
+</channel></rss>`, siteHostBase, siteHostBase)
+			w.Header().Set("Content-Type", "application/rss+xml")
+			_, _ = w.Write([]byte(rss))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer feedSrv.Close()
+
+	f := NewFaviconFetcher(&mockSSRFGuard{})
+	data, mime, err := f.FetchFaviconWithFallback(context.Background(), feedSrv.URL+"/feed.xml")
+	if err != nil {
+		t.Fatalf("FetchFaviconWithFallback returned error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("段階 (d) で favicon が取得できるべき")
+	}
+	if !strings.HasPrefix(mime, "image/") {
+		t.Errorf("MIME は画像であるべき。got %q", mime)
+	}
+}
+
+// TestFetchFaviconWithFallback_NoArticles_StopsAfterStageB はフィードに記事リンクが
+// 1 件もない場合、段階 (b) で打ち切られサイト本体ドメイン側にアクセスしないテスト
+// （要件 1.3）。
+func TestFetchFaviconWithFallback_NoArticles_StopsAfterStageB(t *testing.T) {
+	var siteHit atomic.Bool
+
+	siteSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		siteHit.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer siteSrv.Close()
+
+	feedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/favicon.ico":
+			w.WriteHeader(http.StatusNotFound)
+		case "/":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html></html>`)) // icon 宣言なし
+		case "/feed.xml":
+			// 記事リンク 0 件のフィード
+			rss := `<?xml version="1.0"?>
+<rss version="2.0"><channel>
+<title>Empty Feed</title>
+<link>https://example.com</link>
+</channel></rss>`
+			w.Header().Set("Content-Type", "application/rss+xml")
+			_, _ = w.Write([]byte(rss))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer feedSrv.Close()
+
+	f := NewFaviconFetcher(&mockSSRFGuard{})
+	data, _, err := f.FetchFaviconWithFallback(context.Background(), feedSrv.URL+"/feed.xml")
+	if err != nil {
+		t.Fatalf("FetchFaviconWithFallback returned error: %v", err)
+	}
+	if data != nil {
+		t.Error("全段階で取得不可なら nil を返すべき")
+	}
+	if siteHit.Load() {
+		t.Error("記事リンク 0 件の場合、サイト本体ドメインへのアクセスは行われるべきでない（要件 1.3）")
+	}
+}
+
+// TestFetchFaviconWithFallback_AllStagesFail_ReturnsNil は全段階で取得失敗した場合に
+// nil・空 MIME・エラーなしを返すテスト（要件 1.4）。
+func TestFetchFaviconWithFallback_AllStagesFail_ReturnsNil(t *testing.T) {
+	var siteHostBase string
+	siteSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer siteSrv.Close()
+	siteHostBase = siteSrv.URL
+
+	feedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/favicon.ico", "/":
+			w.WriteHeader(http.StatusNotFound)
+		case "/feed.xml":
+			rss := fmt.Sprintf(`<?xml version="1.0"?>
+<rss version="2.0"><channel>
+<title>Test</title>
+<link>%s</link>
+<item><title>x</title><link>%s/a</link></item>
+</channel></rss>`, siteHostBase, siteHostBase)
+			w.Header().Set("Content-Type", "application/rss+xml")
+			_, _ = w.Write([]byte(rss))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer feedSrv.Close()
+
+	f := NewFaviconFetcher(&mockSSRFGuard{})
+	data, mime, err := f.FetchFaviconWithFallback(context.Background(), feedSrv.URL+"/feed.xml")
+	if err != nil {
+		t.Fatalf("FetchFaviconWithFallback returned error: %v", err)
+	}
+	if data != nil {
+		t.Errorf("全段階失敗時は nil を返すべき。got %d bytes", len(data))
+	}
+	if mime != "" {
+		t.Errorf("全段階失敗時は空 MIME を返すべき。got %q", mime)
+	}
+}
+
+// TestFetchFaviconWithFallback_SameHostArticleLink_NoStageCDExtraFetch は記事リンクの
+// オリジンがフィード配信ドメインと同一の場合、段階 (c)(d) で重複試行しないテスト
+// （要件 4.1 既存正常ケースの非リグレッション）。
+func TestFetchFaviconWithFallback_SameHostArticleLink_NoStageCDExtraFetch(t *testing.T) {
+	var faviconReqs atomic.Int64
+
+	feedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/favicon.ico":
+			faviconReqs.Add(1)
+			w.WriteHeader(http.StatusNotFound) // 段階 (a) 失敗
+		case "/":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html></html>`)) // 段階 (b) icon 宣言なし
+		case "/feed.xml":
+			// 同一ホスト記事リンク
+			rss := `<?xml version="1.0"?>
+<rss version="2.0"><channel>
+<title>Test</title>
+<item><link>/article-1</link></item>
+</channel></rss>`
+			w.Header().Set("Content-Type", "application/rss+xml")
+			_, _ = w.Write([]byte(rss))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer feedSrv.Close()
+
+	// 相対リンクは gofeed で解決されないので、絶対リンクで同一ホストにする
+	feedURL := feedSrv.URL + "/feed.xml"
+	// 上書き: 同一ホスト記事リンクをフルURLで設定
+	feedSrv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/favicon.ico":
+			faviconReqs.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+		case "/":
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html></html>`))
+		case "/feed.xml":
+			rss := fmt.Sprintf(`<?xml version="1.0"?>
+<rss version="2.0"><channel>
+<title>Test</title>
+<item><link>%s/article-1</link></item>
+</channel></rss>`, feedSrv.URL)
+			w.Header().Set("Content-Type", "application/rss+xml")
+			_, _ = w.Write([]byte(rss))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	f := NewFaviconFetcher(&mockSSRFGuard{})
+	_, _, _ = f.FetchFaviconWithFallback(context.Background(), feedURL)
+
+	// 段階 (a) で 1 回、段階 (c) で同一ホスト判定により skip されるので /favicon.ico は 1 回のみ
+	if got := faviconReqs.Load(); got != 1 {
+		t.Errorf("同一ホスト記事リンクの場合、/favicon.ico は段階 (a) のみ 1 回試行されるべき。got %d", got)
+	}
+}
+
+// TestFetchFaviconWithFallback_EmptyFeedURL は feedURL が空文字の場合に
+// nil を返すテスト（境界値）。
+func TestFetchFaviconWithFallback_EmptyFeedURL(t *testing.T) {
+	f := NewFaviconFetcher(&mockSSRFGuard{})
+	data, mime, err := f.FetchFaviconWithFallback(context.Background(), "")
+	if err != nil {
+		t.Fatalf("空 feedURL でエラーを返すべきでない: %v", err)
+	}
+	if data != nil || mime != "" {
+		t.Errorf("空 feedURL では nil/空 MIME を返すべき。data=%v mime=%q", data, mime)
+	}
+}
+
+// TestFetchFaviconWithFallback_SSRFGuardBlocksAll は SSRF ガードが全 URL を
+// ブロックする場合に nil を返し、外部リクエストが発生しないテスト（NFR 1.1）。
+func TestFetchFaviconWithFallback_SSRFGuardBlocksAll(t *testing.T) {
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// blockAll = true の SSRF ガードを使い、各段階がブロックされることを観測する
+	guard := &mockSSRFGuard{blockAll: true}
+	f := NewFaviconFetcher(guard)
+
+	data, _, err := f.FetchFaviconWithFallback(context.Background(), srv.URL+"/feed.xml")
+	if err != nil {
+		t.Fatalf("SSRF ブロック時はエラーを返すべきでない: %v", err)
+	}
+	if data != nil {
+		t.Error("SSRF ブロック時は nil データを返すべき")
+	}
+	if requests.Load() != 0 {
+		t.Errorf("SSRF ブロック時は外部 HTTP リクエストが発生してはならない。got %d", requests.Load())
+	}
+}
+
+// --- 補助関数のテスト ---
+
+// TestFaviconRelPriority は様々な rel 値に対する優先度判定をテストする。
+func TestFaviconRelPriority(t *testing.T) {
+	tests := []struct {
+		rel  string
+		want int
+	}{
+		{"icon", 0},
+		{"shortcut icon", 1},
+		{"icon shortcut", 1},
+		{"apple-touch-icon", 2},
+		{"apple-touch-icon-precomposed", 2},
+		{"", -1},
+		{"stylesheet", -1},
+		{"alternate", -1},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("rel=%q", tt.rel), func(t *testing.T) {
+			got := faviconRelPriority(tt.rel)
+			if got != tt.want {
+				t.Errorf("faviconRelPriority(%q) = %d, want %d", tt.rel, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSelectBestFaviconCandidate_Empty は候補ゼロ件で空文字を返すテスト。
+func TestSelectBestFaviconCandidate_Empty(t *testing.T) {
+	base, _ := url.Parse("https://example.com/")
+	got := selectBestFaviconCandidate(nil, base)
+	if got != "" {
+		t.Errorf("候補 0 件で空文字を返すべき。got %q", got)
+	}
+}
+
+// TestSelectBestFaviconCandidate_PicksLowestPriority は priority が最小の候補が
+// 選択されることをテストする。
+func TestSelectBestFaviconCandidate_PicksLowestPriority(t *testing.T) {
+	base, _ := url.Parse("https://example.com/")
+	cands := []candidate{
+		{href: "/apple.png", priority: 2},
+		{href: "/icon.png", priority: 0},
+		{href: "/shortcut.png", priority: 1},
+	}
+	got := selectBestFaviconCandidate(cands, base)
+	want := "https://example.com/icon.png"
+	if got != want {
+		t.Errorf("priority 最小が選択されるべき。got %q, want %q", got, want)
+	}
+}

--- a/internal/feed/service.go
+++ b/internal/feed/service.go
@@ -138,7 +138,8 @@ func (s *FeedService) RegisterFeed(ctx context.Context, userID string, inputURL 
 	// 取得完了を待たずに登録レスポンスを返す（要件 1）。
 	// ctx のキャンセル/タイムアウトに引きずられないこと（要件 3.3）、
 	// かつ上限時間を付与して goroutine リークを防ぐこと（要件 4）。
-	s.startFaviconFetch(ctx, feed.ID, faviconTargetURL(feed))
+	// feed.FeedURL を起点とした段階的なフォールバック探索を実行する（Issue #122 要件 1, 2）。
+	s.startFaviconFetch(ctx, feed.ID, feed.FeedURL, faviconTargetURL(feed))
 
 	return feed, sub, nil
 }
@@ -147,7 +148,8 @@ func (s *FeedService) RegisterFeed(ctx context.Context, userID string, inputURL 
 // favicon 取得を非同期実行する goroutine を起動する。
 // 独立 context には backgroundFaviconTimeout の上限時間を付与し、
 // goroutine の完了を faviconWG で追跡する。
-func (s *FeedService) startFaviconFetch(ctx context.Context, feedID, siteURL string) {
+// feedURL はフィード配信 URL、siteURL は extractSiteURL で得たフォールバック用サイト URL。
+func (s *FeedService) startFaviconFetch(ctx context.Context, feedID, feedURL, siteURL string) {
 	if s.faviconFetcher == nil {
 		return
 	}
@@ -164,7 +166,7 @@ func (s *FeedService) startFaviconFetch(ctx context.Context, feedID, siteURL str
 		timeoutCtx, cancel := context.WithTimeout(bgCtx, backgroundFaviconTimeout)
 		defer cancel()
 
-		s.fetchAndSaveFavicon(timeoutCtx, feedID, siteURL)
+		s.fetchAndSaveFavicon(timeoutCtx, feedID, feedURL, siteURL)
 	}()
 }
 
@@ -240,21 +242,35 @@ func (s *FeedService) UpdateFeedURL(ctx context.Context, userID, feedID, newURL 
 
 // fetchAndSaveFavicon はフィードのfaviconを取得して保存する。
 // 取得失敗・未検出・タイムアウト時はログ出力のみで、エラーを返さず favicon を null のまま保持する。
-// 返却済みの feed ポインタへの並行書き込みを避けるため、引数は feedID / siteURL のみとし、
+// 返却済みの feed ポインタへの並行書き込みを避けるため、引数は feedID / feedURL / siteURL のみとし、
 // 取得結果はローカル変数経由で DB（UpdateFavicon）にのみ反映する。
-func (s *FeedService) fetchAndSaveFavicon(ctx context.Context, feedID, siteURL string) {
+//
+// 探索戦略（Issue #122 要件 1, 2）: feedURL が空でなければ FetchFaviconWithFallback を用いて
+// (a) フィード配信ドメインの /favicon.ico → (b) フィード配信ドメインの HTML 解析 →
+// (c) サイト本体ドメインの /favicon.ico → (d) サイト本体ドメインの HTML 解析 の順で
+// 段階的に試行する。feedURL が空なら従来通り siteURL を起点に /favicon.ico のみを試行する。
+func (s *FeedService) fetchAndSaveFavicon(ctx context.Context, feedID, feedURL, siteURL string) {
 	if s.faviconFetcher == nil {
 		return
 	}
 
-	data, mimeType, err := s.faviconFetcher.FetchFaviconForSite(ctx, siteURL)
+	var (
+		data     []byte
+		mimeType string
+		err      error
+	)
+	if feedURL != "" {
+		data, mimeType, err = s.faviconFetcher.FetchFaviconWithFallback(ctx, feedURL)
+	} else {
+		data, mimeType, err = s.faviconFetcher.FetchFaviconForSite(ctx, siteURL)
+	}
 	if err != nil {
-		slog.Warn("favicon取得エラー", "feedID", feedID, "siteURL", siteURL, "error", err)
+		slog.Warn("favicon取得エラー", "feedID", feedID, "feedURL", feedURL, "siteURL", siteURL, "error", err)
 		return
 	}
 
 	if data == nil {
-		slog.Info("favicon未検出（nullとして保存）", "feedID", feedID, "siteURL", siteURL)
+		slog.Info("favicon未検出（nullとして保存）", "feedID", feedID, "feedURL", feedURL, "siteURL", siteURL)
 		return
 	}
 

--- a/internal/feed/service_async_test.go
+++ b/internal/feed/service_async_test.go
@@ -32,6 +32,10 @@ func (c *controllableFaviconFetcher) FetchFavicon(ctx context.Context, _ string)
 	return c.FetchFaviconForSite(ctx, "")
 }
 
+func (c *controllableFaviconFetcher) FetchFaviconWithFallback(ctx context.Context, _ string) ([]byte, string, error) {
+	return c.FetchFaviconForSite(ctx, "")
+}
+
 func (c *controllableFaviconFetcher) FetchFaviconForSite(ctx context.Context, _ string) ([]byte, string, error) {
 	c.mu.Lock()
 	c.called = true
@@ -311,6 +315,10 @@ type deadlineObservingFetcher struct {
 }
 
 func (d *deadlineObservingFetcher) FetchFavicon(ctx context.Context, _ string) ([]byte, string, error) {
+	return d.FetchFaviconForSite(ctx, "")
+}
+
+func (d *deadlineObservingFetcher) FetchFaviconWithFallback(ctx context.Context, _ string) ([]byte, string, error) {
 	return d.FetchFaviconForSite(ctx, "")
 }
 

--- a/internal/feed/service_test.go
+++ b/internal/feed/service_test.go
@@ -182,6 +182,10 @@ func (m *mockFaviconFetcher) FetchFaviconForSite(_ context.Context, _ string) ([
 	return m.faviconData, m.faviconMime, m.err
 }
 
+func (m *mockFaviconFetcher) FetchFaviconWithFallback(_ context.Context, _ string) ([]byte, string, error) {
+	return m.faviconData, m.faviconMime, m.err
+}
+
 // mockDetector はテスト用のFeedDetectorモック。
 type mockDetector struct {
 	feedURL string

--- a/web/src/components/feed-list.test.tsx
+++ b/web/src/components/feed-list.test.tsx
@@ -74,6 +74,63 @@ describe("FeedList コンポーネント", () => {
     expect(screen.queryByAltText("News Feed のアイコン")).not.toBeInTheDocument();
   });
 
+  it("faviconがnullの場合に代替アイコン（fallback）を表示すること（要件 3.1）", () => {
+    // Arrange: favicon_url が null の sub-2 (News Feed) を含む mockFeeds を使う
+
+    // Act
+    render(
+      <FeedList feeds={mockFeeds} selectedFeedId={null} onSelectFeed={() => {}} />
+    );
+
+    // Assert: News Feed (sub-2) の代替アイコンが表示される
+    const fallback = screen.getByTestId("feed-favicon-fallback-sub-2");
+    expect(fallback).toBeInTheDocument();
+    expect(fallback).toHaveAttribute("aria-label", "News Feed のアイコン");
+  });
+
+  it("faviconが存在するフィードには代替アイコンを表示しないこと", () => {
+    // Arrange & Act
+    render(
+      <FeedList feeds={mockFeeds} selectedFeedId={null} onSelectFeed={() => {}} />
+    );
+
+    // Assert: Tech Blog (sub-1, favicon_url あり) は fallback を持たない
+    expect(screen.queryByTestId("feed-favicon-fallback-sub-1")).not.toBeInTheDocument();
+  });
+
+  it("favicon画像の読み込みに失敗した場合に代替アイコンに切り替わること（要件 3.2）", () => {
+    // Arrange
+    render(
+      <FeedList feeds={mockFeeds} selectedFeedId={null} onSelectFeed={() => {}} />
+    );
+
+    const img = screen.getByTestId("feed-favicon-sub-1");
+    expect(img).toBeInTheDocument();
+    // 初期状態では fallback は表示されない
+    expect(screen.queryByTestId("feed-favicon-fallback-sub-1")).not.toBeInTheDocument();
+
+    // Act: img の onError を発火させる
+    fireEvent.error(img);
+
+    // Assert: img が消え fallback が表示される
+    expect(screen.queryByTestId("feed-favicon-sub-1")).not.toBeInTheDocument();
+    const fallback = screen.getByTestId("feed-favicon-fallback-sub-1");
+    expect(fallback).toBeInTheDocument();
+    expect(fallback).toHaveAttribute("aria-label", "Tech Blog のアイコン");
+  });
+
+  it("代替アイコン表示時もフィードタイトル・未読数バッジ・ステータスアイコンのレイアウトを維持すること（要件 3.4）", () => {
+    // Arrange & Act: sub-2 (favicon_url null, stopped, unread 0)
+    render(
+      <FeedList feeds={mockFeeds} selectedFeedId={null} onSelectFeed={() => {}} />
+    );
+
+    // Assert: 同じ行に fallback / タイトル / ステータス が全て存在
+    expect(screen.getByTestId("feed-favicon-fallback-sub-2")).toBeInTheDocument();
+    expect(screen.getByText("News Feed")).toBeInTheDocument();
+    expect(screen.getByTestId("feed-status-sub-2")).toBeInTheDocument();
+  });
+
   it("fetch_statusがstoppedの場合に停止アイコンを表示すること", () => {
     render(
       <FeedList feeds={mockFeeds} selectedFeedId={null} onSelectFeed={() => {}} />

--- a/web/src/components/feed-list.tsx
+++ b/web/src/components/feed-list.tsx
@@ -2,7 +2,8 @@
 
 import { cn } from "@/lib/utils";
 import type { Subscription } from "@/types/feed";
-import { CircleAlert, CirclePause } from "lucide-react";
+import { CircleAlert, CirclePause, Rss } from "lucide-react";
+import { useState } from "react";
 
 /** FeedList コンポーネントのプロパティ */
 interface FeedListProps {
@@ -47,18 +48,11 @@ export function FeedList({ feeds, selectedFeedId, onSelectFeed }: FeedListProps)
             )}
             onClick={() => onSelectFeed(feed.feed_id)}
           >
-            {/* favicon */}
-            <div className="flex-shrink-0 w-4 h-4">
-              {feed.favicon_url ? (
-                <img
-                  src={feed.favicon_url}
-                  alt={`${feed.feed_title} のアイコン`}
-                  className="w-4 h-4 rounded-sm object-contain"
-                />
-              ) : (
-                <div className="w-4 h-4" />
-              )}
-            </div>
+            <FeedFavicon
+              feedId={feed.id}
+              faviconURL={feed.favicon_url ?? null}
+              feedTitle={feed.feed_title}
+            />
 
             {/* タイトル */}
             <span className="flex-1 truncate">{feed.feed_title}</span>
@@ -98,5 +92,52 @@ export function FeedList({ feeds, selectedFeedId, onSelectFeed }: FeedListProps)
         );
       })}
     </nav>
+  );
+}
+
+/** FeedFavicon のプロパティ */
+interface FeedFaviconProps {
+  /** 購読 ID（test-id 用） */
+  feedId: string;
+  /** favicon の URL（null/空文字なら代替アイコン表示） */
+  faviconURL: string | null;
+  /** フィードタイトル（alt 属性用） */
+  feedTitle: string;
+}
+
+/**
+ * フィード行先頭の favicon 表示コンポーネント。
+ *
+ * favicon URL が設定されていない場合、および <img> の onError が発火した場合は
+ * lucide-react の Rss アイコンをデフォルトアイコンとして表示する。
+ * 表示サイズは w-4 h-4 で実 favicon と同じ。レイアウトは変化しない（要件 3.3, 3.4）。
+ */
+function FeedFavicon({ feedId, faviconURL, feedTitle }: FeedFaviconProps) {
+  const [imgFailed, setImgFailed] = useState(false);
+
+  const hasURL = faviconURL !== null && faviconURL !== "";
+  const showImage = hasURL && !imgFailed;
+
+  return (
+    <div className="flex-shrink-0 w-4 h-4">
+      {showImage ? (
+        <img
+          data-testid={`feed-favicon-${feedId}`}
+          src={faviconURL}
+          alt={`${feedTitle} のアイコン`}
+          className="w-4 h-4 rounded-sm object-contain"
+          onError={() => setImgFailed(true)}
+        />
+      ) : (
+        <span
+          data-testid={`feed-favicon-fallback-${feedId}`}
+          aria-label={`${feedTitle} のアイコン`}
+          role="img"
+          className="inline-flex items-center justify-center w-4 h-4 text-muted-foreground"
+        >
+          <Rss className="w-4 h-4" aria-hidden="true" />
+        </span>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## 概要

RSS フィード配信 URL とサイト本体ドメインが異なるケースで favicon が取得できず、フィード一覧に空白や壊れた画像が表示される問題を修正する。favicon 取得を 4 段階でフォールバックする仕組みをバックエンドに追加し、すべての段階で取得できない場合はフロントエンド側で代替アイコンを表示するよう改善した。

## 対応 Issue

Closes #122

## 関連 PR

- 設計 PR: なし（design-less impl）

## 実装内容

### Backend (`internal/feed/`)

- `FetchFaviconWithFallback` メソッドを新規追加し、favicon 取得を以下の 4 段階でフォールバック
  - (a) フィード配信 URL のオリジン + `/favicon.ico`（従来経路）
  - (b) フィード配信 URL のオリジン HTML 内 `<link rel="icon">` 等
  - (c) フィード内の記事リンクから推測したサイト本体オリジン + `/favicon.ico`
  - (d) サイト本体オリジン HTML 内 `<link rel="icon">` 等
- 記事リンクが 0 件の場合は段階 (c)(d) をスキップ（Req 1.3）
- 配信ドメインと記事オリジンが同一の場合も段階 (c)(d) をスキップして無駄なリクエストを回避（Req 4.1）
- 各段階の試行内容・URL・成功可否を構造化ログで記録（`slog.Info`）
- 新規依存ライブラリなし（既存 `golang.org/x/net/html` / `mmcdole/gofeed` を利用）

### Frontend (`web/src/components/feed-list.tsx`)

- `FeedFavicon` サブコンポーネントを追加し、`favicon_url` が null/空 または `<img>` の `onError` 発火時に `lucide-react` の `Rss` アイコンを代替アイコンとして表示
- 代替アイコンは実 favicon と同じ `w-4 h-4` サイズ・同じ配置領域を維持（Req 3.3, 3.4）

## 受入基準チェック

- [x] Req 1.1: 配信失敗時にサイト本体ドメインで再取得 ← `TestFetchFaviconWithFallback_StageC_SiteOriginICOSucceeds` / `StageD_SiteOriginHTMLSucceeds`
- [x] Req 1.2: サイト本体取得成功時に永続化 ← `StageC_SiteOriginICOSucceeds` + 既存 service_test.go
- [x] Req 1.3: 記事リンク 0 件のとき再取得しない ← `TestFetchFaviconWithFallback_NoArticles_StopsAfterStageB`
- [x] Req 1.4: 全段階失敗で null 保存 ← `TestFetchFaviconWithFallback_AllStagesFail_ReturnsNil`
- [x] Req 1.5: バックグラウンド処理 ← 既存 `TestRegisterFeed_ReturnsBeforeFaviconCompletes`
- [x] Req 2.1-2.4: 段階フォールバック順序・スキップ・ログ・HTML 解析 ← `TestFetchFaviconWithFallback_*` / `TestParseFaviconURLFromHTML_*` (8 件)
- [x] Req 3.1: favicon 未設定時に代替アイコン ← `feed-list.test.tsx` 「faviconがnullの場合に代替アイコン（fallback）を表示すること」
- [x] Req 3.2: 画像読み込み失敗時に代替アイコン ← `feed-list.test.tsx` 「favicon画像の読み込みに失敗した場合に代替アイコンに切り替わること」
- [x] Req 3.3-3.4: 代替アイコンのサイズ・レイアウト維持 ← CSS クラス `w-4 h-4` / レイアウトテスト
- [x] Req 4.1-4.3: 既存正常ケースの非リグレッション ← `StageA_FeedOriginICOSucceeds` / 既存 feed-list.test.tsx 12 件 green
- [x] NFR 1.1: SSRF 対策 ← `TestFetchFaviconWithFallback_SSRFGuardBlocksAll`
- [x] NFR 1.2: タイムアウト・サイズ上限 ← `faviconTimeout=5s` / `maxFaviconSize=2MB` / `LimitReader`

## テスト結果

```
go test ./...         : ok（全パッケージ pass）
go test -race ./internal/feed/... : ok（race なし）
go vet ./...          : warnings なし
gofmt -l internal/feed/ : 出力なし（clean）
npm test（web/）      : 218 passed / 26 files
npm run lint（web/）  : 0 errors / 5 warnings（すべて preexisting）
```

## 実装上の判断

- サイト本体ドメインの推定は「最初の有効な記事リンク」のオリジンを採用（決定論性とリクエスト数節約のため）
- フィード本体の二重取得（worker 取得とは別に registration 時にも取得）が発生するが、registration 時点でフィードが DB にキャッシュされていないため不可避。最適化は Out of Scope

## 確認事項 / レビュワーへの依頼

- Reviewer 判定: approve — `docs/specs/122-rss-favicon/review-notes.md` を参照
- フィード本体の二重取得が発生する点（registration 時の追加 HTTP リクエスト）: favicon キャッシュ TTL / 共有取得経路の最適化は Out of Scope に明示済みのためこの PR ではスコープ外
- 段階 (c)(d) のサイト本体ドメイン推定は最初の有効な記事リンクのオリジンを採用: 要件 1.1「フィード内の記事リンクから得られるサイト本体ドメイン」を単数として解釈
- HTML 解析ライブラリは既存 `golang.org/x/net/html` を利用。新規依存なし
- base ブランチ検証: --base develop 指定 / baseRefName: develop / 一致 OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #122 のコメントを参照してください。
