### PR TITLE
feat(subscription): implement ManualFetch backend core logic (Issue #115)

### DIFF
--- a/docs/specs/115-issue/impl-notes.md
+++ b/docs/specs/115-issue/impl-notes.md
@@ -29,6 +29,19 @@
 
 残存課題: なし。Task 3（fetcher の成功経路で `UpdateLastSuccessfulFetchAt` を呼ぶ）/ Task 4（subscription.Service.ManualFetch オーケストレーション）が後続。
 
+### Task 3
+
+採用方針: `internal/worker/fetch/fetcher.go` の 304 / 200 OK 双方の `ApplySuccess` 呼び出し直後に、新規 private ヘルパ `(*Fetcher).recordLastSuccessfulFetch(ctx, feedID)` を 1 行ずつ呼ぶ形で `UpdateLastSuccessfulFetchAt` を発火。エラー時は `f.logger.Warn` で構造化ログを出力するだけで、フェッチ自体は成功扱いを維持する。
+
+重要な判断:
+- 呼び出しを 2 箇所にインラインで散らさず private ヘルパに集約（304 / 200 で同じ「成功時刻 + 警告ログ」の 5 行を二重に書くのを避け、CLAUDE.md の「単一責務」「処理は直線的に書く」と整合）。`time.Now()` の取得もヘルパ内で 1 箇所に閉じ込めた
+- 既存の `UpdateFetchState` 失敗時の対称構造（`f.logger.Error` + メトリクス記録）に倣わず、`f.logger.Warn` のみで止めた。理由は本機能の design「成功時刻の記録失敗で fetch 自体は成功扱いを維持」（手動経路のクールダウン判定がレガシー値で動作してもユーザー影響は「次回フェッチ可能になる時刻が少し早まる」だけで safe degradation）に従ったため。メトリクス記録は task 5（manual fetch カウンタ追加）の責務であり、自動経路で `update_state` 系の失敗カウンタを既存メトリクスに追加するのはスコープ外
+- 順序は **`ApplySuccess` → `recordLastSuccessfulFetch` → `UpdateFetchState`** とした。design.md「ApplySuccess 呼び出し直後」を字義通り採用。`UpdateFetchState` の前にしたのは、design.md「`UpdateFetchState` のシグネチャを変更しない後方互換最優先」「別クエリで発行する」記述を尊重し、`updated_at = now()` の二重更新は許容（実害なし）と判断したため
+- テスト用 `mockFeedRepo`（`scheduler_test.go` 内）に追加した可観測フィールドは `lastSuccessfulFetchAtCalls int` / `lastSuccessfulFetchAtFeedIDs []string` / `updateLastSuccessfulFetchAtFn func(...)` の 3 つ。`updateLastSuccessfulFetchAtFn` は failure 注入用（task 3.1 で「エラー時もフェッチ成功扱い」を検証するため）。既存テストはこの mock を fail パスから使用していないため後方互換に動作する
+- 異常系テストは 5 種類（バックオフ 500 / 停止 404 / SSRF 失敗 / パース失敗 / DB エラー注入）。`ApplySuccess` 経路を通らない全分岐をカバーし、`UpdateLastSuccessfulFetchAt` が誤って呼ばれないことを境界として明示
+
+残存課題: なし。Task 4（`subscription.Service.ManualFetch` から手動経路でも `UpdateLastSuccessfulFetchAt` を呼ぶ）が後続。本タスクで自動経路の成功時刻記録は確立されたので、手動経路は同じ feedRepo メソッドを再利用するだけで Req 2.4「自動と手動の成功時刻を同等扱い」が成立する。
+
 ## 補足
 
 - 本実装で追加した依存ライブラリはなし。標準 `database/sql` の `sql.NullTime` のみを利用

--- a/docs/specs/115-issue/impl-notes.md
+++ b/docs/specs/115-issue/impl-notes.md
@@ -1,0 +1,21 @@
+# 実装ノート (Issue #115: フィードの手動更新の機能)
+
+## Implementation Notes
+
+### Task 1
+
+採用方針: `feeds` テーブルに NULL 可な `TIMESTAMPTZ` カラム `last_successful_fetch_at` を追加し、`model.Feed` では `*time.Time` で NULL / 非 NULL を表現。SELECT 経路（`FindByID` / `FindByFeedURL` / `ListDueForFetch`）はすべて `sql.NullTime` 経由で Scan し、共通ヘルパ `nullTimeValue` で `*time.Time` に変換する。
+
+重要な判断:
+- カラム位置は `next_fetch_at` の直後に追加（時刻系カラムを並べる既存のスキーマ慣習に合わせる）。SELECT 句の列順も同じ並びにし、Scan 引数の対応を読みやすくした
+- バックフィルしない設計（`LastSuccessfulFetchAt == nil` をクールダウン非適用に倒す）を design 通りに採用。既存ユーザーの操作性を阻害しない safe default
+- `nullTimeValue` は `nullStringValue` と同じ命名/挙動規約で `postgres_feed_repo.go` に追加（呼び出し側 3 箇所で重複した変換ロジックを書かないため）
+- `migrate_test.go` の `TestFeedsTable.expectedColumns` に新カラムを追加し、マイグレーション適用後のカラム存在を機械的に保証
+- 既存テスト（`TestPostgresFeedRepo_*` / `TestPostgresFeedRepo_UpdateFetchState`）は SELECT 句の追加で Scan 行数が増えるが、行数指定がなく `&feed.X` 単位の Scan 引数のため後方互換に動作する
+
+残存課題: なし（Task 2 以降の `LockFeedForUpdateNowait` / `UpdateLastSuccessfulFetchAt` の interface 拡張は本タスクではスコープ外）。
+
+## 補足
+
+- 本実装で追加した依存ライブラリはなし。標準 `database/sql` の `sql.NullTime` のみを利用
+- DB 結合テスト `TestPostgresFeedRepo_LastSuccessfulFetchAt_Scan` はテスト用 PostgreSQL に接続できない CI 環境では既存テスト同様に skip される

--- a/docs/specs/115-issue/impl-notes.md
+++ b/docs/specs/115-issue/impl-notes.md
@@ -42,7 +42,18 @@
 
 残存課題: なし。Task 4（`subscription.Service.ManualFetch` から手動経路でも `UpdateLastSuccessfulFetchAt` を呼ぶ）が後続。本タスクで自動経路の成功時刻記録は確立されたので、手動経路は同じ feedRepo メソッドを再利用するだけで Req 2.4「自動と手動の成功時刻を同等扱い」が成立する。
 
+### Task 4
+
+採用方針: `subscription.Service` に `ManualFetch` メソッドを追加し、手動フェッチのオーケストレーション（認可・行ロック・クールダウン判定・Fetcher呼び出し・メトリクス記録・結果分類）を実装。また、テストコードを追加して各境界条件やエラーケースを徹底検証。
+
+重要な判断:
+- **自己デッドロックの回避 (重要)**: 既存 `Fetcher` は `*sql.DB`（非トランザクション）経由で `UpdateFetchState` を発行するため、`LockFeedForUpdateNowait` でトランザクション（`FOR UPDATE` ロック）を保持したまま `fetcher.Fetch` を呼び出すと、行更新クエリがロックを待機して自己デッドロックを引き起こす。このため、クールダウン判定が終わった段階で `tx.Commit()` を呼び出して行ロックを事前に解放した上で `fetcher.Fetch` を実行する設計とした。
+- **クールダウンの判定とトランザクション解放**: クールダウン中（10分以内）の場合は外部HTTPリクエストを行わず `FEED_COOLDOWN` を返すが、トランザクションの未コミット状態を防ぐため、エラーを返す前に `tx.Commit()` または `tx.Rollback()` を安全に行うようにした。
+- **結果分類のロバスト性**: `Fetcher` 自体は `nil` を返しても、既存の `ApplyParseFailure` などの仕組みでフィード内部のエラーメッセージに失敗内容が記録される場合がある。そのため、`Fetch` 呼び出し後のフィード状態（`ConsecutiveErrors == 0 && FetchStatus == model.FetchStatusActive` 等）やエラーメッセージの文言（"UPSERT" や "パース" などの文字列検知）に基づいて適切に APIError (FEED_COOLDOWN, FETCH_FAILED, PARSE_FAILED) に変換し、対応するメトリクス（metrics package 実装予定）の Nop stub を定義・呼び出しした。
+- **単体テストの網羅**: `mockManualFetchTx` や `mockManualFetchMetricsRecorder` 等の専用モックを定義し、正常系成功、認可失敗（他ユーザーまたは存在しない購読ID）、ロック競合（`ErrFeedLocked` 発生時）、クールダウンによる拒否、およびSSRF / パース失敗 / 一般HTTPエラーなど各種フェッチエラー時のハンドリングとメトリクス記録が正しく行われることを検証した。
+
 ## 補足
+
 
 - 本実装で追加した依存ライブラリはなし。標準 `database/sql` の `sql.NullTime` のみを利用
 - DB 結合テスト `TestPostgresFeedRepo_LastSuccessfulFetchAt_Scan` はテスト用 PostgreSQL に接続できない CI 環境では既存テスト同様に skip される

--- a/docs/specs/115-issue/impl-notes.md
+++ b/docs/specs/115-issue/impl-notes.md
@@ -15,6 +15,20 @@
 
 残存課題: なし（Task 2 以降の `LockFeedForUpdateNowait` / `UpdateLastSuccessfulFetchAt` の interface 拡張は本タスクではスコープ外）。
 
+### Task 2
+
+採用方針: `FeedRepository` interface に `LockFeedForUpdateNowait` / `UpdateLastSuccessfulFetchAt` の 2 メソッドを追加し、`PostgresFeedRepo` に実装。PostgreSQL の `SELECT ... FOR UPDATE NOWAIT` で非ブロッキング排他ロックを取得し、ErrCode `55P03`（lock_not_available）を `*pq.Error` 経由で判定して sentinel `ErrFeedLocked` に正規化する。
+
+重要な判断:
+- `ErrFeedLocked` は package level の exported sentinel として宣言（doc comment 付き）。上位レイヤ（subscription.Service）が `errors.Is(err, ErrFeedLocked)` で判定できるよう典型的な Go の sentinel error パターンを採用
+- PG ErrCode は const `pgErrCodeLockNotAvailable = "55P03"` として切り出し、マジック文字列を排除（CLAUDE.md「マジックナンバーは定数化」）
+- `LockFeedForUpdateNowait` の Scan ロジックは既存 `FindByID` と同じ列順・同じ NullString/NullTime 経由パターンを踏襲（重複を減らすため共通ヘルパに切り出すのは Task 4.1 で `dbExecutor` interface を導入する際に再検討する）
+- `UpdateLastSuccessfulFetchAt` は `*sql.DB` 経由（非トランザクション）で実装。design.md の「自動経路」（worker fetcher）で `UpdateFetchState` と別クエリで発行する方針に合わせた選択。tx 経由が必要な場合は呼び出し側で別途オーバーロードを検討する
+- 既存 mock `mockFeedRepo`（`internal/feed/` / `internal/subscription/` / `internal/worker/fetch/`）に no-op stub を追加して interface 充足。スコープ外の本物の振る舞いは各 task で必要に応じて差し替える
+- DB 結合テストは既存 `setupListDueTestDB` を流用し、PG 接続不能時の自動 skip を継承。ロック競合テストは 2 つの tx を同時保持して NOWAIT の即時失敗を観測する標準的な PostgreSQL テストパターン
+
+残存課題: なし。Task 3（fetcher の成功経路で `UpdateLastSuccessfulFetchAt` を呼ぶ）/ Task 4（subscription.Service.ManualFetch オーケストレーション）が後続。
+
 ## 補足
 
 - 本実装で追加した依存ライブラリはなし。標準 `database/sql` の `sql.NullTime` のみを利用

--- a/docs/specs/115-issue/tasks.md
+++ b/docs/specs/115-issue/tasks.md
@@ -39,7 +39,7 @@
   - _Boundary: fetch.Fetcher_
   - _Depends: 2.1_
 
-- [ ] 4. Service 層: subscription.Service に ManualFetch メソッド追加
+- [x] 4. Service 層: subscription.Service に ManualFetch メソッド追加
 - [x] 4.1 ManualFetch のオーケストレーション実装（認可 / 行ロック / クールダウン判定 / fetcher 呼び出し / メトリクス）
   - `internal/model/errors.go` に `ErrCodeFeedFetchInProgress = "FEED_FETCH_IN_PROGRESS"` /
     `ErrCodeFeedCooldown = "FEED_COOLDOWN"` 定数と、`NewFeedFetchInProgressError()` /

--- a/docs/specs/115-issue/tasks.md
+++ b/docs/specs/115-issue/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. DB マイグレーション: feeds.last_successful_fetch_at カラム追加
+- [x] 1. DB マイグレーション: feeds.last_successful_fetch_at カラム追加
 - [x] 1.1 up / down マイグレーションファイルを新規作成
   - `internal/database/migrations/20260528120000_add_feeds_last_successful_fetch_at.up.sql` を作成し、
     `ALTER TABLE feeds ADD COLUMN last_successful_fetch_at TIMESTAMPTZ NULL` を記述（バックフィルなし）

--- a/docs/specs/115-issue/tasks.md
+++ b/docs/specs/115-issue/tasks.md
@@ -13,7 +13,7 @@
     SELECT 期待値・Scan 行数が変わるため整合させる
   - _Requirements: 2.4_
 
-- [ ] 2. Repository 層: 行ロック取得 + last_successful_fetch_at 更新メソッド追加
+- [x] 2. Repository 層: 行ロック取得 + last_successful_fetch_at 更新メソッド追加
 - [x] 2.1 LockFeedForUpdateNowait / UpdateLastSuccessfulFetchAt の interface 定義と PostgreSQL 実装
   - `internal/repository/interfaces.go` の `FeedRepository` interface に以下 2 メソッドを追加:
     `LockFeedForUpdateNowait(ctx, tx *sql.Tx, feedID string) (*model.Feed, error)`

--- a/docs/specs/115-issue/tasks.md
+++ b/docs/specs/115-issue/tasks.md
@@ -29,7 +29,7 @@
   - _Depends: 1.1_
 
 - [ ] 3. Worker fetcher の成功経路に UpdateLastSuccessfulFetchAt 反映
-- [ ] 3.1 既存 Fetcher.Fetch の ApplySuccess 直後に成功時刻を記録 (P)
+- [x] 3.1 既存 Fetcher.Fetch の ApplySuccess 直後に成功時刻を記録 (P)
   - `internal/worker/fetch/fetcher.go` の 2 箇所（304 Not Modified パス / 200 OK 成功パス）の `ApplySuccess` 呼び出し直後に
     `f.feedRepo.UpdateLastSuccessfulFetchAt(ctx, feed.ID, time.Now())` を 1 行追加する
   - エラーが発生した場合はログ警告のみ（成功時刻の記録失敗で fetch 自体は成功扱いを維持）

--- a/docs/specs/115-issue/tasks.md
+++ b/docs/specs/115-issue/tasks.md
@@ -1,7 +1,7 @@
 # Implementation Plan
 
 - [ ] 1. DB マイグレーション: feeds.last_successful_fetch_at カラム追加
-- [ ] 1.1 up / down マイグレーションファイルを新規作成
+- [x] 1.1 up / down マイグレーションファイルを新規作成
   - `internal/database/migrations/20260528120000_add_feeds_last_successful_fetch_at.up.sql` を作成し、
     `ALTER TABLE feeds ADD COLUMN last_successful_fetch_at TIMESTAMPTZ NULL` を記述（バックフィルなし）
   - `internal/database/migrations/20260528120000_add_feeds_last_successful_fetch_at.down.sql` を作成し、

--- a/docs/specs/115-issue/tasks.md
+++ b/docs/specs/115-issue/tasks.md
@@ -40,7 +40,7 @@
   - _Depends: 2.1_
 
 - [ ] 4. Service 層: subscription.Service に ManualFetch メソッド追加
-- [ ] 4.1 ManualFetch のオーケストレーション実装（認可 / 行ロック / クールダウン判定 / fetcher 呼び出し / メトリクス）
+- [x] 4.1 ManualFetch のオーケストレーション実装（認可 / 行ロック / クールダウン判定 / fetcher 呼び出し / メトリクス）
   - `internal/model/errors.go` に `ErrCodeFeedFetchInProgress = "FEED_FETCH_IN_PROGRESS"` /
     `ErrCodeFeedCooldown = "FEED_COOLDOWN"` 定数と、`NewFeedFetchInProgressError()` /
     `NewFeedCooldownError(retryAfterSeconds int)` 生成関数を追加。後者は `Details["retry_after_seconds"] = int` をセット

--- a/docs/specs/115-issue/tasks.md
+++ b/docs/specs/115-issue/tasks.md
@@ -14,7 +14,7 @@
   - _Requirements: 2.4_
 
 - [ ] 2. Repository 層: 行ロック取得 + last_successful_fetch_at 更新メソッド追加
-- [ ] 2.1 LockFeedForUpdateNowait / UpdateLastSuccessfulFetchAt の interface 定義と PostgreSQL 実装
+- [x] 2.1 LockFeedForUpdateNowait / UpdateLastSuccessfulFetchAt の interface 定義と PostgreSQL 実装
   - `internal/repository/interfaces.go` の `FeedRepository` interface に以下 2 メソッドを追加:
     `LockFeedForUpdateNowait(ctx, tx *sql.Tx, feedID string) (*model.Feed, error)`
     `UpdateLastSuccessfulFetchAt(ctx, feedID string, at time.Time) error`

--- a/docs/specs/115-issue/tasks.md
+++ b/docs/specs/115-issue/tasks.md
@@ -28,7 +28,7 @@
   - _Boundary: PostgresFeedRepo_
   - _Depends: 1.1_
 
-- [ ] 3. Worker fetcher の成功経路に UpdateLastSuccessfulFetchAt 反映
+- [x] 3. Worker fetcher の成功経路に UpdateLastSuccessfulFetchAt 反映
 - [x] 3.1 既存 Fetcher.Fetch の ApplySuccess 直後に成功時刻を記録 (P)
   - `internal/worker/fetch/fetcher.go` の 2 箇所（304 Not Modified パス / 200 OK 成功パス）の `ApplySuccess` 呼び出し直後に
     `f.feedRepo.UpdateLastSuccessfulFetchAt(ctx, feed.ID, time.Now())` を 1 行追加する

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -214,20 +214,21 @@ func TestFeedsTable(t *testing.T) {
 	}
 
 	expectedColumns := map[string]string{
-		"id":                 "uuid",
-		"feed_url":           "text",
-		"site_url":           "text",
-		"title":              "character varying",
-		"favicon_data":       "bytea",
-		"favicon_mime":       "character varying",
-		"etag":               "character varying",
-		"last_modified":      "character varying",
-		"fetch_status":       "character varying",
-		"consecutive_errors": "integer",
-		"error_message":      "text",
-		"next_fetch_at":      "timestamp with time zone",
-		"created_at":         "timestamp with time zone",
-		"updated_at":         "timestamp with time zone",
+		"id":                       "uuid",
+		"feed_url":                 "text",
+		"site_url":                 "text",
+		"title":                    "character varying",
+		"favicon_data":             "bytea",
+		"favicon_mime":             "character varying",
+		"etag":                     "character varying",
+		"last_modified":            "character varying",
+		"fetch_status":             "character varying",
+		"consecutive_errors":       "integer",
+		"error_message":            "text",
+		"next_fetch_at":            "timestamp with time zone",
+		"last_successful_fetch_at": "timestamp with time zone",
+		"created_at":               "timestamp with time zone",
+		"updated_at":               "timestamp with time zone",
 	}
 	assertTableColumns(t, db, "feeds", expectedColumns)
 

--- a/internal/database/migrations/20260528120000_add_feeds_last_successful_fetch_at.down.sql
+++ b/internal/database/migrations/20260528120000_add_feeds_last_successful_fetch_at.down.sql
@@ -1,0 +1,2 @@
+-- feeds テーブルから last_successful_fetch_at カラムを削除する
+ALTER TABLE feeds DROP COLUMN IF EXISTS last_successful_fetch_at;

--- a/internal/database/migrations/20260528120000_add_feeds_last_successful_fetch_at.up.sql
+++ b/internal/database/migrations/20260528120000_add_feeds_last_successful_fetch_at.up.sql
@@ -1,0 +1,5 @@
+-- feeds テーブルに last_successful_fetch_at カラムを追加する
+-- 用途: 手動フェッチ機能 (Issue #115) のクールダウン判定 (10 分) の起点となる
+-- 自動ワーカー / 手動フェッチの両経路から成功時に更新される
+-- 既存行はバックフィルしない (NULL = 過去成功実績なし = クールダウン非適用の safe default)
+ALTER TABLE feeds ADD COLUMN last_successful_fetch_at TIMESTAMPTZ NULL;

--- a/internal/feed/service_test.go
+++ b/internal/feed/service_test.go
@@ -2,11 +2,13 @@ package feed
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/hitoshi/feedman/internal/model"
 	"github.com/hitoshi/feedman/internal/repository"
@@ -92,6 +94,14 @@ func (m *mockFeedRepo) ListDueForFetch(_ context.Context) ([]*model.Feed, error)
 }
 
 func (m *mockFeedRepo) UpdateFetchState(_ context.Context, _ *model.Feed) error {
+	return nil
+}
+
+func (m *mockFeedRepo) LockFeedForUpdateNowait(_ context.Context, _ *sql.Tx, _ string) (*model.Feed, error) {
+	return nil, nil
+}
+
+func (m *mockFeedRepo) UpdateLastSuccessfulFetchAt(_ context.Context, _ string, _ time.Time) error {
 	return nil
 }
 

--- a/internal/model/errors.go
+++ b/internal/model/errors.go
@@ -5,11 +5,15 @@ import "fmt"
 
 // APIError は統一エラーフォーマットを表す。
 // UIに表示する原因カテゴリと対処方法を含む。
+// Details は任意の構造化追加情報を表し、429（クールダウン中）の retry_after_seconds など
+// 既存 4 フィールド（Code / Message / Category / Action）では表現できない補足情報を載せる。
+// nil の場合は JSON シリアライズ時に出力されない（omitempty 相当）。
 type APIError struct {
-	Code     string // エラーコード
-	Message  string // エラーメッセージ
-	Category string // カテゴリ: auth, validation, feed, system
-	Action   string // ユーザー向け対処方法
+	Code     string         // エラーコード
+	Message  string         // エラーメッセージ
+	Category string         // カテゴリ: auth, validation, feed, system
+	Action   string         // ユーザー向け対処方法
+	Details  map[string]any // 任意の構造化追加情報（429 等で retry_after_seconds 等を載せる）
 }
 
 // Error はerrorインターフェースを実装する。
@@ -31,6 +35,8 @@ const (
 	ErrCodeInvalidFetchInterval  = "INVALID_FETCH_INTERVAL"
 	ErrCodeFeedNotStopped        = "FEED_NOT_STOPPED"
 	ErrCodeUserNotFound          = "USER_NOT_FOUND"
+	ErrCodeFeedFetchInProgress   = "FEED_FETCH_IN_PROGRESS"
+	ErrCodeFeedCooldown          = "FEED_COOLDOWN"
 )
 
 // NewItemNotFoundError は記事未検出エラーを生成する。
@@ -160,5 +166,31 @@ func NewUserNotFoundError() *APIError {
 		Message:  "ユーザーが見つかりません。",
 		Category: "auth",
 		Action:   "ログインし直してください。",
+	}
+}
+
+// NewFeedFetchInProgressError は対象フィードが別トランザクションでフェッチ中のため
+// 行ロック取得に失敗したときのエラーを生成する。HTTP 409 にマップされる。
+func NewFeedFetchInProgressError() *APIError {
+	return &APIError{
+		Code:     ErrCodeFeedFetchInProgress,
+		Message:  "現在フェッチが進行中のためしばらく待ってから再試行してください。",
+		Category: "feed",
+		Action:   "現在フェッチが進行中のためしばらく待ってから再試行してください。",
+	}
+}
+
+// NewFeedCooldownError は対象フィードが 10 分クールダウン中のため手動フェッチが
+// 拒否されたときのエラーを生成する。HTTP 429 にマップされ、Details["retry_after_seconds"]
+// に次回フェッチ可能になるまでの残り秒数（int）を載せる。
+func NewFeedCooldownError(retryAfterSeconds int) *APIError {
+	return &APIError{
+		Code:     ErrCodeFeedCooldown,
+		Message:  fmt.Sprintf("クールダウン中です。再試行まで残り %d 秒です。", retryAfterSeconds),
+		Category: "feed",
+		Action:   "最終成功時刻から10分経過するまで手動フェッチは実行できません。",
+		Details: map[string]any{
+			"retry_after_seconds": retryAfterSeconds,
+		},
 	}
 }

--- a/internal/model/errors_test.go
+++ b/internal/model/errors_test.go
@@ -1,0 +1,107 @@
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNewFeedFetchInProgressError は行ロック競合エラーが
+// 期待する Code / Category と Action 文字列を含むことを検証する（Req 3.2, 3.3）。
+func TestNewFeedFetchInProgressError(t *testing.T) {
+	// Arrange & Act
+	err := NewFeedFetchInProgressError()
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected non-nil APIError, got nil")
+	}
+	if err.Code != ErrCodeFeedFetchInProgress {
+		t.Errorf("Code = %q, want %q", err.Code, ErrCodeFeedFetchInProgress)
+	}
+	if err.Category != "feed" {
+		t.Errorf("Category = %q, want %q", err.Category, "feed")
+	}
+	if !strings.Contains(err.Action, "再試行") {
+		t.Errorf("Action = %q, expected to contain 再試行", err.Action)
+	}
+	if err.Details != nil {
+		t.Errorf("Details = %+v, want nil for lock conflict", err.Details)
+	}
+}
+
+// TestNewFeedCooldownError はクールダウンエラーが
+// retry_after_seconds を Details に int 型で載せることを検証する（Req 2.2）。
+func TestNewFeedCooldownError(t *testing.T) {
+	tests := []struct {
+		name              string
+		retryAfterSeconds int
+	}{
+		{"残り0秒のとき", 0},
+		{"残り1秒のとき", 1},
+		{"残り300秒のとき", 300},
+		{"残り599秒のとき", 599},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange & Act
+			err := NewFeedCooldownError(tt.retryAfterSeconds)
+
+			// Assert
+			if err == nil {
+				t.Fatal("expected non-nil APIError, got nil")
+			}
+			if err.Code != ErrCodeFeedCooldown {
+				t.Errorf("Code = %q, want %q", err.Code, ErrCodeFeedCooldown)
+			}
+			if err.Category != "feed" {
+				t.Errorf("Category = %q, want %q", err.Category, "feed")
+			}
+			if err.Details == nil {
+				t.Fatal("Details must be non-nil for cooldown error")
+			}
+			retry, ok := err.Details["retry_after_seconds"]
+			if !ok {
+				t.Fatal("Details[\"retry_after_seconds\"] not set")
+			}
+			gotInt, ok := retry.(int)
+			if !ok {
+				t.Fatalf("Details[\"retry_after_seconds\"] type = %T, want int", retry)
+			}
+			if gotInt != tt.retryAfterSeconds {
+				t.Errorf("Details[\"retry_after_seconds\"] = %d, want %d", gotInt, tt.retryAfterSeconds)
+			}
+		})
+	}
+}
+
+// TestAPIError_Error_PreservesFormat は既存テストが Details を参照していないため、
+// Error() メソッドの出力フォーマットが Details 追加で変化していないことを検証する。
+func TestAPIError_Error_PreservesFormat(t *testing.T) {
+	// Arrange
+	err := &APIError{
+		Code:    "TEST_CODE",
+		Message: "テストメッセージ",
+	}
+
+	// Act
+	got := err.Error()
+
+	// Assert
+	want := "[TEST_CODE] テストメッセージ"
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+// TestAPIError_Details_OptionalDefault は Details フィールドの既定値が nil である
+// ことを検証する（既存 APIError 生成関数が Details を設定していない箇所での後方互換性）。
+func TestAPIError_Details_OptionalDefault(t *testing.T) {
+	// Arrange
+	err := NewSubscriptionNotFoundError("sub-1")
+
+	// Assert
+	if err.Details != nil {
+		t.Errorf("Details should be nil for existing constructors, got %+v", err.Details)
+	}
+}

--- a/internal/model/feed.go
+++ b/internal/model/feed.go
@@ -5,20 +5,24 @@ import "time"
 
 // Feed はRSS/Atomフィードを表す。
 type Feed struct {
-	ID               string
-	FeedURL          string
-	SiteURL          string
-	Title            string
-	FaviconData      []byte
-	FaviconMime      string
-	ETag             string
-	LastModified     string
-	FetchStatus      FetchStatus
+	ID                string
+	FeedURL           string
+	SiteURL           string
+	Title             string
+	FaviconData       []byte
+	FaviconMime       string
+	ETag              string
+	LastModified      string
+	FetchStatus       FetchStatus
 	ConsecutiveErrors int
-	ErrorMessage     string
-	NextFetchAt      time.Time
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
+	ErrorMessage      string
+	NextFetchAt       time.Time
+	// LastSuccessfulFetchAt は直近のフェッチ成功時刻。
+	// nil の場合は過去に成功実績がないことを表し、手動フェッチのクールダウン判定では非適用となる。
+	// 自動ワーカー / 手動フェッチの双方の成功経路で更新される。
+	LastSuccessfulFetchAt *time.Time
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
 }
 
 // FetchStatus はフィードのフェッチ状態を表す。

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -66,6 +66,16 @@ type FeedRepository interface {
 	// UpdateFetchState はフィードのフェッチ状態を更新する。
 	// fetch_status、consecutive_errors、error_message、next_fetch_at、etag、last_modifiedを更新する。
 	UpdateFetchState(ctx context.Context, feed *model.Feed) error
+
+	// LockFeedForUpdateNowait は指定フィード行に対し非ブロッキング排他ロック（FOR UPDATE NOWAIT）を取得する。
+	// 既に別トランザクションがロックを保持している場合は ErrFeedLocked を返し、待機しない。
+	// 取得したロックは tx の COMMIT / ROLLBACK で自動解放される。
+	// 対象 ID のフィードが存在しないときは (nil, nil) を返す（FindByID と同パターン）。
+	LockFeedForUpdateNowait(ctx context.Context, tx *sql.Tx, feedID string) (*model.Feed, error)
+
+	// UpdateLastSuccessfulFetchAt は指定フィードの last_successful_fetch_at を更新する。
+	// 自動ワーカーの成功経路と手動フェッチの成功経路の双方から呼ばれる共有更新メソッド。
+	UpdateLastSuccessfulFetchAt(ctx context.Context, feedID string, at time.Time) error
 }
 
 // SubscriptionRepository は購読データの永続化インターフェース。

--- a/internal/repository/postgres_feed_repo.go
+++ b/internal/repository/postgres_feed_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/hitoshi/feedman/internal/model"
 )
@@ -23,18 +24,21 @@ func (r *PostgresFeedRepo) FindByID(ctx context.Context, id string) (*model.Feed
 	feed := &model.Feed{}
 	var faviconData []byte
 	var faviconMime, siteURL, etag, lastModified, errorMessage sql.NullString
+	var lastSuccessfulFetchAt sql.NullTime
 
 	err := r.db.QueryRowContext(ctx,
 		`SELECT id, feed_url, site_url, title, favicon_data, favicon_mime,
 		        etag, last_modified, fetch_status, consecutive_errors,
-		        error_message, next_fetch_at, created_at, updated_at
+		        error_message, next_fetch_at, last_successful_fetch_at,
+		        created_at, updated_at
 		 FROM feeds WHERE id = $1`,
 		id,
 	).Scan(
 		&feed.ID, &feed.FeedURL, &siteURL, &feed.Title,
 		&faviconData, &faviconMime,
 		&etag, &lastModified, &feed.FetchStatus, &feed.ConsecutiveErrors,
-		&errorMessage, &feed.NextFetchAt, &feed.CreatedAt, &feed.UpdatedAt,
+		&errorMessage, &feed.NextFetchAt, &lastSuccessfulFetchAt,
+		&feed.CreatedAt, &feed.UpdatedAt,
 	)
 
 	if err == sql.ErrNoRows {
@@ -50,6 +54,7 @@ func (r *PostgresFeedRepo) FindByID(ctx context.Context, id string) (*model.Feed
 	feed.ETag = nullStringValue(etag)
 	feed.LastModified = nullStringValue(lastModified)
 	feed.ErrorMessage = nullStringValue(errorMessage)
+	feed.LastSuccessfulFetchAt = nullTimeValue(lastSuccessfulFetchAt)
 
 	return feed, nil
 }
@@ -59,18 +64,21 @@ func (r *PostgresFeedRepo) FindByFeedURL(ctx context.Context, feedURL string) (*
 	feed := &model.Feed{}
 	var faviconData []byte
 	var faviconMime, siteURL, etag, lastModified, errorMessage sql.NullString
+	var lastSuccessfulFetchAt sql.NullTime
 
 	err := r.db.QueryRowContext(ctx,
 		`SELECT id, feed_url, site_url, title, favicon_data, favicon_mime,
 		        etag, last_modified, fetch_status, consecutive_errors,
-		        error_message, next_fetch_at, created_at, updated_at
+		        error_message, next_fetch_at, last_successful_fetch_at,
+		        created_at, updated_at
 		 FROM feeds WHERE feed_url = $1`,
 		feedURL,
 	).Scan(
 		&feed.ID, &feed.FeedURL, &siteURL, &feed.Title,
 		&faviconData, &faviconMime,
 		&etag, &lastModified, &feed.FetchStatus, &feed.ConsecutiveErrors,
-		&errorMessage, &feed.NextFetchAt, &feed.CreatedAt, &feed.UpdatedAt,
+		&errorMessage, &feed.NextFetchAt, &lastSuccessfulFetchAt,
+		&feed.CreatedAt, &feed.UpdatedAt,
 	)
 
 	if err == sql.ErrNoRows {
@@ -86,6 +94,7 @@ func (r *PostgresFeedRepo) FindByFeedURL(ctx context.Context, feedURL string) (*
 	feed.ETag = nullStringValue(etag)
 	feed.LastModified = nullStringValue(lastModified)
 	feed.ErrorMessage = nullStringValue(errorMessage)
+	feed.LastSuccessfulFetchAt = nullTimeValue(lastSuccessfulFetchAt)
 
 	return feed, nil
 }
@@ -158,6 +167,16 @@ func nullStringValue(ns sql.NullString) string {
 	return ""
 }
 
+// nullTimeValue はsql.NullTimeから*time.Timeを取得する。
+// Valid=false のときは nil を返し、ドメインモデル側で「未設定」を nil で表現できるようにする。
+func nullTimeValue(nt sql.NullTime) *time.Time {
+	if nt.Valid {
+		t := nt.Time
+		return &t
+	}
+	return nil
+}
+
 // ListDueForFetch はフェッチ対象のフィードを取得する。
 // next_fetch_at <= now() かつ fetch_status = 'active' かつ購読者が存在するフィードを
 // FOR UPDATE SKIP LOCKEDで排他的に取得する。
@@ -171,7 +190,8 @@ func (r *PostgresFeedRepo) ListDueForFetch(ctx context.Context) ([]*model.Feed, 
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT f.id, f.feed_url, f.site_url, f.title, f.favicon_data, f.favicon_mime,
 		        f.etag, f.last_modified, f.fetch_status, f.consecutive_errors,
-		        f.error_message, f.next_fetch_at, f.created_at, f.updated_at
+		        f.error_message, f.next_fetch_at, f.last_successful_fetch_at,
+		        f.created_at, f.updated_at
 		 FROM feeds f
 		 WHERE f.next_fetch_at <= now()
 		   AND f.fetch_status = 'active'
@@ -189,12 +209,14 @@ func (r *PostgresFeedRepo) ListDueForFetch(ctx context.Context) ([]*model.Feed, 
 		feed := &model.Feed{}
 		var faviconData []byte
 		var faviconMime, siteURL, etag, lastModified, errorMessage sql.NullString
+		var lastSuccessfulFetchAt sql.NullTime
 
 		if err := rows.Scan(
 			&feed.ID, &feed.FeedURL, &siteURL, &feed.Title,
 			&faviconData, &faviconMime,
 			&etag, &lastModified, &feed.FetchStatus, &feed.ConsecutiveErrors,
-			&errorMessage, &feed.NextFetchAt, &feed.CreatedAt, &feed.UpdatedAt,
+			&errorMessage, &feed.NextFetchAt, &lastSuccessfulFetchAt,
+			&feed.CreatedAt, &feed.UpdatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("フェッチ対象フィードの読み取りに失敗しました: %w", err)
 		}
@@ -205,6 +227,7 @@ func (r *PostgresFeedRepo) ListDueForFetch(ctx context.Context) ([]*model.Feed, 
 		feed.ETag = nullStringValue(etag)
 		feed.LastModified = nullStringValue(lastModified)
 		feed.ErrorMessage = nullStringValue(errorMessage)
+		feed.LastSuccessfulFetchAt = nullTimeValue(lastSuccessfulFetchAt)
 
 		feeds = append(feeds, feed)
 	}

--- a/internal/repository/postgres_feed_repo.go
+++ b/internal/repository/postgres_feed_repo.go
@@ -3,11 +3,23 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/hitoshi/feedman/internal/model"
+	"github.com/lib/pq"
 )
+
+// ErrFeedLocked は対象フィード行が別トランザクションによって既にロックされている場合に返される。
+// PostgreSQL ErrCode 55P03 (lock_not_available) を判定し、上位レイヤ用に sentinel error として正規化する。
+// 行ロック非ブロッキング取得（LockFeedForUpdateNowait）の戻り値として errors.Is(err, ErrFeedLocked) で
+// 検出可能とすることで、subscription.Service 側で FEED_FETCH_IN_PROGRESS APIError へマップする責務を集約する。
+var ErrFeedLocked = errors.New("feed row is currently locked by another transaction")
+
+// pgErrCodeLockNotAvailable は PostgreSQL の lock_not_available エラーコード。
+// SELECT ... FOR UPDATE NOWAIT が既存ロック保持中の行に当たったときに返される。
+const pgErrCodeLockNotAvailable = "55P03"
 
 // PostgresFeedRepo はPostgreSQLを使用したフィードリポジトリ。
 type PostgresFeedRepo struct {
@@ -272,6 +284,67 @@ func (r *PostgresFeedRepo) UpdateFetchState(ctx context.Context, feed *model.Fee
 	)
 	if err != nil {
 		return fmt.Errorf("フェッチ状態の更新に失敗しました: %w", err)
+	}
+	return nil
+}
+
+// LockFeedForUpdateNowait は指定フィード行に対し非ブロッキング排他ロック（FOR UPDATE NOWAIT）を取得する。
+// 既に別トランザクションがロックを保持している場合は ErrFeedLocked を返し、待機しない。
+// 取得したロックは tx の COMMIT / ROLLBACK で自動解放される。
+// 対象 ID のフィードが存在しないときは (nil, nil) を返す（FindByID と同パターン）。
+func (r *PostgresFeedRepo) LockFeedForUpdateNowait(ctx context.Context, tx *sql.Tx, feedID string) (*model.Feed, error) {
+	feed := &model.Feed{}
+	var faviconData []byte
+	var faviconMime, siteURL, etag, lastModified, errorMessage sql.NullString
+	var lastSuccessfulFetchAt sql.NullTime
+
+	err := tx.QueryRowContext(ctx,
+		`SELECT id, feed_url, site_url, title, favicon_data, favicon_mime,
+		        etag, last_modified, fetch_status, consecutive_errors,
+		        error_message, next_fetch_at, last_successful_fetch_at,
+		        created_at, updated_at
+		 FROM feeds WHERE id = $1 FOR UPDATE NOWAIT`,
+		feedID,
+	).Scan(
+		&feed.ID, &feed.FeedURL, &siteURL, &feed.Title,
+		&faviconData, &faviconMime,
+		&etag, &lastModified, &feed.FetchStatus, &feed.ConsecutiveErrors,
+		&errorMessage, &feed.NextFetchAt, &lastSuccessfulFetchAt,
+		&feed.CreatedAt, &feed.UpdatedAt,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		var pgErr *pq.Error
+		if errors.As(err, &pgErr) && string(pgErr.Code) == pgErrCodeLockNotAvailable {
+			return nil, ErrFeedLocked
+		}
+		return nil, fmt.Errorf("フィードのロック取得に失敗しました: %w", err)
+	}
+
+	feed.FaviconData = faviconData
+	feed.FaviconMime = nullStringValue(faviconMime)
+	feed.SiteURL = nullStringValue(siteURL)
+	feed.ETag = nullStringValue(etag)
+	feed.LastModified = nullStringValue(lastModified)
+	feed.ErrorMessage = nullStringValue(errorMessage)
+	feed.LastSuccessfulFetchAt = nullTimeValue(lastSuccessfulFetchAt)
+
+	return feed, nil
+}
+
+// UpdateLastSuccessfulFetchAt は指定フィードの last_successful_fetch_at を更新する。
+// 自動ワーカーの成功経路と手動フェッチの成功経路の双方から呼ばれる共有更新メソッド。
+// 既存値の有無に関わらず単純上書きする（成功時刻は単調増加するため呼び出し側で順序を保証する）。
+func (r *PostgresFeedRepo) UpdateLastSuccessfulFetchAt(ctx context.Context, feedID string, at time.Time) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE feeds SET last_successful_fetch_at = $2, updated_at = now() WHERE id = $1`,
+		feedID, at,
+	)
+	if err != nil {
+		return fmt.Errorf("最終成功時刻の更新に失敗しました: %w", err)
 	}
 	return nil
 }

--- a/internal/repository/postgres_feed_repo_test.go
+++ b/internal/repository/postgres_feed_repo_test.go
@@ -457,3 +457,93 @@ func TestPostgresFeedRepo_UpdateFetchState(t *testing.T) {
 		}
 	})
 }
+
+// TestPostgresFeedRepo_LastSuccessfulFetchAt_Scan は Issue #115 (Req 2.4) の追加カラム
+// last_successful_fetch_at を FindByID / FindByFeedURL / ListDueForFetch が
+// NULL / 非 NULL の両ケースで正しく Scan して *time.Time に詰めることを検証する。
+// テスト用 PostgreSQL に接続できない場合はスキップする。
+func TestPostgresFeedRepo_LastSuccessfulFetchAt_Scan(t *testing.T) {
+	ctx := context.Background()
+
+	// Req 2.4: 過去成功実績なしのフィードは LastSuccessfulFetchAt が nil で返る
+	t.Run("過去成功実績なしのとき LastSuccessfulFetchAt が nil で返る", func(t *testing.T) {
+		db := setupListDueTestDB(t)
+		repo := NewPostgresFeedRepo(db)
+
+		feedURL := "https://example.com/no-success.xml"
+		feedID := insertTestFeed(t, db, feedURL, time.Now().Add(-1*time.Minute), model.FetchStatusActive)
+
+		// FindByID
+		feed, err := repo.FindByID(ctx, feedID)
+		if err != nil {
+			t.Fatalf("FindByID returned error: %v", err)
+		}
+		if feed == nil {
+			t.Fatal("FindByID: expected feed, got nil")
+		}
+		if feed.LastSuccessfulFetchAt != nil {
+			t.Errorf("FindByID: LastSuccessfulFetchAt = %v, want nil", feed.LastSuccessfulFetchAt)
+		}
+
+		// FindByFeedURL
+		feedByURL, err := repo.FindByFeedURL(ctx, feedURL)
+		if err != nil {
+			t.Fatalf("FindByFeedURL returned error: %v", err)
+		}
+		if feedByURL == nil {
+			t.Fatal("FindByFeedURL: expected feed, got nil")
+		}
+		if feedByURL.LastSuccessfulFetchAt != nil {
+			t.Errorf("FindByFeedURL: LastSuccessfulFetchAt = %v, want nil", feedByURL.LastSuccessfulFetchAt)
+		}
+
+		// ListDueForFetch (購読者が必要)
+		user := insertTestUser(t, db, "lsf-nil@example.com")
+		insertTestSubscription(t, db, user, feedID)
+		feeds, err := repo.ListDueForFetch(ctx)
+		if err != nil {
+			t.Fatalf("ListDueForFetch returned error: %v", err)
+		}
+		found := false
+		for _, f := range feeds {
+			if f.ID == feedID {
+				found = true
+				if f.LastSuccessfulFetchAt != nil {
+					t.Errorf("ListDueForFetch: LastSuccessfulFetchAt = %v, want nil", f.LastSuccessfulFetchAt)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("ListDueForFetch: expected to find feed %q in results", feedID)
+		}
+	})
+
+	// Req 2.4: 過去成功実績ありのフィードは LastSuccessfulFetchAt に時刻が入って返る
+	t.Run("過去成功実績ありのとき LastSuccessfulFetchAt に時刻が入って返る", func(t *testing.T) {
+		db := setupListDueTestDB(t)
+		repo := NewPostgresFeedRepo(db)
+
+		feedURL := "https://example.com/with-success.xml"
+		feedID := insertTestFeed(t, db, feedURL, time.Now().Add(-1*time.Minute), model.FetchStatusActive)
+
+		// 直接 SQL で last_successful_fetch_at を更新する（マイグレーション適用済みである前提を兼ねた確認）
+		successAt := time.Now().Add(-5 * time.Minute).UTC().Truncate(time.Microsecond)
+		if _, err := db.Exec(`UPDATE feeds SET last_successful_fetch_at = $1 WHERE id = $2`, successAt, feedID); err != nil {
+			t.Fatalf("テスト前提の last_successful_fetch_at セットに失敗: %v", err)
+		}
+
+		feed, err := repo.FindByID(ctx, feedID)
+		if err != nil {
+			t.Fatalf("FindByID returned error: %v", err)
+		}
+		if feed == nil {
+			t.Fatal("FindByID: expected feed, got nil")
+		}
+		if feed.LastSuccessfulFetchAt == nil {
+			t.Fatal("FindByID: LastSuccessfulFetchAt = nil, want non-nil")
+		}
+		if !feed.LastSuccessfulFetchAt.UTC().Truncate(time.Microsecond).Equal(successAt) {
+			t.Errorf("FindByID: LastSuccessfulFetchAt = %v, want %v", feed.LastSuccessfulFetchAt.UTC(), successAt)
+		}
+	})
+}

--- a/internal/repository/postgres_feed_repo_test.go
+++ b/internal/repository/postgres_feed_repo_test.go
@@ -3,10 +3,12 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hitoshi/feedman/internal/database"
 	"github.com/hitoshi/feedman/internal/model"
 	_ "github.com/lib/pq"
@@ -544,6 +546,184 @@ func TestPostgresFeedRepo_LastSuccessfulFetchAt_Scan(t *testing.T) {
 		}
 		if !feed.LastSuccessfulFetchAt.UTC().Truncate(time.Microsecond).Equal(successAt) {
 			t.Errorf("FindByID: LastSuccessfulFetchAt = %v, want %v", feed.LastSuccessfulFetchAt.UTC(), successAt)
+		}
+	})
+}
+
+// TestPostgresFeedRepo_LockFeedForUpdateNowait は Issue #115 (Req 3.1 / 3.2 / 3.4) の
+// 非ブロッキング行ロック取得メソッドが、ロック未保持時に Feed を返し、
+// 別 tx 保持中に ErrFeedLocked を返し、存在しない ID で (nil, nil) を返すことを検証する。
+// テスト用 PostgreSQL に接続できない場合はスキップする。
+func TestPostgresFeedRepo_LockFeedForUpdateNowait(t *testing.T) {
+	ctx := context.Background()
+
+	// Req 3.1: 競合がない状態で行ロックを取得でき、対象フィードが返る
+	t.Run("ロック未保持のときFeedを返す", func(t *testing.T) {
+		db := setupListDueTestDB(t)
+		repo := NewPostgresFeedRepo(db)
+
+		feedID := insertTestFeed(t, db, "https://example.com/lock-ok.xml", time.Now().Add(-1*time.Minute), model.FetchStatusActive)
+
+		// Arrange: tx を開始
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("BeginTx returned error: %v", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		// Act
+		feed, err := repo.LockFeedForUpdateNowait(ctx, tx, feedID)
+
+		// Assert
+		if err != nil {
+			t.Fatalf("LockFeedForUpdateNowait returned error: %v", err)
+		}
+		if feed == nil {
+			t.Fatal("expected non-nil feed, got nil")
+		}
+		if feed.ID != feedID {
+			t.Errorf("feed.ID = %q, want %q", feed.ID, feedID)
+		}
+
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("Commit returned error: %v", err)
+		}
+	})
+
+	// Req 3.2 / NFR 1.2: 別 tx がロック保持中は ErrFeedLocked を即時に返す
+	t.Run("別tx保持中のときErrFeedLockedを返す", func(t *testing.T) {
+		db := setupListDueTestDB(t)
+		repo := NewPostgresFeedRepo(db)
+
+		feedID := insertTestFeed(t, db, "https://example.com/lock-conflict.xml", time.Now().Add(-1*time.Minute), model.FetchStatusActive)
+
+		// Arrange: tx A で先にロックを取得（生 SQL で同等の SELECT FOR UPDATE を発行）
+		txA, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("BeginTx(A) returned error: %v", err)
+		}
+		defer func() { _ = txA.Rollback() }()
+
+		if _, err := txA.ExecContext(ctx, `SELECT id FROM feeds WHERE id = $1 FOR UPDATE`, feedID); err != nil {
+			t.Fatalf("先行ロック取得に失敗: %v", err)
+		}
+
+		// Act: tx B から NOWAIT で再取得を試みる
+		txB, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("BeginTx(B) returned error: %v", err)
+		}
+		defer func() { _ = txB.Rollback() }()
+
+		start := time.Now()
+		feed, err := repo.LockFeedForUpdateNowait(ctx, txB, feedID)
+		elapsed := time.Since(start)
+
+		// Assert: ErrFeedLocked が返り、500ms 以内に確定する（NFR 1.2 のベストエフォート確認）
+		if feed != nil {
+			t.Errorf("expected nil feed on lock conflict, got %+v", feed)
+		}
+		if !errors.Is(err, ErrFeedLocked) {
+			t.Fatalf("err = %v, want errors.Is(err, ErrFeedLocked) = true", err)
+		}
+		if elapsed > 500*time.Millisecond {
+			t.Errorf("ロック競合検出に %v かかった (want < 500ms / NFR 1.2)", elapsed)
+		}
+	})
+
+	// FindByID と同等: 存在しない ID は (nil, nil) を返す
+	t.Run("存在しないIDのときnilを返す", func(t *testing.T) {
+		db := setupListDueTestDB(t)
+		repo := NewPostgresFeedRepo(db)
+
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("BeginTx returned error: %v", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		missingID := uuid.NewString()
+		feed, err := repo.LockFeedForUpdateNowait(ctx, tx, missingID)
+
+		if err != nil {
+			t.Errorf("expected nil error for missing ID, got: %v", err)
+		}
+		if feed != nil {
+			t.Errorf("expected nil feed for missing ID, got: %+v", feed)
+		}
+	})
+}
+
+// TestPostgresFeedRepo_UpdateLastSuccessfulFetchAt は Issue #115 (Req 1.2) の
+// 最終成功時刻更新メソッドが、初回呼び出しで時刻を永続化し、
+// 2 回目呼び出しで上書きすることを検証する。
+// テスト用 PostgreSQL に接続できない場合はスキップする。
+func TestPostgresFeedRepo_UpdateLastSuccessfulFetchAt(t *testing.T) {
+	ctx := context.Background()
+
+	// Req 1.2: 初回呼び出しで時刻が永続化される
+	t.Run("初回呼び出しで時刻が永続化される", func(t *testing.T) {
+		db := setupListDueTestDB(t)
+		repo := NewPostgresFeedRepo(db)
+
+		feedID := insertTestFeed(t, db, "https://example.com/lsf-initial.xml", time.Now().Add(-1*time.Minute), model.FetchStatusActive)
+
+		t1 := time.Now().UTC().Truncate(time.Microsecond)
+
+		// Act
+		if err := repo.UpdateLastSuccessfulFetchAt(ctx, feedID, t1); err != nil {
+			t.Fatalf("UpdateLastSuccessfulFetchAt returned error: %v", err)
+		}
+
+		// Assert: FindByID で再読込し、値が一致する
+		feed, err := repo.FindByID(ctx, feedID)
+		if err != nil {
+			t.Fatalf("FindByID returned error: %v", err)
+		}
+		if feed == nil {
+			t.Fatal("FindByID returned nil feed")
+		}
+		if feed.LastSuccessfulFetchAt == nil {
+			t.Fatal("expected non-nil LastSuccessfulFetchAt, got nil")
+		}
+		if !feed.LastSuccessfulFetchAt.UTC().Truncate(time.Microsecond).Equal(t1) {
+			t.Errorf("LastSuccessfulFetchAt = %v, want %v", feed.LastSuccessfulFetchAt.UTC().Truncate(time.Microsecond), t1)
+		}
+	})
+
+	// Req 1.2: 2 回目呼び出しで上書きされる（冪等性）
+	t.Run("2回目呼び出しで上書きされる", func(t *testing.T) {
+		db := setupListDueTestDB(t)
+		repo := NewPostgresFeedRepo(db)
+
+		feedID := insertTestFeed(t, db, "https://example.com/lsf-overwrite.xml", time.Now().Add(-1*time.Minute), model.FetchStatusActive)
+
+		t1 := time.Now().Add(-10 * time.Minute).UTC().Truncate(time.Microsecond)
+		t2 := time.Now().UTC().Truncate(time.Microsecond)
+
+		// Arrange: 1 回目
+		if err := repo.UpdateLastSuccessfulFetchAt(ctx, feedID, t1); err != nil {
+			t.Fatalf("1回目の UpdateLastSuccessfulFetchAt returned error: %v", err)
+		}
+
+		// Act: 2 回目
+		if err := repo.UpdateLastSuccessfulFetchAt(ctx, feedID, t2); err != nil {
+			t.Fatalf("2回目の UpdateLastSuccessfulFetchAt returned error: %v", err)
+		}
+
+		// Assert: t2 で上書きされている
+		feed, err := repo.FindByID(ctx, feedID)
+		if err != nil {
+			t.Fatalf("FindByID returned error: %v", err)
+		}
+		if feed == nil {
+			t.Fatal("FindByID returned nil feed")
+		}
+		if feed.LastSuccessfulFetchAt == nil {
+			t.Fatal("expected non-nil LastSuccessfulFetchAt, got nil")
+		}
+		if !feed.LastSuccessfulFetchAt.UTC().Truncate(time.Microsecond).Equal(t2) {
+			t.Errorf("LastSuccessfulFetchAt = %v, want %v (overwrite by t2)", feed.LastSuccessfulFetchAt.UTC().Truncate(time.Microsecond), t2)
 		}
 	})
 }

--- a/internal/subscription/service.go
+++ b/internal/subscription/service.go
@@ -3,13 +3,75 @@ package subscription
 
 import (
 	"context"
+	"database/sql"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"math"
+	"strings"
 	"time"
 
 	"github.com/hitoshi/feedman/internal/model"
 	"github.com/hitoshi/feedman/internal/repository"
+	"github.com/hitoshi/feedman/internal/worker/fetch"
 )
+
+// manualFetchCooldown は同一フィードへの手動フェッチを抑制するクールダウン期間（Req 2.1, 2.3）。
+const manualFetchCooldown = 10 * time.Minute
+
+// ManualFetchTxBeginner は ManualFetch が必要とする最小限のトランザクション開始抽象化。
+// production では *sql.DB をラップする SQLManualFetchTxBeginner を用い、test では mock を使う。
+// repository.TxBeginner（*sql.Tx を直接返す）とは別の subinterface として定義し、
+// commit/rollback も含めた tx ハンドルライフサイクルを抽象化する。
+type ManualFetchTxBeginner interface {
+	BeginManualFetchTx(ctx context.Context) (ManualFetchTx, error)
+}
+
+// ManualFetchTx は ManualFetch が使う tx ハンドルの最小契約。
+// Tx() は repository 層（LockFeedForUpdateNowait）に渡す *sql.Tx を返す。
+type ManualFetchTx interface {
+	Tx() *sql.Tx
+	Commit() error
+	Rollback() error
+}
+
+// ManualFetchMetricsRecorder は ManualFetch が必要とする 4 種のメトリクス記録口を抽象化する。
+// task 5（metrics package 拡張）完了後、metrics.MetricsCollector を実装する型が自然に
+// 本 interface を充足する。本 task 単独で compile / test 可能にする目的でローカル subinterface を採用。
+type ManualFetchMetricsRecorder interface {
+	RecordManualFetchSuccess()
+	RecordManualFetchFailure(reason string)
+	RecordManualFetchCooldownRejected()
+	RecordManualFetchLockConflict()
+}
+
+// SQLManualFetchTxBeginner は *sql.DB をラップして ManualFetchTxBeginner を実装する。
+// runServe での依存配線（task 6.1）から渡される production 実装。
+type SQLManualFetchTxBeginner struct {
+	db *sql.DB
+}
+
+// NewSQLManualFetchTxBeginner は SQLManualFetchTxBeginner を生成する。
+func NewSQLManualFetchTxBeginner(db *sql.DB) *SQLManualFetchTxBeginner {
+	return &SQLManualFetchTxBeginner{db: db}
+}
+
+// BeginManualFetchTx は新しい tx を開始し、ManualFetchTx として返す。
+func (b *SQLManualFetchTxBeginner) BeginManualFetchTx(ctx context.Context) (ManualFetchTx, error) {
+	tx, err := b.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin tx: %w", err)
+	}
+	return &sqlManualFetchTx{tx: tx}, nil
+}
+
+type sqlManualFetchTx struct {
+	tx *sql.Tx
+}
+
+func (h *sqlManualFetchTx) Tx() *sql.Tx     { return h.tx }
+func (h *sqlManualFetchTx) Commit() error   { return h.tx.Commit() }
+func (h *sqlManualFetchTx) Rollback() error { return h.tx.Rollback() }
 
 // SubscriptionInfo は購読情報とフィード情報を結合したドメインオブジェクト。
 type SubscriptionInfo struct {
@@ -27,23 +89,35 @@ type SubscriptionInfo struct {
 }
 
 // Service は購読管理のサービス層。
-// 購読一覧取得、設定更新、購読解除、フェッチ再開のビジネスロジックを提供する。
+// 購読一覧取得、設定更新、購読解除、フェッチ再開、手動フェッチのビジネスロジックを提供する。
 type Service struct {
-	subRepo       repository.SubscriptionRepository
-	itemStateRepo repository.ItemStateRepository
-	feedRepo      repository.FeedRepository
+	subRepo         repository.SubscriptionRepository
+	itemStateRepo   repository.ItemStateRepository
+	feedRepo        repository.FeedRepository
+	feedFetcher     fetch.FeedFetcherService
+	txBeginner      ManualFetchTxBeginner
+	metricsRecorder ManualFetchMetricsRecorder
 }
 
 // NewService はServiceの新しいインスタンスを生成する。
+// feedFetcher / txBeginner / metricsRecorder は ManualFetch でのみ使用され、
+// ListSubscriptions / UpdateSettings / Unsubscribe / ResumeFetch の各経路では参照されない。
+// app.go の wiring（task 6.1）が完了するまでは nil を渡しても既存パスは正常動作する。
 func NewService(
 	subRepo repository.SubscriptionRepository,
 	itemStateRepo repository.ItemStateRepository,
 	feedRepo repository.FeedRepository,
+	feedFetcher fetch.FeedFetcherService,
+	txBeginner ManualFetchTxBeginner,
+	metricsRecorder ManualFetchMetricsRecorder,
 ) *Service {
 	return &Service{
-		subRepo:       subRepo,
-		itemStateRepo: itemStateRepo,
-		feedRepo:      feedRepo,
+		subRepo:         subRepo,
+		itemStateRepo:   itemStateRepo,
+		feedRepo:        feedRepo,
+		feedFetcher:     feedFetcher,
+		txBeginner:      txBeginner,
+		metricsRecorder: metricsRecorder,
 	}
 }
 
@@ -237,4 +311,190 @@ func (s *Service) ResumeFetch(ctx context.Context, userID, subscriptionID string
 	}
 
 	return nil, model.NewSubscriptionNotFoundError(subscriptionID)
+}
+
+
+// ManualFetch は指定購読のフィードを手動で同期フェッチする。
+// クールダウン中は外部 HTTP を発行せず FEED_COOLDOWN を返し、
+// 行ロック競合時は FEED_FETCH_IN_PROGRESS を返す。
+// 成功時は更新後の SubscriptionInfo を返す。
+//
+// フロー（Req 1.1, 2.1, 3.1, 3.4）:
+//
+//	(1) subRepo.FindByID で認可確認（subID 不存在 / UserID 不一致は SUBSCRIPTION_NOT_FOUND）
+//	(2) BeginManualFetchTx で tx 開始（defer rollback）
+//	(3) LockFeedForUpdateNowait で行ロック取得（NOWAIT、競合時は ErrFeedLocked）
+//	(4) クールダウン判定（last_successful_fetch_at + 10min > now なら FEED_COOLDOWN）
+//	(5) クールダウン外: COMMIT で行ロックを解放してから fetcher.Fetch を実行
+//	    （既存 Fetcher は *sql.DB 経由で UpdateFetchState を呼ぶため、tx ロック保持中に
+//	    fetcher を実行すると自己 deadlock するため事前に解放する）
+//	(6) Fetch が nil 返却 + FetchStatus=active + ConsecutiveErrors=0 のとき成功と判定し
+//	    UpdateLastSuccessfulFetchAt + success メトリクスを記録
+//	(7) ListByUserIDWithFeedInfo で最新 SubscriptionInfo を取得して返す
+func (s *Service) ManualFetch(ctx context.Context, userID, subscriptionID string) (*SubscriptionInfo, error) {
+	// (1) 認可確認
+	sub, err := s.subRepo.FindByID(ctx, subscriptionID)
+	if err != nil {
+		return nil, fmt.Errorf("購読の取得に失敗しました: %w", err)
+	}
+	if sub == nil || sub.UserID != userID {
+		return nil, model.NewSubscriptionNotFoundError(subscriptionID)
+	}
+
+	// (2) tx 開始
+	tx, err := s.txBeginner.BeginManualFetchTx(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("トランザクションの開始に失敗しました: %w", err)
+	}
+	txClosed := false
+	defer func() {
+		if !txClosed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// (3) 行ロック取得（NOWAIT）
+	feed, err := s.feedRepo.LockFeedForUpdateNowait(ctx, tx.Tx(), sub.FeedID)
+	if err != nil {
+		if errors.Is(err, repository.ErrFeedLocked) {
+			s.metricsRecorder.RecordManualFetchLockConflict()
+			return nil, model.NewFeedFetchInProgressError()
+		}
+		return nil, fmt.Errorf("フィードのロック取得に失敗しました: %w", err)
+	}
+	if feed == nil {
+		// design 上 subID 存在時は feedID も存在するはずだが防御的に nil チェック
+		return nil, model.NewSubscriptionNotFoundError(subscriptionID)
+	}
+
+	// (4) クールダウン判定
+	now := time.Now()
+	if feed.LastSuccessfulFetchAt != nil {
+		elapsed := now.Sub(*feed.LastSuccessfulFetchAt)
+		if elapsed < manualFetchCooldown {
+			remaining := manualFetchCooldown - elapsed
+			retryAfterSeconds := int(math.Ceil(remaining.Seconds()))
+			if err := tx.Commit(); err != nil {
+				return nil, fmt.Errorf("トランザクションのコミットに失敗しました: %w", err)
+			}
+			txClosed = true
+			s.metricsRecorder.RecordManualFetchCooldownRejected()
+			return nil, model.NewFeedCooldownError(retryAfterSeconds)
+		}
+	}
+
+	// (5) クールダウン外: fetcher を呼ぶ前に COMMIT で行ロックを解放する
+	// 既存 Fetcher は *sql.DB 経由で UpdateFetchState を発行するため、tx ロック保持中に
+	// fetcher を実行すると同一行への UPDATE が自己 deadlock する。design.md は
+	// 「fetcher 内で tx-aware に動作させる」記述があるが、本機能では fetcher のシグネチャを
+	// 変更しない後方互換最優先（design.md「データ更新の責務」節）方針に従い、
+	// クールダウン判定までを tx 内に閉じ、fetcher 開始前に lock を解放する。
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("トランザクションのコミットに失敗しました: %w", err)
+	}
+	txClosed = true
+
+	// (6) fetcher.Fetch 実行
+	fetchErr := s.feedFetcher.Fetch(ctx, feed)
+	if fetchErr != nil {
+		reason := classifyFetchError(fetchErr)
+		s.metricsRecorder.RecordManualFetchFailure(reason)
+		if reason == "ssrf_blocked" {
+			// Req 4.2: SSRF 拒否は中立的失敗（攻撃者に SSRF ガードの存在を露呈しない）
+			return nil, model.NewFetchFailedError("一時的なエラー")
+		}
+		return nil, model.NewFetchFailedError(fetchErr.Error())
+	}
+
+	// (7) 結果分類: fetcher が nil 返却でもフィード状態で成功/失敗を見極める
+	switch {
+	case feed.FetchStatus == model.FetchStatusActive && feed.ConsecutiveErrors == 0:
+		// 成功パス（200 OK / 304 Not Modified）
+		// UpdateLastSuccessfulFetchAt は Fetcher 側で既に呼ばれているが、design.md
+		// 「手動経路: Service.ManualFetch が UpdateLastSuccessfulFetchAt を呼ぶ」に従い
+		// 手動経路の責務として明示的に「リクエスト完了時刻」（Req 1.2）で再度更新する。
+		if updateErr := s.feedRepo.UpdateLastSuccessfulFetchAt(ctx, feed.ID, time.Now()); updateErr != nil {
+			// 成功時刻の更新失敗は degradation。task 3 と同じく warning 扱い相当
+			// （ここでは戻り値で warning を返せないため、エラー値だけ無視）
+			_ = updateErr
+		}
+		s.metricsRecorder.RecordManualFetchSuccess()
+
+	case strings.Contains(feed.ErrorMessage, "記事UPSERT失敗") ||
+		strings.Contains(feed.ErrorMessage, "UPSERT"):
+		// UPSERT 失敗（既存 fetcher の ApplyParseFailure 経由）
+		s.metricsRecorder.RecordManualFetchFailure("upsert_error")
+		return nil, model.NewFetchFailedError("記事の保存に失敗しました")
+
+	case strings.Contains(feed.ErrorMessage, "パース失敗") ||
+		feed.FetchStatus == model.FetchStatusError:
+		// パース失敗
+		s.metricsRecorder.RecordManualFetchFailure("parse_error")
+		return nil, model.NewParseFailedError()
+
+	case strings.Contains(feed.ErrorMessage, "SSRF"):
+		// SSRF 検証失敗（ApplyStopFeed 経由、Fetcher 内で nil 返却にはならないが防御的に分岐）
+		s.metricsRecorder.RecordManualFetchFailure("ssrf_blocked")
+		return nil, model.NewFetchFailedError("一時的なエラー")
+
+	default:
+		// ApplyBackoff / ApplyStopFeed 経由の失敗（5xx / 429 / 404 / 410 等）
+		s.metricsRecorder.RecordManualFetchFailure("fetch_error")
+		msg := feed.ErrorMessage
+		if msg == "" {
+			msg = "フィードの取得に失敗しました"
+		}
+		return nil, model.NewFetchFailedError(msg)
+	}
+
+	// (8) 成功時のみ最新 SubscriptionInfo を返す
+	infos, err := s.subRepo.ListByUserIDWithFeedInfo(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("購読情報の再取得に失敗しました: %w", err)
+	}
+	for _, info := range infos {
+		if info.ID == subscriptionID {
+			result := &SubscriptionInfo{
+				ID:                   info.ID,
+				UserID:               info.UserID,
+				FeedID:               info.FeedID,
+				FeedTitle:            info.FeedTitle,
+				FeedURL:              info.FeedURL,
+				FetchIntervalMinutes: info.FetchIntervalMinutes,
+				FeedStatus:           string(info.FetchStatus),
+				UnreadCount:          info.UnreadCount,
+				CreatedAt:            info.CreatedAt,
+			}
+			if len(info.FaviconData) > 0 && info.FaviconMime != "" {
+				dataURL := fmt.Sprintf("data:%s;base64,%s", info.FaviconMime, base64.StdEncoding.EncodeToString(info.FaviconData))
+				result.FaviconURL = &dataURL
+			}
+			if info.ErrorMessage != "" {
+				msg := info.ErrorMessage
+				result.ErrorMessage = &msg
+			}
+			return result, nil
+		}
+	}
+
+	return nil, model.NewSubscriptionNotFoundError(subscriptionID)
+}
+
+// classifyFetchError は Fetcher が返したエラーから failure metric 用の reason ラベルを推定する。
+// 既存 fetcher のエラーラッピング文字列を見て分類する（SSRF / HTTP 系 / その他）。
+func classifyFetchError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "SSRF") {
+		return "ssrf_blocked"
+	}
+	if strings.Contains(msg, "パース") || strings.Contains(msg, "parse") {
+		return "parse_error"
+	}
+	if strings.Contains(msg, "UPSERT") || strings.Contains(msg, "upsert") {
+		return "upsert_error"
+	}
+	return "fetch_error"
 }

--- a/internal/subscription/service_test.go
+++ b/internal/subscription/service_test.go
@@ -2,6 +2,7 @@ package subscription
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -97,6 +98,12 @@ func (m *mockFeedRepo) UpdateFetchState(ctx context.Context, feed *model.Feed) e
 	if m.updateFetchStateFn != nil {
 		return m.updateFetchStateFn(ctx, feed)
 	}
+	return nil
+}
+func (m *mockFeedRepo) LockFeedForUpdateNowait(ctx context.Context, tx *sql.Tx, feedID string) (*model.Feed, error) {
+	return nil, nil
+}
+func (m *mockFeedRepo) UpdateLastSuccessfulFetchAt(ctx context.Context, feedID string, at time.Time) error {
 	return nil
 }
 

--- a/internal/subscription/service_test.go
+++ b/internal/subscription/service_test.go
@@ -72,8 +72,12 @@ func (m *mockItemStateRepo) DeleteByUserID(ctx context.Context, userID string) e
 }
 
 type mockFeedRepo struct {
-	findByIDFn         func(ctx context.Context, id string) (*model.Feed, error)
-	updateFetchStateFn func(ctx context.Context, feed *model.Feed) error
+	findByIDFn                  func(ctx context.Context, id string) (*model.Feed, error)
+	updateFetchStateFn          func(ctx context.Context, feed *model.Feed) error
+	lockFeedFn                  func(ctx context.Context, tx *sql.Tx, feedID string) (*model.Feed, error)
+	updateLastSuccessfulFetchFn func(ctx context.Context, feedID string, at time.Time) error
+	updateLastSuccessfulFetchAt []time.Time
+	updateLastSuccessfulFeedIDs []string
 }
 
 func (m *mockFeedRepo) FindByID(ctx context.Context, id string) (*model.Feed, error) {
@@ -101,13 +105,91 @@ func (m *mockFeedRepo) UpdateFetchState(ctx context.Context, feed *model.Feed) e
 	return nil
 }
 func (m *mockFeedRepo) LockFeedForUpdateNowait(ctx context.Context, tx *sql.Tx, feedID string) (*model.Feed, error) {
+	if m.lockFeedFn != nil {
+		return m.lockFeedFn(ctx, tx, feedID)
+	}
 	return nil, nil
 }
 func (m *mockFeedRepo) UpdateLastSuccessfulFetchAt(ctx context.Context, feedID string, at time.Time) error {
+	m.updateLastSuccessfulFetchAt = append(m.updateLastSuccessfulFetchAt, at)
+	m.updateLastSuccessfulFeedIDs = append(m.updateLastSuccessfulFeedIDs, feedID)
+	if m.updateLastSuccessfulFetchFn != nil {
+		return m.updateLastSuccessfulFetchFn(ctx, feedID, at)
+	}
 	return nil
 }
 
+
+type mockFeedFetcher struct {
+	fetchFn func(ctx context.Context, feed *model.Feed) error
+}
+
+func (m *mockFeedFetcher) Fetch(ctx context.Context, feed *model.Feed) error {
+	if m.fetchFn != nil {
+		return m.fetchFn(ctx, feed)
+	}
+	return nil
+}
+
+type mockManualFetchTx struct {
+	tx         *sql.Tx
+	commitFn   func() error
+	rollbackFn func() error
+	committed  bool
+	rolledBack bool
+}
+
+func (m *mockManualFetchTx) Tx() *sql.Tx { return m.tx }
+func (m *mockManualFetchTx) Commit() error {
+	m.committed = true
+	if m.commitFn != nil {
+		return m.commitFn()
+	}
+	return nil
+}
+func (m *mockManualFetchTx) Rollback() error {
+	m.rolledBack = true
+	if m.rollbackFn != nil {
+		return m.rollbackFn()
+	}
+	return nil
+}
+
+type mockManualFetchTxBeginner struct {
+	beginFn func(ctx context.Context) (ManualFetchTx, error)
+}
+
+func (m *mockManualFetchTxBeginner) BeginManualFetchTx(ctx context.Context) (ManualFetchTx, error) {
+	if m.beginFn != nil {
+		return m.beginFn(ctx)
+	}
+	return &mockManualFetchTx{}, nil
+}
+
+type mockManualFetchMetricsRecorder struct {
+	successCount      int
+	failureCount      int
+	failureReasons    []string
+	cooldownCount     int
+	lockConflictCount int
+}
+
+func (m *mockManualFetchMetricsRecorder) RecordManualFetchSuccess() {
+	m.successCount++
+}
+func (m *mockManualFetchMetricsRecorder) RecordManualFetchFailure(reason string) {
+	m.failureCount++
+	m.failureReasons = append(m.failureReasons, reason)
+}
+func (m *mockManualFetchMetricsRecorder) RecordManualFetchCooldownRejected() {
+	m.cooldownCount++
+}
+func (m *mockManualFetchMetricsRecorder) RecordManualFetchLockConflict() {
+	m.lockConflictCount++
+}
+
 // --- テスト ---
+
 
 // TestService_ListSubscriptions は購読一覧取得を検証する。
 func TestService_ListSubscriptions(t *testing.T) {
@@ -132,7 +214,7 @@ func TestService_ListSubscriptions(t *testing.T) {
 		},
 	}
 
-	svc := NewService(subRepo, nil, nil)
+	svc := NewService(subRepo, nil, nil, nil, nil, nil)
 
 	results, err := svc.ListSubscriptions(context.Background(), "user-1")
 	if err != nil {
@@ -201,7 +283,7 @@ func TestService_UpdateSettings_BoundaryValues(t *testing.T) {
 				},
 			}
 
-			svc := NewService(subRepo, nil, nil)
+			svc := NewService(subRepo, nil, nil, nil, nil, nil)
 
 			// Act
 			result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", tt.minutes)
@@ -266,7 +348,7 @@ func TestService_Unsubscribe(t *testing.T) {
 		},
 	}
 
-	svc := NewService(subRepo, itemStateRepo, nil)
+	svc := NewService(subRepo, itemStateRepo, nil, nil, nil, nil)
 
 	err := svc.Unsubscribe(context.Background(), "user-1", "sub-1")
 	if err != nil {
@@ -288,7 +370,7 @@ func TestService_Unsubscribe_WrongUser_ReturnsError(t *testing.T) {
 		},
 	}
 
-	svc := NewService(subRepo, nil, nil)
+	svc := NewService(subRepo, nil, nil, nil, nil, nil)
 
 	err := svc.Unsubscribe(context.Background(), "user-1", "sub-1")
 	if err == nil {
@@ -328,7 +410,7 @@ func TestService_ResumeFetch(t *testing.T) {
 		},
 	}
 
-	svc := NewService(subRepo, nil, feedRepo)
+	svc := NewService(subRepo, nil, feedRepo, nil, nil, nil)
 
 	result, err := svc.ResumeFetch(context.Background(), "user-1", "sub-1")
 	if err != nil {
@@ -358,7 +440,7 @@ func TestService_ResumeFetch_NotStopped_ReturnsError(t *testing.T) {
 		},
 	}
 
-	svc := NewService(subRepo, nil, feedRepo)
+	svc := NewService(subRepo, nil, feedRepo, nil, nil, nil)
 
 	_, err := svc.ResumeFetch(context.Background(), "user-1", "sub-1")
 	if err == nil {
@@ -382,7 +464,7 @@ func TestService_Unsubscribe_NilItemStateRepo_SkipsItemStateDelete(t *testing.T)
 		},
 	}
 
-	svc := NewService(subRepo, nil, nil)
+	svc := NewService(subRepo, nil, nil, nil, nil, nil)
 
 	// Act
 	err := svc.Unsubscribe(context.Background(), "user-1", "sub-1")
@@ -418,7 +500,7 @@ func TestService_Unsubscribe_ItemStateDeleteError_PropagatesError(t *testing.T) 
 		},
 	}
 
-	svc := NewService(subRepo, itemStateRepo, nil)
+	svc := NewService(subRepo, itemStateRepo, nil, nil, nil, nil)
 
 	// Act
 	err := svc.Unsubscribe(context.Background(), "user-1", "sub-1")
@@ -457,7 +539,7 @@ func TestService_ResumeFetch_NotStopped_ReturnsFeedNotStoppedAndDoesNotUpdate(t 
 		},
 	}
 
-	svc := NewService(subRepo, nil, feedRepo)
+	svc := NewService(subRepo, nil, feedRepo, nil, nil, nil)
 
 	// Act
 	result, err := svc.ResumeFetch(context.Background(), "user-1", "sub-1")
@@ -515,7 +597,7 @@ func TestService_UpdateSettings_Success(t *testing.T) {
 		},
 	}
 
-	svc := NewService(subRepo, nil, nil)
+	svc := NewService(subRepo, nil, nil, nil, nil, nil)
 
 	// Act
 	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", wantMinutes)
@@ -563,7 +645,7 @@ func TestService_UpdateSettings_WrongUser_ReturnsSubscriptionNotFound(t *testing
 		},
 	}
 
-	svc := NewService(subRepo, nil, nil)
+	svc := NewService(subRepo, nil, nil, nil, nil, nil)
 
 	// Act
 	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", 60)
@@ -606,7 +688,7 @@ func TestService_UpdateSettings_SubscriptionNotFound(t *testing.T) {
 		},
 	}
 
-	svc := NewService(subRepo, nil, nil)
+	svc := NewService(subRepo, nil, nil, nil, nil, nil)
 
 	// Act
 	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", 60)
@@ -650,7 +732,7 @@ func TestService_UpdateSettings_FindByIDError(t *testing.T) {
 		},
 	}
 
-	svc := NewService(subRepo, nil, nil)
+	svc := NewService(subRepo, nil, nil, nil, nil, nil)
 
 	// Act
 	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", 60)
@@ -688,7 +770,7 @@ func TestService_UpdateSettings_UpdateFetchIntervalError(t *testing.T) {
 		},
 	}
 
-	svc := NewService(subRepo, nil, nil)
+	svc := NewService(subRepo, nil, nil, nil, nil, nil)
 
 	// Act
 	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", 60)
@@ -723,7 +805,7 @@ func TestService_UpdateSettings_ListByUserIDWithFeedInfoError(t *testing.T) {
 		},
 	}
 
-	svc := NewService(subRepo, nil, nil)
+	svc := NewService(subRepo, nil, nil, nil, nil, nil)
 
 	// Act
 	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", 60)
@@ -772,7 +854,7 @@ func TestService_UpdateSettings_NotFoundAfterUpdate(t *testing.T) {
 		},
 	}
 
-	svc := NewService(subRepo, nil, nil)
+	svc := NewService(subRepo, nil, nil, nil, nil, nil)
 
 	// Act
 	result, err := svc.UpdateSettings(context.Background(), "user-1", "sub-1", 60)
@@ -792,3 +874,286 @@ func TestService_UpdateSettings_NotFoundAfterUpdate(t *testing.T) {
 		t.Errorf("expected nil result, got %+v", result)
 	}
 }
+
+// TestService_ManualFetch_Success は手動フェッチが正常に成功し、
+// 最新の購読情報を返すこと、クールダウンが更新されることを検証する。
+func TestService_ManualFetch_Success(t *testing.T) {
+	sub := &model.Subscription{ID: "sub-1", UserID: "user-1", FeedID: "feed-1"}
+	feed := &model.Feed{
+		ID:          "feed-1",
+		FetchStatus: model.FetchStatusActive,
+	}
+
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return sub, nil
+		},
+		listByUserIDWithFeedFn: func(ctx context.Context, userID string) ([]repository.SubscriptionWithFeedInfo, error) {
+			return []repository.SubscriptionWithFeedInfo{
+				{
+					Subscription: *sub,
+					FeedTitle:    "Test Feed",
+					FeedURL:      "https://example.com/feed.xml",
+					FetchStatus:  model.FetchStatusActive,
+				},
+			}, nil
+		},
+	}
+
+	feedRepo := &mockFeedRepo{
+		lockFeedFn: func(ctx context.Context, tx *sql.Tx, feedID string) (*model.Feed, error) {
+			return feed, nil
+		},
+	}
+
+	fetcher := &mockFeedFetcher{
+		fetchFn: func(ctx context.Context, f *model.Feed) error {
+			// フェッチャーの中で成功したと仮定して状態を更新
+			f.ConsecutiveErrors = 0
+			f.FetchStatus = model.FetchStatusActive
+			return nil
+		},
+	}
+
+	txBeginner := &mockManualFetchTxBeginner{}
+	metrics := &mockManualFetchMetricsRecorder{}
+
+	svc := NewService(subRepo, nil, feedRepo, fetcher, txBeginner, metrics)
+
+	// Act
+	result, err := svc.ManualFetch(context.Background(), "user-1", "sub-1")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.ID != "sub-1" {
+		t.Errorf("expected subscription ID sub-1, got %q", result.ID)
+	}
+	if metrics.successCount != 1 {
+		t.Errorf("expected successCount to be 1, got %d", metrics.successCount)
+	}
+	if len(feedRepo.updateLastSuccessfulFetchAt) != 1 {
+		t.Errorf("expected UpdateLastSuccessfulFetchAt to be called once, got %d", len(feedRepo.updateLastSuccessfulFetchAt))
+	}
+}
+
+// TestService_ManualFetch_SubscriptionNotFound は購読情報が存在しないか、
+// 他ユーザーのものである場合に SUBSCRIPTION_NOT_FOUND を返すことを検証する。
+func TestService_ManualFetch_SubscriptionNotFound(t *testing.T) {
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			// 他ユーザーの購読
+			return &model.Subscription{ID: "sub-1", UserID: "user-other", FeedID: "feed-1"}, nil
+		},
+	}
+
+	svc := NewService(subRepo, nil, nil, nil, nil, nil)
+
+	// Act
+	_, err := svc.ManualFetch(context.Background(), "user-1", "sub-1")
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("error type = %T, want *model.APIError", err)
+	}
+	if apiErr.Code != model.ErrCodeSubscriptionNotFound {
+		t.Errorf("error code = %q, want %q", apiErr.Code, model.ErrCodeSubscriptionNotFound)
+	}
+}
+
+// TestService_ManualFetch_LockConflict は行ロック競合時に
+// FEED_FETCH_IN_PROGRESS を返すことを検証する。
+func TestService_ManualFetch_LockConflict(t *testing.T) {
+	sub := &model.Subscription{ID: "sub-1", UserID: "user-1", FeedID: "feed-1"}
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return sub, nil
+		},
+	}
+
+	feedRepo := &mockFeedRepo{
+		lockFeedFn: func(ctx context.Context, tx *sql.Tx, feedID string) (*model.Feed, error) {
+			return nil, repository.ErrFeedLocked
+		},
+	}
+
+	txBeginner := &mockManualFetchTxBeginner{}
+	metrics := &mockManualFetchMetricsRecorder{}
+
+	svc := NewService(subRepo, nil, feedRepo, nil, txBeginner, metrics)
+
+	// Act
+	_, err := svc.ManualFetch(context.Background(), "user-1", "sub-1")
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("error type = %T, want *model.APIError", err)
+	}
+	if apiErr.Code != model.ErrCodeFeedFetchInProgress {
+		t.Errorf("error code = %q, want %q", apiErr.Code, model.ErrCodeFeedFetchInProgress)
+	}
+	if metrics.lockConflictCount != 1 {
+		t.Errorf("expected lockConflictCount to be 1, got %d", metrics.lockConflictCount)
+	}
+}
+
+// TestService_ManualFetch_Cooldown はクールダウン判定（10分以内）により、
+// FEED_COOLDOWN を返すことを検証する。
+func TestService_ManualFetch_Cooldown(t *testing.T) {
+	sub := &model.Subscription{ID: "sub-1", UserID: "user-1", FeedID: "feed-1"}
+	// 5分前に成功した履歴がある
+	lastFetch := time.Now().Add(-5 * time.Minute)
+	feed := &model.Feed{
+		ID:                    "feed-1",
+		FetchStatus:           model.FetchStatusActive,
+		LastSuccessfulFetchAt: &lastFetch,
+	}
+
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return sub, nil
+		},
+	}
+
+	feedRepo := &mockFeedRepo{
+		lockFeedFn: func(ctx context.Context, tx *sql.Tx, feedID string) (*model.Feed, error) {
+			return feed, nil
+		},
+	}
+
+	txBeginner := &mockManualFetchTxBeginner{}
+	metrics := &mockManualFetchMetricsRecorder{}
+
+	svc := NewService(subRepo, nil, feedRepo, nil, txBeginner, metrics)
+
+	// Act
+	_, err := svc.ManualFetch(context.Background(), "user-1", "sub-1")
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("error type = %T, want *model.APIError", err)
+	}
+	if apiErr.Code != model.ErrCodeFeedCooldown {
+		t.Errorf("error code = %q, want %q", apiErr.Code, model.ErrCodeFeedCooldown)
+	}
+	if metrics.cooldownCount != 1 {
+		t.Errorf("expected cooldownCount to be 1, got %d", metrics.cooldownCount)
+	}
+}
+
+// TestService_ManualFetch_FetchError はフェッチ失敗時に、
+// 適切な API エラーを返すこと、メトリクスが記録されることを検証する。
+func TestService_ManualFetch_FetchError(t *testing.T) {
+	sub := &model.Subscription{ID: "sub-1", UserID: "user-1", FeedID: "feed-1"}
+	feed := &model.Feed{
+		ID:          "feed-1",
+		FetchStatus: model.FetchStatusActive,
+	}
+
+	subRepo := &mockSubRepo{
+		findByIDFn: func(ctx context.Context, id string) (*model.Subscription, error) {
+			return sub, nil
+		},
+	}
+
+	feedRepo := &mockFeedRepo{
+		lockFeedFn: func(ctx context.Context, tx *sql.Tx, feedID string) (*model.Feed, error) {
+			return feed, nil
+		},
+	}
+
+	tests := []struct {
+		name       string
+		fetchErr   error
+		feedErrMsg string
+		feedStatus model.FetchStatus
+		wantCode   string
+		wantReason string
+	}{
+		{
+			name:       "SSRF error",
+			fetchErr:   errors.New("SSRF detected"),
+			wantCode:   model.ErrCodeFetchFailed,
+			wantReason: "ssrf_blocked",
+		},
+		{
+			name:       "Parse error in fetch",
+			fetchErr:   errors.New("parse failed"),
+			wantCode:   model.ErrCodeFetchFailed,
+			wantReason: "parse_error",
+		},
+		{
+			name:       "Normal fetch error",
+			fetchErr:   errors.New("http 500"),
+			wantCode:   model.ErrCodeFetchFailed,
+			wantReason: "fetch_error",
+		},
+		{
+			name:       "Parse failed in feed message status",
+			fetchErr:   nil,
+			feedErrMsg: "パース失敗しました",
+			feedStatus: model.FetchStatusError,
+			wantCode:   model.ErrCodeParseFailed,
+			wantReason: "parse_error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			feed.ErrorMessage = tt.feedErrMsg
+			feed.FetchStatus = tt.feedStatus
+			if tt.feedStatus == "" {
+				feed.FetchStatus = model.FetchStatusActive
+			}
+
+			fetcher := &mockFeedFetcher{
+				fetchFn: func(ctx context.Context, f *model.Feed) error {
+					return tt.fetchErr
+				},
+			}
+
+			txBeginner := &mockManualFetchTxBeginner{}
+			metrics := &mockManualFetchMetricsRecorder{}
+
+			svc := NewService(subRepo, nil, feedRepo, fetcher, txBeginner, metrics)
+
+			// Act
+			_, err := svc.ManualFetch(context.Background(), "user-1", "sub-1")
+
+			// Assert
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			apiErr, ok := err.(*model.APIError)
+			if !ok {
+				t.Fatalf("error type = %T, want *model.APIError", err)
+			}
+			if apiErr.Code != tt.wantCode {
+				t.Errorf("error code = %q, want %q", apiErr.Code, tt.wantCode)
+			}
+			if metrics.failureCount != 1 {
+				t.Errorf("expected failureCount to be 1, got %d", metrics.failureCount)
+			}
+			if metrics.failureReasons[0] != tt.wantReason {
+				t.Errorf("expected failure reason %q, got %q", tt.wantReason, metrics.failureReasons[0])
+			}
+		})
+	}
+}
+

--- a/internal/worker/fetch/fetcher.go
+++ b/internal/worker/fetch/fetcher.go
@@ -176,6 +176,7 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 		// 304 は「変更なしで取得成功」として扱い成功数を増加させる（Requirement 2.1）。
 		f.metrics.RecordFetchSuccess(feed.ID)
 		ApplySuccess(feed, interval)
+		f.recordLastSuccessfulFetch(ctx, feed.ID)
 		return f.feedRepo.UpdateFetchState(ctx, feed)
 
 	case FetchResultStop:
@@ -299,6 +300,7 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 	}
 
 	ApplySuccess(feed, interval)
+	f.recordLastSuccessfulFetch(ctx, feed.ID)
 
 	// フィード状態を更新
 	if updateErr := f.feedRepo.UpdateFetchState(ctx, feed); updateErr != nil {
@@ -324,6 +326,18 @@ func (f *Fetcher) Fetch(ctx context.Context, feed *model.Feed) error {
 	)
 
 	return nil
+}
+
+// recordLastSuccessfulFetch は ApplySuccess 直後にフィードの最終成功時刻を更新する。
+// 更新失敗時は警告ログのみ出力し、フェッチ自体は成功扱いを維持する（手動フェッチ側の
+// クールダウン判定の起点を温存することを目的とし、Issue #115 Req 2.4 を満たす）。
+func (f *Fetcher) recordLastSuccessfulFetch(ctx context.Context, feedID string) {
+	if err := f.feedRepo.UpdateLastSuccessfulFetchAt(ctx, feedID, time.Now()); err != nil {
+		f.logger.Warn("最終成功時刻の更新に失敗しました",
+			slog.String("feed_id", feedID),
+			slog.String("error", err.Error()),
+		)
+	}
 }
 
 // getMinFetchInterval はフィードの全購読者の中で最小のfetch_interval_minutesを取得する。

--- a/internal/worker/fetch/fetcher_test.go
+++ b/internal/worker/fetch/fetcher_test.go
@@ -1156,3 +1156,256 @@ func TestNewFetcher_DefaultMetricsIsNopAndNilSafe(t *testing.T) {
 		t.Fatalf("option 未指定の Fetch() がエラーを返した: %v", err)
 	}
 }
+
+// --- Task 3.1: ApplySuccess 直後の UpdateLastSuccessfulFetchAt 反映テスト ---
+
+// TestFetcher_Fetch_RecordsLastSuccessfulFetchAt_200 は 200 OK 成功時に
+// UpdateLastSuccessfulFetchAt が feed.ID 付きで 1 回呼ばれることを検証する
+// （Issue #115 Req 2.4 / 自動経路の成功時刻記録）。
+func TestFetcher_Fetch_RecordsLastSuccessfulFetchAt_200(t *testing.T) {
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel><title>T</title><item><title>A</title><guid>g1</guid></item></channel>
+</rss>`)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	feedRepo := &mockFeedRepo{
+		updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil },
+	}
+	f := NewFetcher(
+		feedRepo,
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{insertCount: 1},
+		&mockSSRFGuard{},
+		newTestLogger(&buf),
+		10*time.Second,
+		5*1024*1024,
+	)
+	feed := &model.Feed{ID: "feed-1", FeedURL: server.URL, FetchStatus: model.FetchStatusActive}
+
+	// Act
+	if err := f.Fetch(context.Background(), feed); err != nil {
+		t.Fatalf("Fetch() がエラーを返した: %v", err)
+	}
+
+	// Assert: 200 成功で UpdateLastSuccessfulFetchAt が 1 回 / feed.ID 引数で呼ばれる
+	if feedRepo.lastSuccessfulFetchAtCalls != 1 {
+		t.Errorf("UpdateLastSuccessfulFetchAt 呼び出し回数 = %d, want 1", feedRepo.lastSuccessfulFetchAtCalls)
+	}
+	if len(feedRepo.lastSuccessfulFetchAtFeedIDs) != 1 || feedRepo.lastSuccessfulFetchAtFeedIDs[0] != "feed-1" {
+		t.Errorf("UpdateLastSuccessfulFetchAt に渡された feedID = %v, want [feed-1]", feedRepo.lastSuccessfulFetchAtFeedIDs)
+	}
+}
+
+// TestFetcher_Fetch_RecordsLastSuccessfulFetchAt_304 は 304 Not Modified 成功時に
+// UpdateLastSuccessfulFetchAt が 1 回呼ばれることを検証する（Issue #115 Req 2.4）。
+func TestFetcher_Fetch_RecordsLastSuccessfulFetchAt_304(t *testing.T) {
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	feedRepo := &mockFeedRepo{
+		updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil },
+	}
+	f := NewFetcher(
+		feedRepo,
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{},
+		&mockSSRFGuard{},
+		newTestLogger(&buf),
+		10*time.Second,
+		5*1024*1024,
+	)
+	feed := &model.Feed{ID: "feed-1", FeedURL: server.URL, ETag: `"abc"`}
+
+	// Act
+	if err := f.Fetch(context.Background(), feed); err != nil {
+		t.Fatalf("Fetch() がエラーを返した: %v", err)
+	}
+
+	// Assert: 304 成功で UpdateLastSuccessfulFetchAt が 1 回呼ばれる
+	if feedRepo.lastSuccessfulFetchAtCalls != 1 {
+		t.Errorf("304 時の UpdateLastSuccessfulFetchAt 呼び出し回数 = %d, want 1", feedRepo.lastSuccessfulFetchAtCalls)
+	}
+}
+
+// TestFetcher_Fetch_DoesNotRecordOnBackoff は 429 / 5xx バックオフ経路で
+// UpdateLastSuccessfulFetchAt が呼ばれないことを検証する（Issue #115 Req 2.4: 成功時刻は ApplySuccess 経由のみ）。
+func TestFetcher_Fetch_DoesNotRecordOnBackoff(t *testing.T) {
+	// Arrange: 500 を返してバックオフ経路に入れる
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	feedRepo := &mockFeedRepo{
+		updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil },
+	}
+	f := NewFetcher(
+		feedRepo,
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{},
+		&mockSSRFGuard{},
+		newTestLogger(&buf),
+		10*time.Second,
+		5*1024*1024,
+	)
+	feed := &model.Feed{ID: "feed-1", FeedURL: server.URL, FetchStatus: model.FetchStatusActive}
+
+	// Act
+	_ = f.Fetch(context.Background(), feed)
+
+	// Assert: バックオフ経路では成功時刻を記録しない
+	if feedRepo.lastSuccessfulFetchAtCalls != 0 {
+		t.Errorf("バックオフ時の UpdateLastSuccessfulFetchAt 呼び出し回数 = %d, want 0", feedRepo.lastSuccessfulFetchAtCalls)
+	}
+}
+
+// TestFetcher_Fetch_DoesNotRecordOnStopFeed は 404 等の停止経路で
+// UpdateLastSuccessfulFetchAt が呼ばれないことを検証する。
+func TestFetcher_Fetch_DoesNotRecordOnStopFeed(t *testing.T) {
+	// Arrange: 404 を返して停止経路に入れる
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	feedRepo := &mockFeedRepo{
+		updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil },
+	}
+	f := NewFetcher(
+		feedRepo,
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{},
+		&mockSSRFGuard{},
+		newTestLogger(&buf),
+		10*time.Second,
+		5*1024*1024,
+	)
+	feed := &model.Feed{ID: "feed-1", FeedURL: server.URL, FetchStatus: model.FetchStatusActive}
+
+	// Act
+	_ = f.Fetch(context.Background(), feed)
+
+	// Assert: 停止経路では成功時刻を記録しない
+	if feedRepo.lastSuccessfulFetchAtCalls != 0 {
+		t.Errorf("停止経路時の UpdateLastSuccessfulFetchAt 呼び出し回数 = %d, want 0", feedRepo.lastSuccessfulFetchAtCalls)
+	}
+}
+
+// TestFetcher_Fetch_DoesNotRecordOnSSRFFailure は SSRF 検証失敗経路で
+// UpdateLastSuccessfulFetchAt が呼ばれないことを検証する。
+func TestFetcher_Fetch_DoesNotRecordOnSSRFFailure(t *testing.T) {
+	// Arrange
+	var buf bytes.Buffer
+	feedRepo := &mockFeedRepo{
+		updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil },
+	}
+	ssrfGuard := &mockSSRFGuard{validateErr: fmt.Errorf("blocked IP address")}
+	f := NewFetcher(
+		feedRepo,
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{},
+		ssrfGuard,
+		newTestLogger(&buf),
+		10*time.Second,
+		5*1024*1024,
+	)
+	feed := &model.Feed{ID: "feed-1", FeedURL: "http://192.168.1.1/feed.xml", FetchStatus: model.FetchStatusActive}
+
+	// Act
+	_ = f.Fetch(context.Background(), feed)
+
+	// Assert: SSRF 失敗時は成功時刻を記録しない
+	if feedRepo.lastSuccessfulFetchAtCalls != 0 {
+		t.Errorf("SSRF 失敗時の UpdateLastSuccessfulFetchAt 呼び出し回数 = %d, want 0", feedRepo.lastSuccessfulFetchAtCalls)
+	}
+}
+
+// TestFetcher_Fetch_DoesNotRecordOnParseFailure はパース失敗経路で
+// UpdateLastSuccessfulFetchAt が呼ばれないことを検証する。
+func TestFetcher_Fetch_DoesNotRecordOnParseFailure(t *testing.T) {
+	// Arrange: 不正な XML を返す
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, `not valid XML!!!`)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	feedRepo := &mockFeedRepo{
+		updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil },
+	}
+	f := NewFetcher(
+		feedRepo,
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{},
+		&mockSSRFGuard{},
+		newTestLogger(&buf),
+		10*time.Second,
+		5*1024*1024,
+	)
+	feed := &model.Feed{ID: "feed-1", FeedURL: server.URL, FetchStatus: model.FetchStatusActive}
+
+	// Act
+	_ = f.Fetch(context.Background(), feed)
+
+	// Assert: パース失敗時は成功時刻を記録しない
+	if feedRepo.lastSuccessfulFetchAtCalls != 0 {
+		t.Errorf("パース失敗時の UpdateLastSuccessfulFetchAt 呼び出し回数 = %d, want 0", feedRepo.lastSuccessfulFetchAtCalls)
+	}
+}
+
+// TestFetcher_Fetch_LastSuccessfulFetchAtErrorDoesNotFailFetch は
+// UpdateLastSuccessfulFetchAt がエラーを返してもフェッチ自体は成功扱いを維持することを検証する
+// （Issue #115 Req 2.4: 成功時刻の記録失敗は fetch 全体の失敗にしない）。
+func TestFetcher_Fetch_LastSuccessfulFetchAtErrorDoesNotFailFetch(t *testing.T) {
+	// Arrange: 200 + 成功時刻記録だけ失敗するモック
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel><title>T</title><item><title>A</title><guid>g1</guid></item></channel>
+</rss>`)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	feedRepo := &mockFeedRepo{
+		updateFetchStateFunc: func(_ context.Context, _ *model.Feed) error { return nil },
+		updateLastSuccessfulFetchAtFn: func(_ context.Context, _ string, _ time.Time) error {
+			return fmt.Errorf("simulated db error")
+		},
+	}
+	f := NewFetcher(
+		feedRepo,
+		&mockSubRepo{minInterval: 60},
+		&mockUpsertService{insertCount: 1},
+		&mockSSRFGuard{},
+		newTestLogger(&buf),
+		10*time.Second,
+		5*1024*1024,
+	)
+	feed := &model.Feed{ID: "feed-1", FeedURL: server.URL, FetchStatus: model.FetchStatusActive}
+
+	// Act
+	err := f.Fetch(context.Background(), feed)
+
+	// Assert: 成功時刻の記録失敗で fetch 自体は失敗扱いしない
+	if err != nil {
+		t.Fatalf("Fetch() は last_successful_fetch_at 更新失敗時もエラーを返さないべき: %v", err)
+	}
+	if feedRepo.lastSuccessfulFetchAtCalls != 1 {
+		t.Errorf("UpdateLastSuccessfulFetchAt 呼び出し回数 = %d, want 1", feedRepo.lastSuccessfulFetchAtCalls)
+	}
+}

--- a/internal/worker/fetch/scheduler_test.go
+++ b/internal/worker/fetch/scheduler_test.go
@@ -20,13 +20,16 @@ import (
 
 // mockFeedRepo はFeedRepositoryのテスト用モック。
 type mockFeedRepo struct {
-	listDueForFetchFunc   func(ctx context.Context) ([]*model.Feed, error)
-	updateFetchStateFunc  func(ctx context.Context, feed *model.Feed) error
-	findByIDFunc          func(ctx context.Context, id string) (*model.Feed, error)
-	findByFeedURLFunc     func(ctx context.Context, feedURL string) (*model.Feed, error)
-	createFunc            func(ctx context.Context, feed *model.Feed) error
-	updateFunc            func(ctx context.Context, feed *model.Feed) error
-	updateFaviconFunc     func(ctx context.Context, feedID string, faviconData []byte, faviconMime string) error
+	listDueForFetchFunc           func(ctx context.Context) ([]*model.Feed, error)
+	updateFetchStateFunc          func(ctx context.Context, feed *model.Feed) error
+	findByIDFunc                  func(ctx context.Context, id string) (*model.Feed, error)
+	findByFeedURLFunc             func(ctx context.Context, feedURL string) (*model.Feed, error)
+	createFunc                    func(ctx context.Context, feed *model.Feed) error
+	updateFunc                    func(ctx context.Context, feed *model.Feed) error
+	updateFaviconFunc             func(ctx context.Context, feedID string, faviconData []byte, faviconMime string) error
+	updateLastSuccessfulFetchAtFn func(ctx context.Context, feedID string, at time.Time) error
+	lastSuccessfulFetchAtCalls    int
+	lastSuccessfulFetchAtFeedIDs  []string
 }
 
 func (m *mockFeedRepo) FindByID(ctx context.Context, id string) (*model.Feed, error) {
@@ -83,6 +86,11 @@ func (m *mockFeedRepo) LockFeedForUpdateNowait(ctx context.Context, tx *sql.Tx, 
 }
 
 func (m *mockFeedRepo) UpdateLastSuccessfulFetchAt(ctx context.Context, feedID string, at time.Time) error {
+	m.lastSuccessfulFetchAtCalls++
+	m.lastSuccessfulFetchAtFeedIDs = append(m.lastSuccessfulFetchAtFeedIDs, feedID)
+	if m.updateLastSuccessfulFetchAtFn != nil {
+		return m.updateLastSuccessfulFetchAtFn(ctx, feedID, at)
+	}
 	return nil
 }
 

--- a/internal/worker/fetch/scheduler_test.go
+++ b/internal/worker/fetch/scheduler_test.go
@@ -3,6 +3,7 @@ package fetch
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -74,6 +75,14 @@ func (m *mockFeedRepo) UpdateFetchState(ctx context.Context, feed *model.Feed) e
 	if m.updateFetchStateFunc != nil {
 		return m.updateFetchStateFunc(ctx, feed)
 	}
+	return nil
+}
+
+func (m *mockFeedRepo) LockFeedForUpdateNowait(ctx context.Context, tx *sql.Tx, feedID string) (*model.Feed, error) {
+	return nil, nil
+}
+
+func (m *mockFeedRepo) UpdateLastSuccessfulFetchAt(ctx context.Context, feedID string, at time.Time) error {
 	return nil
 }
 


### PR DESCRIPTION
# 概要
Issue #115 「手動フィード更新の機能」のうち、バックエンド層（コアロジック）の実装（Task 1, 2, 3, 4）を独立してマージするためのPull Requestです。

# 変更内容
- **Task 1: DBマイグレーション**
  - `feeds` テーブルに `last_successful_fetch_at` カラムを追加。
  - `model.Feed` 構造体へのフィールド追加および Repository レイヤでの SELECT 時の Scan 整合。
- **Task 2: Repository 層の拡張**
  - ロック競合を即時エラー化する `LockFeedForUpdateNowait` および `UpdateLastSuccessfulFetchAt` の追加。
- **Task 3: 自動フェッチ（Worker Fetcher）の対応**
  - 自動フェッチ成功時にも `UpdateLastSuccessfulFetchAt` で最新時刻が同期記録されるよう対応。
- **Task 4: Service 層の実装**
  - `subscription.Service` に `ManualFetch` メソッドを実装し、認可チェック、非ブロッキング行ロック、10分間のクールダウン判定、およびフェッチャーの呼び出し・結果分類のオーケストレーションを定義。
  - 既存 fetcher が `*sql.DB` 経由で更新する際の自己デッドロックを防ぐため、fetcher 実行前にトランザクション（行ロック）をコミット解放する設計を適用。
  - モックを使用した comprehensive な単体テスト（正常系、クールダウン、ロック競合、SSRF検知、フェッチエラー等）を追加。

# 検証内容
- [x] `go test ./internal/subscription/...` (全テストが正常パスすることを確認済み)
