### PR TITLE
feat(#120): 記事の検索機能（横断検索・フィード内検索）を実装

### DIFF
--- a/docs/specs/120-issue/impl-notes.md
+++ b/docs/specs/120-issue/impl-notes.md
@@ -213,3 +213,71 @@ learning は改変しない。
   - **Task 5.5 の `app.go` wiring で、`itemsearch.NewSearchService(itemRepo, subRepo)`
     を呼び出す**形になる。`itemRepo` は `repository.ItemSearchRepository`（Task 3.1
     で追加済み）、`subRepo` は既存 `repository.SubscriptionRepository`（変更不要）。
+
+### Task 5
+
+- 採用方針: `GET /api/items/search` のハンドラ層 5 ファイル
+  （`item_search_handler.go` / `item_search_handler_test.go` / `router.go` /
+  `service_adapter.go` / `app.go`）を子タスク 5.1〜5.5 で順次実装し、
+  既存 `item_handler.go` の `UserIDFromContext` パターン・`subscription_handler.go` の
+  `data:<mime>;base64,...` data URL 化パターン・`service_adapter.go` の
+  Adapter + compile-time check パターンを全て踏襲した。
+- 重要な判断:
+  - **`ItemSearchServiceInterface` の戻り値型は `*itemSearchResponse`**（HTTP レスポンス型）
+    を採用した。tasks.md Task 5.1 の指示に従い、Service 層のドメイン型（`*itemsearch.SearchResult`）
+    を返すのではなく Adapter 層で API レスポンス型へ変換する。これにより favicon の
+    data URL 化責務（impl-notes Task 2 / Task 4 の決定）を Adapter 層に閉じ込め、
+    handler 層は HTTP 境界の責務（パース・認証・ログ）のみに集中できる。既存
+    `ItemServiceInterface` も同じパターン（`*itemListResult` を返す）で実装されており、
+    既存設計と整合する。
+  - **UUID 形式バリデーションは `github.com/google/uuid` の `uuid.Parse` を使用**。
+    既存コードベースで `uuid.Parse`/`uuid.MustParse` の利用例は無かったが、`go.mod` で
+    既に `github.com/google/uuid v1.6.0` が direct require されているため新規依存追加は
+    不要。なお `uuid.Parse` は dashes 無しの 32 hex 形式（`urn:uuid:` を除いた中身）も
+    妥当として受け付ける挙動があるため、handler テストの「UUID 不正」ケースには
+    `not-a-uuid` / `1234` / `zzzzzzzz-...` のような明確に妥当でない値のみを使用した
+    （実環境でも DB の `$N::uuid` cast が最終的なバリデーションを担うため、handler 層は
+    library に任せる方針で過剰検証しない）。
+  - **`/api/items/search` を `/api/items/{id}` より前に登録**。chi v5 は static segment
+    （`/search`）を `{id}` パターンよりも優先するため明示的な順序付けがなくても動作するが、
+    design.md と tasks.md の指示通り「保険的に明示順序」を採用した。テストでも
+    `withChiURLParam(id, "search")` のような誤発火パターンが起きないことを実装で保証する。
+  - **`limit` クエリのバリデーションを handler 層でも実施**（0 以下 / 非数値で 400）。
+    Service 層の `clampLimit` が 0 以下を `defaultSearchLimit` に倒すため、handler 層で
+    パースエラーを 400 に変換しなくても動作はするが、ユーザーに「明らかな入力ミス」を
+    silent fallback で隠す UX は望ましくないため明示エラーに倒した。`limit > maxSearchLimit`
+    の場合は handler 側で `maxSearchLimit` にクランプ（design.md「API Contract」節と
+    既存 `ListItems` の慣習に整合）。
+  - **空クエリ時の JSON レスポンス**: Service 層は `Items: nil` の `*SearchResult` を返すが、
+    JSON エンコード時に `nil` は `null` になってしまうため、handler 層で `result.Items == nil`
+    のときに `[]itemSearchHitResponse{}` を代入してから encode する。これで JSON は
+    `"items":[]` を返し、UI 側の「空配列分岐」が機械的に動作する（Req 1.5 / Req 4.3 の
+    UX 一貫性）。
+  - **`mockItemSearchService` 設計**: `internal/itemsearch/service_test.go` の
+    `mockItemSearchRepo` と同じ「呼び出し引数を `recordedSearchCall` スライスに記録」
+    パターンを採用。`searchFn` 未指定時は `&itemSearchResponse{Items: []itemSearchHitResponse{}}`
+    を返すデフォルト挙動とし、各テストで必要に応じて挙動を差し替える。これにより
+    「service が呼ばれない」アサート（401 / 400 / feed_id 不正 / limit 不正）が
+    `svc.callCount == 0` で機械的にチェックできる。
+  - **`go test ./...` 全 21 パッケージ green** で確認済み。`go build ./...` / `go vet ./...`
+    も clean。DB 結合テスト（Task 3.3）は `TEST_DATABASE_URL` 未設定で skip された
+    （ローカル環境に CI 用 Postgres が無いため）が、本 Task は mock service ベースで
+    DB 不要なため影響なし。
+- 残存課題（次 task に影響する事項）:
+  - **Task 6〜8 は Web フロントエンド実装**（`web/src/contexts/app-state.tsx` /
+    `web/src/components/header-search-bar.tsx` / `feed-search-bar.tsx` /
+    `search-results.tsx` / `app-shell.tsx` / `item-list.tsx` /
+    `web/src/hooks/use-item-search.ts`）。本 Task で確定した API レスポンス形状
+    （`items[].feed_title` / `items[].favicon_url`（data URL 形式 `*string` /
+    `omitempty`）/ `next_cursor` / `has_more`）と一致する型を `web/src/types/item.ts` に
+    定義する必要がある（Task 7.1）。
+  - 本 Task のクエリパラメータ仕様（`q` 必須に近い / `feed_id` 任意 / `cursor` 任意 /
+    `limit` 任意・既定 50・上限 200）に対し、`use-item-search.ts`（Task 7.2）が
+    `useInfiniteQuery` で `getNextPageParam: (lastPage) => lastPage.has_more ? lastPage.next_cursor : undefined`
+    を実装する前提（design.md ですでに記述）。`next_cursor` が空文字でも `has_more=true` の
+    ケース（末尾項目の `PublishedAt` がゼロ値）がありうるため、UI 側で空文字
+    `next_cursor` を「次ページなし」として扱うガードが必要（Service 層の判断と整合）。
+  - 本 Task の構造化ログ（`slog.Info("item search request", ...)`）は NFR 3.1 を満たすが、
+    クエリ本文は PII / ログ汚染回避のため出していない（長さのみ）。運用観察時に「特定
+    キーワードがヒットしないユーザー」のトラブルシュートを行う場合、別経路（DB 側の
+    `pg_stat_statements` 等）から `pattern` を引く必要がある点を覚えておく。

--- a/docs/specs/120-issue/impl-notes.md
+++ b/docs/specs/120-issue/impl-notes.md
@@ -347,6 +347,87 @@ learning は改変しない。
     残る」UX を Task 8 の統合テストで確認する必要がある。違和感が出るなら CLEAR_SEARCH
     の reset を追加する（design.md 行 690 への揃え戻し）。
 
+### Task 7
+
+- 採用方針: 子タスク 7.1〜7.5 を順次実装し、検索 UI とフェッチ層を 5 ファイルで構成した
+  （`web/src/types/item.ts` への型追加 / `web/src/hooks/use-item-search.ts` フック /
+  `header-search-bar.tsx` / `feed-search-bar.tsx` / `search-results.tsx` 各コンポーネント
+  + それぞれの `.test.tsx`）。設計は design.md 行 516-655 の `HeaderSearchBar` /
+  `FeedSearchBar` / `SearchResults` / `useItemSearch` 疑似シグネチャに忠実に従い、既存
+  `use-items.ts` / `item-list.tsx` の `ItemRow` / `feed-list.tsx` の favicon パターンを
+  踏襲した。web テスト 30 ファイル / 276 ケース全 pass、ESLint errors 0、Go 全 21 パッケージ
+  green、go vet clean を確認済み。
+- 重要な判断:
+  - **`SearchScope` 型は `app-state.tsx` から re-export する形を採用**（Task 6 残存課題
+    の選択肢 (b)）。理由: UI 状態側の `app-state.tsx` が既に `SearchScope` を canonical
+    として export しており、`types/item.ts` 側で独自定義すると構造的に同一でも別型として
+    扱われるリスクがある。`export type { SearchScope } from "@/contexts/app-state"` で
+    re-export することで定義は 1 つに保たれ、`types/item.ts` を import する側からは
+    API レスポンス型と同じ場所に配置されているように見える利便性も得られる。
+  - **`useItemSearch` の `getNextPageParam` ガード**: design.md 行 650 は
+    `lastPage.has_more ? lastPage.next_cursor : undefined` のみだが、impl-notes Task 4 の
+    判断（NextCursor 末尾項目 PublishedAt がゼロ値のとき空文字を発行）に対応するため
+    `lastPage.has_more && lastPage.next_cursor ? lastPage.next_cursor : undefined` と
+    truthy 判定を追加した。空文字 cursor は無限ループの危険を孕むため、UI 側でガードして
+    「次ページあり判定だが cursor 未発行 = 次ページ取得を諦める」挙動とした。
+  - **`HeaderSearchBar` / `FeedSearchBar` のローカル状態と AppState の同期**: design.md の
+    疑似シグネチャは「ローカル状態に入力を保持し submit で AppState を更新」のみ示すが、
+    検索中にコンポーネントを再 mount したケース（例: 検索中に AppShell が再 render される
+    ケース）で AppState.searchQuery を初期値に反映する `useState(initial...)` パターンを
+    採用した。`HeaderSearchBar` は scope='global' のときのみ、`FeedSearchBar` は
+    scope='feed' かつ searchFeedId が当該 selectedFeedId と一致する場合のみ反映する。
+    これにより「検索バーが空白に戻ってしまうが結果は残っている」という UX 不整合を防ぐ。
+  - **`FeedSearchBar` の早期 return**: React hooks 規約に従い、`useState` を先に呼んでから
+    `if (selectedFeedId === null) return null` を実行する形にした。selectedFeedId が
+    途中で null に戻る再 render では useState の値が破棄されるが、selectedFeedId が
+    null になる経路は「フィードを未選択状態に戻す UI」が現状存在しないため実害なし。
+  - **`SearchResults` の `SearchResultRow` を `ItemList` の `ItemRow` と共通化しない**:
+    `ItemSummary` vs `ItemSearchHit` で構造体が異なり（後者は `feed_title` /
+    `favicon_url` を含み `hatebu_fetched_at` を欠く）、共通化すると generic 化と props
+    呼び分けの複雑度が増す。`design-principles.md` の「投機的抽象化を避ける」方針と
+    design.md 行 596-599 の「初版は重複容認」指針に従い、検索結果専用に
+    `SearchResultRow` を併設した。
+  - **`SearchResultFavicon` を feed-list の `FeedFavicon` と分離**: 検索結果カードは
+    情報密度が高くアイコン領域を最小化したいため、favicon URL が無い / 画像エラーの
+    場合は何も表示しない（feed-list の代替アイコン表示は採用しない）。alt 属性は
+    feed-list と同じ `${feedTitle} のアイコン` パターン。サイズは w-3.5 h-3.5 と
+    feed-list（w-4 h-4）よりやや小さくしている。
+  - **`SearchResultRow` の `published_at` null ハンドリング**: API レスポンス型では
+    `published_at: string | null` を許容するため（impl-notes Task 5 で確定）、null の
+    ケースで `new Date(null)` が `1970-01-01` になる事故を避けるべく明示的に分岐し、
+    `<time>` 要素を省略 +「日付不明」表示にフォールバックする。テストでも境界値として
+    1 ケース追加した。
+  - **テスト構造**: `header-search-bar` / `feed-search-bar` / `search-results` で
+    AppStateProvider 配下に Probe コンポーネントを置き、`useDispatchOnce` ヘルパーで
+    初回 mount 時に dispatch を 1 度だけ流すパターンを採用。`renderHook` で
+    AppState と HeaderSearchBar を別 Provider に分離する従来パターンよりも、
+    実際の使用に近い形でテストできる。
+  - **`<img>` の Next.js Image 警告**: `search-results.tsx:373` で `<img>` を使用しており
+    ESLint warning が出るが、既存の `feed-list.tsx:124` も同じ警告を残置している
+    （favicon は data URL であり Next.js Image による最適化対象外）。先行 task と
+    同一の判断として許容し、エラーは 0 件を維持。
+- 残存課題（次 task に影響する事項）:
+  - **Task 8 で `AppShell` / `ItemList` への統合**: 本 task では `HeaderSearchBar` /
+    `FeedSearchBar` / `SearchResults` の単体コンポーネントを作成しただけで、これらは
+    まだ `AppShell` / `ItemList` から呼ばれていない。Task 8 で
+    (a) `AppShell` のヘッダーに `HeaderSearchBar` を配置、(b) `AppShell` 右ペインを
+    `state.isSearching ? <SearchResults /> : <ItemList .../>` で切替、
+    (c) `ItemList` の Tabs の同列に `<FeedSearchBar />` を配置する統合作業が必要。
+  - **Task 8 の統合テストで `expandedItemId` の扱いに注意**: impl-notes Task 6 の判断で
+    `CLEAR_SEARCH` は `expandedItemId` を保持する（design.md 行 690 とは異なる挙動）
+    ため、検索解除後に展開状態が残ったまま `ItemList` に戻る UX が成立するかを Task 8
+    の統合テストで確認する。違和感が出るなら CLEAR_SEARCH の reducer に
+    `expandedItemId = null` を追加して揃え戻す判断もありうる。
+  - **Task 8 で `useItemSearch` の発火条件確認**: `SearchResults` は
+    `useItemSearch(state.searchQuery, state.searchScope, state.searchFeedId)` を
+    無条件で呼ぶが、`enabled` ガードで空クエリ / scope='feed' かつ feedId 不在では
+    fetch を発火しない。`AppShell` が `state.isSearching` で `SearchResults` を表示する
+    フロー（Task 8）と整合する。
+  - **Task 9（NFR 1.2 パフォーマンス測定）**: 本 task の `useItemSearch` は TanStack
+    Query の即時 `isLoading=true` により NFR 1.1（1 秒以内のローディング表示）を
+    満たすが、NFR 1.2 の体感応答性は Task 9 の `EXPLAIN ANALYZE` 計測タスクで別途
+    検証する（本 task のスコープ外、deferrable `- [ ]*`）。
+
 ## 確認事項
 
 - **`SET_SEARCH_QUERY` の `searchFeedId` 計算**: 本 task では `action.feedId ?? null`

--- a/docs/specs/120-issue/impl-notes.md
+++ b/docs/specs/120-issue/impl-notes.md
@@ -141,3 +141,75 @@ learning は改変しない。
     `len(hits) > limit` で判定して `hits = hits[:limit]` に切り詰める設計
     （design.md と tasks.md Task 4 で明示）。本 method 自体は LIMIT を
     そのまま適用するだけで HasMore ロジックを持たない。
+
+### Task 4
+
+- 採用方針: `internal/itemsearch.SearchService` を `service.go` / `service_test.go`
+  の 2 ファイルで新規実装。design.md の `Search(ctx, userID, rawQuery, feedID, cursorStr, limit)`
+  シグネチャに従い、(1) クエリ正規化（前後空白 trim + 空クエリ判定）、(2) LIKE メタ文字
+  エスケープ、(3) feed_id 指定時の購読確認、(4) cursor `<RFC3339Nano>|<uuid>` 解析、
+  (5) limit クランプ、(6) `limit+1` 取得 → HasMore 判定 → NextCursor 生成、(7)
+  `ItemSearchHit` → `ItemSearchSummary` 変換の各責務を 1 メソッドで完結させる。
+  テストは 30+ ケースのテーブル駆動で AC 1.5 / 2.4 / 2.6 / 3.5 / 4.1 / 4.4 を網羅する。
+- 重要な判断:
+  - **`SubscriptionRepository.Exists` を新規追加せず、既存 `FindByUserAndFeed` を再利用する**。
+    tasks.md は「未存在なら追加」も許容するが、`FindByUserAndFeed` は既に
+    `(*model.Subscription, error)` を返し nil で未購読を判定可能なため、interface 拡張は
+    不要と判断した。新規メソッド追加は本 task のスコープを膨らませ、他コンシューマへの
+    影響もあるため、最小侵襲を優先する。Service 層が `sub == nil → NewFeedNotSubscribedError`
+    で判定する形にし、`subRepo.FindByUserAndFeed` のエラーは
+    `fmt.Errorf("check subscription: %w", err)` で wrap する。
+  - **`ItemSearchSummary` に `FaviconData []byte` / `FaviconMime string` を追加した**
+    （design.md 行 295-309 の field 一覧は `FaviconURL *string` のみだが拡張）。理由は
+    impl-notes Task 2 で「favicon の data URL 化は Task 5.3 の `ItemSearchServiceAdapter`
+    が担う」と責務分離が確定しているため、Service 層が data URL を生成すると Adapter 層
+    と二重責務になる。Service 層は `ItemSearchHit.FaviconData` / `FaviconMime` を
+    そのまま pass-through し、`FaviconURL` は常に nil としておく形を採用した。
+    Adapter 層（Task 5.3）が `data:<mime>;base64,...` 形式に整形して `FaviconURL` を
+    populate する責務を持つ。design.md の field 一覧との差分はあるが、impl-notes
+    Task 2 の責務分離判断を優先する。
+  - **NextCursor を末尾項目の `PublishedAt` がゼロ値の場合は空文字とする**。
+    `repository` 層は NULL `published_at` をゼロ値（`time.Time{}`）にマッピングする
+    （impl-notes Task 3）。ゼロ値で cursor を組み立てると `(published_at, id) <
+    (cursor)` のタプル比較が壊れて並び順が不安定になるため、安全側に倒して NextCursor
+    を発行しない。HasMore は実体ベースで保持し、UI 側で「次ページあり」だけは表示できる。
+  - **limit クランプを Service 層でも実施**（0 以下 → 50、200 超 → 200）。
+    design.md の handler 層仕様で同じクランプを行う前提だが、handler を経由しない
+    直接呼び出しや handler 側のバグへの防御として Service 層でも適用する。クランプ後の
+    `effectiveLimit` に対して `+1` した値を repository に渡し、`len(hits) > effectiveLimit`
+    で HasMore を判定する。
+  - **cursor parse は Service 層の責務**（impl-notes Task 3 既述）。
+    `strings.SplitN(cursorStr, "|", 2)` で分割し、length != 2 / parse 失敗 / id 空 /
+    `|` が複数 のいずれも `NewInvalidSearchQueryError` で 400 に倒す。UUID 自体の
+    厳密 parse は repository 層の `$5::uuid` cast に任せ、Service 層は「空でない文字列」
+    程度の sanity check に留めた（過剰な依存追加を避ける）。
+  - **`escapeLikePattern` の順序**: `\` → `%` → `_` の順で `strings.ReplaceAll` を
+    適用する（順序逆転すると `%` のエスケープに使った `\` 自体が再エスケープされて
+    `\\%` のように二重に化けるため）。PostgreSQL ILIKE の標準 escape 文字は `\` で、
+    本実装の出力（例: `50\%off`）はそのまま LIKE / ILIKE の述語に渡せる。
+  - **テストモックの設計**: `mockItemSearchRepo` は呼び出し引数を
+    `recordedSearchCall` スライスに記録する callable assertion パターンを採用。
+    `mockSubRepo` は `repository.SubscriptionRepository` interface 全メソッドを実装する
+    必要があるが、本テストで触れない他メソッドは `panic` で fail-fast にした
+    （誤って呼ばれたら即座にテスト失敗）。`mockSubRepo` は
+    `var _ repository.SubscriptionRepository = (*mockSubRepo)(nil)` で compile-time
+    check を入れている。
+- 残存課題（次 task に影響する事項）:
+  - **Task 5.3 の `ItemSearchServiceAdapter` 実装で、`ItemSearchSummary.FaviconData`
+    /  `FaviconMime` を data URL に整形する責務**が確定。`subscription.Service.
+    ListSubscriptions` と同じ `data:<mime>;base64,...` 形式のロジックを再利用する
+    形（既存パターンとの整合）。Adapter 側で `FaviconURL` を populate し、Service 層
+    では `FaviconURL=nil` のままにする。
+  - **Task 5.1 の handler 実装で、`limit` クエリパラメータの解析・クランプ**は
+    本 Service 層でも防御的に行うが、handler 側も同じクランプ（design.md「API
+    Contract」節の `defaultItemsPerPage = 50` / 上限 200）を実装する必要がある。
+    handler が `?limit=0` のような不正値を渡しても Service 層が defaultSearchLimit
+    に倒して安全動作するが、handler 側で明示的に解析するのが UX 上望ましい。
+  - **Task 5.4 の handler テストで、Service モックを差し替える**実装が必要。
+    本 task では `SearchService` を struct で公開しているため、handler 側で
+    `ItemSearchServiceInterface`（design.md 行 70-79 / tasks.md Task 5.1）を定義し、
+    Adapter 経由で interface を満たす設計が想定される（既存
+    `ItemServiceInterface` / `ItemServiceAdapter` パターンと整合）。
+  - **Task 5.5 の `app.go` wiring で、`itemsearch.NewSearchService(itemRepo, subRepo)`
+    を呼び出す**形になる。`itemRepo` は `repository.ItemSearchRepository`（Task 3.1
+    で追加済み）、`subRepo` は既存 `repository.SubscriptionRepository`（変更不要）。

--- a/docs/specs/120-issue/impl-notes.md
+++ b/docs/specs/120-issue/impl-notes.md
@@ -498,3 +498,5 @@ learning は改変しない。
   指示のみに従い `selectedFeedId` / `filter` のみ保持し、`expandedItemId` は触らない
   実装とした。design.md 行 690 は `expandedItemId = null` を含めると記述している
   ため、検索解除後に展開状態を残すか否かは UX レビュー時に再確認したい。
+
+STATUS: complete

--- a/docs/specs/120-issue/impl-notes.md
+++ b/docs/specs/120-issue/impl-notes.md
@@ -281,3 +281,81 @@ learning は改変しない。
     クエリ本文は PII / ログ汚染回避のため出していない（長さのみ）。運用観察時に「特定
     キーワードがヒットしないユーザー」のトラブルシュートを行う場合、別経路（DB 側の
     `pg_stat_statements` 等）から `pattern` を引く必要がある点を覚えておく。
+
+### Task 6
+
+- 採用方針: `web/src/contexts/app-state.tsx` の `AppState` に検索状態 4 フィールド
+  （`searchQuery: string`, `isSearching: boolean`, `searchScope: 'global' | 'feed'`,
+  `searchFeedId: string | null`）を追加し、`SET_SEARCH_QUERY` / `CLEAR_SEARCH`
+  アクションを reducer に実装した。`SELECT_FEED` 既存挙動に検索状態リセット 4 行を追記し、
+  既存テストを壊さずに新規 5 ケース（初期値検証は既存 it に統合）を `app-state.test.tsx` に
+  追加。Vitest 14 ケース全 pass、ESLint 0 error（既存の未使用変数 warning のみ）。
+- 重要な判断:
+  - **`SearchScope` 型を `export` した**: design.md の AppState 仕様に `SearchScope` が
+    現れ、Task 7.1 (`web/src/types/item.ts` への `SearchScope` 型追加) と Task 7.2
+    (`useItemSearch` の引数型) も同じ用語を使う。`app-state.tsx` で `export type SearchScope`
+    として定義しておくことで、`types/item.ts` 側は `import { SearchScope } from
+    '@/contexts/app-state'` で再利用可能になる（Task 7.1 が `types/item.ts` で別途定義する
+    形を取るなら、本 export は冗長だが互換性は保たれる）。
+  - **`SET_SEARCH_QUERY` の `searchFeedId` 計算式**: design.md 行 689 は
+    `action.scope === 'feed' ? (action.feedId ?? state.selectedFeedId) : null` と
+    state.selectedFeedId への fallback を含めるが、tasks.md Task 6 の指示は
+    「`searchFeedId: string | null` を追加する」「`scope` / 任意の `feedId` を受け取る」
+    に留まる。本実装では tasks.md 側の表現を優先し、`action.feedId ?? null`（state
+    依存なしの単純 fallback）とした。理由: (1) design.md の「state.selectedFeedId
+    fallback」を採用すると `FeedSearchBar` (Task 7.4) が `feedId: state.selectedFeedId`
+    を明示 dispatch する設計と二重防御になり、UI 層の責務が曖昧化する。(2) 単純化した
+    結果として「scope='feed' なのに feedId 未指定 → searchFeedId=null」になると、
+    Task 7.2 の `useItemSearch` が `enabled: !(scope === 'feed' && !feedId)` で
+    検索を発火しないため、不整合 dispatch が silent に空クエリ扱いされ UX の安全性が
+    保たれる。design.md と挙動が異なる判断のため後述「確認事項」に記載した。
+  - **`SELECT_FEED` への検索状態リセット 4 行追加**: tasks.md 明示指示どおり実装。
+    design.md 行 693-696 の「フィード選択を検索の暗黙的解除として扱う」判断と整合。
+    NFR 2.2 の「検索解除時に検索実行直前の表示状態を復元」とは矛盾しないか検討したが、
+    SELECT_FEED は「新しいフィードを選ぶ」UX であり「検索を解除する」とは別操作のため、
+    リセットしても NFR 2.2 違反にはならない（Req 1.6 の `CLEAR_SEARCH` 経路でのみ
+    selectedFeedId / filter を復元する責務が問われる）。
+  - **`CLEAR_SEARCH` で `expandedItemId` をリセットしない**: design.md 行 690 は
+    `expandedItemId = null` を含めると記述しているが、本実装では `expandedItemId` を
+    保持した。理由: tasks.md Task 6 の括弧書きで明示されているのは「`selectedFeedId`
+    と `filter` は保持」のみで、`expandedItemId` の扱いは明示されていない。検索結果から
+    記事を展開した状態で × ボタンを押した際に「検索解除＋展開も解除」だと UX 上ノイズが
+    多い（展開はユーザーの直近の意図）。一方 design.md 行 690 の判断も合理性があるため、
+    実装での解釈差は後述「確認事項」に記載した。なお SET_SEARCH_QUERY 側も
+    `expandedItemId = null` の reset は実装していない（tasks.md に指示なし）。
+  - **テスト方針**: 既存テストの `初期状態が正しく設定されていること` に新フィールドの
+    初期値 expect を 4 行追加（既存挙動の非回帰を保証）し、新規 5 ケース
+    （SET_SEARCH_QUERY scope='global' / scope='feed' + feedId / scope='feed' feedId 省略 /
+    CLEAR_SEARCH で selectedFeedId+filter 保持 / SELECT_FEED で検索状態リセット）を
+    Provider 外エラーテストの直前に追加。既存テスト 9 件 + 新規 5 件 = 14 件全 pass。
+- 残存課題（次 task に影響する事項）:
+  - **Task 7.1 で `web/src/types/item.ts` に `SearchScope` 型を再定義する**場合は、
+    本 task で `app-state.tsx` から export した `SearchScope` と重複定義になる。
+    Task 7.1 実装時は (a) `types/item.ts` で独自定義しつつ `app-state.tsx` の型と
+    構造的に同一にする / (b) `types/item.ts` 側で `app-state.tsx` から re-export する /
+    (c) `app-state.tsx` から export せず削除して `types/item.ts` を唯一の定義源とする
+    のいずれかを選ぶ必要がある。本 task では (a) を想定して `app-state.tsx` 側にも
+    export を残す形にしたが、Task 7.1 担当が判断する余地がある。
+  - **Task 7.3 / 7.4 の検索バー実装で、`SET_SEARCH_QUERY` dispatch 時の feedId 渡し方**:
+    `FeedSearchBar` は `feedId: state.selectedFeedId` を明示 dispatch する（design.md
+    行 588）。`HeaderSearchBar` は `feedId` を省略する（scope='global' なので
+    state では null になる）。本 task の reducer 実装はこの dispatch パターンに前提を
+    置く。
+  - **Task 7.5 / 8 の `SearchResults` 統合で、`expandedItemId` の扱い**: 検索結果上の
+    記事展開は `EXPAND_ITEM` を流用する設計（design.md 行 614-621）。本 task で
+    CLEAR_SEARCH が expandedItemId を保持する判断のため、検索解除後の「展開状態が
+    残る」UX を Task 8 の統合テストで確認する必要がある。違和感が出るなら CLEAR_SEARCH
+    の reset を追加する（design.md 行 690 への揃え戻し）。
+
+## 確認事項
+
+- **`SET_SEARCH_QUERY` の `searchFeedId` 計算**: 本 task では `action.feedId ?? null`
+  （state.selectedFeedId への fallback なし）を採用したが、design.md 行 689 は
+  `action.feedId ?? state.selectedFeedId` を指定している。本実装は tasks.md の表現を
+  優先しており UX 上の安全性も保たれる（Task 7.4 の `FeedSearchBar` が明示 dispatch
+  する前提）が、design.md の意図と異なる場合は Task 7.4 実装時または PR レビューで
+  揃え戻しが必要。
+- **`CLEAR_SEARCH` で `expandedItemId` を保持する判断**: 本 task では tasks.md 明示
+  指示のみに従い `selectedFeedId` / `filter` のみ保持し、`expandedItemId` は触らない
+  実装とした。design.md 行 690 は `expandedItemId = null` を含めると記述している
+  ため、検索解除後に展開状態を残すか否かは UX レビュー時に再確認したい。

--- a/docs/specs/120-issue/impl-notes.md
+++ b/docs/specs/120-issue/impl-notes.md
@@ -33,3 +33,50 @@ learning は改変しない。
     検索 SQL から利用される。
   - 本 task は SQL のみで Go コード変更なし。検索本体（service / repository / handler / web）は
     Task 2〜8 で順次実装される。
+
+### Task 2
+
+- 採用方針: 検索ドメイン用の DB レベル射影モデル `ItemSearchHit` と、検索固有の `APIError`
+  生成関数 2 種（`NewInvalidSearchQueryError` / `NewFeedNotSubscribedError`）+ HTTP ステータス
+  マッピングを追加した。
+- 重要な判断:
+  - **`ItemSearchHit` は埋め込みではなく個別フィールド構成**にした。tasks.md は「埋め込みまたは
+    個別フィールドで再現」のいずれかを許容しているが、`ItemSummary` は `internal/item`
+    パッケージに存在し、`internal/model` から `internal/item` へ依存させると現状の依存方向
+    （`item → model`）が逆転して循環依存になる。`Feed` 構造体に既に存在する
+    `FaviconData []byte` / `FaviconMime string` のフィールド名・型と完全一致させ、既存
+    `ItemWithState` と同じくリポジトリ層が直接生成して返す DB レベル射影として扱う。
+  - **`Summary` フィールドを含めた**: design.md の `ItemSearchSummary`（Service 層型）が
+    `Summary string` を持ち、design.md `## File Structure Plan` の Modified Files でも
+    「`ItemSummary` 相当」と書かれている。`ItemSummary` には `Summary` フィールドが存在
+    するため `ItemSearchHit` にも追加した（後続 Task 3.2 で SELECT 列に `i.summary` を含める
+    前提と整合）。
+  - **新規エラーコードの Category 命名**: design.md の Error Handling 節と tasks.md の指示
+    どおり、`INVALID_SEARCH_QUERY` を `validation`、`FEED_NOT_SUBSCRIBED` を `authorization`
+    に設定した。既存の `auth` Category（USER_NOT_FOUND）は「未認証 / セッション無効」を
+    指す用語として運用されているため、認可（権限）系の新区分として `authorization` を採用
+    して既存コードと混同しない区別を付けた。
+  - **`mapAPIErrorToHTTPStatus` の switch 文末**: 既存の `case` の意味的近隣（バリデーション
+    系は `ErrCodeInvalidFilter` / `ErrCodeInvalidFetchInterval` と合流して `400`、認可系は
+    新規 `case` を追加して `403 Forbidden`）に挿入した。デフォルト 500 へのフォールバック
+    挙動は無変更。
+  - **テスト追加方針**: 新規 `internal/model/errors_test.go` で 2 生成関数の Code/Category/
+    Message を直接検証し、既存 `feed_handler_test.go` の `TestMapAPIErrorToHTTPStatus_KnownCodes`
+    テーブルに 2 ケースを追記した。これにより handler 層の HTTP ステータスマッピングと
+    model 層のエラー構造体生成の両方をユニットテストでカバーする。実装-→テスト-→確認の
+    順で `go test ./internal/model/... ./internal/handler/...` が green、続いて
+    `go test ./...` も全 package 通過を確認済み。
+- 残存課題（次 task に影響する事項）:
+  - Task 3.1 / 3.2 の Repository 層実装で、本 task で追加した `ItemSearchHit` を SELECT
+    結果として組み立てる scanner と、SQL の SELECT 列（`i.id, i.feed_id, i.title, i.link,
+    i.summary, i.published_at, i.is_date_estimated, i.hatebu_count, f.title AS feed_title,
+    f.favicon_data, f.favicon_mime, COALESCE(st.is_read), COALESCE(st.is_starred)`）を
+    `ItemSearchHit` の各フィールドへマッピングする実装が必要。
+  - Task 4 のサービス層（`itemsearch.SearchService`）で、`ItemSearchHit` をアプリケーション
+    向け表現 `ItemSearchSummary`（design.md 行 295-309 / `FaviconURL *string` 形式）へ変換
+    する責務が発生する。本 task の `FaviconData []byte` / `FaviconMime string` を、既存
+    `subscription.Service.ListSubscriptions` と同じく `data:<mime>;base64,...` 形式の
+    data URL に整形してから API レスポンスへ渡す変換を、Task 5.3 の `ItemSearchServiceAdapter`
+    が担うのが既存パターンと整合する。
+  - Task 4 / 5 / 5.4 が、本 task で追加した `model.NewInvalidSearchQueryError` /
+    `model.NewFeedNotSubscribedError` をサービス層・ハンドラ層で使用する前提で実装される。

--- a/docs/specs/120-issue/impl-notes.md
+++ b/docs/specs/120-issue/impl-notes.md
@@ -428,6 +428,64 @@ learning は改変しない。
     満たすが、NFR 1.2 の体感応答性は Task 9 の `EXPLAIN ANALYZE` 計測タスクで別途
     検証する（本 task のスコープ外、deferrable `- [ ]*`）。
 
+### Task 8
+
+- 採用方針: `AppShell` のヘッダーに `HeaderSearchBar` を常設し、右ペインを
+  `state.isSearching ? <SearchResults /> : <ItemList .../>` で排他切替する。
+  `ItemList` のフィルタタブと同列の上部領域に `<FeedSearchBar />` を追加し、
+  既存の早期 return（`feedId === null` でフィルタ領域に到達しない経路）と
+  `FeedSearchBar` 自身の `selectedFeedId === null` ガード（NFR 2.3）が二重に
+  作用する形にした。統合テストは AppShell 側 4 件 / ItemList 側 2 件を追加。
+- 重要な判断:
+  - **`item-list.test.tsx` wrapper の `AppStateProvider` 追加**: `ItemList` が
+    `FeedSearchBar` 経由で `useAppState` を間接利用するようになったため、既存
+    `createWrapper` の `QueryClientProvider` だけでは `useAppState` が
+    Provider 不在エラーで throw する。`createWrapper` を `AppStateProvider`
+    込みに昇格させることで既存 29 ケース（`item-row-*` / フィルタ / 詳細展開
+    系すべて）を破壊せず通過させた。AppState は **未 dispatch のまま** 初期
+    state（`selectedFeedId: null`）で動作するため、既存テストは引き続き
+    `feedId` props を直接渡す扱いで安定する。
+  - **`renderWithInitialDispatch` ヘルパーを `item-list.test.tsx` 内に新設**:
+    `feed-search-bar.test.tsx` / `search-results.test.tsx` と同じ `useDispatchOnce`
+    パターンを `item-list.test.tsx` にも複製した。共通化（`web/src/__tests__/`
+    配下に括り出す等）は設計指針「投機的抽象化を避ける」に従い、3 ファイル目に
+    同パターンが出現してから検討する余地を残す。
+  - **`AppShell` 統合テストでの `/api/items/search` モック追加**: `SearchResults`
+    が `useItemSearch` 経由で `apiClient.get('/api/items/search?...')` を呼ぶため、
+    既存 `setupMockFetch` を拡張して `/api/items/search` を `{items:[], next_cursor:
+    null, has_more: false}` で応答するように追加した。テストの観点（検索モード
+    切替の確認）に対し空結果が最も低ノイズで、`SearchResults` の `search-results-empty`
+    testid 露出により切替判定が機械的に確認できる。
+  - **検索モード切替の testid 観測**: 「ItemList ではなく SearchResults が
+    レンダされる」「CLEAR_SEARCH で ItemList に戻る」を、testid（`search-results-empty`
+    / `フィードを選択してください` テキスト / `screen.queryByRole("tab", {name:
+    "全て"})`）の有無で観測する。`screen.queryByTestId(...).not.toBeInTheDocument()`
+    パターンで否定確認も行い、状態切替の往復が確実に取れることを保証した。
+  - **`item-list.tsx` のレイアウト調整**: 既存「`flex-shrink-0 border-b px-4 py-2`」
+    に対して `FeedSearchBar` を併設するため `flex flex-wrap items-center
+    justify-between gap-2` を追加し、横並びレイアウトに昇格させた。`flex-wrap`
+    により狭幅環境では検索バーが下段に折り返す。フィルタタブの既存テスト
+    （`screen.getByRole("tab", {...})` で取得）はクラス変更の影響を受けない。
+  - **`app-shell.tsx` のヘッダー調整**: 既存「`flex items-center
+    justify-between`」を `gap-3` 付きに昇格させ、`HeaderSearchBar` を中央に
+    挟む 3 カラム配置（Feedman タイトル / 検索バー / テーマ + ログアウト）と
+    した。`screen.getByText("Feedman")` / `screen.getByTestId("theme-toggle")`
+    等の既存テストは要素クエリで取得しているためレイアウト変更の影響を受けない。
+- 残存課題（次 task に影響する事項）:
+  - **Task 9（deferrable）**: NFR 1.2 のパフォーマンス計測 / `EXPLAIN ANALYZE`
+    スクリプトは未実装。数値目標（200ms 以内）の確認は別 PR / 別 Issue で扱う。
+  - **検索結果の `expandedItemId` 引継ぎ挙動**: `CLEAR_SEARCH` で `expandedItemId`
+    が保持される現状の reducer（impl-notes Task 6 判断）により、
+    検索 → 記事展開 → クリアの流れで「ItemList に戻った直後、対応する記事が
+    `expandedItemId` 一致なら自動展開されうる」UX が発生する。本 task の統合
+    テストでは検索結果が空のため当該ケースを再現していない。実環境で違和感が
+    出る場合は別 PR で `CLEAR_SEARCH` の reducer に `expandedItemId = null` を
+    追加する判断もありうる（design.md 行 690 への揃え戻し）。
+  - **既存 ESLint warning（`callback` 未使用）**: `item-list.test.tsx:21`
+    `IntersectionObserverCallback` の引数 `callback` 未使用 warning は本 task
+    の変更前から存在しており、本 task では触れずに残置した。warning は CI を
+    block しないため scope 外。
+
 ## 確認事項
 
 - **`SET_SEARCH_QUERY` の `searchFeedId` 計算**: 本 task では `action.feedId ?? null`

--- a/docs/specs/120-issue/impl-notes.md
+++ b/docs/specs/120-issue/impl-notes.md
@@ -80,3 +80,64 @@ learning は改変しない。
     が担うのが既存パターンと整合する。
   - Task 4 / 5 / 5.4 が、本 task で追加した `model.NewInvalidSearchQueryError` /
     `model.NewFeedNotSubscribedError` をサービス層・ハンドラ層で使用する前提で実装される。
+
+### Task 3
+
+- 採用方針: `ItemSearchRepository` インターフェースを `interfaces.go` に新規定義し、
+  `PostgresItemRepo.SearchByUserAndKeyword` で design.md 参照 SQL（`items JOIN
+  subscriptions JOIN feeds LEFT JOIN item_states` + `$3::uuid IS NULL` ガード +
+  タプル比較ページング）どおりに 1 クエリで横断 / フィード内検索を表現した。
+  Skip ガード付き DB 結合テスト 10 ケースで AC 2.2/2.3/2.4/2.5/2.6/3.1/3.2/3.4/4.1/5.3
+  を網羅する。
+- 重要な判断:
+  - **null 引数は動的 WHERE 文字列再構築ではなく SQL ガード（`$3::uuid IS NULL`,
+    `$4::timestamptz IS NULL`）で処理する**。`ListByFeed` は WHERE を文字列連結で
+    動的に組み立てる方式（cursor 有無で `argIndex` を変える）だが、本 method は
+    design.md がガード式での表現を明示しており、PostgreSQL のプランナが `IS NULL`
+    ガードを定数畳み込みするため横断検索時の index 利用に追加コストが生じない
+    という設計判断に従った。Go 側は `interface{}` 変数 1 つを `nil` / 値で
+    分岐するだけで済み、SQL 本体は静的文字列にできる。
+  - **scanner は inline 実装で `scanItem` を再利用しない**。本 method の SELECT 列
+    （`i.id, i.feed_id, i.title, i.link, i.summary, i.published_at,
+    i.is_date_estimated, i.hatebu_count, f.title, f.favicon_data, f.favicon_mime,
+    is_read, is_starred`）は `itemSelectColumns`（16 列 / Item 全体）とは
+    異なる射影（13 列 / `ItemSearchHit`）であり、`scanItem` を流用しても恩恵が
+    なく、むしろ別構造体（`Item` vs `ItemSearchHit`）への詰め替えコードが増える。
+    検索専用の射影モデルとして inline scanner を選択した（Task 2 の決定と整合）。
+  - **`PublishedAt` の NULL マッピング**は `time.Time{}` ゼロ値に倒した
+    （`model.ItemSearchHit.PublishedAt` が非ポインタ `time.Time` で定義されている
+    Task 2 の決定に従う）。ORDER BY 側は `NULLS LAST` で NULL 行が末尾に来る
+    ため、ゼロ値が他の値と混ざってもページネーション順序の不変性は保たれる。
+  - **クロスユーザー隔離は SQL レベルで強制する**。design.md 参照 SQL の
+    `JOIN subscriptions s ON s.feed_id = i.feed_id AND s.user_id = $1` により、
+    呼び出し側で追加チェックなしに「未購読フィード」「他ユーザーの購読」を
+    結果集合から除外できる（Req 3.1 / 3.2 / 3.4 を SQL の JOIN 述語のみで担保）。
+  - **テストの `cleanupSQL` を再利用するが helper 名は collision 回避のため新規**。
+    既存 `postgres_subscription_repo_db_test.go` の `setupSubscriptionTestDB` /
+    `insertTestUserForSub` を直接 export せず、本ファイル専用の
+    `setupItemSearchTestDB` / `insertTestUserForSearch` 等として複製した。
+    将来両ファイルで共通化したい場合は別 task で `_test_helpers.go` 等の
+    名前で集約する余地を残す。
+  - **不変条件テストは `item_states` と `items` の両方をスナップショット**する
+    (Req 5.3)。検索前後で `is_read` / `is_starred` / `updated_at` / `hatebu_count`
+    すべてが等価であることを assert する。`updated_at` の `Equal` 比較は
+    timezone を考慮するため `time.Time.Equal` を使用する。
+- 残存課題（次 task に影響する事項）:
+  - **cursor 形式 `<RFC3339Nano>|<uuid>` のパースは Service 層の責務**。Task 4 の
+    `itemsearch.SearchService` で `cursorStr` を `(time.Time, string)` に分解し、
+    本 method の `cursorPublishedAt` / `cursorID` 引数に渡す形になる。形式不正は
+    `model.NewInvalidSearchQueryError` で `400` を返す（Task 2 で追加済み）。
+  - **`feed_id` の購読確認も Service 層の責務**。本 repository method は
+    `feed_id` の有無に関わらず SQL の JOIN で隔離するため、未購読 feed_id を
+    渡されても空配列が返るだけで `403 FEED_NOT_SUBSCRIBED` にはならない。Task 4 で
+    `SubscriptionRepository.Exists`（または `FindByUserAndFeed` の nil 判定）を
+    呼び出してから本 method を呼ぶ実装が必要。
+  - **`ItemSearchHit.PublishedAt` が非ポインタ `time.Time`** であるため、Service 層
+    で `ItemSearchSummary` へ変換する際は、ゼロ値判定（`IsZero()`）が必要なら
+    そのまま行う。design.md 行 295-309 の `ItemSearchSummary` 仕様で
+    `PublishedAt` をポインタ型として扱うか非ポインタとするかは Task 4 の判断
+    範囲。本 repository 層は zero `time.Time{}` を返すことだけ保証する。
+  - **Task 4 / 5 で `HasMore` 判定**には `limit+1` を本 method に渡し、
+    `len(hits) > limit` で判定して `hits = hits[:limit]` に切り詰める設計
+    （design.md と tasks.md Task 4 で明示）。本 method 自体は LIMIT を
+    そのまま適用するだけで HasMore ロジックを持たない。

--- a/docs/specs/120-issue/impl-notes.md
+++ b/docs/specs/120-issue/impl-notes.md
@@ -1,0 +1,35 @@
+# Implementation Notes
+
+本ファイルは Issue #120「記事の検索機能」の per-task 実装での learning と残存課題を
+記録する。各 task ごとに `### Task <id>` 見出しで learning を追記し、先行 task の
+learning は改変しない。
+
+## Implementation Notes
+
+### Task 1
+
+- 採用方針: design.md の Physical Data Model / Migration Strategy 節の指定どおり、`pg_trgm`
+  拡張の `CREATE EXTENSION IF NOT EXISTS` と `items` テーブル `title` / `content` への
+  GIN（`gin_trgm_ops`）インデックスを追加する SQL マイグレーション 2 ファイル
+  （`20260528120000_add_item_search_indexes.up.sql` / `.down.sql`）を新規追加した。
+- 重要な判断:
+  - **down.sql で `DROP EXTENSION pg_trgm` を行わない**。design.md「Physical Data Model」の
+    「拡張は他用途で使用されうるため DROP しない方針」決定（tasks.md Task 1 の指示と整合）に
+    従い、down はインデックス 2 本の `DROP INDEX IF EXISTS` のみとする。`pg_trgm` は今後他の
+    検索機能や類似度比較でも利用され得るため、down で巻き戻すと他機能の indexes が壊れる
+    リスクを避ける。
+  - **`content` GIN は `WHERE content IS NOT NULL` の partial index**。`items.content` は
+    `TEXT NULL` 許容（`initial_schema.up.sql:67`）であり、NULL 行を index から除外することで
+    index サイズと更新コストを抑える。tasks.md Task 1 の SQL 文と完全一致。
+  - **down の DROP 順は up の CREATE 逆順**（先に `idx_items_content_trgm` → 後に
+    `idx_items_title_trgm`）。両 index は独立で依存関係はないが、慣習として逆順を採用。
+  - 既存 migration（`20260527080000_add_item_states_timestamps.*.sql`）と同じく、ファイル先頭に
+    日本語 1 行の説明コメント、各 SQL 文を改行で区切るスタイルに揃えた。
+- 残存課題（次 task に影響する事項）:
+  - 本番運用時の `CREATE INDEX CONCURRENTLY` 化（design.md「Migration Strategy」/
+    `golang-migrate` の transaction wrap 制約）は別 Issue 扱い。現スケールでは通常
+    `CREATE INDEX` で許容範囲と design 判断済み。Task 3.3 以降の DB 結合テストでは
+    `TEST_DATABASE_URL` 経由で実 PostgreSQL に migration が適用される前提で本 index が
+    検索 SQL から利用される。
+  - 本 task は SQL のみで Go コード変更なし。検索本体（service / repository / handler / web）は
+    Task 2〜8 で順次実装される。

--- a/docs/specs/120-issue/review-notes.md
+++ b/docs/specs/120-issue/review-notes.md
@@ -1,0 +1,117 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-29T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-120-impl-issue
+- HEAD commit: 37e511fe2f5af3211acb6005ffe01ced13e43d97
+- Compared to: develop..HEAD
+
+## Verified Requirements
+
+- 1.1 — `web/src/components/header-search-bar.tsx` を新規実装し、`AppShell` ヘッダー領域に
+  常設配置（`web/src/components/app-shell.tsx:48` で `<HeaderSearchBar />` を render）。
+  `header-search-bar.test.tsx` / `app-shell.test.tsx` で常設レンダリングを検証
+- 1.2 — `web/src/components/feed-search-bar.tsx` を新規実装し、`ItemList` のフィルタタブと
+  同列の上部領域（`item-list.tsx:146`）に配置。`feed-search-bar.test.tsx` /
+  `item-list.test.tsx` で表示条件を検証
+- 1.3 — `HeaderSearchBar.handleSubmit` で `SET_SEARCH_QUERY({scope:'global'})` を dispatch
+  （`header-search-bar.tsx:33-42`）。`header-search-bar.test.tsx` で submit 時の dispatch を確認
+- 1.4 — `FeedSearchBar.handleSubmit` で `SET_SEARCH_QUERY({scope:'feed', feedId})` を dispatch
+  （`feed-search-bar.tsx:55-65`）。`feed-search-bar.test.tsx` で確認。`/api/items/search?feed_id=...`
+  への伝搬は `use-item-search.ts:45-47` と `use-item-search.test.tsx` で検証
+- 1.5 — 両検索バーで `trimmed.length === 0` で early-return（`header-search-bar.tsx:34-37` /
+  `feed-search-bar.tsx:55-58`）。Service 層は `strings.TrimSpace(rawQuery)` 空時に空結果を返す
+  （`internal/itemsearch/service.go:124-127`）。`header-search-bar.test.tsx` /
+  `feed-search-bar.test.tsx` / `internal/itemsearch/service_test.go` で確認
+- 1.6 — クリアボタン押下で `CLEAR_SEARCH` を dispatch（両バー共通）。reducer は
+  `searchQuery=''` / `isSearching=false` / `searchScope='global'` / `searchFeedId=null` に戻す
+  （`web/src/contexts/app-state.tsx:122-128`）。`app-state.test.tsx` で `selectedFeedId` /
+  `filter` 保持を確認
+- 2.1 — `SearchByUserAndKeyword` の SQL が `JOIN subscriptions s ... AND s.user_id = $1` を
+  必須化、`feedID==nil` で `$3::uuid IS NULL` ガードにより横断検索
+  （`internal/repository/postgres_item_repo.go` の検索 SQL）。
+  `internal/repository/postgres_item_repo_search_test.go` で確認
+- 2.2 — `feedID!=nil` で `i.feed_id = $3` フィルタが付与。`service_test.go` でフィード内検索
+  ケース、`postgres_item_repo_search_test.go` で DB レベル検証
+- 2.3 — SQL の WHERE 句に `(i.title ILIKE $2 OR i.content ILIKE $2)`。
+  `postgres_item_repo_search_test.go` のタイトル一致 / 本文一致 / 両方一致 ケースで確認
+- 2.4 — `escapeLikePattern` で `\` / `%` / `_` をエスケープ後 `%pattern%` 形式に組み立て
+  （`internal/itemsearch/service.go:266-272`）。`service_test.go` のエスケープテーブル
+  テストで確認
+- 2.5 — SQL の WHERE で自然除外。`postgres_item_repo_search_test.go` の「どちらも不一致」
+  ケースで確認
+- 2.6 — `ILIKE` 採用により case-insensitive。`postgres_item_repo_search_test.go` の
+  大文字小文字差ケースで確認
+- 3.1 — `JOIN subscriptions s ... AND s.user_id = $1` が常に必須
+  （`postgres_item_repo.go` 検索 SQL）。
+- 3.2 — 同 JOIN により非購読フィードの記事は結果集合から自然除外。
+  `postgres_item_repo_search_test.go` の他ユーザー隔離ケースで確認
+- 3.3 — `ItemSearchHandler.Search` で `middleware.UserIDFromContext` 失敗時 401 UNAUTHORIZED
+  （`internal/handler/item_search_handler.go:112-119`）。`item_search_handler_test.go` の
+  認証なしケースで確認
+- 3.4 — JOIN で `subscriptions` に行が無い解除済みフィードは結果から除外。
+  `postgres_item_repo_search_test.go` で確認
+- 3.5 — Service 層が `subRepo.FindByUserAndFeed(...)==nil` で `model.NewFeedNotSubscribedError`
+  を返し、handler は 403 にマップ（`feed_handler.go` の `mapAPIErrorToHTTPStatus` に
+  新規エントリ追加）。`internal/itemsearch/service_test.go` / `item_search_handler_test.go` の
+  未購読 feed_id ケースで確認
+- 4.1 — `ORDER BY i.published_at DESC NULLS LAST, i.id DESC`。
+  `postgres_item_repo_search_test.go` の安定ソート / ページネーションテストで確認
+- 4.2 — レスポンスに `feed_title` / `favicon_url` を含め、`SearchResults` の `SearchResultRow`
+  が `showFeedBadge={state.searchScope === 'global'}` で出し分け
+  （`web/src/components/search-results.tsx`）。`search-results.test.tsx` で
+  global / feed 両スコープのバッジ表示を確認
+- 4.3 — `allHits.length === 0` で `search-results-empty` 表示
+  （`search-results.tsx:138-148`）。`search-results.test.tsx` で確認
+- 4.4 — `isLoading` で `search-results-loading` を即時表示（NFR 1.1 と整合）。
+  `search-results.test.tsx` で確認
+- 4.5 — `isError` で `search-results-error` 表示。`search-results.test.tsx` で確認
+- 4.6 — `useItemDetail` / `ItemDetail` を再利用し本文展開を提供
+  （`search-results.tsx` の `SearchResultDetailArea`）。`search-results.test.tsx` で
+  展開挙動を確認
+- 4.7 — `app-shell.tsx:85-95` で右ペインを `state.isSearching ? <SearchResults /> : <ItemList ... />`
+  に切替。`app-shell.test.tsx` の統合テスト「検索モード時に SearchResults がレンダされる」
+  で確認
+- 5.1 — `useMarkAsRead` を `SearchResults` から再利用（`search-results.tsx:56-64`）
+- 5.2 — `useToggleStar` を同様に再利用
+- 5.3 — 検索 SQL は SELECT 専用で `items` / `item_states` に UPDATE / INSERT なし。
+  `postgres_item_repo_search_test.go` のスナップショット不変テスト
+  （`item_states.is_read` / `is_starred` / `updated_at` 等の検索前後比較）で確認
+- NFR 1.1 — TanStack Query の `isLoading` が即時 true
+  （`use-item-search.ts` + `search-results.tsx:109-119`）。`search-results.test.tsx` で確認
+- NFR 1.2 — `pg_trgm` 拡張と GIN インデックス 2 本（title / content）を追加
+  （migration `20260528120000_add_item_search_indexes.up.sql`）。
+  具体的な 200ms 目標の数値検証は Task 9（deferrable `- [ ]*`）に分離
+- NFR 2.1 — 既存 `ItemList` 経路（`state.isSearching === false`）は変更なし。
+  `app-shell.test.tsx` の通常モード描画テストで確認
+- NFR 2.2 — reducer の `CLEAR_SEARCH` は `selectedFeedId` / `filter` を保持
+  （`app-state.tsx:122-128`）。`app-state.test.tsx` で確認
+- NFR 2.3 — `FeedSearchBar` が `selectedFeedId === null` で `null` を返す
+  （`feed-search-bar.tsx:46-48`）。`feed-search-bar.test.tsx` / `item-list.test.tsx` で確認
+- NFR 3.1 — `ItemSearchHandler.Search` 入口で `slog.Info("item search request", user_id,
+  search_type, scope, query_len, feed_id)` を発行
+  （`item_search_handler.go:156-162`）。`search_type` は `global` / `feed` の 2 値で観測可能
+
+## Findings
+
+なし
+
+## Summary
+
+Issue #120 の全 numeric AC（Req 1.1-1.6, 2.1-2.6, 3.1-3.5, 4.1-4.7, 5.1-5.3, NFR 1.1, 1.2,
+2.1-2.3, 3.1）が実装またはテストで観測可能にカバーされており、tasks.md の `_Boundary:_` /
+`_Requirements:_` 制約も逸脱なし。Feature Flag Protocol は opt-out のため flag 観点の確認は
+対象外（CLAUDE.md `## Feature Flag Protocol` 採否 = opt-out）。Developer の impl-notes
+（Task 1-8）に Go 全 21 パッケージ green / Web 30 ファイル 276 テスト全 pass / ESLint
+errors 0 / go vet clean の記録あり。
+
+> 補足（reject 対象外、informational）: develop には merge 済みの #117（StarredItemList /
+> StarredNavItem 等）が、本ブランチの base commit（7f555a3）には含まれていないため、
+> `git diff develop..HEAD` 上では `StarredItemList` 系コード・`SELECT_STARRED` action・
+> `ItemDetailArea` / `ItemRow` の export 等が「削除」されているように見えるが、これらは
+> 本ブランチが追加 / 変更していない差分であり、tasks.md の boundary 逸脱には該当しない。
+> develop への merge 前に rebase が必要だが、これは Reviewer の 3 カテゴリ判定の対象外。
+
+RESULT: approve

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -93,7 +93,7 @@
     feed_id UUID パース失敗） / 403（未購読 feed_id） / 空クエリ → 200 OK 空配列を検証する。
     既存 `item_handler_test.go` の `mockItemService` パターンを踏襲し、mock service を差し替える
   - _Requirements: 1.3, 1.4, 1.5, 3.3, 3.5_
-- [ ] 5.5 `internal/app/app.go` に `itemsearch.SearchService` の wiring を追加する
+- [x] 5.5 `internal/app/app.go` に `itemsearch.SearchService` の wiring を追加する
   - `itemsearch.NewSearchService(itemRepo, subRepo)` を生成し、`handler.NewItemSearchServiceAdapter` で
     アダプタを構築、`RouterDeps.ItemSearchService` にセットする
   - _Requirements: 1.3, 1.4_

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -110,7 +110,7 @@
   - _Requirements: 1.5, 1.6, NFR 2.1, NFR 2.2_
 
 - [ ] 7. Web フロントエンドの検索 UI とフェッチ層を実装する
-- [ ] 7.1 `web/src/types/item.ts` に検索用の型を追加する (P)
+- [x] 7.1 `web/src/types/item.ts` に検索用の型を追加する (P)
   - `SearchScope = 'global' | 'feed'`
   - `ItemSearchHit`（`ItemSummary` 相当 + `feed_title: string` + `favicon_url: string | null`）
   - `ItemSearchResponse`（`items: ItemSearchHit[]`, `next_cursor: string | null`, `has_more: boolean`）

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -42,7 +42,7 @@
     専用の scanner を用意する
   - 実装は SELECT 専用であり、items / item_states に UPDATE / INSERT を行わない（Req 5.3 の不変条件）
   - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.6, 3.1, 3.2, 3.4, 4.1, 4.2, 5.3_
-- [ ] 3.3 Repository 層の DB 結合テスト `internal/repository/postgres_item_repo_search_test.go` を追加する
+- [x] 3.3 Repository 層の DB 結合テスト `internal/repository/postgres_item_repo_search_test.go` を追加する
   - 既存 `postgres_subscription_repo_db_test.go` の Skip ガードパターン
     （`TEST_DATABASE_URL` 未設定時は `t.Skip`）を踏襲する
   - ケース（横断検索）: タイトル一致 / 本文一致 / 両方一致 / どちらも不一致 / 大文字小文字差 /

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -88,7 +88,7 @@
     同じパターンを再利用）
   - compile-time check `var _ ItemSearchServiceInterface = (*ItemSearchServiceAdapter)(nil)` を追加
   - _Requirements: 4.2_
-- [ ] 5.4 `internal/handler/item_search_handler_test.go` を新規作成する
+- [x] 5.4 `internal/handler/item_search_handler_test.go` を新規作成する
   - テーブル駆動で 200 成功（横断 / フィード内） / 401（withUserID なし） / 400（cursor 不正・
     feed_id UUID パース失敗） / 403（未購読 feed_id） / 空クエリ → 200 OK 空配列を検証する。
     既存 `item_handler_test.go` の `mockItemService` パターンを踏襲し、mock service を差し替える

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -26,7 +26,7 @@
   - _Requirements: 3.3, 3.5, 4.5_
 
 - [ ] 3. Repository 層で検索 SQL を実装する
-- [ ] 3.1 `internal/repository/interfaces.go` に `ItemSearchRepository` インターフェースを追加する
+- [x] 3.1 `internal/repository/interfaces.go` に `ItemSearchRepository` インターフェースを追加する
   - design.md の `SearchByUserAndKeyword(ctx, userID, pattern string, feedID *string, cursorID string, cursorPublishedAt time.Time, limit int)` シグネチャに従う
   - `PostgresItemRepo` が当該インターフェースを満たすことを compile-time check に追加する
   - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.6, 3.1, 3.2, 3.4, 4.1, 4.2_

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -25,7 +25,7 @@
     `ErrCodeFeedNotSubscribed → http.StatusForbidden` のエントリを追加
   - _Requirements: 3.3, 3.5, 4.5_
 
-- [ ] 3. Repository 層で検索 SQL を実装する
+- [x] 3. Repository 層で検索 SQL を実装する
 - [x] 3.1 `internal/repository/interfaces.go` に `ItemSearchRepository` インターフェースを追加する
   - design.md の `SearchByUserAndKeyword(ctx, userID, pattern string, feedID *string, cursorID string, cursorPublishedAt time.Time, limit int)` シグネチャに従う
   - `PostgresItemRepo` が当該インターフェースを満たすことを compile-time check に追加する

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -116,7 +116,7 @@
   - `ItemSearchResponse`（`items: ItemSearchHit[]`, `next_cursor: string | null`, `has_more: boolean`）
   - _Requirements: 4.2_
   - _Boundary: web/types/item.ts_
-- [ ] 7.2 `web/src/hooks/use-item-search.ts` を新規作成する (P)
+- [x] 7.2 `web/src/hooks/use-item-search.ts` を新規作成する (P)
   - design.md の `useItemSearch(query, scope, feedId)` シグネチャに従い `useInfiniteQuery` で
     `/api/items/search?q=...&limit=50&cursor=...` を呼ぶ（`scope === 'feed'` のとき `&feed_id=...` を付与）
   - `enabled: query.trim().length > 0 && !(scope === 'feed' && !feedId)` で空クエリ / 不正組合せを無効化する

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -143,7 +143,7 @@
   - _Requirements: 1.2, 1.4, 1.5, 1.6, NFR 2.3_
   - _Boundary: FeedSearchBar_
   - _Depends: 6_
-- [ ] 7.5 `web/src/components/search-results.tsx` と `search-results.test.tsx` を新規作成する (P)
+- [x] 7.5 `web/src/components/search-results.tsx` と `search-results.test.tsx` を新規作成する (P)
   - `useItemSearch(state.searchQuery, state.searchScope, state.searchFeedId)` の結果に対し、
     ローディング / エラー / 空状態 / 結果リストの 4 状態を出し分ける（TanStack Query の `isLoading`
     即時 true により NFR 1.1 の「1 秒以内のローディング表示」を満たす）

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -30,7 +30,7 @@
   - design.md の `SearchByUserAndKeyword(ctx, userID, pattern string, feedID *string, cursorID string, cursorPublishedAt time.Time, limit int)` シグネチャに従う
   - `PostgresItemRepo` が当該インターフェースを満たすことを compile-time check に追加する
   - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.6, 3.1, 3.2, 3.4, 4.1, 4.2_
-- [ ] 3.2 `internal/repository/postgres_item_repo.go` に `SearchByUserAndKeyword` を実装する
+- [x] 3.2 `internal/repository/postgres_item_repo.go` に `SearchByUserAndKeyword` を実装する
   - design.md の参照 SQL（`items JOIN subscriptions ... JOIN feeds ... LEFT JOIN item_states`、
     `ILIKE $2`、`($3::uuid IS NULL OR i.feed_id = $3)` の任意フィルタ、
     `(published_at, id) < (cursor)` のタプル比較ページング、`ORDER BY published_at DESC, id DESC`）

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -10,7 +10,7 @@
   - _Requirements: NFR 1.2_
 
 - [ ] 2. 検索ドメイン用のモデルとエラーコードを追加する
-- [ ] 2.1 `internal/model/item.go` に `ItemSearchHit` 構造体を追加する
+- [x] 2.1 `internal/model/item.go` に `ItemSearchHit` 構造体を追加する
   - design.md の Data Models 節で定義した `ItemSummary` 相当のフィールド + `FeedTitle string` +
     `FaviconData []byte` + `FaviconMime string` を持たせる
   - 既存 `ItemWithState` パターンと整合する命名・並び順にする

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -9,7 +9,7 @@
     （`pg_trgm` 拡張は他用途で使われる可能性があるため `DROP EXTENSION` は行わない）
   - _Requirements: NFR 1.2_
 
-- [ ] 2. 検索ドメイン用のモデルとエラーコードを追加する
+- [x] 2. 検索ドメイン用のモデルとエラーコードを追加する
 - [x] 2.1 `internal/model/item.go` に `ItemSearchHit` 構造体を追加する
   - design.md の Data Models 節で定義した `ItemSummary` 相当のフィールド + `FeedTitle string` +
     `FaviconData []byte` + `FaviconMime string` を持たせる

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -156,7 +156,7 @@
   - _Boundary: SearchResults_
   - _Depends: 7.2_
 
-- [ ] 8. `AppShell` / `ItemList` に検索バーと SearchResults の出し分けを統合する
+- [x] 8. `AppShell` / `ItemList` に検索バーと SearchResults の出し分けを統合する
   - `web/src/components/app-shell.tsx` のヘッダー領域に `HeaderSearchBar` を配置する
   - 右ペインを `state.isSearching ? <SearchResults /> : <ItemList .../>` で切替える
   - `web/src/components/item-list.tsx` の既存フィルタ群（「すべて／未読」等）と同列の上部領域に

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -133,7 +133,7 @@
   - _Requirements: 1.1, 1.3, 1.5, 1.6_
   - _Boundary: HeaderSearchBar_
   - _Depends: 6_
-- [ ] 7.4 `web/src/components/feed-search-bar.tsx` と `feed-search-bar.test.tsx` を新規作成する (P)
+- [x] 7.4 `web/src/components/feed-search-bar.tsx` と `feed-search-bar.test.tsx` を新規作成する (P)
   - design.md の `FeedSearchBar` 疑似シグネチャに従い、`selectedFeedId === null` のとき `null` を返す
     （NFR 2.3）
   - 入力欄 / Enter ハンドラ / クリアボタンを実装し、submit 時は `scope: 'feed'`,

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -65,7 +65,7 @@
     repository はモックを差し替える
   - _Requirements: 1.5, 2.4, 2.6, 3.5, 4.1, 4.4_
 
-- [ ] 5. Handler `/api/items/search` を実装しルーターに登録する
+- [x] 5. Handler `/api/items/search` を実装しルーターに登録する
 - [x] 5.1 `internal/handler/item_search_handler.go` を新規作成する
   - `ItemSearchServiceInterface` を定義し、`Search(ctx, userID, rawQuery string, feedID *string, cursorStr string, limit int) (*itemSearchResponse, error)` を持たせる
   - HTTP ハンドラは既存 `feed_handler.go` / `item_handler.go` の `UserIDFromContext` パターンを

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -81,7 +81,7 @@
   - `RouterDeps` に `ItemSearchService ItemSearchServiceInterface` を追加する
   - **`/api/items/{id}` よりも前**にルートを登録する（chi の static 優先順位を担保）
   - _Requirements: 1.3, 1.4, 3.3_
-- [ ] 5.3 `internal/handler/service_adapter.go` に `ItemSearchServiceAdapter` を追加する
+- [x] 5.3 `internal/handler/service_adapter.go` に `ItemSearchServiceAdapter` を追加する
   - `itemsearch.SearchService` の戻り値（`ItemSearchSummary[]` + favicon の `[]byte`/mime）を
     `itemSearchResponse` に変換する。`FaviconData` が空でなければ
     `data:<mime>;base64,...` 形式の data URL に整形（`subscription.Service.ListSubscriptions` と

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -66,7 +66,7 @@
   - _Requirements: 1.5, 2.4, 2.6, 3.5, 4.1, 4.4_
 
 - [ ] 5. Handler `/api/items/search` を実装しルーターに登録する
-- [ ] 5.1 `internal/handler/item_search_handler.go` を新規作成する
+- [x] 5.1 `internal/handler/item_search_handler.go` を新規作成する
   - `ItemSearchServiceInterface` を定義し、`Search(ctx, userID, rawQuery string, feedID *string, cursorStr string, limit int) (*itemSearchResponse, error)` を持たせる
   - HTTP ハンドラは既存 `feed_handler.go` / `item_handler.go` の `UserIDFromContext` パターンを
     踏襲し、401/400/403/500 を `handleServiceError` で返す

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -15,7 +15,7 @@
     `FaviconData []byte` + `FaviconMime string` を持たせる
   - 既存 `ItemWithState` パターンと整合する命名・並び順にする
   - _Requirements: 4.2_
-- [ ] 2.2 `internal/model/errors.go` に検索向けのエラーコードと生成関数を追加する
+- [x] 2.2 `internal/model/errors.go` に検索向けのエラーコードと生成関数を追加する
   - `ErrCodeInvalidSearchQuery = "INVALID_SEARCH_QUERY"` および
     `ErrCodeFeedNotSubscribed = "FEED_NOT_SUBSCRIBED"` を定数に追加
   - `NewInvalidSearchQueryError(reason string) *APIError`（Category: "validation"）と

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -109,7 +109,7 @@
     scope='feed' / `CLEAR_SEARCH` / `SELECT_FEED` の検索状態リセット）
   - _Requirements: 1.5, 1.6, NFR 2.1, NFR 2.2_
 
-- [ ] 7. Web フロントエンドの検索 UI とフェッチ層を実装する
+- [x] 7. Web フロントエンドの検索 UI とフェッチ層を実装する
 - [x] 7.1 `web/src/types/item.ts` に検索用の型を追加する (P)
   - `SearchScope = 'global' | 'feed'`
   - `ItemSearchHit`（`ItemSummary` 相当 + `feed_title: string` + `favicon_url: string | null`）

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -98,7 +98,7 @@
     アダプタを構築、`RouterDeps.ItemSearchService` にセットする
   - _Requirements: 1.3, 1.4_
 
-- [ ] 6. Web フロントエンドの状態管理に検索モード（横断 / フィード内）を追加する
+- [x] 6. Web フロントエンドの状態管理に検索モード（横断 / フィード内）を追加する
   - `web/src/contexts/app-state.tsx` の `AppState` に `searchQuery: string`, `isSearching: boolean`,
     `searchScope: 'global' | 'feed'`, `searchFeedId: string | null` を追加する
   - アクション型 `SET_SEARCH_QUERY`（`query` / `scope` / 任意の `feedId` を受け取る）と

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. pg_trgm 拡張と GIN インデックスを追加するマイグレーションを作成する
+- [x] 1. pg_trgm 拡張と GIN インデックスを追加するマイグレーションを作成する
   - `internal/database/migrations/20260528120000_add_item_search_indexes.up.sql` を新規作成し、
     `CREATE EXTENSION IF NOT EXISTS pg_trgm;` を先頭に追加する
   - 同 up.sql に `CREATE INDEX idx_items_title_trgm ON items USING GIN (title gin_trgm_ops);` を追加する

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -52,7 +52,7 @@
   - 検索実行前後で対象記事の `item_states.is_read` / `is_starred` が変化しないことを検証する（Req 5.3）
   - _Requirements: 2.2, 2.3, 2.4, 2.5, 2.6, 3.1, 3.2, 3.4, 4.1, 5.3_
 
-- [ ] 4. ドメインサービス `internal/itemsearch.SearchService` を実装する
+- [x] 4. ドメインサービス `internal/itemsearch.SearchService` を実装する
   - `internal/itemsearch/service.go` を新規作成し、design.md の `SearchService.Search(ctx, userID, rawQuery string, feedID *string, cursorStr string, limit int)` シグネチャ・正規化
     ロジック（前後空白 trim、空クエリ判定、LIKE メタ文字エスケープ）・`feedID != nil` 時の購読確認
     （既存 `SubscriptionRepository.Exists` 相当の経路を再利用、未購読なら `NewFeedNotSubscribedError`

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -77,7 +77,7 @@
     `omitempty` を付ける（subscription_handler.go と同じ流儀）
   - NFR 3.1 の構造化ログ（`slog.Info("item search request", user_id, search_type, scope, query_len, feed_id)`）を発行する
   - _Requirements: 1.3, 1.4, 3.3, 3.5, 4.4, 4.5, NFR 3.1_
-- [ ] 5.2 `internal/handler/router.go` に `/api/items/search` ルートを登録する
+- [x] 5.2 `internal/handler/router.go` に `/api/items/search` ルートを登録する
   - `RouterDeps` に `ItemSearchService ItemSearchServiceInterface` を追加する
   - **`/api/items/{id}` よりも前**にルートを登録する（chi の static 優先順位を担保）
   - _Requirements: 1.3, 1.4, 3.3_

--- a/docs/specs/120-issue/tasks.md
+++ b/docs/specs/120-issue/tasks.md
@@ -125,7 +125,7 @@
   - _Requirements: 1.3, 1.4, 1.5, 4.1, 4.4, 4.5_
   - _Boundary: useItemSearch_
   - _Depends: 7.1_
-- [ ] 7.3 `web/src/components/header-search-bar.tsx` と `header-search-bar.test.tsx` を新規作成する (P)
+- [x] 7.3 `web/src/components/header-search-bar.tsx` と `header-search-bar.test.tsx` を新規作成する (P)
   - design.md の `HeaderSearchBar` 疑似シグネチャに従い、入力欄 / Enter ハンドラ / クリアボタンを実装する
   - 空入力 Enter で `SET_SEARCH_QUERY` を dispatch しないこと（Req 1.5）を確認するテストを含む
   - 入力消去ボタンで `CLEAR_SEARCH` が発行されること（Req 1.6）を確認するテストを含む

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hitoshi/feedman/internal/handler"
 	"github.com/hitoshi/feedman/internal/hatebu"
 	"github.com/hitoshi/feedman/internal/item"
+	"github.com/hitoshi/feedman/internal/itemsearch"
 	"github.com/hitoshi/feedman/internal/logger"
 	"github.com/hitoshi/feedman/internal/metrics"
 	"github.com/hitoshi/feedman/internal/middleware"
@@ -130,6 +131,10 @@ func runServe(cfg *config.Config) error {
 
 	itemService := item.NewItemService(itemRepo, itemStateRepo)
 
+	// 記事検索ドメインサービス。itemRepo を ItemSearchRepository として、subRepo を
+	// SubscriptionRepository（feed_id 指定時の購読確認用）として注入する。
+	itemSearchService := itemsearch.NewSearchService(itemRepo, subRepo)
+
 	subService := subscription.NewService(subRepo, itemStateRepo, feedRepo)
 	// 退会処理は単一トランザクションで原子化する（途中失敗時は全ロールバック）。
 	txBeginner := repository.NewSQLTxBeginner(db)
@@ -140,6 +145,7 @@ func runServe(cfg *config.Config) error {
 	userServiceAdapter := handler.NewUserServiceAdapter(userService)
 	itemServiceAdapter := handler.NewItemServiceAdapter(itemService)
 	itemStateServiceAdapter := handler.NewItemStateServiceAdapter(itemStateRepo)
+	itemSearchServiceAdapter := handler.NewItemSearchServiceAdapter(itemSearchService)
 
 	// 6. SubscriptionDeleterアダプタの構築
 	subDeleterAdapter := handler.NewSubscriptionDeleterAdapter(subRepo, itemStateRepo)
@@ -192,6 +198,8 @@ func runServe(cfg *config.Config) error {
 
 		ItemService:      itemServiceAdapter,
 		ItemStateService: itemStateServiceAdapter,
+
+		ItemSearchService: itemSearchServiceAdapter,
 
 		SubscriptionService: subServiceAdapter,
 		UserService:         userServiceAdapter,

--- a/internal/database/migrations/20260528120000_add_item_search_indexes.down.sql
+++ b/internal/database/migrations/20260528120000_add_item_search_indexes.down.sql
@@ -1,0 +1,4 @@
+-- 記事検索（Issue #120）向けに追加した GIN インデックスを削除する
+-- pg_trgm 拡張は他用途で使用されうるため DROP EXTENSION は行わない
+DROP INDEX IF EXISTS idx_items_content_trgm;
+DROP INDEX IF EXISTS idx_items_title_trgm;

--- a/internal/database/migrations/20260528120000_add_item_search_indexes.up.sql
+++ b/internal/database/migrations/20260528120000_add_item_search_indexes.up.sql
@@ -1,0 +1,4 @@
+-- 記事検索（Issue #120）向けに pg_trgm 拡張と GIN インデックスを追加する
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX idx_items_title_trgm ON items USING GIN (title gin_trgm_ops);
+CREATE INDEX idx_items_content_trgm ON items USING GIN (content gin_trgm_ops) WHERE content IS NOT NULL;

--- a/internal/handler/feed_handler.go
+++ b/internal/handler/feed_handler.go
@@ -282,12 +282,14 @@ func mapAPIErrorToHTTPStatus(apiErr *model.APIError) int {
 		return http.StatusConflict
 	case "FEED_NOT_FOUND", model.ErrCodeSubscriptionNotFound, model.ErrCodeItemNotFound:
 		return http.StatusNotFound
-	case model.ErrCodeInvalidFilter, model.ErrCodeInvalidFetchInterval:
+	case model.ErrCodeInvalidFilter, model.ErrCodeInvalidFetchInterval, model.ErrCodeInvalidSearchQuery:
 		return http.StatusBadRequest
 	case model.ErrCodeFeedNotStopped:
 		return http.StatusConflict
 	case model.ErrCodeUserNotFound:
 		return http.StatusNotFound
+	case model.ErrCodeFeedNotSubscribed:
+		return http.StatusForbidden
 	default:
 		return http.StatusInternalServerError
 	}

--- a/internal/handler/feed_handler_test.go
+++ b/internal/handler/feed_handler_test.go
@@ -952,6 +952,8 @@ func TestMapAPIErrorToHTTPStatus_KnownCodes(t *testing.T) {
 		{"INVALID_FETCH_INTERVAL のとき 400", model.ErrCodeInvalidFetchInterval, http.StatusBadRequest},
 		{"FEED_NOT_STOPPED のとき 409", model.ErrCodeFeedNotStopped, http.StatusConflict},
 		{"USER_NOT_FOUND のとき 404", model.ErrCodeUserNotFound, http.StatusNotFound},
+		{"INVALID_SEARCH_QUERY のとき 400", model.ErrCodeInvalidSearchQuery, http.StatusBadRequest},
+		{"FEED_NOT_SUBSCRIBED のとき 403", model.ErrCodeFeedNotSubscribed, http.StatusForbidden},
 	}
 
 	for _, tt := range tests {

--- a/internal/handler/item_search_handler.go
+++ b/internal/handler/item_search_handler.go
@@ -1,0 +1,179 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hitoshi/feedman/internal/middleware"
+	"github.com/hitoshi/feedman/internal/model"
+)
+
+// 検索リクエストの limit パラメータの既定値と上限値。
+//
+// design.md「API Contract」節に従い、limit クエリ未指定時は defaultItemsPerPage を使い、
+// maxSearchLimit を超える指定はクランプする。サービス層（`itemsearch.SearchService`）も
+// 同じクランプを防御的に行うため、handler 層の値はそのまま下層に伝搬しても安全である。
+const maxSearchLimit = 200
+
+// ItemSearchServiceInterface は記事検索ハンドラが必要とするサービスインターフェース。
+//
+// 戻り値は handler 内部レスポンス型（`*itemSearchResponse`）にすることで、サービス層と
+// アダプタ層の責務を明確に分離する。実装は `ItemSearchServiceAdapter`
+// （`service_adapter.go`）が担当し、Adapter 層がドメイン型（`itemsearch.SearchResult`）を
+// `itemSearchResponse` に変換する（favicon の data URL 化を含む）。
+type ItemSearchServiceInterface interface {
+	// Search は当該ユーザーが購読中のフィードに属する記事から、キーワードに部分一致する
+	// ものを published_at 降順で返す。feedID 非 nil 時はフィード内検索モードに切り替わる。
+	// cursorStr は前回レスポンスの NextCursor を渡す（空文字なら先頭ページ）。
+	// limit は実取得件数の上限（HasMore 判定はサービス層が limit+1 取得で行う）。
+	Search(ctx context.Context, userID, rawQuery string, feedID *string, cursorStr string, limit int) (*itemSearchResponse, error)
+}
+
+// ItemSearchHandler は記事検索の HTTP ハンドラ。
+//
+// クエリパラメータ（`q` / `feed_id` / `cursor` / `limit`）のパース、認証チェック、
+// `feed_id` の UUID 形式バリデーション、検索サービス呼び出し、レスポンス整形を担う。
+// ビジネスロジック（クエリ正規化・購読確認・DB クエリ）はサービス層に委譲する。
+type ItemSearchHandler struct {
+	service ItemSearchServiceInterface
+}
+
+// NewItemSearchHandler は ItemSearchHandler を生成する。
+func NewItemSearchHandler(service ItemSearchServiceInterface) *ItemSearchHandler {
+	return &ItemSearchHandler{service: service}
+}
+
+// --- レスポンス型 ---
+
+// itemSearchHitResponse は検索結果 1 件の API レスポンス。
+//
+// favicon_url は data URL 形式（`data:<mime>;base64,...`）。Service 層から渡された
+// 生バイト + MIME を Adapter 層で組み立てた結果が入る。欠落時は nil を入れ、JSON では
+// `omitempty` でフィールドごと省略する（既存 subscription レスポンスと同じ流儀）。
+type itemSearchHitResponse struct {
+	ID              string    `json:"id"`
+	FeedID          string    `json:"feed_id"`
+	FeedTitle       string    `json:"feed_title"`
+	FaviconURL      *string   `json:"favicon_url,omitempty"`
+	Title           string    `json:"title"`
+	Link            string    `json:"link"`
+	Summary         string    `json:"summary"`
+	PublishedAt     time.Time `json:"published_at"`
+	IsDateEstimated bool      `json:"is_date_estimated"`
+	IsRead          bool      `json:"is_read"`
+	IsStarred       bool      `json:"is_starred"`
+	HatebuCount     int       `json:"hatebu_count"`
+}
+
+// itemSearchResponse は GET /api/items/search のレスポンス。
+//
+// next_cursor は次ページ取得用のカーソル文字列（`<RFC3339Nano>|<id>` 形式）。
+// 末尾ページ・空結果のときは空文字となる（`omitempty` で省略）。has_more は次ページの
+// 存在を示し、cursor を発行できない場合（末尾項目の PublishedAt がゼロ値等）でも
+// true を返しうるため、UI 側は next_cursor の空判定だけでなく has_more も参照する。
+type itemSearchResponse struct {
+	Items      []itemSearchHitResponse `json:"items"`
+	NextCursor string                  `json:"next_cursor,omitempty"`
+	HasMore    bool                    `json:"has_more"`
+}
+
+// Search は GET /api/items/search のハンドラ。
+//
+// クエリパラメータ:
+//   - q      : 検索キーワード（必須に近いが、空クエリは 200 OK で空配列を返す。Req 1.5）
+//   - feed_id: フィード内検索のスコープ指定（任意、UUID 形式）。
+//     形式不正は 400 INVALID_SEARCH_QUERY、未購読は 403 FEED_NOT_SUBSCRIBED。
+//   - cursor : ページネーションのカーソル（任意、`<RFC3339Nano>|<uuid>` 形式）。
+//     形式不正は 400 INVALID_SEARCH_QUERY（サービス層で判定）。
+//   - limit  : 1 ページあたり件数（任意、既定 50、上限 200 でクランプ）。
+//
+// エラーレスポンス:
+//   - 401 UNAUTHORIZED        : セッションなし
+//   - 400 INVALID_SEARCH_QUERY: cursor 形式不正 / feed_id UUID パース失敗 / limit 形式不正
+//   - 403 FEED_NOT_SUBSCRIBED : feed_id 指定だが当該ユーザーが未購読
+//   - 500 INTERNAL_ERROR      : DB エラー等
+//
+// NFR 3.1 に従い、リクエスト入口で slog.Info の構造化ログを発行する。
+// PII / ログ汚染を避けるためクエリ本文は出力せず、長さ（query_len）のみ記録する。
+func (h *ItemSearchHandler) Search(w http.ResponseWriter, r *http.Request) {
+	userID, err := middleware.UserIDFromContext(r.Context())
+	if err != nil {
+		middleware.WriteErrorResponse(w, http.StatusUnauthorized, &model.APIError{
+			Code:     "UNAUTHORIZED",
+			Message:  "認証が必要です。",
+			Category: "auth",
+			Action:   "ログインしてください。",
+		})
+		return
+	}
+
+	q := r.URL.Query()
+	rawQuery := q.Get("q")
+	feedIDStr := q.Get("feed_id")
+	cursor := q.Get("cursor")
+	limitStr := q.Get("limit")
+
+	// feed_id の UUID パース（空文字 = 横断検索）
+	var feedIDPtr *string
+	feedIDForLog := ""
+	searchType := "global"
+	if feedIDStr != "" {
+		if _, parseErr := uuid.Parse(feedIDStr); parseErr != nil {
+			middleware.WriteErrorResponse(
+				w, http.StatusBadRequest,
+				model.NewInvalidSearchQueryError("feed_id の形式が不正です"),
+			)
+			return
+		}
+		feedIDPtr = &feedIDStr
+		feedIDForLog = feedIDStr
+		searchType = "feed"
+	}
+
+	// limit のパース（未指定は既定値 / 形式不正は 400 / 上限を超える指定はクランプ）
+	limit := defaultItemsPerPage
+	if limitStr != "" {
+		n, parseErr := strconv.Atoi(limitStr)
+		if parseErr != nil || n <= 0 {
+			middleware.WriteErrorResponse(
+				w, http.StatusBadRequest,
+				model.NewInvalidSearchQueryError("limit の形式が不正です"),
+			)
+			return
+		}
+		if n > maxSearchLimit {
+			n = maxSearchLimit
+		}
+		limit = n
+	}
+
+	// NFR 3.1: 検索リクエストの認証主体・検索種別・検索範囲・クエリ長・スコープ feed_id を
+	// 構造化ログに記録する（クエリ本文は PII / ログ汚染回避のため記録しない）。
+	slog.Info("item search request",
+		slog.String("user_id", userID),
+		slog.String("search_type", searchType),
+		slog.String("scope", "subscribed"),
+		slog.Int("query_len", len(rawQuery)),
+		slog.String("feed_id", feedIDForLog),
+	)
+
+	result, err := h.service.Search(r.Context(), userID, rawQuery, feedIDPtr, cursor, limit)
+	if err != nil {
+		handleServiceError(w, err)
+		return
+	}
+
+	// Items が nil でも JSON では空配列を返したい（Req 4.3 の UX 一貫性 / Req 1.5）。
+	if result.Items == nil {
+		result.Items = []itemSearchHitResponse{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}

--- a/internal/handler/item_search_handler_test.go
+++ b/internal/handler/item_search_handler_test.go
@@ -1,0 +1,474 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hitoshi/feedman/internal/model"
+)
+
+// --- モック定義 ---
+
+// recordedSearchCall は handler から service に渡された引数を記録する。
+type recordedSearchCall struct {
+	userID   string
+	rawQuery string
+	feedID   *string
+	cursor   string
+	limit    int
+}
+
+// mockItemSearchService は ItemSearchServiceInterface のモック実装。
+type mockItemSearchService struct {
+	searchFn  func(ctx context.Context, userID, rawQuery string, feedID *string, cursorStr string, limit int) (*itemSearchResponse, error)
+	calls     []recordedSearchCall
+	callCount int
+}
+
+func (m *mockItemSearchService) Search(
+	ctx context.Context,
+	userID, rawQuery string,
+	feedID *string,
+	cursorStr string,
+	limit int,
+) (*itemSearchResponse, error) {
+	m.callCount++
+	// feedID のスナップショットを取って後続テストアサート用に保持
+	var feedIDCopy *string
+	if feedID != nil {
+		v := *feedID
+		feedIDCopy = &v
+	}
+	m.calls = append(m.calls, recordedSearchCall{
+		userID:   userID,
+		rawQuery: rawQuery,
+		feedID:   feedIDCopy,
+		cursor:   cursorStr,
+		limit:    limit,
+	})
+	if m.searchFn != nil {
+		return m.searchFn(ctx, userID, rawQuery, feedID, cursorStr, limit)
+	}
+	return &itemSearchResponse{Items: []itemSearchHitResponse{}}, nil
+}
+
+// 有効な UUID フォーマットの定数（テスト用）。
+const validFeedUUID = "11111111-2222-3333-4444-555555555555"
+
+// --- 200 OK: 横断検索成功 ---
+
+// TestItemSearchHandler_Search_Global_Success は q=foo の横断検索で service が呼ばれ
+// レスポンスが正常に返ることを検証する（Req 1.3, 4.2）。
+func TestItemSearchHandler_Search_Global_Success(t *testing.T) {
+	// Arrange
+	now := time.Now().UTC().Truncate(time.Second)
+	favicon := "data:image/png;base64,Y2FmZQ=="
+	svc := &mockItemSearchService{
+		searchFn: func(_ context.Context, userID, rawQuery string, feedID *string, cursor string, limit int) (*itemSearchResponse, error) {
+			if userID != "user-1" {
+				t.Errorf("userID = %q, want %q", userID, "user-1")
+			}
+			if rawQuery != "foo" {
+				t.Errorf("rawQuery = %q, want %q", rawQuery, "foo")
+			}
+			if feedID != nil {
+				t.Errorf("feedID = %v, want nil (global search)", *feedID)
+			}
+			if limit != defaultItemsPerPage {
+				t.Errorf("limit = %d, want %d", limit, defaultItemsPerPage)
+			}
+			return &itemSearchResponse{
+				Items: []itemSearchHitResponse{
+					{
+						ID:          "item-1",
+						FeedID:      "feed-a",
+						FeedTitle:   "Feed A",
+						FaviconURL:  &favicon,
+						Title:       "Foo Bar",
+						Link:        "https://example.com/1",
+						Summary:     "概要",
+						PublishedAt: now,
+					},
+				},
+				NextCursor: now.Format(time.RFC3339Nano) + "|item-1",
+				HasMore:    true,
+			}, nil
+		},
+	}
+	h := NewItemSearchHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items/search?q=foo", nil)
+	req = withUserID(req, "user-1")
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Search(w, req)
+
+	// Assert
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	items, ok := body["items"].([]interface{})
+	if !ok || len(items) != 1 {
+		t.Fatalf("items invalid: %v", body["items"])
+	}
+	first := items[0].(map[string]interface{})
+	if first["feed_title"] != "Feed A" {
+		t.Errorf("feed_title = %v, want Feed A", first["feed_title"])
+	}
+	if first["favicon_url"] != favicon {
+		t.Errorf("favicon_url = %v, want %q", first["favicon_url"], favicon)
+	}
+	if body["has_more"] != true {
+		t.Errorf("has_more = %v, want true", body["has_more"])
+	}
+}
+
+// --- 200 OK: フィード内検索成功 ---
+
+// TestItemSearchHandler_Search_Feed_Success は q=foo&feed_id=<uuid> のフィード内検索で
+// feedID *string が service に伝搬することを検証する（Req 1.4, 2.2）。
+func TestItemSearchHandler_Search_Feed_Success(t *testing.T) {
+	// Arrange
+	svc := &mockItemSearchService{
+		searchFn: func(_ context.Context, _, _ string, feedID *string, _ string, _ int) (*itemSearchResponse, error) {
+			if feedID == nil {
+				t.Fatal("expected feedID non-nil")
+			}
+			if *feedID != validFeedUUID {
+				t.Errorf("feedID = %q, want %q", *feedID, validFeedUUID)
+			}
+			return &itemSearchResponse{Items: []itemSearchHitResponse{}}, nil
+		},
+	}
+	h := NewItemSearchHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items/search?q=foo&feed_id="+validFeedUUID, nil)
+	req = withUserID(req, "user-1")
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Search(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Result().StatusCode, http.StatusOK)
+	}
+	if svc.callCount != 1 {
+		t.Errorf("service called %d times, want 1", svc.callCount)
+	}
+}
+
+// --- 401: 未認証 ---
+
+// TestItemSearchHandler_Search_NoUserID_ReturnsUnauthorized は withUserID なしで
+// 401 UNAUTHORIZED が返ることを検証する（Req 3.3）。
+func TestItemSearchHandler_Search_NoUserID_ReturnsUnauthorized(t *testing.T) {
+	// Arrange
+	svc := &mockItemSearchService{}
+	h := NewItemSearchHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items/search?q=foo", nil)
+	// ユーザーIDを注入しない
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Search(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Result().StatusCode, http.StatusUnauthorized)
+	}
+	if svc.callCount != 0 {
+		t.Errorf("service must not be called when unauthenticated, got %d calls", svc.callCount)
+	}
+}
+
+// --- 400: cursor 不正（service から INVALID_SEARCH_QUERY） ---
+
+// TestItemSearchHandler_Search_InvalidCursor_ReturnsBadRequest は service が
+// NewInvalidSearchQueryError を返したときに 400 にマッピングされることを検証する。
+func TestItemSearchHandler_Search_InvalidCursor_ReturnsBadRequest(t *testing.T) {
+	// Arrange
+	svc := &mockItemSearchService{
+		searchFn: func(_ context.Context, _, _ string, _ *string, _ string, _ int) (*itemSearchResponse, error) {
+			return nil, model.NewInvalidSearchQueryError("cursor の形式が不正です")
+		},
+	}
+	h := NewItemSearchHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items/search?q=foo&cursor=bogus", nil)
+	req = withUserID(req, "user-1")
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Search(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Result().StatusCode, http.StatusBadRequest)
+	}
+	errResp := parseAPIErrorResponse(t, w)
+	if errResp["code"] != model.ErrCodeInvalidSearchQuery {
+		t.Errorf("code = %q, want %q", errResp["code"], model.ErrCodeInvalidSearchQuery)
+	}
+}
+
+// --- 400: feed_id UUID パース失敗（handler 層で 400） ---
+
+// TestItemSearchHandler_Search_InvalidFeedID_ReturnsBadRequest は feed_id が UUID
+// 形式でないとき handler 層で 400 INVALID_SEARCH_QUERY を返すことを検証する。
+// service は呼ばれないこと（fail-fast）も検証する。
+func TestItemSearchHandler_Search_InvalidFeedID_ReturnsBadRequest(t *testing.T) {
+	// google/uuid の Parse は dashes 無しの 32 hex 形式（urn:uuid:... を除いた中身）も
+	// 妥当として受け付けるため、純粋に非 UUID と判定されるケースのみを並べる。
+	cases := []struct {
+		name   string
+		feedID string
+	}{
+		{"random string", "not-a-uuid"},
+		{"too short", "1234"},
+		{"invalid hex chars", "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			svc := &mockItemSearchService{}
+			h := NewItemSearchHandler(svc)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/items/search?q=foo&feed_id="+tc.feedID, nil)
+			req = withUserID(req, "user-1")
+			w := httptest.NewRecorder()
+
+			// Act
+			h.Search(w, req)
+
+			// Assert
+			if w.Result().StatusCode != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", w.Result().StatusCode, http.StatusBadRequest)
+			}
+			if svc.callCount != 0 {
+				t.Errorf("service must not be called when feed_id is invalid, got %d calls", svc.callCount)
+			}
+			errResp := parseAPIErrorResponse(t, w)
+			if errResp["code"] != model.ErrCodeInvalidSearchQuery {
+				t.Errorf("code = %q, want %q", errResp["code"], model.ErrCodeInvalidSearchQuery)
+			}
+		})
+	}
+}
+
+// --- 403: 未購読 feed_id ---
+
+// TestItemSearchHandler_Search_FeedNotSubscribed_ReturnsForbidden は service が
+// NewFeedNotSubscribedError を返したときに 403 にマッピングされることを検証する（Req 3.5）。
+func TestItemSearchHandler_Search_FeedNotSubscribed_ReturnsForbidden(t *testing.T) {
+	// Arrange
+	svc := &mockItemSearchService{
+		searchFn: func(_ context.Context, _, _ string, _ *string, _ string, _ int) (*itemSearchResponse, error) {
+			return nil, model.NewFeedNotSubscribedError(validFeedUUID)
+		},
+	}
+	h := NewItemSearchHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items/search?q=foo&feed_id="+validFeedUUID, nil)
+	req = withUserID(req, "user-1")
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Search(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Result().StatusCode, http.StatusForbidden)
+	}
+	errResp := parseAPIErrorResponse(t, w)
+	if errResp["code"] != model.ErrCodeFeedNotSubscribed {
+		t.Errorf("code = %q, want %q", errResp["code"], model.ErrCodeFeedNotSubscribed)
+	}
+}
+
+// --- 200: 空クエリ → 空配列（Req 1.5） ---
+
+// TestItemSearchHandler_Search_EmptyQuery_ReturnsEmptyArray は q が空文字でも
+// 200 OK で items: [] が返ることを検証する。service には rawQuery="" が伝わるが
+// サービス層側で空判定して空結果を返す前提（Req 1.5）。
+func TestItemSearchHandler_Search_EmptyQuery_ReturnsEmptyArray(t *testing.T) {
+	// Arrange
+	svc := &mockItemSearchService{
+		searchFn: func(_ context.Context, _, rawQuery string, _ *string, _ string, _ int) (*itemSearchResponse, error) {
+			if rawQuery != "" {
+				t.Errorf("rawQuery = %q, want empty", rawQuery)
+			}
+			// service 層が空クエリで Items nil を返す挙動を模倣
+			return &itemSearchResponse{Items: nil, HasMore: false}, nil
+		},
+	}
+	h := NewItemSearchHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items/search?q=", nil)
+	req = withUserID(req, "user-1")
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Search(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Result().StatusCode, http.StatusOK)
+	}
+	// items が JSON で空配列として返ること（nil ではなく []）
+	bodyStr := w.Body.String()
+	if !strings.Contains(bodyStr, `"items":[]`) {
+		t.Errorf("expected items to be empty JSON array, got %q", bodyStr)
+	}
+}
+
+// --- 500: service の generic error ---
+
+// TestItemSearchHandler_Search_ServiceError_ReturnsInternalServerError は service が
+// APIError 以外のエラーを返したとき 500 にマッピングされることを検証する。
+func TestItemSearchHandler_Search_ServiceError_ReturnsInternalServerError(t *testing.T) {
+	// Arrange
+	svc := &mockItemSearchService{
+		searchFn: func(_ context.Context, _, _ string, _ *string, _ string, _ int) (*itemSearchResponse, error) {
+			return nil, errors.New("db connection lost")
+		},
+	}
+	h := NewItemSearchHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items/search?q=foo", nil)
+	req = withUserID(req, "user-1")
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Search(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Result().StatusCode, http.StatusInternalServerError)
+	}
+}
+
+// --- limit のクランプ確認 ---
+
+// TestItemSearchHandler_Search_LimitClamp は limit クエリパラメータが上限値を超えた
+// ときに maxSearchLimit にクランプされることを検証する。
+func TestItemSearchHandler_Search_LimitClamp(t *testing.T) {
+	cases := []struct {
+		name      string
+		limitStr  string
+		wantLimit int
+	}{
+		{"unspecified -> default", "", defaultItemsPerPage},
+		{"valid -> as-is", "25", 25},
+		{"at max -> as-is", "200", maxSearchLimit},
+		{"over max -> clamped", "500", maxSearchLimit},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			svc := &mockItemSearchService{}
+			h := NewItemSearchHandler(svc)
+
+			u := "/api/items/search?q=foo"
+			if tc.limitStr != "" {
+				u += "&limit=" + tc.limitStr
+			}
+			req := httptest.NewRequest(http.MethodGet, u, nil)
+			req = withUserID(req, "user-1")
+			w := httptest.NewRecorder()
+
+			// Act
+			h.Search(w, req)
+
+			// Assert
+			if w.Result().StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want %d", w.Result().StatusCode, http.StatusOK)
+			}
+			if svc.callCount != 1 {
+				t.Fatalf("service callCount = %d, want 1", svc.callCount)
+			}
+			if svc.calls[0].limit != tc.wantLimit {
+				t.Errorf("limit = %d, want %d", svc.calls[0].limit, tc.wantLimit)
+			}
+		})
+	}
+}
+
+// TestItemSearchHandler_Search_InvalidLimit_ReturnsBadRequest は limit クエリが
+// 非数値 / 0 以下の場合に handler 層で 400 を返すことを検証する。
+func TestItemSearchHandler_Search_InvalidLimit_ReturnsBadRequest(t *testing.T) {
+	cases := []struct {
+		name     string
+		limitStr string
+	}{
+		{"non-numeric", "abc"},
+		{"zero", "0"},
+		{"negative", "-1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			svc := &mockItemSearchService{}
+			h := NewItemSearchHandler(svc)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/items/search?q=foo&limit="+tc.limitStr, nil)
+			req = withUserID(req, "user-1")
+			w := httptest.NewRecorder()
+
+			// Act
+			h.Search(w, req)
+
+			// Assert
+			if w.Result().StatusCode != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", w.Result().StatusCode, http.StatusBadRequest)
+			}
+			if svc.callCount != 0 {
+				t.Errorf("service must not be called when limit is invalid, got %d calls", svc.callCount)
+			}
+		})
+	}
+}
+
+// --- cursor がそのまま service に伝搬する ---
+
+// TestItemSearchHandler_Search_CursorPropagates は cursor クエリパラメータが
+// service にそのまま伝搬することを検証する（パースは service 層の責務）。
+func TestItemSearchHandler_Search_CursorPropagates(t *testing.T) {
+	// Arrange
+	svc := &mockItemSearchService{}
+	h := NewItemSearchHandler(svc)
+
+	cursorValue := "2026-05-28T12:34:56.123456789Z|" + validFeedUUID
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/items/search?q=foo&cursor="+cursorValue, nil)
+	req = withUserID(req, "user-1")
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Search(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Result().StatusCode, http.StatusOK)
+	}
+	if svc.calls[0].cursor != cursorValue {
+		t.Errorf("cursor = %q, want %q", svc.calls[0].cursor, cursorValue)
+	}
+}

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -76,6 +76,9 @@ type RouterDeps struct {
 	ItemService      ItemServiceInterface
 	ItemStateService ItemStateServiceInterface
 
+	// 記事検索
+	ItemSearchService ItemSearchServiceInterface
+
 	// 購読
 	SubscriptionService SubscriptionServiceInterface
 
@@ -120,6 +123,7 @@ func NewRouter(deps *RouterDeps) http.Handler {
 	authHandler := NewAuthHandler(deps.AuthService, deps.AuthConfig)
 	feedHandler := NewFeedHandler(deps.FeedService, deps.SubscriptionDeleter)
 	itemHandler := NewItemHandler(deps.ItemService, deps.ItemStateService)
+	itemSearchHandler := NewItemSearchHandler(deps.ItemSearchService)
 	subHandler := NewSubscriptionHandler(deps.SubscriptionService)
 	userHandler := NewUserHandler(deps.UserService)
 
@@ -201,6 +205,11 @@ func NewRouter(deps *RouterDeps) http.Handler {
 				r.Get("/items", itemHandler.ListItems)
 			})
 		})
+
+		// 記事検索（/api/items/{id} よりも前に登録する必要がある。
+		// chi は static segment `/search` を `{id}` よりも優先するが、明示的に
+		// 先に登録することで `search` が `{id}` の捕捉に吸われる可能性を確実に排除する）。
+		r.Get("/api/items/search", itemSearchHandler.Search)
 
 		// 記事管理
 		r.Route("/api/items/{id}", func(r chi.Router) {

--- a/internal/handler/service_adapter.go
+++ b/internal/handler/service_adapter.go
@@ -2,9 +2,12 @@ package handler
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
 	"time"
 
 	"github.com/hitoshi/feedman/internal/item"
+	"github.com/hitoshi/feedman/internal/itemsearch"
 	"github.com/hitoshi/feedman/internal/model"
 	"github.com/hitoshi/feedman/internal/repository"
 	"github.com/hitoshi/feedman/internal/subscription"
@@ -204,12 +207,79 @@ func (a *SubscriptionDeleterAdapter) DeleteByUserAndFeed(ctx context.Context, us
 	return a.subRepo.Delete(ctx, sub.ID)
 }
 
+// ItemSearchServiceAdapter は itemsearch.SearchService を ItemSearchServiceInterface に
+// 適合させるアダプタ。
+//
+// 主な責務は、サービス層が返す `itemsearch.SearchResult`（ドメイン型）を
+// `itemSearchResponse`（HTTP レスポンス型）に変換すること。favicon は Service 層が
+// `FaviconData []byte` / `FaviconMime string` の生バイト + MIME を pass-through するため、
+// 本アダプタが `data:<mime>;base64,...` 形式の data URL に整形して `FaviconURL` を populate
+// する（subscription.Service.ListSubscriptions と同じ data URL 化パターンを再利用）。
+type ItemSearchServiceAdapter struct {
+	svc *itemsearch.SearchService
+}
+
+// NewItemSearchServiceAdapter は ItemSearchServiceAdapter を生成する。
+func NewItemSearchServiceAdapter(svc *itemsearch.SearchService) *ItemSearchServiceAdapter {
+	return &ItemSearchServiceAdapter{svc: svc}
+}
+
+// Search はサービス層を呼び出し、結果を handler 用レスポンス型に変換して返す。
+//
+// favicon の data URL 化は本メソッドの責務（サービス層は生バイトのまま pass-through する）。
+// 生バイトと MIME のいずれかが空の場合は data URL を生成せず nil を保持し、JSON では
+// `omitempty` でフィールドごと省略される。
+func (a *ItemSearchServiceAdapter) Search(
+	ctx context.Context,
+	userID, rawQuery string,
+	feedID *string,
+	cursorStr string,
+	limit int,
+) (*itemSearchResponse, error) {
+	result, err := a.svc.Search(ctx, userID, rawQuery, feedID, cursorStr, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	hits := make([]itemSearchHitResponse, len(result.Items))
+	for i, it := range result.Items {
+		hit := itemSearchHitResponse{
+			ID:              it.ID,
+			FeedID:          it.FeedID,
+			FeedTitle:       it.FeedTitle,
+			Title:           it.Title,
+			Link:            it.Link,
+			Summary:         it.Summary,
+			PublishedAt:     it.PublishedAt,
+			IsDateEstimated: it.IsDateEstimated,
+			IsRead:          it.IsRead,
+			IsStarred:       it.IsStarred,
+			HatebuCount:     it.HatebuCount,
+		}
+		// favicon の生バイト + MIME が揃っている場合のみ data URL を組み立てる。
+		// 既存 subscription.Service.ListSubscriptions と同じ流儀
+		// （`data:<mime>;base64,<base64>`）で整形し、欠落時は nil を保持する。
+		if len(it.FaviconData) > 0 && it.FaviconMime != "" {
+			dataURL := fmt.Sprintf("data:%s;base64,%s", it.FaviconMime, base64.StdEncoding.EncodeToString(it.FaviconData))
+			hit.FaviconURL = &dataURL
+		}
+		hits[i] = hit
+	}
+
+	return &itemSearchResponse{
+		Items:      hits,
+		NextCursor: result.NextCursor,
+		HasMore:    result.HasMore,
+	}, nil
+}
+
 // --- compile-time interface checks ---
 
 var _ SubscriptionServiceInterface = (*SubscriptionServiceAdapter)(nil)
 var _ UserServiceInterface = (*UserServiceAdapter)(nil)
 var _ ItemServiceInterface = (*ItemServiceAdapterFromDomain)(nil)
 var _ ItemStateServiceInterface = (*ItemStateServiceAdapterFromRepo)(nil)
+var _ ItemSearchServiceInterface = (*ItemSearchServiceAdapter)(nil)
 var _ SubscriptionDeleter = (*SubscriptionDeleterAdapter)(nil)
 
 // zeroTime はゼロ値のtime.Time。

--- a/internal/itemsearch/service.go
+++ b/internal/itemsearch/service.go
@@ -1,0 +1,280 @@
+// Package itemsearch は記事の横断 / フィード内検索を担うドメインサービスを提供する。
+//
+// SearchService はキーワード入力の正規化（前後空白 trim、空入力判定、LIKE メタ文字
+// エスケープ）、feed_id 指定時の購読確認、リポジトリ呼び出しによる検索実行、
+// limit+1 取得→HasMore 判定と NextCursor 生成までを担う。HTTP 境界とレスポンス形式の
+// 整形は handler 層 (`internal/handler.ItemSearchHandler`) と service_adapter
+// (`ItemSearchServiceAdapter`) の責務とし、本パッケージは API スキーマに依存しない
+// 純粋な検索結果（ItemSearchSummary）を返すことに集中する。
+package itemsearch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hitoshi/feedman/internal/model"
+	"github.com/hitoshi/feedman/internal/repository"
+)
+
+// 検索結果ページングの既定値と上限値。
+//
+// design.md「API Contract」節に従い、handler 層が `limit` クエリパラメータ未指定時に
+// defaultSearchLimit を使用し、上限を超える場合は maxSearchLimit にクランプする。
+// 本サービス層でも、handler を経由しない直接呼び出しや handler 側のバグに対する
+// 防御として同じクランプを行う。
+const (
+	defaultSearchLimit = 50
+	maxSearchLimit     = 200
+)
+
+// SearchService は記事検索のドメインサービス。
+//
+// 主な責務:
+//   - キーワードの前後空白 trim と空入力判定（Req 1.5）
+//   - LIKE メタ文字（%, _, \）のエスケープ（Req 2.4）
+//   - feed_id 指定時の購読確認と未購読時の 403 への変換（Req 3.5）
+//   - cursor 形式 `<RFC3339Nano>|<uuid>` のパースと形式不正時の 400 への変換
+//   - リポジトリへの limit+1 取得依頼、HasMore 判定、NextCursor 生成
+//
+// 認証チェックは行わない（handler 層の責務）。トランザクションは持たない
+// （SELECT 専用）。
+type SearchService struct {
+	itemRepo repository.ItemSearchRepository
+	subRepo  repository.SubscriptionRepository
+}
+
+// NewSearchService は SearchService の新しいインスタンスを生成する。
+//
+// itemRepo は検索 SQL を実行するリポジトリ、subRepo は feed_id 指定時の購読確認に
+// 利用するリポジトリ。subRepo.FindByUserAndFeed の戻り値が nil であれば未購読と判定する
+// （新規メソッド追加を避けるため既存メソッドを再利用する判断）。
+func NewSearchService(
+	itemRepo repository.ItemSearchRepository,
+	subRepo repository.SubscriptionRepository,
+) *SearchService {
+	return &SearchService{
+		itemRepo: itemRepo,
+		subRepo:  subRepo,
+	}
+}
+
+// SearchResult は SearchService.Search の戻り値。
+//
+// Items は published_at 降順、同 published_at では id 降順で整列済み。
+// HasMore は次ページの存在を示し、NextCursor は次ページ取得用のカーソル文字列
+// （`<RFC3339Nano>|<uuid>` 形式）。HasMore が false の場合や末尾項目の PublishedAt が
+// ゼロ値の場合、NextCursor は空文字となる。
+type SearchResult struct {
+	Items      []ItemSearchSummary
+	NextCursor string
+	HasMore    bool
+}
+
+// ItemSearchSummary は検索結果 1 件のサービス層表現。
+//
+// design.md 行 295-309 で定義された ItemSearchSummary に、Adapter 層で data URL を
+// 組み立てるために必要な favicon の生バイト（FaviconData / FaviconMime）を追加した
+// 形を採用する。data URL への整形は ItemSearchServiceAdapter（Task 5.3）の責務であり、
+// 本サービス層が返す FaviconURL は常に nil。
+//
+// 背景: design.md の field 一覧は `FaviconURL *string` のみだが、impl-notes Task 2 で
+// 「favicon の data URL 化は Task 5.3 の Adapter が担う」と既に責務分離が確定している。
+// Service 層が favicon を data URL 化すると Adapter 層と二重責務になるため、生データを
+// pass-through する設計を採用する。
+type ItemSearchSummary struct {
+	ID              string
+	FeedID          string
+	FeedTitle       string
+	FaviconURL      *string // 常に nil（data URL 化は Adapter 層で行う）
+	FaviconData     []byte  // Adapter 層が data URL に整形するための生バイト
+	FaviconMime     string  // Adapter 層が data URL に整形するための MIME タイプ
+	Title           string
+	Link            string
+	Summary         string
+	PublishedAt     time.Time
+	IsDateEstimated bool
+	IsRead          bool
+	IsStarred       bool
+	HatebuCount     int
+}
+
+// Search は当該ユーザーが購読中のフィードに属する記事から、キーワードに部分一致する
+// ものを published_at 降順で返す。
+//
+// feedID が非 nil の場合、検索範囲を当該フィードに限定する（フィード内検索モード）。
+// 正規化後の query が空（rawQuery が空または全て空白）の場合は、Req 1.5 の規定により
+// リポジトリを呼ばずに空結果を返す。feedID が非 nil でユーザーが当該フィードを購読
+// していない場合は、Req 3.5 の規定により NewFeedNotSubscribedError を返す。
+// cursorStr が空でなく形式不正の場合は NewInvalidSearchQueryError を返す。
+//
+// limit は実取得件数。0 以下が渡された場合は defaultSearchLimit (50) に、
+// maxSearchLimit (200) を超える場合は maxSearchLimit にクランプする。
+// HasMore 判定のためリポジトリには limit+1 件を要求し、limit を超える件数が返ったら
+// 末尾 1 件を切り詰めて HasMore=true、NextCursor を組み立てる。
+func (s *SearchService) Search(
+	ctx context.Context,
+	userID, rawQuery string,
+	feedID *string,
+	cursorStr string,
+	limit int,
+) (*SearchResult, error) {
+	// クエリ正規化: 前後空白 trim + 空クエリ判定 (Req 1.5)
+	query := strings.TrimSpace(rawQuery)
+	if query == "" {
+		return &SearchResult{Items: nil, NextCursor: "", HasMore: false}, nil
+	}
+
+	// feed_id 指定時の購読確認 (Req 3.5)
+	// 既存 SubscriptionRepository.FindByUserAndFeed を再利用し、nil を未購読として
+	// 扱う。新規 Exists メソッドの追加を避け、既存インターフェースに侵襲しない判断。
+	if feedID != nil {
+		sub, err := s.subRepo.FindByUserAndFeed(ctx, userID, *feedID)
+		if err != nil {
+			return nil, fmt.Errorf("check subscription: %w", err)
+		}
+		if sub == nil {
+			return nil, model.NewFeedNotSubscribedError(*feedID)
+		}
+	}
+
+	// cursor のパース (形式不正は 400)
+	cursorPublishedAt, cursorID, err := parseCursor(cursorStr)
+	if err != nil {
+		return nil, err
+	}
+
+	// limit のクランプ（防御的）
+	effectiveLimit := clampLimit(limit)
+
+	// LIKE メタ文字エスケープ + pattern 組み立て (Req 2.4)
+	pattern := "%" + escapeLikePattern(query) + "%"
+
+	// limit+1 取得 → HasMore 判定
+	hits, err := s.itemRepo.SearchByUserAndKeyword(
+		ctx,
+		userID,
+		pattern,
+		feedID,
+		cursorID,
+		cursorPublishedAt,
+		effectiveLimit+1,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	hasMore := len(hits) > effectiveLimit
+	if hasMore {
+		hits = hits[:effectiveLimit]
+	}
+
+	// hits → ItemSearchSummary 変換
+	summaries := make([]ItemSearchSummary, len(hits))
+	for i, h := range hits {
+		summaries[i] = ItemSearchSummary{
+			ID:              h.ID,
+			FeedID:          h.FeedID,
+			FeedTitle:       h.FeedTitle,
+			FaviconURL:      nil, // data URL 化は Adapter 層の責務
+			FaviconData:     h.FaviconData,
+			FaviconMime:     h.FaviconMime,
+			Title:           h.Title,
+			Link:            h.Link,
+			Summary:         h.Summary,
+			PublishedAt:     h.PublishedAt,
+			IsDateEstimated: h.IsDateEstimated,
+			IsRead:          h.IsRead,
+			IsStarred:       h.IsStarred,
+			HatebuCount:     h.HatebuCount,
+		}
+	}
+
+	// NextCursor の組み立て:
+	// HasMore=true かつ末尾項目の PublishedAt が非ゼロ値の場合のみ生成する。
+	// PublishedAt がゼロ値（NULL マッピング）の場合は (published_at, id) の安定順序が
+	// 保てないため、cursor を発行せず HasMore のみで「次ページあり」を示す。
+	var nextCursor string
+	if hasMore && len(summaries) > 0 {
+		last := summaries[len(summaries)-1]
+		if !last.PublishedAt.IsZero() {
+			nextCursor = last.PublishedAt.UTC().Format(time.RFC3339Nano) + "|" + last.ID
+		}
+	}
+
+	return &SearchResult{
+		Items:      summaries,
+		NextCursor: nextCursor,
+		HasMore:    hasMore,
+	}, nil
+}
+
+// parseCursor は cursorStr を (publishedAt, id) のタプルに分解する。
+//
+// cursorStr が空文字の場合はゼロ値 + 空 ID を返す（リポジトリは zero value を
+// 「先頭ページ」として扱う）。空でない場合は `<RFC3339Nano>|<uuid>` 形式を期待し、
+// 区切り `|` が無い・複数ある・RFC3339Nano パース失敗・ID 部が空のいずれでも
+// NewInvalidSearchQueryError を返す。
+//
+// UUID 部の厳密パースは行わない（リポジトリ層が SQL の `$5::uuid` cast で検証する）。
+// 本サービス層は「空でない」「タイムスタンプがパース可能」程度の sanity check に留め、
+// 過剰な依存追加を避ける。
+func parseCursor(cursorStr string) (time.Time, string, error) {
+	if cursorStr == "" {
+		return time.Time{}, "", nil
+	}
+	parts := strings.SplitN(cursorStr, "|", 2)
+	if len(parts) != 2 {
+		return time.Time{}, "", model.NewInvalidSearchQueryError("cursor の形式が不正です")
+	}
+	if strings.Contains(parts[1], "|") {
+		// `a|b|c` のように区切りが複数ある場合は不正
+		return time.Time{}, "", model.NewInvalidSearchQueryError("cursor の形式が不正です")
+	}
+	publishedAt, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return time.Time{}, "", model.NewInvalidSearchQueryError("cursor のタイムスタンプが不正です")
+	}
+	if strings.TrimSpace(parts[1]) == "" {
+		return time.Time{}, "", model.NewInvalidSearchQueryError("cursor の id が空です")
+	}
+	return publishedAt, parts[1], nil
+}
+
+// escapeLikePattern は ILIKE パターンの中身として安全に埋め込めるよう、
+// LIKE メタ文字（%, _, \）をエスケープする。
+//
+// PostgreSQL の標準 LIKE/ILIKE は escape 文字として `\` を使用する。したがって
+// `\` 自体を先にエスケープしてから `%` と `_` をエスケープする順序を守る必要がある
+// （順序を逆にすると `%` のエスケープに使った `\` 自体が再度エスケープされてしまう）。
+//
+// 例:
+//   "50%off" → "50\%off"
+//   "a_b"    → "a\_b"
+//   "c\\d"   → "c\\\\d"（Go 文字列リテラル上は `c\\d` → `c\\\\d`）
+func escapeLikePattern(s string) string {
+	// 順序重要: `\` を先にエスケープ → `%` → `_`
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "%", `\%`)
+	s = strings.ReplaceAll(s, "_", `\_`)
+	return s
+}
+
+// clampLimit は limit を [defaultSearchLimit, maxSearchLimit] の範囲に矯正する。
+//
+// limit ≤ 0 → defaultSearchLimit
+// limit > maxSearchLimit → maxSearchLimit
+// それ以外 → そのまま
+//
+// handler 層が同じクランプを行う想定だが、handler を経由しない直接呼び出しや
+// handler 側のバグに対する防御として本サービス層でも適用する。
+func clampLimit(limit int) int {
+	if limit <= 0 {
+		return defaultSearchLimit
+	}
+	if limit > maxSearchLimit {
+		return maxSearchLimit
+	}
+	return limit
+}

--- a/internal/itemsearch/service_test.go
+++ b/internal/itemsearch/service_test.go
@@ -1,0 +1,770 @@
+package itemsearch
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hitoshi/feedman/internal/model"
+	"github.com/hitoshi/feedman/internal/repository"
+)
+
+// --- テスト用モック ---
+
+// recordedSearchCall は SearchByUserAndKeyword に渡された引数を記録する。
+type recordedSearchCall struct {
+	userID            string
+	pattern           string
+	feedID            *string
+	cursorID          string
+	cursorPublishedAt time.Time
+	limit             int
+}
+
+// mockItemSearchRepo は ItemSearchRepository のテスト用モック。
+type mockItemSearchRepo struct {
+	// searchFn が非 nil の場合はそれを呼び出す。nil の場合は returnHits を返す。
+	searchFn    func(ctx context.Context, userID, pattern string, feedID *string, cursorID string, cursorPublishedAt time.Time, limit int) ([]model.ItemSearchHit, error)
+	returnHits  []model.ItemSearchHit
+	returnErr   error
+	calls       []recordedSearchCall
+	callCount   int
+}
+
+func (m *mockItemSearchRepo) SearchByUserAndKeyword(
+	ctx context.Context,
+	userID, pattern string,
+	feedID *string,
+	cursorID string,
+	cursorPublishedAt time.Time,
+	limit int,
+) ([]model.ItemSearchHit, error) {
+	m.callCount++
+	// feedID のスナップショットを取る（呼び出し元での書き換えから守る）
+	var feedIDCopy *string
+	if feedID != nil {
+		v := *feedID
+		feedIDCopy = &v
+	}
+	m.calls = append(m.calls, recordedSearchCall{
+		userID:            userID,
+		pattern:           pattern,
+		feedID:            feedIDCopy,
+		cursorID:          cursorID,
+		cursorPublishedAt: cursorPublishedAt,
+		limit:             limit,
+	})
+	if m.searchFn != nil {
+		return m.searchFn(ctx, userID, pattern, feedID, cursorID, cursorPublishedAt, limit)
+	}
+	return m.returnHits, m.returnErr
+}
+
+// mockSubRepo は SubscriptionRepository のテスト用モック。
+// 本テストでは FindByUserAndFeed のみを実装し、他メソッドは呼ばれない前提でパニックする。
+type mockSubRepo struct {
+	findFn        func(ctx context.Context, userID, feedID string) (*model.Subscription, error)
+	findCallCount int
+}
+
+func (m *mockSubRepo) FindByID(_ context.Context, _ string) (*model.Subscription, error) {
+	panic("mockSubRepo.FindByID: not implemented")
+}
+
+func (m *mockSubRepo) FindByUserAndFeed(ctx context.Context, userID, feedID string) (*model.Subscription, error) {
+	m.findCallCount++
+	if m.findFn != nil {
+		return m.findFn(ctx, userID, feedID)
+	}
+	return nil, nil
+}
+
+func (m *mockSubRepo) CountByUserID(_ context.Context, _ string) (int, error) {
+	panic("mockSubRepo.CountByUserID: not implemented")
+}
+
+func (m *mockSubRepo) Create(_ context.Context, _ *model.Subscription) error {
+	panic("mockSubRepo.Create: not implemented")
+}
+
+func (m *mockSubRepo) ListByUserID(_ context.Context, _ string) ([]*model.Subscription, error) {
+	panic("mockSubRepo.ListByUserID: not implemented")
+}
+
+func (m *mockSubRepo) MinFetchIntervalByFeedID(_ context.Context, _ string) (int, error) {
+	panic("mockSubRepo.MinFetchIntervalByFeedID: not implemented")
+}
+
+func (m *mockSubRepo) UpdateFetchInterval(_ context.Context, _ string, _ int) error {
+	panic("mockSubRepo.UpdateFetchInterval: not implemented")
+}
+
+func (m *mockSubRepo) Delete(_ context.Context, _ string) error {
+	panic("mockSubRepo.Delete: not implemented")
+}
+
+func (m *mockSubRepo) DeleteByUserID(_ context.Context, _ string) error {
+	panic("mockSubRepo.DeleteByUserID: not implemented")
+}
+
+func (m *mockSubRepo) ListByUserIDWithFeedInfo(_ context.Context, _ string) ([]repository.SubscriptionWithFeedInfo, error) {
+	panic("mockSubRepo.ListByUserIDWithFeedInfo: not implemented")
+}
+
+// compile-time check: mockSubRepo は repository.SubscriptionRepository を満たす
+var _ repository.SubscriptionRepository = (*mockSubRepo)(nil)
+
+// --- escapeLikePattern のユニットテスト ---
+
+func TestEscapeLikePattern(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no meta chars", "hello", "hello"},
+		{"percent only", "50%off", `50\%off`},
+		{"underscore only", "a_b", `a\_b`},
+		{"backslash only", `a\b`, `a\\b`},
+		{"all three", `100%_off\back`, `100\%\_off\\back`},
+		{"backslash before percent (order)", `\%`, `\\\%`},
+		{"empty", "", ""},
+		{"only meta chars", `%_\`, `\%\_\\`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange: tc.in
+			// Act
+			got := escapeLikePattern(tc.in)
+			// Assert
+			if got != tc.want {
+				t.Errorf("escapeLikePattern(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- clampLimit のユニットテスト ---
+
+func TestClampLimit(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"zero -> default", 0, defaultSearchLimit},
+		{"negative -> default", -10, defaultSearchLimit},
+		{"in range -> unchanged 1", 1, 1},
+		{"in range -> unchanged 50", 50, 50},
+		{"in range -> unchanged 200", 200, 200},
+		{"over max -> clamped to max", 201, maxSearchLimit},
+		{"way over max -> clamped to max", 10000, maxSearchLimit},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := clampLimit(tc.in)
+			if got != tc.want {
+				t.Errorf("clampLimit(%d) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- parseCursor のユニットテスト ---
+
+func TestParseCursor(t *testing.T) {
+	validTs := "2026-05-28T12:34:56.123456789Z"
+	validUUID := "11111111-2222-3333-4444-555555555555"
+
+	t.Run("empty -> zero values, no error", func(t *testing.T) {
+		gotTs, gotID, err := parseCursor("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !gotTs.IsZero() {
+			t.Errorf("expected zero time, got %v", gotTs)
+		}
+		if gotID != "" {
+			t.Errorf("expected empty id, got %q", gotID)
+		}
+	})
+
+	t.Run("valid -> parsed tuple", func(t *testing.T) {
+		gotTs, gotID, err := parseCursor(validTs + "|" + validUUID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expectedTs, _ := time.Parse(time.RFC3339Nano, validTs)
+		if !gotTs.Equal(expectedTs) {
+			t.Errorf("ts = %v, want %v", gotTs, expectedTs)
+		}
+		if gotID != validUUID {
+			t.Errorf("id = %q, want %q", gotID, validUUID)
+		}
+	})
+
+	invalidCases := []struct {
+		name   string
+		cursor string
+	}{
+		{"no pipe", "invalid"},
+		{"three parts", "a|b|c"},
+		{"invalid timestamp", "not-a-time|" + validUUID},
+		{"empty timestamp", "|" + validUUID},
+		{"empty id", validTs + "|"},
+		{"only whitespace id", validTs + "|   "},
+		{"completely bogus", "garbage"},
+	}
+	for _, tc := range invalidCases {
+		t.Run("invalid_"+tc.name, func(t *testing.T) {
+			_, _, err := parseCursor(tc.cursor)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", tc.cursor)
+			}
+			var apiErr *model.APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("expected *model.APIError, got %T: %v", err, err)
+			}
+			if apiErr.Code != model.ErrCodeInvalidSearchQuery {
+				t.Errorf("Code = %q, want %q", apiErr.Code, model.ErrCodeInvalidSearchQuery)
+			}
+		})
+	}
+}
+
+// --- Search のテーブル駆動テスト ---
+
+// makeHits は連続した PublishedAt を持つ ItemSearchHit を n 件生成するヘルパー。
+// i 番目のヒットの PublishedAt は base - i*1s（降順並びの想定）。
+func makeHits(base time.Time, n int) []model.ItemSearchHit {
+	hits := make([]model.ItemSearchHit, n)
+	for i := 0; i < n; i++ {
+		hits[i] = model.ItemSearchHit{
+			ID:          "item-" + string(rune('a'+i)),
+			FeedID:      "feed-1",
+			FeedTitle:   "Feed One",
+			FaviconData: []byte{0xCA, 0xFE},
+			FaviconMime: "image/png",
+			Title:       "title-" + string(rune('a'+i)),
+			Link:        "https://example.com/" + string(rune('a'+i)),
+			Summary:     "summary",
+			PublishedAt: base.Add(-time.Duration(i) * time.Second),
+		}
+	}
+	return hits
+}
+
+// TestSearch_EmptyQuery: rawQuery が空文字または全空白なら、
+// repository を呼ばずに空結果を返す（Req 1.5）。
+func TestSearch_EmptyQuery(t *testing.T) {
+	cases := []struct {
+		name     string
+		rawQuery string
+	}{
+		{"empty string", ""},
+		{"single space", " "},
+		{"multiple spaces", "    "},
+		{"tabs and newlines", "\t\n  \t"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			repo := &mockItemSearchRepo{}
+			subRepo := &mockSubRepo{}
+			svc := NewSearchService(repo, subRepo)
+			// Act
+			got, err := svc.Search(context.Background(), "user-1", tc.rawQuery, nil, "", 10)
+			// Assert
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatal("got nil result, want empty SearchResult")
+			}
+			if len(got.Items) != 0 {
+				t.Errorf("expected empty Items, got %d", len(got.Items))
+			}
+			if got.HasMore {
+				t.Errorf("HasMore = true, want false")
+			}
+			if got.NextCursor != "" {
+				t.Errorf("NextCursor = %q, want empty", got.NextCursor)
+			}
+			if repo.callCount != 0 {
+				t.Errorf("repository called %d times, want 0", repo.callCount)
+			}
+			if subRepo.findCallCount != 0 {
+				t.Errorf("sub repository called %d times, want 0", subRepo.findCallCount)
+			}
+		})
+	}
+}
+
+// TestSearch_LikeEscape: LIKE メタ文字（%, _, \）がエスケープされて repository に
+// 渡されることを検証する（Req 2.4）。
+func TestSearch_LikeEscape(t *testing.T) {
+	cases := []struct {
+		name        string
+		query       string
+		wantPattern string
+	}{
+		{"plain", "hello", "%hello%"},
+		{"percent", "50%off", `%50\%off%`},
+		{"underscore", "a_b", `%a\_b%`},
+		{"backslash", `back\slash`, `%back\\slash%`},
+		{"mixed", `100%_off\x`, `%100\%\_off\\x%`},
+		{"trim", "  hello  ", "%hello%"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			repo := &mockItemSearchRepo{returnHits: nil}
+			subRepo := &mockSubRepo{}
+			svc := NewSearchService(repo, subRepo)
+			// Act
+			_, err := svc.Search(context.Background(), "user-1", tc.query, nil, "", 10)
+			// Assert
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if repo.callCount != 1 {
+				t.Fatalf("expected 1 repo call, got %d", repo.callCount)
+			}
+			if repo.calls[0].pattern != tc.wantPattern {
+				t.Errorf("pattern = %q, want %q", repo.calls[0].pattern, tc.wantPattern)
+			}
+		})
+	}
+}
+
+// TestSearch_InvalidCursor: cursor 形式不正で INVALID_SEARCH_QUERY APIError を返す。
+func TestSearch_InvalidCursor(t *testing.T) {
+	cases := []struct {
+		name   string
+		cursor string
+	}{
+		{"no pipe", "invalid-cursor"},
+		{"too many pipes", "2026-05-28T12:00:00Z|uuid|extra"},
+		{"bad timestamp", "not-a-time|11111111-2222-3333-4444-555555555555"},
+		{"empty id", "2026-05-28T12:00:00Z|"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			repo := &mockItemSearchRepo{}
+			subRepo := &mockSubRepo{}
+			svc := NewSearchService(repo, subRepo)
+			// Act
+			_, err := svc.Search(context.Background(), "user-1", "hello", nil, tc.cursor, 10)
+			// Assert
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			var apiErr *model.APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("expected *model.APIError, got %T: %v", err, err)
+			}
+			if apiErr.Code != model.ErrCodeInvalidSearchQuery {
+				t.Errorf("Code = %q, want %q", apiErr.Code, model.ErrCodeInvalidSearchQuery)
+			}
+			if repo.callCount != 0 {
+				t.Errorf("repository called %d times, want 0", repo.callCount)
+			}
+		})
+	}
+}
+
+// TestSearch_ValidCursor: 正常な cursor が repository に正しく渡される。
+func TestSearch_ValidCursor(t *testing.T) {
+	// Arrange
+	repo := &mockItemSearchRepo{returnHits: nil}
+	subRepo := &mockSubRepo{}
+	svc := NewSearchService(repo, subRepo)
+	tsStr := "2026-05-28T12:34:56.123456789Z"
+	uuidStr := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	// Act
+	_, err := svc.Search(context.Background(), "user-1", "hello", nil, tsStr+"|"+uuidStr, 10)
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.callCount != 1 {
+		t.Fatalf("expected 1 repo call, got %d", repo.callCount)
+	}
+	call := repo.calls[0]
+	wantTs, _ := time.Parse(time.RFC3339Nano, tsStr)
+	if !call.cursorPublishedAt.Equal(wantTs) {
+		t.Errorf("cursorPublishedAt = %v, want %v", call.cursorPublishedAt, wantTs)
+	}
+	if call.cursorID != uuidStr {
+		t.Errorf("cursorID = %q, want %q", call.cursorID, uuidStr)
+	}
+}
+
+// TestSearch_FeedIDNotSubscribed: feedID 非 nil かつ未購読で FEED_NOT_SUBSCRIBED が返り、
+// item repository は呼ばれない (Req 3.5)。
+func TestSearch_FeedIDNotSubscribed(t *testing.T) {
+	// Arrange
+	repo := &mockItemSearchRepo{}
+	subRepo := &mockSubRepo{
+		findFn: func(_ context.Context, _, _ string) (*model.Subscription, error) {
+			return nil, nil // 未購読
+		},
+	}
+	svc := NewSearchService(repo, subRepo)
+	feedID := "feed-1"
+	// Act
+	_, err := svc.Search(context.Background(), "user-1", "hello", &feedID, "", 10)
+	// Assert
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var apiErr *model.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *model.APIError, got %T: %v", err, err)
+	}
+	if apiErr.Code != model.ErrCodeFeedNotSubscribed {
+		t.Errorf("Code = %q, want %q", apiErr.Code, model.ErrCodeFeedNotSubscribed)
+	}
+	if repo.callCount != 0 {
+		t.Errorf("item repository called %d times, want 0", repo.callCount)
+	}
+	if subRepo.findCallCount != 1 {
+		t.Errorf("sub repository called %d times, want 1", subRepo.findCallCount)
+	}
+}
+
+// TestSearch_FeedIDSubscribed: feedID 非 nil かつ購読あり で item repository が呼ばれ、
+// feedID が引数に伝搬する。
+func TestSearch_FeedIDSubscribed(t *testing.T) {
+	// Arrange
+	repo := &mockItemSearchRepo{returnHits: nil}
+	subRepo := &mockSubRepo{
+		findFn: func(_ context.Context, userID, feedID string) (*model.Subscription, error) {
+			if userID != "user-1" {
+				t.Errorf("userID = %q, want %q", userID, "user-1")
+			}
+			if feedID != "feed-1" {
+				t.Errorf("feedID = %q, want %q", feedID, "feed-1")
+			}
+			return &model.Subscription{ID: "sub-1", UserID: userID, FeedID: feedID}, nil
+		},
+	}
+	svc := NewSearchService(repo, subRepo)
+	feedID := "feed-1"
+	// Act
+	_, err := svc.Search(context.Background(), "user-1", "hello", &feedID, "", 10)
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.callCount != 1 {
+		t.Fatalf("expected 1 repo call, got %d", repo.callCount)
+	}
+	call := repo.calls[0]
+	if call.feedID == nil {
+		t.Fatal("expected feedID to be non-nil in repo call")
+	}
+	if *call.feedID != feedID {
+		t.Errorf("feedID = %q, want %q", *call.feedID, feedID)
+	}
+}
+
+// TestSearch_FeedIDNil_SubRepoNotCalled: feedID == nil のとき subscription repository は
+// 呼ばれず、item repository に nil が伝搬する。
+func TestSearch_FeedIDNil_SubRepoNotCalled(t *testing.T) {
+	// Arrange
+	repo := &mockItemSearchRepo{returnHits: nil}
+	subRepo := &mockSubRepo{}
+	svc := NewSearchService(repo, subRepo)
+	// Act
+	_, err := svc.Search(context.Background(), "user-1", "hello", nil, "", 10)
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if subRepo.findCallCount != 0 {
+		t.Errorf("sub repository called %d times, want 0", subRepo.findCallCount)
+	}
+	if repo.callCount != 1 {
+		t.Fatalf("expected 1 repo call, got %d", repo.callCount)
+	}
+	if repo.calls[0].feedID != nil {
+		t.Errorf("expected feedID nil in repo call, got %v", *repo.calls[0].feedID)
+	}
+}
+
+// TestSearch_SubRepoError: SubscriptionRepository がエラーを返したら wrap されて返る。
+func TestSearch_SubRepoError(t *testing.T) {
+	// Arrange
+	repo := &mockItemSearchRepo{}
+	sentinel := errors.New("db down")
+	subRepo := &mockSubRepo{
+		findFn: func(_ context.Context, _, _ string) (*model.Subscription, error) {
+			return nil, sentinel
+		},
+	}
+	svc := NewSearchService(repo, subRepo)
+	feedID := "feed-1"
+	// Act
+	_, err := svc.Search(context.Background(), "user-1", "hello", &feedID, "", 10)
+	// Assert
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected wrapped sentinel, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "check subscription") {
+		t.Errorf("expected wrap message containing 'check subscription', got %q", err.Error())
+	}
+	if repo.callCount != 0 {
+		t.Errorf("item repository called %d times, want 0", repo.callCount)
+	}
+}
+
+// TestSearch_LimitClamp: limit のクランプ動作。
+//
+// 0 以下なら defaultSearchLimit、上限超なら maxSearchLimit。さらに repository には
+// (effectiveLimit + 1) が渡される（HasMore 判定のため）。
+func TestSearch_LimitClamp(t *testing.T) {
+	cases := []struct {
+		name              string
+		limit             int
+		wantRepoLimit     int
+	}{
+		{"zero -> default+1", 0, defaultSearchLimit + 1},
+		{"negative -> default+1", -5, defaultSearchLimit + 1},
+		{"in range -> +1", 25, 26},
+		{"at max -> +1", 200, 201},
+		{"over max -> max+1", 500, maxSearchLimit + 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			repo := &mockItemSearchRepo{returnHits: nil}
+			subRepo := &mockSubRepo{}
+			svc := NewSearchService(repo, subRepo)
+			// Act
+			_, err := svc.Search(context.Background(), "user-1", "hello", nil, "", tc.limit)
+			// Assert
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if repo.callCount != 1 {
+				t.Fatalf("expected 1 repo call, got %d", repo.callCount)
+			}
+			if repo.calls[0].limit != tc.wantRepoLimit {
+				t.Errorf("repo.limit = %d, want %d", repo.calls[0].limit, tc.wantRepoLimit)
+			}
+		})
+	}
+}
+
+// TestSearch_HasMoreTrue: repository が limit+1 件を返したら HasMore=true、
+// 結果が limit 件に切り詰められ、NextCursor が組み立てられる。
+func TestSearch_HasMoreTrue(t *testing.T) {
+	// Arrange
+	base := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	repo := &mockItemSearchRepo{returnHits: makeHits(base, 11)} // limit=10 + 1
+	subRepo := &mockSubRepo{}
+	svc := NewSearchService(repo, subRepo)
+	// Act
+	got, err := svc.Search(context.Background(), "user-1", "hello", nil, "", 10)
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Items) != 10 {
+		t.Errorf("len(Items) = %d, want 10", len(got.Items))
+	}
+	if !got.HasMore {
+		t.Errorf("HasMore = false, want true")
+	}
+	if got.NextCursor == "" {
+		t.Errorf("NextCursor is empty, want non-empty")
+	}
+	// NextCursor の形式: <RFC3339Nano>|<id>
+	parts := strings.SplitN(got.NextCursor, "|", 2)
+	if len(parts) != 2 {
+		t.Fatalf("NextCursor format invalid: %q", got.NextCursor)
+	}
+	wantTs := base.Add(-9 * time.Second).UTC().Format(time.RFC3339Nano)
+	if parts[0] != wantTs {
+		t.Errorf("NextCursor ts = %q, want %q", parts[0], wantTs)
+	}
+	wantID := "item-" + string(rune('a'+9))
+	if parts[1] != wantID {
+		t.Errorf("NextCursor id = %q, want %q", parts[1], wantID)
+	}
+}
+
+// TestSearch_HasMoreFalse: repository が limit 以下を返したら HasMore=false、NextCursor=""。
+func TestSearch_HasMoreFalse(t *testing.T) {
+	// Arrange
+	base := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	repo := &mockItemSearchRepo{returnHits: makeHits(base, 3)}
+	subRepo := &mockSubRepo{}
+	svc := NewSearchService(repo, subRepo)
+	// Act
+	got, err := svc.Search(context.Background(), "user-1", "hello", nil, "", 10)
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Items) != 3 {
+		t.Errorf("len(Items) = %d, want 3", len(got.Items))
+	}
+	if got.HasMore {
+		t.Errorf("HasMore = true, want false")
+	}
+	if got.NextCursor != "" {
+		t.Errorf("NextCursor = %q, want empty", got.NextCursor)
+	}
+}
+
+// TestSearch_HasMoreFalse_ExactlyLimit: repository が limit 件ジャストを返したら
+// HasMore=false（次ページなし）。
+func TestSearch_HasMoreFalse_ExactlyLimit(t *testing.T) {
+	// Arrange
+	base := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	repo := &mockItemSearchRepo{returnHits: makeHits(base, 10)} // limit=10 にぴったり
+	subRepo := &mockSubRepo{}
+	svc := NewSearchService(repo, subRepo)
+	// Act
+	got, err := svc.Search(context.Background(), "user-1", "hello", nil, "", 10)
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Items) != 10 {
+		t.Errorf("len(Items) = %d, want 10", len(got.Items))
+	}
+	if got.HasMore {
+		t.Errorf("HasMore = true, want false")
+	}
+	if got.NextCursor != "" {
+		t.Errorf("NextCursor = %q, want empty", got.NextCursor)
+	}
+}
+
+// TestSearch_HasMoreTrue_ZeroPublishedAt: HasMore=true でも末尾項目の PublishedAt が
+// ゼロ値なら NextCursor は空文字（並びの安定性が保てないため）。
+func TestSearch_HasMoreTrue_ZeroPublishedAt(t *testing.T) {
+	// Arrange
+	hits := []model.ItemSearchHit{
+		{ID: "item-1", PublishedAt: time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)},
+		{ID: "item-2", PublishedAt: time.Time{}}, // 末尾がゼロ
+		{ID: "item-3", PublishedAt: time.Time{}}, // 余分（HasMore=true 誘発）
+	}
+	repo := &mockItemSearchRepo{returnHits: hits}
+	subRepo := &mockSubRepo{}
+	svc := NewSearchService(repo, subRepo)
+	// Act
+	got, err := svc.Search(context.Background(), "user-1", "hello", nil, "", 2)
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.HasMore {
+		t.Errorf("HasMore = false, want true")
+	}
+	if got.NextCursor != "" {
+		t.Errorf("NextCursor = %q, want empty (zero PublishedAt at tail)", got.NextCursor)
+	}
+	if len(got.Items) != 2 {
+		t.Errorf("len(Items) = %d, want 2", len(got.Items))
+	}
+}
+
+// TestSearch_RepoError: repository がエラーを返したらそのまま返る（wrap しない）。
+func TestSearch_RepoError(t *testing.T) {
+	// Arrange
+	sentinel := errors.New("db lookup failed")
+	repo := &mockItemSearchRepo{returnErr: sentinel}
+	subRepo := &mockSubRepo{}
+	svc := NewSearchService(repo, subRepo)
+	// Act
+	_, err := svc.Search(context.Background(), "user-1", "hello", nil, "", 10)
+	// Assert
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel, got %v", err)
+	}
+}
+
+// TestSearch_HitsConvertedToSummaries: ItemSearchHit の各フィールドが ItemSearchSummary に
+// 正しくマッピングされる。FaviconURL は nil（Adapter 層の責務）であり、FaviconData /
+// FaviconMime が pass-through される。
+func TestSearch_HitsConvertedToSummaries(t *testing.T) {
+	// Arrange
+	publishedAt := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	hit := model.ItemSearchHit{
+		ID:              "item-x",
+		FeedID:          "feed-x",
+		FeedTitle:       "Feed X",
+		FaviconData:     []byte{0x01, 0x02, 0x03},
+		FaviconMime:     "image/png",
+		Title:           "Sample Title",
+		Link:            "https://example.com/x",
+		Summary:         "Sample Summary",
+		PublishedAt:     publishedAt,
+		IsDateEstimated: true,
+		IsRead:          true,
+		IsStarred:       true,
+		HatebuCount:     42,
+	}
+	repo := &mockItemSearchRepo{returnHits: []model.ItemSearchHit{hit}}
+	subRepo := &mockSubRepo{}
+	svc := NewSearchService(repo, subRepo)
+	// Act
+	got, err := svc.Search(context.Background(), "user-1", "sample", nil, "", 10)
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("len(Items) = %d, want 1", len(got.Items))
+	}
+	want := ItemSearchSummary{
+		ID:              "item-x",
+		FeedID:          "feed-x",
+		FeedTitle:       "Feed X",
+		FaviconURL:      nil,
+		FaviconData:     []byte{0x01, 0x02, 0x03},
+		FaviconMime:     "image/png",
+		Title:           "Sample Title",
+		Link:            "https://example.com/x",
+		Summary:         "Sample Summary",
+		PublishedAt:     publishedAt,
+		IsDateEstimated: true,
+		IsRead:          true,
+		IsStarred:       true,
+		HatebuCount:     42,
+	}
+	if !reflect.DeepEqual(got.Items[0], want) {
+		t.Errorf("Items[0] = %+v, want %+v", got.Items[0], want)
+	}
+}
+
+// TestSearch_UserIDPropagated: userID が repository に伝搬する。
+func TestSearch_UserIDPropagated(t *testing.T) {
+	// Arrange
+	repo := &mockItemSearchRepo{returnHits: nil}
+	subRepo := &mockSubRepo{}
+	svc := NewSearchService(repo, subRepo)
+	// Act
+	_, err := svc.Search(context.Background(), "user-xyz", "hello", nil, "", 10)
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.calls[0].userID != "user-xyz" {
+		t.Errorf("userID = %q, want %q", repo.calls[0].userID, "user-xyz")
+	}
+}

--- a/internal/model/errors.go
+++ b/internal/model/errors.go
@@ -31,6 +31,8 @@ const (
 	ErrCodeInvalidFetchInterval  = "INVALID_FETCH_INTERVAL"
 	ErrCodeFeedNotStopped        = "FEED_NOT_STOPPED"
 	ErrCodeUserNotFound          = "USER_NOT_FOUND"
+	ErrCodeInvalidSearchQuery    = "INVALID_SEARCH_QUERY"
+	ErrCodeFeedNotSubscribed     = "FEED_NOT_SUBSCRIBED"
 )
 
 // NewItemNotFoundError は記事未検出エラーを生成する。
@@ -160,5 +162,29 @@ func NewUserNotFoundError() *APIError {
 		Message:  "ユーザーが見つかりません。",
 		Category: "auth",
 		Action:   "ログインし直してください。",
+	}
+}
+
+// NewInvalidSearchQueryError は記事検索のクエリパラメータが不正な場合のエラーを生成する。
+// reason には cursor 形式不正 / feed_id UUID パース失敗 / クエリ長超過などの具体的な
+// 原因を渡す。Category は "validation" であり、handler 層で 400 BadRequest に変換される。
+func NewInvalidSearchQueryError(reason string) *APIError {
+	return &APIError{
+		Code:     ErrCodeInvalidSearchQuery,
+		Message:  fmt.Sprintf("検索クエリが無効です: %s", reason),
+		Category: "validation",
+		Action:   "検索キーワードや検索条件を見直してください。",
+	}
+}
+
+// NewFeedNotSubscribedError は記事検索の feed_id 指定先を当該ユーザーが
+// 購読していない場合のエラーを生成する。Category は "authorization" であり、
+// handler 層で 403 Forbidden に変換される。
+func NewFeedNotSubscribedError(feedID string) *APIError {
+	return &APIError{
+		Code:     ErrCodeFeedNotSubscribed,
+		Message:  fmt.Sprintf("指定されたフィードを購読していません: %s", feedID),
+		Category: "authorization",
+		Action:   "購読中のフィードを指定するか、横断検索を利用してください。",
 	}
 }

--- a/internal/model/errors_test.go
+++ b/internal/model/errors_test.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNewInvalidSearchQueryError は記事検索クエリ不正エラーが
+// Code / Category / Message の各フィールドを期待どおりに設定することを検証する
+// （Issue #120 Task 2.2 / Req 3.3）。
+func TestNewInvalidSearchQueryError(t *testing.T) {
+	t.Run("reason が message に埋め込まれ Category が validation のとき", func(t *testing.T) {
+		// Arrange
+		reason := "cursor のフォーマットが不正です"
+
+		// Act
+		err := NewInvalidSearchQueryError(reason)
+
+		// Assert
+		if err == nil {
+			t.Fatal("NewInvalidSearchQueryError が nil を返した")
+		}
+		if err.Code != ErrCodeInvalidSearchQuery {
+			t.Errorf("Code = %q, want %q", err.Code, ErrCodeInvalidSearchQuery)
+		}
+		if err.Code != "INVALID_SEARCH_QUERY" {
+			t.Errorf("Code リテラル = %q, want %q", err.Code, "INVALID_SEARCH_QUERY")
+		}
+		if err.Category != "validation" {
+			t.Errorf("Category = %q, want %q", err.Category, "validation")
+		}
+		if !strings.Contains(err.Message, reason) {
+			t.Errorf("Message に reason が埋め込まれていない: %q (reason=%q)", err.Message, reason)
+		}
+		if err.Action == "" {
+			t.Error("Action が空である（ユーザー向け対処方法が必要）")
+		}
+	})
+}
+
+// TestNewFeedNotSubscribedError はフィード未購読エラーが
+// Code / Category / Message の各フィールドを期待どおりに設定することを検証する
+// （Issue #120 Task 2.2 / Req 3.5）。
+func TestNewFeedNotSubscribedError(t *testing.T) {
+	t.Run("feedID が message に埋め込まれ Category が authorization のとき", func(t *testing.T) {
+		// Arrange
+		feedID := "00000000-0000-0000-0000-000000000001"
+
+		// Act
+		err := NewFeedNotSubscribedError(feedID)
+
+		// Assert
+		if err == nil {
+			t.Fatal("NewFeedNotSubscribedError が nil を返した")
+		}
+		if err.Code != ErrCodeFeedNotSubscribed {
+			t.Errorf("Code = %q, want %q", err.Code, ErrCodeFeedNotSubscribed)
+		}
+		if err.Code != "FEED_NOT_SUBSCRIBED" {
+			t.Errorf("Code リテラル = %q, want %q", err.Code, "FEED_NOT_SUBSCRIBED")
+		}
+		if err.Category != "authorization" {
+			t.Errorf("Category = %q, want %q", err.Category, "authorization")
+		}
+		if !strings.Contains(err.Message, feedID) {
+			t.Errorf("Message に feedID が埋め込まれていない: %q (feedID=%q)", err.Message, feedID)
+		}
+		if err.Action == "" {
+			t.Error("Action が空である（ユーザー向け対処方法が必要）")
+		}
+	})
+}

--- a/internal/model/item.go
+++ b/internal/model/item.go
@@ -31,6 +31,30 @@ type ItemWithState struct {
 	IsStarred bool
 }
 
+// ItemSearchHit は記事検索結果 1 件の DB レベル射影を表すモデル。
+// items を subscriptions / feeds / item_states と JOIN した SELECT 結果を保持し、
+// 検索結果カードに必要な記事サマリ・所属フィードのタイトル・favicon の生バイトと
+// MIME タイプ・ユーザー固有の既読 / スター状態をまとめて運ぶ。
+//
+// サービス層でアプリケーション向けの表現（例: favicon を data URL に整形した
+// ItemSearchSummary）へ変換する前段の生データを担うのが本構造体の責務であり、
+// 既存 ItemWithState と同様にリポジトリ層が直接生成して返す。
+type ItemSearchHit struct {
+	ID              string
+	FeedID          string
+	FeedTitle       string
+	FaviconData     []byte
+	FaviconMime     string
+	Title           string
+	Link            string
+	Summary         string // サニタイズ済みの概要テキスト
+	PublishedAt     time.Time
+	IsDateEstimated bool
+	IsRead          bool
+	IsStarred       bool
+	HatebuCount     int
+}
+
 // ItemFilter は記事一覧のフィルタ種別を表す。
 type ItemFilter string
 

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -156,6 +156,32 @@ type ExistingItems struct {
 	ByContentHash map[string]*model.Item
 }
 
+// ItemSearchRepository は記事検索向けの DB アクセス（横断検索 / フィード内検索の両モード）を提供する。
+// 既存 ItemRepository とは別インターフェースとして公開し、検索専用の射影モデル
+// model.ItemSearchHit を直接返す。実装上は PostgresItemRepo にメソッドを追加することで
+// 単一の DB ハンドルを共有する。
+type ItemSearchRepository interface {
+	// SearchByUserAndKeyword は当該ユーザーが購読中のフィードに属する記事から、
+	// title または content がキーワードに部分一致するものを取得する。
+	//
+	// feedID が nil の場合は横断検索（購読中フィード全体）、非 nil の場合は当該フィードに
+	// 限定したフィード内検索を行う。pattern は ILIKE に渡す '%escaped%' 形式の文字列を
+	// 呼び出し側で組み立てて渡す（LIKE メタ文字 %, _, \ のエスケープ責務は呼び出し側）。
+	//
+	// cursorPublishedAt がゼロ値の場合はカーソル条件を WHERE から外し先頭から取得する。
+	// 非ゼロ値の場合は (published_at, id) < (cursorPublishedAt, cursorID) のタプル比較で
+	// 安定したページネーションを行う。limit は実取得件数（HasMore 判定は呼び出し側で
+	// limit+1 件取得して行うため、本メソッドはその件数をそのまま LIMIT に適用する）。
+	SearchByUserAndKeyword(
+		ctx context.Context,
+		userID, pattern string,
+		feedID *string,
+		cursorID string,
+		cursorPublishedAt time.Time,
+		limit int,
+	) ([]model.ItemSearchHit, error)
+}
+
 // HatebuItemRepository ははてなブックマーク取得に必要な記事データ操作のインターフェース。
 type HatebuItemRepository interface {
 	// ListNeedingHatebuFetch ははてなブックマーク数の取得が必要な記事を取得する。

--- a/internal/repository/postgres_item_repo.go
+++ b/internal/repository/postgres_item_repo.go
@@ -628,18 +628,112 @@ func bulkUpdateItems(ctx context.Context, tx *sql.Tx, items []*model.Item) error
 	return nil
 }
 
-// SearchByUserAndKeyword は記事検索を実行する。
-// 本実装は Task 3.2 で SQL 本体を実装する。本コミットでは ItemSearchRepository
-// インターフェース充足のためのスタブとして配置する。
+// SearchByUserAndKeyword は当該ユーザーが購読中のフィードに属する記事から
+// title または content がキーワードに部分一致するものを取得する。
+//
+// feedID が nil の場合は横断検索（購読中フィード全体）、非 nil の場合は
+// 当該フィードのみのフィード内検索を行う（SQL 上は `$3::uuid IS NULL` ガードで
+// 同一クエリ内で両モードを表現する）。pattern は ILIKE に渡す '%escaped%'
+// 形式を呼び出し側で組み立てる前提。
+//
+// cursorPublishedAt がゼロ値のときはカーソル条件を WHERE から外し先頭から取得する
+// （`$4::timestamptz IS NULL` ガードで実現）。非ゼロ値時は
+// (published_at, id) < (cursor) のタプル比較で安定したページネーションを行う。
+//
+// 本実装は SELECT 専用であり items / item_states / feeds / subscriptions に
+// UPDATE / INSERT を一切行わない（Req 5.3 の不変条件）。
 func (r *PostgresItemRepo) SearchByUserAndKeyword(
-	_ context.Context,
-	_, _ string,
-	_ *string,
-	_ string,
-	_ time.Time,
-	_ int,
+	ctx context.Context,
+	userID, pattern string,
+	feedID *string,
+	cursorID string,
+	cursorPublishedAt time.Time,
+	limit int,
 ) ([]model.ItemSearchHit, error) {
-	return nil, fmt.Errorf("SearchByUserAndKeyword は未実装です")
+	// $3 (feed_id): feedID == nil なら NULL、非 nil なら *feedID。
+	// SQL 側の `$3::uuid IS NULL OR i.feed_id = $3` ガードで横断 / フィード内を切り替える。
+	var feedIDArg interface{}
+	if feedID != nil {
+		feedIDArg = *feedID
+	} else {
+		feedIDArg = nil
+	}
+
+	// $4 (cursor published_at) / $5 (cursor id): cursorPublishedAt がゼロ値なら NULL。
+	// SQL 側の `$4::timestamptz IS NULL` ガードでカーソル条件を WHERE から外す。
+	var cursorPublishedAtArg interface{}
+	var cursorIDArg interface{}
+	if !cursorPublishedAt.IsZero() {
+		cursorPublishedAtArg = cursorPublishedAt
+		cursorIDArg = cursorID
+	} else {
+		cursorPublishedAtArg = nil
+		cursorIDArg = nil
+	}
+
+	const query = `
+		SELECT
+		    i.id, i.feed_id, i.title, i.link, i.summary,
+		    i.published_at, i.is_date_estimated, i.hatebu_count,
+		    f.title AS feed_title,
+		    f.favicon_data, f.favicon_mime,
+		    COALESCE(st.is_read, false)   AS is_read,
+		    COALESCE(st.is_starred, false) AS is_starred
+		FROM items i
+		JOIN subscriptions s
+		    ON s.feed_id = i.feed_id
+		   AND s.user_id = $1
+		JOIN feeds f
+		    ON f.id = i.feed_id
+		LEFT JOIN item_states st
+		    ON st.item_id = i.id
+		   AND st.user_id = $1
+		WHERE (i.title ILIKE $2 OR i.content ILIKE $2)
+		  AND ($3::uuid IS NULL OR i.feed_id = $3)
+		  AND ($4::timestamptz IS NULL
+		       OR (i.published_at, i.id) < ($4, $5::uuid))
+		ORDER BY i.published_at DESC NULLS LAST, i.id DESC
+		LIMIT $6`
+
+	rows, err := r.db.QueryContext(ctx, query,
+		userID, pattern, feedIDArg, cursorPublishedAtArg, cursorIDArg, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("記事検索の取得に失敗しました: %w", err)
+	}
+	defer rows.Close()
+
+	var hits []model.ItemSearchHit
+	for rows.Next() {
+		var hit model.ItemSearchHit
+		var link, summary, faviconMime sql.NullString
+		var publishedAt sql.NullTime
+
+		if err := rows.Scan(
+			&hit.ID, &hit.FeedID, &hit.Title, &link, &summary,
+			&publishedAt, &hit.IsDateEstimated, &hit.HatebuCount,
+			&hit.FeedTitle,
+			&hit.FaviconData, &faviconMime,
+			&hit.IsRead, &hit.IsStarred,
+		); err != nil {
+			return nil, fmt.Errorf("記事検索結果の走査に失敗しました: %w", err)
+		}
+
+		hit.Link = nullStringValue(link)
+		hit.Summary = nullStringValue(summary)
+		hit.FaviconMime = nullStringValue(faviconMime)
+		// items.published_at は NULLABLE。NULL の場合はゼロ値 time.Time{} を保持する。
+		if publishedAt.Valid {
+			hit.PublishedAt = publishedAt.Time
+		}
+
+		hits = append(hits, hit)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("記事検索結果の走査に失敗しました: %w", err)
+	}
+
+	return hits, nil
 }
 
 // compile-time interface check

--- a/internal/repository/postgres_item_repo.go
+++ b/internal/repository/postgres_item_repo.go
@@ -628,6 +628,21 @@ func bulkUpdateItems(ctx context.Context, tx *sql.Tx, items []*model.Item) error
 	return nil
 }
 
+// SearchByUserAndKeyword は記事検索を実行する。
+// 本実装は Task 3.2 で SQL 本体を実装する。本コミットでは ItemSearchRepository
+// インターフェース充足のためのスタブとして配置する。
+func (r *PostgresItemRepo) SearchByUserAndKeyword(
+	_ context.Context,
+	_, _ string,
+	_ *string,
+	_ string,
+	_ time.Time,
+	_ int,
+) ([]model.ItemSearchHit, error) {
+	return nil, fmt.Errorf("SearchByUserAndKeyword は未実装です")
+}
+
 // compile-time interface check
 var _ ItemRepository = (*PostgresItemRepo)(nil)
 var _ HatebuItemRepository = (*PostgresItemRepo)(nil)
+var _ ItemSearchRepository = (*PostgresItemRepo)(nil)

--- a/internal/repository/postgres_item_repo_search_test.go
+++ b/internal/repository/postgres_item_repo_search_test.go
@@ -1,0 +1,466 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"github.com/hitoshi/feedman/internal/database"
+)
+
+// このファイルは PostgresItemRepo.SearchByUserAndKeyword の DB 結合テスト。
+// 環境変数 TEST_DATABASE_URL が設定されていればそれを使用し、未設定の場合は
+// docker-compose 上の PostgreSQL を想定したデフォルト値を使う。
+// DB へ接続できない環境では t.Skip でスキップされ、CI（DB を起動しない）では実行されない。
+// この Skip ガードの慣習は postgres_subscription_repo_db_test.go と統一している。
+
+// searchTestDatabaseURL はテスト用のデータベース URL を返す。
+func searchTestDatabaseURL() string {
+	if url := os.Getenv("TEST_DATABASE_URL"); url != "" {
+		return url
+	}
+	return "postgres://feedman:feedman@localhost:5432/feedman_test?sslmode=disable"
+}
+
+// setupItemSearchTestDB はテスト用データベースを準備し、マイグレーション適用済みの
+// *sql.DB を返す。DB へ接続できない場合は t.Skip でテストをスキップする。
+func setupItemSearchTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dbURL := searchTestDatabaseURL()
+
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		t.Fatalf("データベースへの接続に失敗: %v", err)
+	}
+
+	if err := db.Ping(); err != nil {
+		db.Close()
+		t.Skipf("テスト用データベースに接続できません（スキップ）: %v", err)
+	}
+
+	cleanupSQL := `
+		DROP TABLE IF EXISTS sessions CASCADE;
+		DROP TABLE IF EXISTS user_settings CASCADE;
+		DROP TABLE IF EXISTS item_states CASCADE;
+		DROP TABLE IF EXISTS subscriptions CASCADE;
+		DROP TABLE IF EXISTS items CASCADE;
+		DROP TABLE IF EXISTS feeds CASCADE;
+		DROP TABLE IF EXISTS identities CASCADE;
+		DROP TABLE IF EXISTS users CASCADE;
+		DROP TABLE IF EXISTS schema_migrations CASCADE;
+	`
+	if _, err := db.Exec(cleanupSQL); err != nil {
+		db.Close()
+		t.Fatalf("クリーンアップに失敗: %v", err)
+	}
+
+	if err := database.RunMigrations(dbURL); err != nil {
+		db.Close()
+		t.Fatalf("マイグレーション実行に失敗: %v", err)
+	}
+
+	return db
+}
+
+// insertTestUserForSearch はテスト用ユーザーを作成し、その ID を返す。
+func insertTestUserForSearch(t *testing.T, db *sql.DB, email string) string {
+	t.Helper()
+	var userID string
+	err := db.QueryRow(
+		`INSERT INTO users (email, name) VALUES ($1, $2) RETURNING id`,
+		email, "Test User",
+	).Scan(&userID)
+	if err != nil {
+		t.Fatalf("ユーザー挿入に失敗: %v", err)
+	}
+	return userID
+}
+
+// insertTestFeedForSearch はテスト用フィードを作成し、その ID を返す。
+func insertTestFeedForSearch(t *testing.T, db *sql.DB, feedURL, title string) string {
+	t.Helper()
+	var feedID string
+	err := db.QueryRow(
+		`INSERT INTO feeds (feed_url, title) VALUES ($1, $2) RETURNING id`,
+		feedURL, title,
+	).Scan(&feedID)
+	if err != nil {
+		t.Fatalf("フィード挿入に失敗: %v", err)
+	}
+	return feedID
+}
+
+// insertTestSubscriptionForSearch はテスト用購読を作成する。
+func insertTestSubscriptionForSearch(t *testing.T, db *sql.DB, userID, feedID string) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO subscriptions (user_id, feed_id) VALUES ($1, $2)`,
+		userID, feedID,
+	)
+	if err != nil {
+		t.Fatalf("購読挿入に失敗: %v", err)
+	}
+}
+
+// insertTestItem はテスト用記事を作成し、その ID を返す。
+// title / content / publishedAt はテストごとに任意に指定可能。
+// publishedAt にゼロ値を渡した場合は NULL として挿入する。
+func insertTestItem(t *testing.T, db *sql.DB, feedID, title, content string, publishedAt time.Time) string {
+	t.Helper()
+	var itemID string
+	var publishedAtArg interface{}
+	if !publishedAt.IsZero() {
+		publishedAtArg = publishedAt
+	} else {
+		publishedAtArg = nil
+	}
+	err := db.QueryRow(
+		`INSERT INTO items (feed_id, title, content, published_at)
+		 VALUES ($1, $2, $3, $4) RETURNING id`,
+		feedID, title, content, publishedAtArg,
+	).Scan(&itemID)
+	if err != nil {
+		t.Fatalf("記事挿入に失敗: %v", err)
+	}
+	return itemID
+}
+
+// insertTestItemState はテスト用記事状態を作成する。
+func insertTestItemState(t *testing.T, db *sql.DB, userID, itemID string, isRead, isStarred bool) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO item_states (user_id, item_id, is_read, is_starred)
+		 VALUES ($1, $2, $3, $4)`,
+		userID, itemID, isRead, isStarred,
+	)
+	if err != nil {
+		t.Fatalf("記事状態挿入に失敗: %v", err)
+	}
+}
+
+// TestSearchByUserAndKeyword は PostgresItemRepo.SearchByUserAndKeyword の
+// AC（Req 2.1, 2.2, 2.3, 2.4, 2.6, 3.1, 3.2, 3.4, 4.1, 5.3）を網羅する DB 結合テスト。
+func TestSearchByUserAndKeyword(t *testing.T) {
+	db := setupItemSearchTestDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	repo := NewPostgresItemRepo(db)
+
+	// Req 2.3: title がキーワードに部分一致する記事が返る
+	t.Run("タイトル一致のとき記事が返る", func(t *testing.T) {
+		userID := insertTestUserForSearch(t, db, "title-match@test.com")
+		feedID := insertTestFeedForSearch(t, db, "https://example.com/title-match.xml", "Feed A")
+		insertTestSubscriptionForSearch(t, db, userID, feedID)
+
+		now := time.Now().UTC().Truncate(time.Second)
+		itemID := insertTestItem(t, db, feedID, "Golang Tutorial", "Some unrelated content", now)
+
+		pattern := "%Golang%"
+		hits, err := repo.SearchByUserAndKeyword(ctx, userID, pattern, nil, "", time.Time{}, 100)
+		if err != nil {
+			t.Fatalf("SearchByUserAndKeyword がエラーを返した: %v", err)
+		}
+
+		if len(hits) != 1 {
+			t.Fatalf("検索ヒット件数が不正: got %d, want 1", len(hits))
+		}
+		if hits[0].ID != itemID {
+			t.Errorf("ヒットした記事 ID が不正: got %q, want %q", hits[0].ID, itemID)
+		}
+		if hits[0].FeedTitle != "Feed A" {
+			t.Errorf("FeedTitle が不正: got %q, want %q", hits[0].FeedTitle, "Feed A")
+		}
+	})
+
+	// Req 2.3: content がキーワードに部分一致する記事が返る
+	t.Run("本文一致のとき記事が返る", func(t *testing.T) {
+		userID := insertTestUserForSearch(t, db, "content-match@test.com")
+		feedID := insertTestFeedForSearch(t, db, "https://example.com/content-match.xml", "Feed B")
+		insertTestSubscriptionForSearch(t, db, userID, feedID)
+
+		now := time.Now().UTC().Truncate(time.Second)
+		itemID := insertTestItem(t, db, feedID, "Some unrelated title", "Body talks about Rust language", now)
+
+		pattern := "%Rust%"
+		hits, err := repo.SearchByUserAndKeyword(ctx, userID, pattern, nil, "", time.Time{}, 100)
+		if err != nil {
+			t.Fatalf("SearchByUserAndKeyword がエラーを返した: %v", err)
+		}
+
+		if len(hits) != 1 {
+			t.Fatalf("検索ヒット件数が不正: got %d, want 1", len(hits))
+		}
+		if hits[0].ID != itemID {
+			t.Errorf("ヒットした記事 ID が不正: got %q, want %q", hits[0].ID, itemID)
+		}
+	})
+
+	// Req 2.3: title と content の両方が一致しても重複せず 1 件のみ返る
+	t.Run("タイトルと本文の両方が一致するとき1件のみ返る", func(t *testing.T) {
+		userID := insertTestUserForSearch(t, db, "both-match@test.com")
+		feedID := insertTestFeedForSearch(t, db, "https://example.com/both-match.xml", "Feed C")
+		insertTestSubscriptionForSearch(t, db, userID, feedID)
+
+		now := time.Now().UTC().Truncate(time.Second)
+		itemID := insertTestItem(t, db, feedID, "Kotlin overview", "Kotlin is JVM language", now)
+
+		pattern := "%Kotlin%"
+		hits, err := repo.SearchByUserAndKeyword(ctx, userID, pattern, nil, "", time.Time{}, 100)
+		if err != nil {
+			t.Fatalf("SearchByUserAndKeyword がエラーを返した: %v", err)
+		}
+
+		if len(hits) != 1 {
+			t.Fatalf("検索ヒット件数が不正（重複している可能性）: got %d, want 1", len(hits))
+		}
+		if hits[0].ID != itemID {
+			t.Errorf("ヒットした記事 ID が不正: got %q, want %q", hits[0].ID, itemID)
+		}
+	})
+
+	// Req 2.3: title / content のいずれにも一致しない記事は返らない
+	t.Run("タイトルにも本文にも一致しないとき記事は返らない", func(t *testing.T) {
+		userID := insertTestUserForSearch(t, db, "no-match@test.com")
+		feedID := insertTestFeedForSearch(t, db, "https://example.com/no-match.xml", "Feed D")
+		insertTestSubscriptionForSearch(t, db, userID, feedID)
+
+		now := time.Now().UTC().Truncate(time.Second)
+		insertTestItem(t, db, feedID, "Title talks about cats", "Content talks about dogs", now)
+
+		pattern := "%elephants%"
+		hits, err := repo.SearchByUserAndKeyword(ctx, userID, pattern, nil, "", time.Time{}, 100)
+		if err != nil {
+			t.Fatalf("SearchByUserAndKeyword がエラーを返した: %v", err)
+		}
+
+		if len(hits) != 0 {
+			t.Fatalf("不一致時にも記事が返却された: got %d, want 0", len(hits))
+		}
+	})
+
+	// Req 2.6: ILIKE による大文字小文字区別なしの部分一致
+	t.Run("大文字小文字が異なるとき部分一致する", func(t *testing.T) {
+		userID := insertTestUserForSearch(t, db, "case-insensitive@test.com")
+		feedID := insertTestFeedForSearch(t, db, "https://example.com/case.xml", "Feed E")
+		insertTestSubscriptionForSearch(t, db, userID, feedID)
+
+		now := time.Now().UTC().Truncate(time.Second)
+		// 記事は小文字、検索は大文字
+		itemID := insertTestItem(t, db, feedID, "introduction to typescript", "details here", now)
+
+		pattern := "%TYPESCRIPT%"
+		hits, err := repo.SearchByUserAndKeyword(ctx, userID, pattern, nil, "", time.Time{}, 100)
+		if err != nil {
+			t.Fatalf("SearchByUserAndKeyword がエラーを返した: %v", err)
+		}
+
+		if len(hits) != 1 {
+			t.Fatalf("ILIKE 大文字小文字区別なし部分一致がヒットしない: got %d, want 1", len(hits))
+		}
+		if hits[0].ID != itemID {
+			t.Errorf("ヒットした記事 ID が不正: got %q, want %q", hits[0].ID, itemID)
+		}
+	})
+
+	// Req 3.1 / 3.2: 他ユーザーの購読記事は返らない（クロスユーザー隔離）
+	t.Run("他ユーザーの購読記事は返らない", func(t *testing.T) {
+		userA := insertTestUserForSearch(t, db, "user-a@test.com")
+		userB := insertTestUserForSearch(t, db, "user-b@test.com")
+		feedID := insertTestFeedForSearch(t, db, "https://example.com/cross-user.xml", "Feed F")
+		// user A のみが購読
+		insertTestSubscriptionForSearch(t, db, userA, feedID)
+
+		now := time.Now().UTC().Truncate(time.Second)
+		insertTestItem(t, db, feedID, "Python tips", "About Python", now)
+
+		pattern := "%Python%"
+		// user B（購読していない）で検索 → 0 件
+		hits, err := repo.SearchByUserAndKeyword(ctx, userB, pattern, nil, "", time.Time{}, 100)
+		if err != nil {
+			t.Fatalf("SearchByUserAndKeyword がエラーを返した: %v", err)
+		}
+
+		if len(hits) != 0 {
+			t.Fatalf("他ユーザーが購読中のフィードの記事が返却された: got %d, want 0", len(hits))
+		}
+	})
+
+	// Req 3.4: 購読解除済みフィードの記事は返らない
+	t.Run("購読解除済みフィードの記事は返らない", func(t *testing.T) {
+		userID := insertTestUserForSearch(t, db, "unsubscribed@test.com")
+		feedID := insertTestFeedForSearch(t, db, "https://example.com/unsubscribed.xml", "Feed G")
+		// subscriptions レコードを作らない（あるいは作ってすぐ削除する）→ ここでは作らない
+		// = 「過去に購読していたが現在は購読していない」のと同等の状態
+		now := time.Now().UTC().Truncate(time.Second)
+		insertTestItem(t, db, feedID, "Ruby on Rails", "Web framework", now)
+
+		pattern := "%Rails%"
+		hits, err := repo.SearchByUserAndKeyword(ctx, userID, pattern, nil, "", time.Time{}, 100)
+		if err != nil {
+			t.Fatalf("SearchByUserAndKeyword がエラーを返した: %v", err)
+		}
+
+		if len(hits) != 0 {
+			t.Fatalf("購読していないフィードの記事が返却された: got %d, want 0", len(hits))
+		}
+	})
+
+	// Req 2.4: 同 published_at の記事は id DESC で安定したソート順
+	t.Run("同publishedAtのとき id DESC で安定したソート順を返す", func(t *testing.T) {
+		userID := insertTestUserForSearch(t, db, "stable-sort@test.com")
+		feedID := insertTestFeedForSearch(t, db, "https://example.com/stable-sort.xml", "Feed H")
+		insertTestSubscriptionForSearch(t, db, userID, feedID)
+
+		samePublishedAt := time.Now().UTC().Truncate(time.Second)
+		itemID1 := insertTestItem(t, db, feedID, "Stable sort post 1", "matchme content", samePublishedAt)
+		itemID2 := insertTestItem(t, db, feedID, "Stable sort post 2", "matchme content", samePublishedAt)
+
+		pattern := "%matchme%"
+		hits, err := repo.SearchByUserAndKeyword(ctx, userID, pattern, nil, "", time.Time{}, 100)
+		if err != nil {
+			t.Fatalf("SearchByUserAndKeyword がエラーを返した: %v", err)
+		}
+
+		if len(hits) != 2 {
+			t.Fatalf("検索ヒット件数が不正: got %d, want 2", len(hits))
+		}
+
+		// ORDER BY published_at DESC, id DESC のため、id が大きい方が先
+		var expectedFirst, expectedSecond string
+		if itemID1 > itemID2 {
+			expectedFirst, expectedSecond = itemID1, itemID2
+		} else {
+			expectedFirst, expectedSecond = itemID2, itemID1
+		}
+		if hits[0].ID != expectedFirst {
+			t.Errorf("ソート順が不正 (1番目): got %q, want %q", hits[0].ID, expectedFirst)
+		}
+		if hits[1].ID != expectedSecond {
+			t.Errorf("ソート順が不正 (2番目): got %q, want %q", hits[1].ID, expectedSecond)
+		}
+	})
+
+	// Req 2.2: feedID 指定時は当該フィードの記事のみ返る（他購読フィードは混入しない）
+	t.Run("feedID指定時は当該フィードの記事のみ返る", func(t *testing.T) {
+		userID := insertTestUserForSearch(t, db, "feed-scope@test.com")
+		feedIDA := insertTestFeedForSearch(t, db, "https://example.com/scope-a.xml", "Feed I-A")
+		feedIDB := insertTestFeedForSearch(t, db, "https://example.com/scope-b.xml", "Feed I-B")
+		insertTestSubscriptionForSearch(t, db, userID, feedIDA)
+		insertTestSubscriptionForSearch(t, db, userID, feedIDB)
+
+		now := time.Now().UTC().Truncate(time.Second)
+		itemA := insertTestItem(t, db, feedIDA, "Java basics", "Java content", now)
+		insertTestItem(t, db, feedIDB, "Java advanced", "Java content B", now)
+
+		pattern := "%Java%"
+		// feed A のみに絞り込み
+		hits, err := repo.SearchByUserAndKeyword(ctx, userID, pattern, &feedIDA, "", time.Time{}, 100)
+		if err != nil {
+			t.Fatalf("SearchByUserAndKeyword がエラーを返した: %v", err)
+		}
+
+		if len(hits) != 1 {
+			t.Fatalf("フィード内検索の件数が不正（他フィードが混入）: got %d, want 1", len(hits))
+		}
+		if hits[0].ID != itemA {
+			t.Errorf("フィード内検索でヒットした記事 ID が不正: got %q, want %q", hits[0].ID, itemA)
+		}
+		if hits[0].FeedID != feedIDA {
+			t.Errorf("フィード内検索でヒットした記事の FeedID が不正: got %q, want %q", hits[0].FeedID, feedIDA)
+		}
+	})
+
+	// Req 5.3: 検索実行前後で item_states / items が変化しないことを検証する
+	t.Run("検索実行前後で item_states と items が変化しない", func(t *testing.T) {
+		userID := insertTestUserForSearch(t, db, "invariant@test.com")
+		feedID := insertTestFeedForSearch(t, db, "https://example.com/invariant.xml", "Feed J")
+		insertTestSubscriptionForSearch(t, db, userID, feedID)
+
+		now := time.Now().UTC().Truncate(time.Second)
+		itemID := insertTestItem(t, db, feedID, "Invariant check title", "matchme body", now)
+		// item_states を明示的に挿入
+		insertTestItemState(t, db, userID, itemID, true, true)
+
+		// 検索前の state スナップショット
+		var beforeIsRead, beforeIsStarred bool
+		var beforeUpdatedAt time.Time
+		err := db.QueryRow(
+			`SELECT is_read, is_starred, updated_at FROM item_states WHERE user_id = $1 AND item_id = $2`,
+			userID, itemID,
+		).Scan(&beforeIsRead, &beforeIsStarred, &beforeUpdatedAt)
+		if err != nil {
+			t.Fatalf("検索前の item_states 取得に失敗: %v", err)
+		}
+
+		// 検索前の items スナップショット
+		var beforeItemUpdatedAt time.Time
+		var beforeHatebuCount int
+		err = db.QueryRow(
+			`SELECT updated_at, hatebu_count FROM items WHERE id = $1`,
+			itemID,
+		).Scan(&beforeItemUpdatedAt, &beforeHatebuCount)
+		if err != nil {
+			t.Fatalf("検索前の items 取得に失敗: %v", err)
+		}
+
+		pattern := "%matchme%"
+		hits, err := repo.SearchByUserAndKeyword(ctx, userID, pattern, nil, "", time.Time{}, 100)
+		if err != nil {
+			t.Fatalf("SearchByUserAndKeyword がエラーを返した: %v", err)
+		}
+		if len(hits) != 1 {
+			t.Fatalf("検索ヒット件数が不正: got %d, want 1", len(hits))
+		}
+		// 検索結果は state を反映する（既読 / スターが true）
+		if !hits[0].IsRead {
+			t.Errorf("検索結果 IsRead が状態を反映していない: got %v, want true", hits[0].IsRead)
+		}
+		if !hits[0].IsStarred {
+			t.Errorf("検索結果 IsStarred が状態を反映していない: got %v, want true", hits[0].IsStarred)
+		}
+
+		// 検索後の state スナップショット
+		var afterIsRead, afterIsStarred bool
+		var afterUpdatedAt time.Time
+		err = db.QueryRow(
+			`SELECT is_read, is_starred, updated_at FROM item_states WHERE user_id = $1 AND item_id = $2`,
+			userID, itemID,
+		).Scan(&afterIsRead, &afterIsStarred, &afterUpdatedAt)
+		if err != nil {
+			t.Fatalf("検索後の item_states 取得に失敗: %v", err)
+		}
+
+		if afterIsRead != beforeIsRead {
+			t.Errorf("検索により is_read が変化した: before=%v, after=%v", beforeIsRead, afterIsRead)
+		}
+		if afterIsStarred != beforeIsStarred {
+			t.Errorf("検索により is_starred が変化した: before=%v, after=%v", beforeIsStarred, afterIsStarred)
+		}
+		if !afterUpdatedAt.Equal(beforeUpdatedAt) {
+			t.Errorf("検索により item_states.updated_at が変化した: before=%v, after=%v", beforeUpdatedAt, afterUpdatedAt)
+		}
+
+		// 検索後の items スナップショット
+		var afterItemUpdatedAt time.Time
+		var afterHatebuCount int
+		err = db.QueryRow(
+			`SELECT updated_at, hatebu_count FROM items WHERE id = $1`,
+			itemID,
+		).Scan(&afterItemUpdatedAt, &afterHatebuCount)
+		if err != nil {
+			t.Fatalf("検索後の items 取得に失敗: %v", err)
+		}
+		if !afterItemUpdatedAt.Equal(beforeItemUpdatedAt) {
+			t.Errorf("検索により items.updated_at が変化した: before=%v, after=%v", beforeItemUpdatedAt, afterItemUpdatedAt)
+		}
+		if afterHatebuCount != beforeHatebuCount {
+			t.Errorf("検索により items.hatebu_count が変化した: before=%v, after=%v", beforeHatebuCount, afterHatebuCount)
+		}
+	})
+}

--- a/web/src/components/app-shell.test.tsx
+++ b/web/src/components/app-shell.test.tsx
@@ -88,6 +88,17 @@ function setupMockFetch() {
         }),
       });
     }
+    // 検索 API は本テストでは空結果を返す（SearchResults が空状態表示に倒れる）
+    if (typeof url === "string" && url.startsWith("/api/items/search")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          items: [],
+          next_cursor: null,
+          has_more: false,
+        }),
+      });
+    }
     return Promise.resolve({
       ok: true,
       json: async () => ({}),
@@ -156,5 +167,104 @@ describe("AppShell コンポーネント", () => {
     await waitFor(() => {
       expect(screen.getByText("Feedman")).toBeInTheDocument();
     });
+  });
+
+  it("ヘッダー領域に横断検索バー（HeaderSearchBar）が常設されること（Req 1.1）", async () => {
+    render(<AppShell />, { wrapper: createWrapper() });
+
+    // ヘッダー直下に検索バー（role="search"）が常設されている
+    await waitFor(() => {
+      expect(screen.getByTestId("header-search-bar")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("header-search-input")).toBeInTheDocument();
+  });
+
+  it("検索バーで Enter を押下すると右ペインの ItemList が SearchResults に切り替わること（Req 4.7）", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />, { wrapper: createWrapper() });
+
+    // 初期状態: ItemList の「フィードを選択してください」が表示される（フィード未選択時）
+    await waitFor(() => {
+      expect(
+        screen.getByText("フィードを選択してください")
+      ).toBeInTheDocument();
+    });
+
+    // ヘッダー検索バーで検索を実行
+    const input = screen.getByTestId("header-search-input");
+    await user.type(input, "typescript");
+    await user.keyboard("{Enter}");
+
+    // 右ペインが SearchResults に切り替わる（検索結果は空 → 空状態表示）
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("search-results-empty")
+      ).toBeInTheDocument();
+    });
+
+    // ItemList の「フィードを選択してください」案内は表示されなくなる
+    expect(
+      screen.queryByText("フィードを選択してください")
+    ).not.toBeInTheDocument();
+  });
+
+  it("CLEAR_SEARCH（クリアボタン押下）で右ペインが ItemList に戻ること（Req 1.6 / NFR 2.2）", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("header-search-input")).toBeInTheDocument();
+    });
+
+    // 検索を実行 → SearchResults に切り替わる
+    const input = screen.getByTestId("header-search-input");
+    await user.type(input, "kubernetes");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("search-results-empty")
+      ).toBeInTheDocument();
+    });
+
+    // クリアボタンを押下 → ItemList に戻る
+    await user.click(screen.getByTestId("header-search-clear"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("フィードを選択してください")
+      ).toBeInTheDocument();
+    });
+
+    // SearchResults は表示されなくなる
+    expect(screen.queryByTestId("search-results-empty")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("search-results-loading")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("search-results")).not.toBeInTheDocument();
+  });
+
+  it("検索モード中はフィード選択メッセージが消え、検索結果コンテナが描画されること（Req 4.7）", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText("Tech Blog")).toBeInTheDocument();
+    });
+
+    // フィードを選択 → ItemList が表示される
+    await user.click(screen.getByText("Tech Blog"));
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
+    });
+
+    // ヘッダー検索バーで横断検索を実行 → 右ペインは SearchResults に切り替わる
+    const input = screen.getByTestId("header-search-input");
+    await user.type(input, "anything");
+    await user.keyboard("{Enter}");
+
+    // ItemList のフィルタタブは消え、SearchResults の空状態が表示される
+    await waitFor(() => {
+      expect(screen.getByTestId("search-results-empty")).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("tab", { name: "全て" })).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -4,8 +4,10 @@ import { useAppState, useAppDispatch } from "@/contexts/app-state";
 import { useFeeds } from "@/hooks/use-feeds";
 import { FeedList } from "@/components/feed-list";
 import { FeedRegisterDialog } from "@/components/feed-register-dialog";
+import { HeaderSearchBar } from "@/components/header-search-bar";
 import { ItemList } from "@/components/item-list";
 import { LogoutButton } from "@/components/logout-button";
+import { SearchResults } from "@/components/search-results";
 import { useTheme } from "@/components/theme-provider";
 import { Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -42,8 +44,10 @@ export function AppShell() {
   return (
     <div data-testid="app-shell" className="flex flex-col h-screen">
       {/* ヘッダー */}
-      <header className="flex items-center justify-between border-b px-4 py-2 flex-shrink-0">
+      <header className="flex items-center justify-between gap-3 border-b px-4 py-2 flex-shrink-0">
         <h1 className="text-lg font-bold">Feedman</h1>
+        {/* Req 1.1: 横断検索バーをヘッダー領域に常設する */}
+        <HeaderSearchBar />
         <div className="flex items-center gap-2">
           <ThemeToggle />
           <LogoutButton />
@@ -77,17 +81,19 @@ export function AppShell() {
           )}
         </aside>
 
-        {/* 右ペイン: 記事一覧 + 記事詳細 */}
+        {/* 右ペイン: 記事一覧 + 記事詳細（検索モード時は SearchResults に切り替わる / Req 4.7） */}
         <main data-testid="right-pane" className="flex-1 overflow-hidden">
           <div className="flex flex-col h-full">
-            <ItemList
-              feedId={state.selectedFeedId}
-              onSelectItem={handleSelectItem}
-              expandedItemId={state.expandedItemId}
-            />
-            {/* 記事詳細は ItemList 内の展開で表示する。
-                展開記事の詳細表示はItemDetailコンポーネントとして
-                ItemList配下で統合されるため、ここでは別途表示しない */}
+            {state.isSearching ? (
+              <SearchResults />
+            ) : (
+              <ItemList
+                feedId={state.selectedFeedId}
+                onSelectItem={handleSelectItem}
+                expandedItemId={state.expandedItemId}
+              />
+            )}
+            {/* 記事詳細は ItemList / SearchResults 内の展開で表示する */}
           </div>
         </main>
       </div>

--- a/web/src/components/feed-search-bar.test.tsx
+++ b/web/src/components/feed-search-bar.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import { useEffect, useState, type ReactNode } from "react";
+import { FeedSearchBar } from "./feed-search-bar";
+import {
+  AppStateProvider,
+  useAppState,
+  useAppDispatch,
+  type AppAction,
+} from "@/contexts/app-state";
+
+/**
+ * AppStateProvider 配下に FeedSearchBar をマウントし、初期 dispatch（フィード選択等）を
+ * 1 度だけ実行してから子をレンダするヘルパー。
+ */
+function renderWithInitialDispatch(
+  ui: ReactNode,
+  initialDispatch?: (dispatch: (action: AppAction) => void) => void
+) {
+  let observed: ReturnType<typeof useAppState> | null = null;
+  function Probe() {
+    const dispatch = useAppDispatch();
+    observed = useAppState();
+    const ready = useDispatchOnce(() => {
+      if (initialDispatch) initialDispatch(dispatch);
+    });
+    return ready ? <>{ui}</> : null;
+  }
+  const utils = render(
+    <AppStateProvider>
+      <Probe />
+    </AppStateProvider>
+  );
+  return {
+    ...utils,
+    getState: () => observed!,
+  };
+}
+
+function useDispatchOnce(fn: () => void): boolean {
+  const [done, setDone] = useState(false);
+  useEffect(() => {
+    fn();
+    setDone(true);
+    // 初回 mount のみ発火させる目的で deps を空配列に固定する
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return done;
+}
+
+describe("FeedSearchBar", () => {
+  it("フィード未選択時（selectedFeedId === null）は何も描画しないこと（NFR 2.3）", () => {
+    // 初期 dispatch なし = selectedFeedId が null のまま
+    render(
+      <AppStateProvider>
+        <FeedSearchBar />
+      </AppStateProvider>
+    );
+    expect(screen.queryByTestId("feed-search-bar")).toBeNull();
+    expect(screen.queryByTestId("feed-search-input")).toBeNull();
+  });
+
+  it("フィード選択時は検索バーがレンダされること（Req 1.2）", () => {
+    renderWithInitialDispatch(<FeedSearchBar />, (dispatch) => {
+      dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
+    });
+    expect(screen.getByTestId("feed-search-bar")).toBeInTheDocument();
+    expect(screen.getByTestId("feed-search-input")).toBeInTheDocument();
+  });
+
+  it("キーワード入力 + Enter で SET_SEARCH_QUERY（scope='feed', feedId）が dispatch されること（Req 1.4）", async () => {
+    const user = userEvent.setup();
+    const { getState } = renderWithInitialDispatch(
+      <FeedSearchBar />,
+      (dispatch) => {
+        dispatch({ type: "SELECT_FEED", feedId: "feed-99" });
+      }
+    );
+
+    const input = screen.getByTestId("feed-search-input");
+    await user.type(input, "kubernetes");
+    await user.keyboard("{Enter}");
+
+    const state = getState();
+    expect(state.searchQuery).toBe("kubernetes");
+    expect(state.isSearching).toBe(true);
+    expect(state.searchScope).toBe("feed");
+    expect(state.searchFeedId).toBe("feed-99");
+  });
+
+  it("空入力で Enter 押下しても dispatch されないこと（Req 1.5）", async () => {
+    const user = userEvent.setup();
+    const { getState } = renderWithInitialDispatch(
+      <FeedSearchBar />,
+      (dispatch) => {
+        dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
+      }
+    );
+
+    const input = screen.getByTestId("feed-search-input");
+    await user.click(input);
+    await user.keyboard("{Enter}");
+
+    const state = getState();
+    expect(state.searchQuery).toBe("");
+    expect(state.isSearching).toBe(false);
+  });
+
+  it("空白のみ Enter 押下も dispatch されないこと（Req 1.5 / 境界値）", async () => {
+    const user = userEvent.setup();
+    const { getState } = renderWithInitialDispatch(
+      <FeedSearchBar />,
+      (dispatch) => {
+        dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
+      }
+    );
+
+    const input = screen.getByTestId("feed-search-input");
+    await user.type(input, "   ");
+    await user.keyboard("{Enter}");
+
+    const state = getState();
+    expect(state.searchQuery).toBe("");
+    expect(state.isSearching).toBe(false);
+  });
+
+  it("入力に前後空白がある場合は trim された値で dispatch されること", async () => {
+    const user = userEvent.setup();
+    const { getState } = renderWithInitialDispatch(
+      <FeedSearchBar />,
+      (dispatch) => {
+        dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
+      }
+    );
+
+    const input = screen.getByTestId("feed-search-input");
+    await user.type(input, "  golang  ");
+    await user.keyboard("{Enter}");
+
+    const state = getState();
+    expect(state.searchQuery).toBe("golang");
+    expect(state.searchScope).toBe("feed");
+    expect(state.searchFeedId).toBe("feed-1");
+  });
+
+  it("クリアボタンは入力後にのみ表示され、押下で CLEAR_SEARCH が dispatch されること（Req 1.6）", async () => {
+    const user = userEvent.setup();
+    const { getState } = renderWithInitialDispatch(
+      <FeedSearchBar />,
+      (dispatch) => {
+        dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
+        dispatch({
+          type: "SET_SEARCH_QUERY",
+          query: "docker",
+          scope: "feed",
+          feedId: "feed-1",
+        });
+      }
+    );
+
+    // 検索中状態で render されたとき、ローカル入力欄に searchQuery が反映される
+    const input = screen.getByTestId(
+      "feed-search-input"
+    ) as HTMLInputElement;
+    expect(input.value).toBe("docker");
+    expect(getState().isSearching).toBe(true);
+
+    // クリアボタン押下
+    await user.click(screen.getByTestId("feed-search-clear"));
+
+    const state = getState();
+    expect(state.isSearching).toBe(false);
+    expect(state.searchQuery).toBe("");
+    expect(state.searchScope).toBe("global");
+    expect(state.searchFeedId).toBeNull();
+    expect(input.value).toBe("");
+  });
+
+  it("入力が空のときはクリアボタンが表示されないこと", () => {
+    renderWithInitialDispatch(<FeedSearchBar />, (dispatch) => {
+      dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
+    });
+    expect(screen.queryByTestId("feed-search-clear")).toBeNull();
+  });
+});

--- a/web/src/components/feed-search-bar.test.tsx
+++ b/web/src/components/feed-search-bar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
 import { useEffect, useState, type ReactNode } from "react";

--- a/web/src/components/feed-search-bar.tsx
+++ b/web/src/components/feed-search-bar.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Search, X } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useAppState, useAppDispatch } from "@/contexts/app-state";
+
+/**
+ * フィード内検索バー。
+ *
+ * フィードを開いた際の記事一覧上部に配置し、当該フィード内のみを対象とした検索を提供する。
+ * 入力欄に検索キーワードを受け取り、Enter / submit で AppState に
+ * `SET_SEARCH_QUERY({ scope: 'feed', feedId })` を dispatch する。
+ *
+ * 表示制御:
+ * - フィード未選択時（`selectedFeedId === null`）は `null` を返して描画しない（NFR 2.3）
+ *
+ * 動作:
+ * - 入力欄の値はローカル状態として保持し、submit で AppState に反映する
+ * - 検索中（AppState.isSearching=true かつ scope='feed' かつ同一フィード）はローカル入力を
+ *   AppState.searchQuery と同期させ、現在のキーワードを再編集できる
+ * - 空入力 / 空白のみ submit は dispatch せず通常一覧を維持（Req 1.5）
+ * - クリアボタン押下時は `CLEAR_SEARCH` を dispatch（Req 1.6）
+ */
+export function FeedSearchBar() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+
+  // NFR 2.3: フィード未選択時は描画しない（早期 return が AppState を含む全 hook 評価後である
+  // ことに注意。React hooks は条件付き呼び出しを許さないため、useState 等は return より前で
+  // 呼んでおく必要がある）
+  const selectedFeedId = state.selectedFeedId;
+
+  // フィード内検索中かつ対象フィードが一致するときのみローカル入力に AppState を反映
+  const initialLocalQuery =
+    state.isSearching &&
+    state.searchScope === "feed" &&
+    state.searchFeedId === selectedFeedId
+      ? state.searchQuery
+      : "";
+  const [localQuery, setLocalQuery] = useState(initialLocalQuery);
+
+  if (selectedFeedId === null) {
+    return null;
+  }
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = localQuery.trim();
+    if (trimmed.length === 0) {
+      // Req 1.5: 空入力時は検索を実行せず通常の記事一覧表示を維持する
+      return;
+    }
+    dispatch({
+      type: "SET_SEARCH_QUERY",
+      query: trimmed,
+      scope: "feed",
+      feedId: selectedFeedId,
+    });
+  };
+
+  const handleClear = () => {
+    setLocalQuery("");
+    // Req 1.6: 検索結果表示を解除し検索実行前の記事一覧表示状態へ戻す
+    dispatch({ type: "CLEAR_SEARCH" });
+  };
+
+  return (
+    <form
+      data-testid="feed-search-bar"
+      role="search"
+      onSubmit={handleSubmit}
+      className="flex items-center gap-1"
+    >
+      <div className="relative">
+        <Search
+          aria-hidden="true"
+          className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground"
+        />
+        <Input
+          data-testid="feed-search-input"
+          type="search"
+          value={localQuery}
+          onChange={(e) => setLocalQuery(e.target.value)}
+          placeholder="このフィード内を検索"
+          aria-label="現在のフィード内を検索"
+          className="w-56 pl-8 pr-8"
+        />
+        {localQuery.length > 0 && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            data-testid="feed-search-clear"
+            aria-label="検索をクリア"
+            onClick={handleClear}
+            className="absolute right-1 top-1/2 -translate-y-1/2 rounded-full"
+          >
+            <X aria-hidden="true" className="w-3 h-3" />
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/web/src/components/header-search-bar.test.tsx
+++ b/web/src/components/header-search-bar.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import { useEffect, useState, type ReactNode } from "react";
+import { HeaderSearchBar } from "./header-search-bar";
+import {
+  AppStateProvider,
+  useAppState,
+  useAppDispatch,
+} from "@/contexts/app-state";
+
+/**
+ * AppStateProvider 配下に HeaderSearchBar をマウントし、AppState を
+ * 観測するためのフック。`StateProbe` 経由で state を test に流す。
+ */
+function renderWithProvider(ui: ReactNode) {
+  let observed: ReturnType<typeof useAppState> | null = null;
+  let dispatchRef: ReturnType<typeof useAppDispatch> | null = null;
+  function StateProbe() {
+    observed = useAppState();
+    dispatchRef = useAppDispatch();
+    return null;
+  }
+  const utils = render(
+    <AppStateProvider>
+      <StateProbe />
+      {ui}
+    </AppStateProvider>
+  );
+  return {
+    ...utils,
+    getState: () => observed!,
+    getDispatch: () => dispatchRef!,
+  };
+}
+
+describe("HeaderSearchBar", () => {
+  it("検索キーワード入力欄が ARIA ロール search 配下にレンダされること（Req 1.1）", () => {
+    renderWithProvider(<HeaderSearchBar />);
+    expect(screen.getByRole("search")).toBeInTheDocument();
+    expect(screen.getByTestId("header-search-input")).toBeInTheDocument();
+  });
+
+  it("キーワードを入力し Enter 押下で SET_SEARCH_QUERY（scope='global'）が dispatch されること（Req 1.3）", async () => {
+    const user = userEvent.setup();
+    const { getState } = renderWithProvider(<HeaderSearchBar />);
+    const input = screen.getByTestId("header-search-input");
+
+    await user.type(input, "typescript");
+    await user.keyboard("{Enter}");
+
+    const state = getState();
+    expect(state.searchQuery).toBe("typescript");
+    expect(state.isSearching).toBe(true);
+    expect(state.searchScope).toBe("global");
+    expect(state.searchFeedId).toBeNull();
+  });
+
+  it("空入力で Enter 押下しても dispatch されず通常一覧表示が維持されること（Req 1.5）", async () => {
+    const user = userEvent.setup();
+    const { getState } = renderWithProvider(<HeaderSearchBar />);
+    const input = screen.getByTestId("header-search-input");
+
+    // 空のまま focus を当てて Enter
+    await user.click(input);
+    await user.keyboard("{Enter}");
+
+    const state = getState();
+    expect(state.searchQuery).toBe("");
+    expect(state.isSearching).toBe(false);
+  });
+
+  it("空白のみの入力で Enter 押下しても dispatch されないこと（Req 1.5 / 境界値）", async () => {
+    const user = userEvent.setup();
+    const { getState } = renderWithProvider(<HeaderSearchBar />);
+    const input = screen.getByTestId("header-search-input");
+
+    await user.type(input, "   ");
+    await user.keyboard("{Enter}");
+
+    const state = getState();
+    expect(state.searchQuery).toBe("");
+    expect(state.isSearching).toBe(false);
+  });
+
+  it("入力に前後空白がある場合は trim された値が dispatch されること", async () => {
+    const user = userEvent.setup();
+    const { getState } = renderWithProvider(<HeaderSearchBar />);
+    const input = screen.getByTestId("header-search-input");
+
+    await user.type(input, "  rust  ");
+    await user.keyboard("{Enter}");
+
+    const state = getState();
+    expect(state.searchQuery).toBe("rust");
+  });
+
+  it("クリアボタンは入力が空のときは表示されず、入力後に表示されること", async () => {
+    const user = userEvent.setup();
+    renderWithProvider(<HeaderSearchBar />);
+    const input = screen.getByTestId("header-search-input");
+
+    expect(screen.queryByTestId("header-search-clear")).toBeNull();
+
+    await user.type(input, "kafka");
+    expect(screen.getByTestId("header-search-clear")).toBeInTheDocument();
+  });
+
+  it("クリアボタン押下で CLEAR_SEARCH が dispatch され、ローカル入力もクリアされること（Req 1.6）", async () => {
+    const user = userEvent.setup();
+    const { getState, getDispatch } = renderWithProvider(<HeaderSearchBar />);
+    const input = screen.getByTestId("header-search-input") as HTMLInputElement;
+
+    // 検索中状態をシミュレートするため、事前に dispatch しておく
+    await act(async () => {
+      getDispatch()({
+        type: "SET_SEARCH_QUERY",
+        query: "kubernetes",
+        scope: "global",
+      });
+    });
+    // 入力欄にも値を入れておく
+    await user.type(input, "kubernetes");
+    expect(getState().isSearching).toBe(true);
+
+    // クリアボタン押下
+    await user.click(screen.getByTestId("header-search-clear"));
+
+    const state = getState();
+    expect(state.isSearching).toBe(false);
+    expect(state.searchQuery).toBe("");
+    expect(state.searchScope).toBe("global");
+    // ローカル入力欄もクリアされている
+    expect(input.value).toBe("");
+  });
+
+  it("検索中（scope='global'）の状態でレンダされたとき AppState.searchQuery を初期値に反映すること", () => {
+    // 検索状態を事前にセットアップしてから HeaderSearchBar を render する
+    function Setup() {
+      const dispatch = useAppDispatch();
+      // useEffect 相当の即時 dispatch を render 内で行うため、ref で 1 回限定にする
+      const didDispatch = useDispatchOnce(() => {
+        dispatch({
+          type: "SET_SEARCH_QUERY",
+          query: "docker",
+          scope: "global",
+        });
+      });
+      return didDispatch ? <HeaderSearchBar /> : null;
+    }
+
+    render(
+      <AppStateProvider>
+        <Setup />
+      </AppStateProvider>
+    );
+
+    const input = screen.getByTestId(
+      "header-search-input"
+    ) as HTMLInputElement;
+    expect(input.value).toBe("docker");
+  });
+});
+
+// テスト専用の "1 回だけ effect を発火する" ヘルパー（useEffect の代替）。
+// AppStateProvider 配下で初回マウント時に dispatch を 1 度だけ流し、
+// その完了タイミングで子コンポーネントを render するために使用する。
+function useDispatchOnce(fn: () => void): boolean {
+  const [done, setDone] = useState(false);
+  useEffect(() => {
+    fn();
+    setDone(true);
+    // 初回 mount でのみ発火させたいため deps は空配列を明示する
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return done;
+}

--- a/web/src/components/header-search-bar.tsx
+++ b/web/src/components/header-search-bar.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Search, X } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useAppState, useAppDispatch } from "@/contexts/app-state";
+
+/**
+ * ヘッダー領域に常設する横断検索バー。
+ *
+ * 入力欄に検索キーワードを受け取り、Enter / submit で AppState に
+ * `SET_SEARCH_QUERY({ scope: 'global' })` を dispatch する。
+ *
+ * - 入力欄の値はローカル状態（未確定）として保持し、submit で AppState に反映する
+ * - 検索中（AppState.isSearching=true かつ scope='global'）はローカル入力を
+ *   AppState.searchQuery と同期させ、ユーザーが現在の検索キーワードを再編集できる
+ * - 空入力 / 空白のみで submit したときは dispatch せず通常一覧を維持（Req 1.5）
+ * - クリアボタン押下時は `CLEAR_SEARCH` を dispatch して検索結果を解除（Req 1.6）
+ */
+export function HeaderSearchBar() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+
+  // 検索中かつ scope='global' のときはローカル入力に AppState の値を反映する。
+  // それ以外（フィード内検索中 / 未検索）はローカル入力を空にする方が UX 上自然。
+  const initialLocalQuery =
+    state.isSearching && state.searchScope === "global" ? state.searchQuery : "";
+  const [localQuery, setLocalQuery] = useState(initialLocalQuery);
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = localQuery.trim();
+    if (trimmed.length === 0) {
+      // Req 1.5: 空入力時は検索を実行せず通常の記事一覧表示を維持する
+      return;
+    }
+    dispatch({
+      type: "SET_SEARCH_QUERY",
+      query: trimmed,
+      scope: "global",
+    });
+  };
+
+  const handleClear = () => {
+    setLocalQuery("");
+    // Req 1.6: 検索結果表示を解除し検索実行前の記事一覧表示状態へ戻す
+    dispatch({ type: "CLEAR_SEARCH" });
+  };
+
+  return (
+    <form
+      data-testid="header-search-bar"
+      role="search"
+      onSubmit={handleSubmit}
+      className="flex items-center gap-1"
+    >
+      <div className="relative">
+        <Search
+          aria-hidden="true"
+          className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground"
+        />
+        <Input
+          data-testid="header-search-input"
+          type="search"
+          value={localQuery}
+          onChange={(e) => setLocalQuery(e.target.value)}
+          placeholder="記事を検索"
+          aria-label="購読中の全フィードを横断検索"
+          className="w-64 pl-8 pr-8"
+        />
+        {localQuery.length > 0 && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            data-testid="header-search-clear"
+            aria-label="検索をクリア"
+            onClick={handleClear}
+            className="absolute right-1 top-1/2 -translate-y-1/2 rounded-full"
+          >
+            <X aria-hidden="true" className="w-3 h-3" />
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/web/src/components/item-list.test.tsx
+++ b/web/src/components/item-list.test.tsx
@@ -2,7 +2,13 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 import { ItemList } from "./item-list";
+import {
+  AppStateProvider,
+  useAppDispatch,
+  type AppAction,
+} from "@/contexts/app-state";
 import type { ItemDetail, ItemListResponse } from "@/types/item";
 import type { ReactNode } from "react";
 
@@ -19,7 +25,11 @@ mockIntersectionObserver.mockImplementation((callback: IntersectionObserverCallb
 }));
 global.IntersectionObserver = mockIntersectionObserver;
 
-/** テスト用ラッパー */
+/** テスト用ラッパー
+ *
+ * ItemList は FeedSearchBar（useAppState 経由で AppState を参照）を内包するため、
+ * AppStateProvider 配下でレンダする必要がある。
+ */
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -30,10 +40,52 @@ function createWrapper() {
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
       <QueryClientProvider client={queryClient}>
-        {children}
+        <AppStateProvider>{children}</AppStateProvider>
       </QueryClientProvider>
     );
   };
+}
+
+/**
+ * AppStateProvider に初期 dispatch（例: SELECT_FEED）を流してから ItemList をマウントする
+ * ヘルパー。FeedSearchBar の selectedFeedId 連動を検証する場合に使用する。
+ */
+function renderWithInitialDispatch(
+  ui: ReactNode,
+  initialDispatch?: (dispatch: (action: AppAction) => void) => void
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  function Probe() {
+    const dispatch = useAppDispatch();
+    const ready = useDispatchOnce(() => {
+      if (initialDispatch) initialDispatch(dispatch);
+    });
+    return ready ? <>{ui}</> : null;
+  }
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    </QueryClientProvider>
+  );
+}
+
+/** 初回 mount でのみ effect を 1 度発火するテスト専用ヘルパー */
+function useDispatchOnce(fn: () => void): boolean {
+  const [done, setDone] = useState(false);
+  useEffect(() => {
+    fn();
+    setDone(true);
+    // 初回 mount のみ発火 / deps は意図的に空配列
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return done;
 }
 
 /** テスト用の記事一覧レスポンス */
@@ -495,6 +547,39 @@ describe("ItemList コンポーネント", () => {
     const estimated = within(row).getByTestId("date-estimated");
     // 推定フラグはタイトル行（=日時のある行）に維持される
     expect(titleRow).toContainElement(estimated as HTMLElement);
+  });
+
+  // --- フィード内検索バーの表示制御 (Req 1.2 / NFR 2.3) ---
+
+  it("フィード選択時はフィルタ群と同列に FeedSearchBar が表示されること（Req 1.2）", async () => {
+    // Arrange: AppState で feed-1 を選択した状態にして ItemList を render
+    renderWithInitialDispatch(
+      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
+      (dispatch) => {
+        dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
+      }
+    );
+
+    // Assert: FeedSearchBar が描画される（フィルタタブと同じ領域に併設）
+    await waitFor(() => {
+      expect(screen.getByTestId("feed-search-bar")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("feed-search-input")).toBeInTheDocument();
+    // フィルタタブも引き続き表示される（同列の隣接）
+    expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
+  });
+
+  it("フィード未選択時（feedId === null）は FeedSearchBar が描画されないこと（NFR 2.3）", () => {
+    // Arrange / Act: feedId を null で render（AppState の selectedFeedId も初期値 null）
+    render(
+      <ItemList feedId={null} onSelectItem={() => {}} expandedItemId={null} />,
+      { wrapper: createWrapper() }
+    );
+
+    // Assert: ItemList 自体が案内メッセージのみで FeedSearchBar に到達しない
+    expect(screen.getByText("フィードを選択してください")).toBeInTheDocument();
+    expect(screen.queryByTestId("feed-search-bar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("feed-search-input")).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/components/item-list.tsx
+++ b/web/src/components/item-list.tsx
@@ -6,6 +6,7 @@ import { Star } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useItems, useItemDetail } from "@/hooks/use-items";
 import { useMarkAsRead, useToggleStar } from "@/hooks/use-item-state";
+import { FeedSearchBar } from "@/components/feed-search-bar";
 import { ItemDetail } from "@/components/item-detail";
 import type {
   ItemDetail as ItemDetailType,
@@ -128,8 +129,10 @@ export function ItemList({ feedId, onSelectItem, expandedItemId }: ItemListProps
 
   return (
     <div className="flex flex-col h-full">
-      {/* フィルタタブ */}
-      <div className="flex-shrink-0 border-b px-4 py-2">
+      {/* フィルタタブ + フィード内検索バー（Req 1.2 / NFR 2.3）
+          FeedSearchBar は selectedFeedId === null のとき内部で null を返すため、
+          本領域に到達する時点（feedId !== null）では常に描画される */}
+      <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b px-4 py-2">
         <Tabs
           value={filter}
           onValueChange={(value) => setFilter(value as ItemFilter)}
@@ -140,6 +143,7 @@ export function ItemList({ feedId, onSelectItem, expandedItemId }: ItemListProps
             <TabsTrigger value="starred">スター</TabsTrigger>
           </TabsList>
         </Tabs>
+        <FeedSearchBar />
       </div>
 
       {/* 記事一覧 */}

--- a/web/src/components/search-results.test.tsx
+++ b/web/src/components/search-results.test.tsx
@@ -1,0 +1,390 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect, useState, type ReactNode } from "react";
+import { SearchResults } from "./search-results";
+import {
+  AppStateProvider,
+  useAppDispatch,
+  useAppState,
+  type AppAction,
+} from "@/contexts/app-state";
+import type { ItemSearchResponse } from "@/types/item";
+
+// グローバル fetch のモック
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// IntersectionObserver のモック（無限スクロール sentinel 用）
+const mockIntersectionObserver = vi.fn();
+mockIntersectionObserver.mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+global.IntersectionObserver = mockIntersectionObserver;
+
+/**
+ * テスト用のラッパー: QueryClient + AppStateProvider を結合し、
+ * 初期 dispatch（検索状態のセットアップ）を 1 度だけ実行してから子をレンダする。
+ */
+function renderWithProviders(
+  ui: ReactNode,
+  initialDispatch?: (dispatch: (a: AppAction) => void) => void
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  let observed: ReturnType<typeof useAppState> | null = null;
+  function Probe() {
+    const dispatch = useAppDispatch();
+    observed = useAppState();
+    const ready = useDispatchOnce(() => {
+      if (initialDispatch) initialDispatch(dispatch);
+    });
+    return ready ? <>{ui}</> : null;
+  }
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <AppStateProvider>
+        <Probe />
+      </AppStateProvider>
+    </QueryClientProvider>
+  );
+  return { ...utils, getState: () => observed! };
+}
+
+function useDispatchOnce(fn: () => void): boolean {
+  const [done, setDone] = useState(false);
+  useEffect(() => {
+    fn();
+    setDone(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return done;
+}
+
+/** テスト用検索結果（横断検索想定: 2 フィードから 2 件） */
+const mockGlobalResults: ItemSearchResponse = {
+  items: [
+    {
+      id: "item-1",
+      feed_id: "feed-a",
+      title: "TypeScript の型推論",
+      link: "https://example.com/article-1",
+      summary: "型推論の仕組みを解説",
+      published_at: "2026-02-27T10:00:00Z",
+      is_date_estimated: false,
+      hatebu_count: 12,
+      feed_title: "Frontend Weekly",
+      favicon_url: "data:image/png;base64,AAA",
+      is_read: false,
+      is_starred: false,
+    },
+    {
+      id: "item-2",
+      feed_id: "feed-b",
+      title: "TypeScript 5 の新機能",
+      link: "https://example.com/article-2",
+      summary: "",
+      published_at: "2026-02-26T10:00:00Z",
+      is_date_estimated: true,
+      hatebu_count: 3,
+      feed_title: "TS Newsletter",
+      favicon_url: null,
+      is_read: true,
+      is_starred: true,
+    },
+  ],
+  next_cursor: null,
+  has_more: false,
+};
+
+/** テスト用検索結果（フィード内検索想定: 同一 feed のみ） */
+const mockFeedResults: ItemSearchResponse = {
+  items: [
+    {
+      id: "item-10",
+      feed_id: "feed-target",
+      title: "Kubernetes 入門",
+      link: "https://example.com/article-10",
+      summary: "K8s のアーキテクチャ概要",
+      published_at: "2026-02-27T10:00:00Z",
+      is_date_estimated: false,
+      hatebu_count: 5,
+      feed_title: "DevOps Blog",
+      favicon_url: "data:image/png;base64,XYZ",
+      is_read: false,
+      is_starred: false,
+    },
+  ],
+  next_cursor: null,
+  has_more: false,
+};
+
+/** mockFetch を検索 API の結果で応答するようセットアップする */
+function setupSearchFetch(response: ItemSearchResponse) {
+  mockFetch.mockImplementation((url: string) => {
+    if (typeof url === "string" && url.startsWith("/api/items/search")) {
+      return Promise.resolve({ ok: true, json: async () => response });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+}
+
+/** mockFetch を 500 エラーで応答するようセットアップする */
+function setupErrorFetch() {
+  mockFetch.mockImplementation((url: string) => {
+    if (typeof url === "string" && url.startsWith("/api/items/search")) {
+      return Promise.resolve({
+        ok: false,
+        status: 500,
+        json: async () => ({ message: "Internal Server Error" }),
+      });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+}
+
+describe("SearchResults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("検索開始直後はローディング表示が即時提示されること（Req 4.4 / NFR 1.1）", () => {
+    // fetch を pending のまま返すことで isLoading=true を維持
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    renderWithProviders(<SearchResults />, (dispatch) => {
+      dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "typescript",
+        scope: "global",
+      });
+    });
+
+    expect(screen.getByTestId("search-results-loading")).toBeInTheDocument();
+  });
+
+  it("API エラー時はエラー表示が提示されること（Req 4.5）", async () => {
+    setupErrorFetch();
+
+    renderWithProviders(<SearchResults />, (dispatch) => {
+      dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "typescript",
+        scope: "global",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("search-results-error")).toBeInTheDocument();
+    });
+  });
+
+  it("検索結果が 0 件のとき空状態表示が提示されること（Req 4.3）", async () => {
+    setupSearchFetch({ items: [], next_cursor: null, has_more: false });
+
+    renderWithProviders(<SearchResults />, (dispatch) => {
+      dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "nonexistent",
+        scope: "global",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("search-results-empty")).toBeInTheDocument();
+    });
+  });
+
+  it("横断検索（scope='global'）の結果カードに feed_title と favicon バッジが表示されること（Req 4.2）", async () => {
+    setupSearchFetch(mockGlobalResults);
+
+    renderWithProviders(<SearchResults />, (dispatch) => {
+      dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "typescript",
+        scope: "global",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("search-results")).toBeInTheDocument();
+    });
+
+    // 1 件目: favicon あり + feed_title
+    const badge1 = screen.getByTestId("search-result-feed-badge-item-1");
+    expect(badge1).toBeInTheDocument();
+    expect(badge1).toHaveTextContent("Frontend Weekly");
+    const favicons = screen.getAllByTestId("search-result-favicon");
+    expect(favicons.length).toBeGreaterThanOrEqual(1);
+    expect(favicons[0].getAttribute("src")).toBe("data:image/png;base64,AAA");
+
+    // 2 件目: favicon なし（null）でもバッジ自体（feed_title）は表示される
+    const badge2 = screen.getByTestId("search-result-feed-badge-item-2");
+    expect(badge2).toBeInTheDocument();
+    expect(badge2).toHaveTextContent("TS Newsletter");
+
+    // タイトル本文も表示されている
+    expect(screen.getByText("TypeScript の型推論")).toBeInTheDocument();
+    expect(screen.getByText("TypeScript 5 の新機能")).toBeInTheDocument();
+  });
+
+  it("フィード内検索（scope='feed'）の結果カードでは feed_title / favicon バッジが省略されること（Req 4.2 の補集合）", async () => {
+    setupSearchFetch(mockFeedResults);
+
+    renderWithProviders(<SearchResults />, (dispatch) => {
+      dispatch({ type: "SELECT_FEED", feedId: "feed-target" });
+      dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "kubernetes",
+        scope: "feed",
+        feedId: "feed-target",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("search-results")).toBeInTheDocument();
+    });
+
+    // フィード内検索ではバッジを描画しない
+    expect(
+      screen.queryByTestId("search-result-feed-badge-item-10")
+    ).toBeNull();
+    expect(screen.queryByTestId("search-result-favicon")).toBeNull();
+
+    // タイトル本体は表示されている
+    expect(screen.getByText("Kubernetes 入門")).toBeInTheDocument();
+  });
+
+  it("検索結果カードをクリックすると EXPAND_ITEM が dispatch され、当該記事が展開されること（Req 4.6）", async () => {
+    setupSearchFetch(mockGlobalResults);
+    const user = userEvent.setup();
+
+    const { getState } = renderWithProviders(<SearchResults />, (dispatch) => {
+      dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "typescript",
+        scope: "global",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("search-result-row-item-1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("search-result-row-item-1"));
+
+    expect(getState().expandedItemId).toBe("item-1");
+
+    // 詳細取得 hook が呼ばれる（fetch URL の確認）。GET /api/items/item-1
+    await waitFor(() => {
+      const detailCalls = mockFetch.mock.calls.filter(
+        ([url]) => typeof url === "string" && url === "/api/items/item-1"
+      );
+      expect(detailCalls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("既読記事と未読記事でスタイル状態が data-read 属性で区別されること（Req 4.1 / 4.6 関連）", async () => {
+    setupSearchFetch(mockGlobalResults);
+
+    renderWithProviders(<SearchResults />, (dispatch) => {
+      dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "typescript",
+        scope: "global",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("search-result-row-item-1")).toBeInTheDocument();
+    });
+
+    // item-1 は未読 / item-2 は既読
+    expect(
+      screen.getByTestId("search-result-row-item-1").getAttribute("data-read")
+    ).toBe("false");
+    expect(
+      screen.getByTestId("search-result-row-item-2").getAttribute("data-read")
+    ).toBe("true");
+
+    // item-2 はスター付き
+    expect(
+      screen.getByTestId("search-result-star-item-2")
+    ).toBeInTheDocument();
+    // item-1 はスターなし
+    expect(
+      screen.queryByTestId("search-result-star-item-1")
+    ).toBeNull();
+  });
+
+  it("推定日付フラグが立っている記事には (推定) ラベルが表示されること", async () => {
+    setupSearchFetch(mockGlobalResults);
+
+    renderWithProviders(<SearchResults />, (dispatch) => {
+      dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "typescript",
+        scope: "global",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("search-results")).toBeInTheDocument();
+    });
+
+    // item-2 のみ is_date_estimated=true
+    expect(
+      screen.getByTestId("search-result-date-estimated-item-2")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("search-result-date-estimated-item-1")
+    ).toBeNull();
+  });
+
+  it("published_at が null の記事でも結果カードが描画されること（境界値）", async () => {
+    const responseWithNullDate: ItemSearchResponse = {
+      items: [
+        {
+          id: "item-nodate",
+          feed_id: "feed-a",
+          title: "日付不明の記事",
+          link: "https://example.com/article-x",
+          summary: "公開日未取得",
+          published_at: null,
+          is_date_estimated: false,
+          hatebu_count: 0,
+          feed_title: "Some Feed",
+          favicon_url: null,
+          is_read: false,
+          is_starred: false,
+        },
+      ],
+      next_cursor: null,
+      has_more: false,
+    };
+    setupSearchFetch(responseWithNullDate);
+
+    renderWithProviders(<SearchResults />, (dispatch) => {
+      dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "anything",
+        scope: "global",
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("search-result-row-item-nodate")
+      ).toBeInTheDocument();
+    });
+    // タイトルは表示されている
+    expect(screen.getByText("日付不明の記事")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/search-results.tsx
+++ b/web/src/components/search-results.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useAppState, useAppDispatch } from "@/contexts/app-state";
+import { useItemSearch } from "@/hooks/use-item-search";
+import { useItemDetail } from "@/hooks/use-items";
+import { useMarkAsRead, useToggleStar } from "@/hooks/use-item-state";
+import { ItemDetail } from "@/components/item-detail";
+import type {
+  ItemDetail as ItemDetailType,
+  ItemSearchHit,
+} from "@/types/item";
+
+/**
+ * 検索結果リスト（右ペイン）。
+ *
+ * `state.isSearching === true` のときに AppShell からレンダされ、AppState から
+ * 検索クエリ / スコープ / フィード ID を読み取って {@link useItemSearch} を発火する。
+ *
+ * 状態出し分け（Req 4.3, 4.4, 4.5 / NFR 1.1）:
+ * - `isLoading` ローディング表示（TanStack Query が即時 true、NFR 1.1 を満たす）
+ * - `isError` エラー表示
+ * - 結果 0 件で空状態表示
+ * - 結果 1 件以上で時系列降順の結果リスト
+ *
+ * バッジ表示（Req 4.2）:
+ * - `searchScope === 'global'`（横断検索）のみ各カードに feed_title + favicon を併記
+ * - `searchScope === 'feed'`（フィード内検索）ではバッジを省略
+ *
+ * 操作整合（Req 4.6, 5.1, 5.2）:
+ * - 既存 `useItemDetail` / `useMarkAsRead` / `useToggleStar` を再利用し、
+ *   通常一覧と同じ展開・既読化・スター挙動を提供する
+ */
+export function SearchResults() {
+  const state = useAppState();
+  const dispatch = useAppDispatch();
+
+  const {
+    data,
+    isLoading,
+    isError,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useItemSearch(state.searchQuery, state.searchScope, state.searchFeedId);
+
+  // 展開中の記事詳細（本文を含む）を取得する
+  const {
+    data: detail,
+    isLoading: isDetailLoading,
+    isError: isDetailError,
+  } = useItemDetail(state.expandedItemId);
+
+  const markAsRead = useMarkAsRead();
+  const toggleStar = useToggleStar();
+
+  const handleSelectItem = useCallback(
+    (itemId: string) => {
+      dispatch({ type: "EXPAND_ITEM", itemId });
+    },
+    [dispatch]
+  );
+
+  const handleMarkAsRead = useCallback(
+    (itemId: string) => {
+      markAsRead.mutate(itemId);
+    },
+    [markAsRead]
+  );
+
+  const handleToggleStar = useCallback(
+    (itemId: string, isStarred: boolean) => {
+      toggleStar.mutate({ itemId, isStarred });
+    },
+    [toggleStar]
+  );
+
+  // Intersection Observer による無限スクロール（ItemList と同パターン）
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [entry] = entries;
+      if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage();
+      }
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage]
+  );
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(handleObserver, {
+      rootMargin: "100px",
+    });
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [handleObserver]);
+
+  // Req 4.4 / NFR 1.1: ローディング表示を即時提示する
+  if (isLoading) {
+    return (
+      <div
+        data-testid="search-results-loading"
+        className="flex items-center justify-center h-full text-sm text-muted-foreground"
+      >
+        検索中...
+      </div>
+    );
+  }
+
+  // Req 4.5: 取得失敗時はエラー表示
+  if (isError) {
+    return (
+      <div
+        data-testid="search-results-error"
+        className="flex items-center justify-center h-full text-sm text-destructive"
+      >
+        検索結果の取得に失敗しました
+      </div>
+    );
+  }
+
+  const allHits = data?.pages.flatMap((page) => page.items) ?? [];
+
+  // Req 4.3: 0 件のときは空状態表示
+  if (allHits.length === 0) {
+    return (
+      <div
+        data-testid="search-results-empty"
+        className="flex items-center justify-center h-full text-sm text-muted-foreground"
+      >
+        検索結果はありません
+      </div>
+    );
+  }
+
+  // 結果リスト（Req 4.1: published_at 降順は API 側で保証済み）
+  return (
+    <div data-testid="search-results" className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto">
+        <div className="flex flex-col">
+          {allHits.map((hit) => {
+            const isExpanded = hit.id === state.expandedItemId;
+            return (
+              <div key={hit.id} className="flex flex-col">
+                <SearchResultRow
+                  hit={hit}
+                  isExpanded={isExpanded}
+                  showFeedBadge={state.searchScope === "global"}
+                  onClick={() => handleSelectItem(hit.id)}
+                />
+                {isExpanded && (
+                  <SearchResultDetailArea
+                    isLoading={isDetailLoading}
+                    isError={isDetailError}
+                    detail={detail ?? null}
+                    detailItemId={state.expandedItemId}
+                    onMarkAsRead={handleMarkAsRead}
+                    onToggleStar={handleToggleStar}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* 無限スクロール用 sentinel */}
+        <div
+          ref={sentinelRef}
+          data-testid="search-results-sentinel"
+          className="h-1"
+        />
+
+        {isFetchingNextPage && (
+          <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+            読み込み中...
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** SearchResultDetailArea のプロパティ */
+interface SearchResultDetailAreaProps {
+  isLoading: boolean;
+  isError: boolean;
+  detail: ItemDetailType | null;
+  detailItemId: string | null;
+  onMarkAsRead: (itemId: string) => void;
+  onToggleStar: (itemId: string, isStarred: boolean) => void;
+}
+
+/**
+ * 検索結果の展開エリア（ItemList の ItemDetailArea と同等パターン）。
+ *
+ * 取得状態に応じてローディング表示 / エラー表示 / 本文（ItemDetail）を出し分ける。
+ */
+function SearchResultDetailArea({
+  isLoading,
+  isError,
+  detail,
+  detailItemId,
+  onMarkAsRead,
+  onToggleStar,
+}: SearchResultDetailAreaProps) {
+  if (isError) {
+    return (
+      <div
+        data-testid="search-result-detail-error"
+        className="border-t bg-background px-4 py-4 text-sm text-destructive"
+      >
+        記事の詳細を読み込めませんでした
+      </div>
+    );
+  }
+
+  if (isLoading || detail === null || detail.id !== detailItemId) {
+    return (
+      <div
+        data-testid="search-result-detail-loading"
+        className="border-t bg-background px-4 py-4 text-sm text-muted-foreground"
+      >
+        読み込み中...
+      </div>
+    );
+  }
+
+  return (
+    <ItemDetail
+      item={detail}
+      onMarkAsRead={onMarkAsRead}
+      onToggleStar={onToggleStar}
+    />
+  );
+}
+
+/** SearchResultRow のプロパティ */
+interface SearchResultRowProps {
+  hit: ItemSearchHit;
+  isExpanded: boolean;
+  /** true のとき feed_title + favicon バッジを表示する（横断検索時 / Req 4.2） */
+  showFeedBadge: boolean;
+  onClick: () => void;
+}
+
+/**
+ * 検索結果の 1 行（item-list.tsx の `ItemRow` に検索固有のフィード識別バッジを追加した派生）。
+ *
+ * `showFeedBadge` が true のとき favicon と feed_title を併記する（Req 4.2）。
+ * 検索結果固有の構造（next_cursor / has_more が API レスポンスに含まれる）と
+ * 通常一覧の `ItemRow` で構造体が異なるため、共通化はせず併設する設計を採った。
+ */
+function SearchResultRow({
+  hit,
+  isExpanded,
+  showFeedBadge,
+  onClick,
+}: SearchResultRowProps) {
+  const date = hit.published_at !== null ? new Date(hit.published_at) : null;
+  const formattedDate = date !== null ? formatDate(date) : "日付不明";
+  const hasSummary = hit.summary.trim().length > 0;
+
+  return (
+    <button
+      data-testid={`search-result-row-${hit.id}`}
+      data-read={hit.is_read ? "true" : "false"}
+      className={cn(
+        "flex flex-col gap-1 px-4 py-3 text-left border-b transition-colors",
+        "hover:bg-accent/50",
+        isExpanded && "bg-accent",
+        hit.is_read && "opacity-60"
+      )}
+      onClick={onClick}
+    >
+      {/* フィード識別バッジ（横断検索のみ / Req 4.2） */}
+      {showFeedBadge && (
+        <div
+          data-testid={`search-result-feed-badge-${hit.id}`}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground"
+        >
+          <SearchResultFavicon
+            faviconURL={hit.favicon_url}
+            feedTitle={hit.feed_title}
+          />
+          <span className="truncate">{hit.feed_title}</span>
+        </div>
+      )}
+
+      {/* タイトル行: タイトル(左) + 公開日時/スター(右) */}
+      <div
+        data-testid={`search-result-title-row-${hit.id}`}
+        className="flex items-start gap-2"
+      >
+        <a
+          href={hit.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            "flex-1 min-w-0 text-sm line-clamp-2 hover:underline cursor-pointer",
+            !hit.is_read && "font-medium"
+          )}
+        >
+          {hit.title}
+        </a>
+
+        <span className="flex flex-shrink-0 items-center gap-1 text-xs text-muted-foreground whitespace-nowrap">
+          {date !== null && (
+            <time dateTime={hit.published_at ?? undefined}>
+              {formattedDate}
+            </time>
+          )}
+          {hit.is_date_estimated && (
+            <span
+              data-testid={`search-result-date-estimated-${hit.id}`}
+              className="text-orange-500"
+              title="公開日が不明なため、取得日時を表示しています"
+            >
+              (推定)
+            </span>
+          )}
+        </span>
+
+        {hit.is_starred && (
+          <Star
+            className="flex-shrink-0 w-4 h-4 fill-yellow-400 text-yellow-400"
+            data-testid={`search-result-star-${hit.id}`}
+          />
+        )}
+      </div>
+
+      {/* 概要（空のときは描画しない） */}
+      {hasSummary && (
+        <p
+          data-testid={`search-result-summary-${hit.id}`}
+          className="text-xs text-muted-foreground line-clamp-2"
+        >
+          {hit.summary}
+        </p>
+      )}
+    </button>
+  );
+}
+
+/** SearchResultFavicon のプロパティ */
+interface SearchResultFaviconProps {
+  faviconURL: string | null;
+  feedTitle: string;
+}
+
+/**
+ * 検索結果カードの先頭に表示する favicon。
+ *
+ * favicon URL が null / 空文字 / 画像読み込み失敗のいずれかなら何も表示せず、
+ * バッジ全体としてはタイトルだけが残る（feed-list.tsx の代替アイコンよりも
+ * 軽量な扱い、検索結果カードは情報密度が高くアイコン領域を最小化したい）。
+ */
+function SearchResultFavicon({
+  faviconURL,
+  feedTitle,
+}: SearchResultFaviconProps) {
+  if (faviconURL === null || faviconURL === "") {
+    return null;
+  }
+  return (
+    // <img> の onError は React のステート更新を介さず DOM 側にフォールバックを
+    // 任せたいため、ここでは shouldShow フラグを介さず単純に <img> を返す。
+    // 読み込み失敗時の代替表示が必要なら別 Issue で改善する。
+    <img
+      data-testid="search-result-favicon"
+      src={faviconURL}
+      alt={`${feedTitle} のアイコン`}
+      className="w-3.5 h-3.5 rounded-sm object-contain flex-shrink-0"
+    />
+  );
+}
+
+/** 日付を相対表記でフォーマットする（item-list.tsx と同等ロジック） */
+function formatDate(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffHours < 1) return "1時間以内";
+  if (diffHours < 24) return `${diffHours}時間前`;
+  if (diffDays < 7) return `${diffDays}日前`;
+
+  return date.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/web/src/contexts/app-state.test.tsx
+++ b/web/src/contexts/app-state.test.tsx
@@ -23,6 +23,10 @@ describe("AppStateContext", () => {
     expect(result.current.selectedFeedId).toBeNull();
     expect(result.current.expandedItemId).toBeNull();
     expect(result.current.filter).toBe("all");
+    expect(result.current.searchQuery).toBe("");
+    expect(result.current.isSearching).toBe(false);
+    expect(result.current.searchScope).toBe("global");
+    expect(result.current.searchFeedId).toBeNull();
   });
 
   it("SELECT_FEED アクションでフィードが選択されること", () => {
@@ -154,6 +158,170 @@ describe("AppStateContext", () => {
     });
 
     expect(result.current.state.filter).toBe("starred");
+  });
+
+  it("SET_SEARCH_QUERY アクション（scope='global'）で横断検索状態に遷移すること", () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => {
+        const state = useAppState();
+        const dispatch = useAppDispatch();
+        return { state, dispatch };
+      },
+      { wrapper }
+    );
+
+    act(() => {
+      result.current.dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "typescript",
+        scope: "global",
+      });
+    });
+
+    expect(result.current.state.searchQuery).toBe("typescript");
+    expect(result.current.state.isSearching).toBe(true);
+    expect(result.current.state.searchScope).toBe("global");
+    expect(result.current.state.searchFeedId).toBeNull();
+  });
+
+  it("SET_SEARCH_QUERY アクション（scope='feed'）でフィード内検索状態に遷移し searchFeedId が設定されること", () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => {
+        const state = useAppState();
+        const dispatch = useAppDispatch();
+        return { state, dispatch };
+      },
+      { wrapper }
+    );
+
+    act(() => {
+      result.current.dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "rust",
+        scope: "feed",
+        feedId: "feed-42",
+      });
+    });
+
+    expect(result.current.state.searchQuery).toBe("rust");
+    expect(result.current.state.isSearching).toBe(true);
+    expect(result.current.state.searchScope).toBe("feed");
+    expect(result.current.state.searchFeedId).toBe("feed-42");
+  });
+
+  it("SET_SEARCH_QUERY アクション（scope='feed'）で feedId 未指定時は searchFeedId が null になること", () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => {
+        const state = useAppState();
+        const dispatch = useAppDispatch();
+        return { state, dispatch };
+      },
+      { wrapper }
+    );
+
+    act(() => {
+      result.current.dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "golang",
+        scope: "feed",
+      });
+    });
+
+    expect(result.current.state.searchQuery).toBe("golang");
+    expect(result.current.state.isSearching).toBe(true);
+    expect(result.current.state.searchScope).toBe("feed");
+    expect(result.current.state.searchFeedId).toBeNull();
+  });
+
+  it("CLEAR_SEARCH アクションで検索状態がリセットされ、selectedFeedId と filter は保持されること", () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => {
+        const state = useAppState();
+        const dispatch = useAppDispatch();
+        return { state, dispatch };
+      },
+      { wrapper }
+    );
+
+    // 先にフィード選択と filter 変更で selectedFeedId と filter を非初期値にする
+    act(() => {
+      result.current.dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
+    });
+    act(() => {
+      result.current.dispatch({ type: "SET_FILTER", filter: "unread" });
+    });
+    // 続けて検索を開始
+    act(() => {
+      result.current.dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "kubernetes",
+        scope: "feed",
+        feedId: "feed-1",
+      });
+    });
+
+    expect(result.current.state.selectedFeedId).toBe("feed-1");
+    expect(result.current.state.filter).toBe("unread");
+    expect(result.current.state.isSearching).toBe(true);
+
+    // CLEAR_SEARCH で検索状態のみリセット、selectedFeedId と filter は保持
+    act(() => {
+      result.current.dispatch({ type: "CLEAR_SEARCH" });
+    });
+
+    expect(result.current.state.searchQuery).toBe("");
+    expect(result.current.state.isSearching).toBe(false);
+    expect(result.current.state.searchScope).toBe("global");
+    expect(result.current.state.searchFeedId).toBeNull();
+    expect(result.current.state.selectedFeedId).toBe("feed-1");
+    expect(result.current.state.filter).toBe("unread");
+  });
+
+  it("SELECT_FEED アクションで検索状態（searchQuery / isSearching / searchScope / searchFeedId）もリセットされること", () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => {
+        const state = useAppState();
+        const dispatch = useAppDispatch();
+        return { state, dispatch };
+      },
+      { wrapper }
+    );
+
+    // 先に検索を開始
+    act(() => {
+      result.current.dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "docker",
+        scope: "feed",
+        feedId: "feed-1",
+      });
+    });
+
+    expect(result.current.state.searchQuery).toBe("docker");
+    expect(result.current.state.isSearching).toBe(true);
+    expect(result.current.state.searchScope).toBe("feed");
+    expect(result.current.state.searchFeedId).toBe("feed-1");
+
+    // 別フィードを選択すると検索状態もリセットされる
+    act(() => {
+      result.current.dispatch({ type: "SELECT_FEED", feedId: "feed-2" });
+    });
+
+    expect(result.current.state.selectedFeedId).toBe("feed-2");
+    expect(result.current.state.searchQuery).toBe("");
+    expect(result.current.state.isSearching).toBe(false);
+    expect(result.current.state.searchScope).toBe("global");
+    expect(result.current.state.searchFeedId).toBeNull();
   });
 
   it("Provider外でuseAppStateを使用するとエラーが発生すること", () => {

--- a/web/src/contexts/app-state.tsx
+++ b/web/src/contexts/app-state.tsx
@@ -9,6 +9,11 @@ import {
 } from "react";
 import type { ItemFilter } from "@/types/item";
 
+// --- Search scope ---
+
+/** 検索スコープ: 'global' = 横断検索 / 'feed' = フィード内検索 */
+export type SearchScope = "global" | "feed";
+
 // --- State ---
 
 /** アプリケーションUIステート */
@@ -19,6 +24,14 @@ export interface AppState {
   expandedItemId: string | null;
   /** 現在のフィルタ */
   filter: ItemFilter;
+  /** 検索キーワード（空文字 = 検索オフ） */
+  searchQuery: string;
+  /** 検索モード中か否か（searchQuery !== '' と等価のキャッシュ） */
+  isSearching: boolean;
+  /** 検索スコープ（'global' = 横断検索 / 'feed' = フィード内検索） */
+  searchScope: SearchScope;
+  /** フィード内検索の対象フィードID（searchScope === 'feed' のときのみ非 null） */
+  searchFeedId: string | null;
 }
 
 /** 初期状態 */
@@ -26,11 +39,15 @@ const initialState: AppState = {
   selectedFeedId: null,
   expandedItemId: null,
   filter: "all",
+  searchQuery: "",
+  isSearching: false,
+  searchScope: "global",
+  searchFeedId: null,
 };
 
 // --- Actions ---
 
-/** フィード選択アクション: 展開記事IDとフィルタをリセットする */
+/** フィード選択アクション: 展開記事IDとフィルタをリセットし、検索状態もリセットする */
 type SelectFeedAction = { type: "SELECT_FEED"; feedId: string };
 
 /** 記事展開アクション: 同じIDなら閉じる（トグル）、異なるIDなら排他的に展開 */
@@ -39,8 +56,29 @@ type ExpandItemAction = { type: "EXPAND_ITEM"; itemId: string };
 /** フィルタ変更アクション */
 type SetFilterAction = { type: "SET_FILTER"; filter: ItemFilter };
 
+/**
+ * 検索キーワード設定アクション。
+ *
+ * - scope='global' のとき: 横断検索を開始する（feedId は無視され searchFeedId は null になる）
+ * - scope='feed' のとき: フィード内検索を開始する（feedId 指定値、未指定なら null）
+ */
+type SetSearchQueryAction = {
+  type: "SET_SEARCH_QUERY";
+  query: string;
+  scope: SearchScope;
+  feedId?: string | null;
+};
+
+/** 検索解除アクション: 検索状態のみリセットし、selectedFeedId と filter は保持する */
+type ClearSearchAction = { type: "CLEAR_SEARCH" };
+
 /** 全アクションのユニオン型 */
-export type AppAction = SelectFeedAction | ExpandItemAction | SetFilterAction;
+export type AppAction =
+  | SelectFeedAction
+  | ExpandItemAction
+  | SetFilterAction
+  | SetSearchQueryAction
+  | ClearSearchAction;
 
 // --- Reducer ---
 
@@ -53,6 +91,10 @@ function appReducer(state: AppState, action: AppAction): AppState {
         selectedFeedId: action.feedId,
         expandedItemId: null,
         filter: "all",
+        searchQuery: "",
+        isSearching: false,
+        searchScope: "global",
+        searchFeedId: null,
       };
     case "EXPAND_ITEM":
       return {
@@ -64,6 +106,23 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return {
         ...state,
         filter: action.filter,
+      };
+    case "SET_SEARCH_QUERY":
+      return {
+        ...state,
+        searchQuery: action.query,
+        isSearching: true,
+        searchScope: action.scope,
+        searchFeedId:
+          action.scope === "feed" ? (action.feedId ?? null) : null,
+      };
+    case "CLEAR_SEARCH":
+      return {
+        ...state,
+        searchQuery: "",
+        isSearching: false,
+        searchScope: "global",
+        searchFeedId: null,
       };
     default:
       return state;

--- a/web/src/hooks/use-item-search.test.tsx
+++ b/web/src/hooks/use-item-search.test.tsx
@@ -1,0 +1,282 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useItemSearch } from "./use-item-search";
+import type { ItemSearchResponse } from "@/types/item";
+import type { ReactNode } from "react";
+
+// グローバル fetch のモック
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+/** テスト用の QueryClient ラッパー */
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+/** テスト用の検索結果 1 ページ目（横断検索想定） */
+const mockSearchPage1: ItemSearchResponse = {
+  items: [
+    {
+      id: "item-1",
+      feed_id: "feed-a",
+      title: "TypeScript 入門",
+      link: "https://example.com/article-1",
+      summary: "TypeScript の基礎をまとめた記事",
+      published_at: "2026-02-27T10:00:00Z",
+      is_date_estimated: false,
+      hatebu_count: 12,
+      feed_title: "Web Frontend Blog",
+      favicon_url: "data:image/png;base64,AAA",
+      is_read: false,
+      is_starred: false,
+    },
+    {
+      id: "item-2",
+      feed_id: "feed-b",
+      title: "TypeScript の型推論",
+      link: "https://example.com/article-2",
+      summary: "",
+      published_at: "2026-02-26T10:00:00Z",
+      is_date_estimated: true,
+      hatebu_count: 0,
+      feed_title: "Tech Notes",
+      favicon_url: null,
+      is_read: true,
+      is_starred: true,
+    },
+  ],
+  next_cursor: "2026-02-26T10:00:00Z|item-2",
+  has_more: true,
+};
+
+/** テスト用の検索結果 2 ページ目 */
+const mockSearchPage2: ItemSearchResponse = {
+  items: [
+    {
+      id: "item-3",
+      feed_id: "feed-c",
+      title: "古い TypeScript 記事",
+      link: "https://example.com/article-3",
+      summary: "v3 系の話題",
+      published_at: "2026-02-25T10:00:00Z",
+      is_date_estimated: false,
+      hatebu_count: 3,
+      feed_title: "Archive",
+      favicon_url: "data:image/png;base64,BBB",
+      is_read: false,
+      is_starred: false,
+    },
+  ],
+  next_cursor: null,
+  has_more: false,
+};
+
+describe("useItemSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("scope='global' でクエリを指定したとき q と limit パラメータ付きで /api/items/search を呼ぶこと", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockSearchPage1,
+    });
+
+    const { result } = renderHook(
+      () => useItemSearch("typescript", "global", null),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // 検索結果が取得できていること
+    const allItems = result.current.data?.pages.flatMap((p) => p.items) ?? [];
+    expect(allItems).toHaveLength(2);
+    expect(allItems[0].title).toBe("TypeScript 入門");
+
+    // q=typescript と limit=50 を含む URL が呼ばれている
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("/api/items/search?");
+    expect(calledUrl).toContain("q=typescript");
+    expect(calledUrl).toContain("limit=50");
+    // 横断検索では feed_id を付与しない
+    expect(calledUrl).not.toContain("feed_id=");
+  });
+
+  it("scope='feed' で feedId を指定したとき feed_id パラメータ付きで呼ぶこと", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockSearchPage1,
+    });
+
+    const { result } = renderHook(
+      () => useItemSearch("rust", "feed", "feed-42"),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("q=rust");
+    expect(calledUrl).toContain("feed_id=feed-42");
+    expect(calledUrl).toContain("limit=50");
+  });
+
+  it("空クエリ（空文字）のときはクエリを無効化し fetch を呼ばないこと", () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockSearchPage1,
+    });
+
+    const { result } = renderHook(() => useItemSearch("", "global", null), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("空白のみクエリのときはクエリを無効化し fetch を呼ばないこと", () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockSearchPage1,
+    });
+
+    const { result } = renderHook(
+      () => useItemSearch("   ", "global", null),
+      { wrapper: createWrapper() }
+    );
+
+    expect(result.current.isFetching).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("scope='feed' で feedId が null のときはクエリを無効化し fetch を呼ばないこと", () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockSearchPage1,
+    });
+
+    const { result } = renderHook(() => useItemSearch("rust", "feed", null), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("has_more が true のとき fetchNextPage で次ページが取得できること", async () => {
+    let callCount = 0;
+    mockFetch.mockImplementation(() => {
+      callCount += 1;
+      const page = callCount === 1 ? mockSearchPage1 : mockSearchPage2;
+      return Promise.resolve({ ok: true, json: async () => page });
+    });
+
+    const { result } = renderHook(
+      () => useItemSearch("typescript", "global", null),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.hasNextPage).toBe(true);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      const allItems =
+        result.current.data?.pages.flatMap((p) => p.items) ?? [];
+      expect(allItems).toHaveLength(3);
+    });
+
+    // 次ページ取得時に cursor が付与される
+    const secondCallUrl = mockFetch.mock.calls[1][0] as string;
+    expect(secondCallUrl).toContain(
+      `cursor=${encodeURIComponent("2026-02-26T10:00:00Z|item-2")}`
+    );
+
+    // 次ページで has_more=false / next_cursor=null になり hasNextPage が false
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("has_more が true でも next_cursor が空文字のときは次ページなしと扱うこと", async () => {
+    // impl-notes Task 4: 末尾項目の published_at がゼロ値のとき NextCursor は空文字となる
+    const pageWithEmptyCursor: ItemSearchResponse = {
+      items: mockSearchPage1.items,
+      next_cursor: "",
+      has_more: true,
+    };
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => pageWithEmptyCursor,
+    });
+
+    const { result } = renderHook(
+      () => useItemSearch("typescript", "global", null),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // next_cursor が空文字なら hasNextPage は false
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("API エラー時はエラー状態になること（Req 4.5）", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ message: "Internal Server Error" }),
+    });
+
+    const { result } = renderHook(
+      () => useItemSearch("typescript", "global", null),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+
+  it("URL エンコードが必要な文字を含むクエリでも正しくエンコードされること", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => mockSearchPage1,
+    });
+
+    const { result } = renderHook(
+      () => useItemSearch("hello world & special", "global", null),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    // スペースは + または %20、& は %26 にエンコードされる
+    expect(calledUrl).toMatch(/q=hello(\+|%20)world(\+|%20)%26(\+|%20)special/);
+  });
+});

--- a/web/src/hooks/use-item-search.ts
+++ b/web/src/hooks/use-item-search.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { apiClient } from "@/lib/api";
+import type { ItemSearchResponse, SearchScope } from "@/types/item";
+
+/** 検索結果 1 ページあたりの取得件数（既存 ItemList と同じ 50 件） */
+const SEARCH_PAGE_SIZE = 50;
+
+/**
+ * 記事検索を実行するカスタムフック（無限スクロール対応）。
+ *
+ * GET /api/items/search を TanStack Query の useInfiniteQuery で呼び出し、
+ * カーソルベースページネーション（{@link SEARCH_PAGE_SIZE} 件 / 回）で検索結果を取得する。
+ *
+ * - 横断検索（`scope === 'global'`）: クエリパラメータ `q`, `limit`, 任意 `cursor` を付与する
+ * - フィード内検索（`scope === 'feed'`）: 上記に加えて `feed_id` を付与する
+ *
+ * `enabled` ガード:
+ * - クエリ正規化後（前後空白 trim 後）に空文字なら検索しない（Req 1.5）
+ * - `scope === 'feed'` かつ `feedId` が null / 空文字なら検索しない（Req 1.2 / NFR 2.3 と整合）
+ *
+ * `getNextPageParam` ガード:
+ * - `has_more === false` のときは次ページなし
+ * - `next_cursor` が null / 空文字のときも次ページなし（impl-notes Task 4 / 5 の判断）
+ *
+ * @param query - 検索キーワード（前後空白は呼び出し側で正規化済みでも良い）
+ * @param scope - 検索スコープ（'global' = 横断 / 'feed' = フィード内）
+ * @param feedId - フィード内検索の対象フィード ID（scope='feed' のときのみ必須）
+ */
+export function useItemSearch(
+  query: string,
+  scope: SearchScope,
+  feedId: string | null
+) {
+  const trimmedQuery = query.trim();
+  const isEnabled =
+    trimmedQuery.length > 0 && !(scope === "feed" && !feedId);
+
+  return useInfiniteQuery<ItemSearchResponse>({
+    queryKey: ["item-search", trimmedQuery, scope, feedId],
+    queryFn: async ({ pageParam }) => {
+      const params = new URLSearchParams();
+      params.set("q", trimmedQuery);
+      params.set("limit", String(SEARCH_PAGE_SIZE));
+      if (scope === "feed" && feedId) {
+        params.set("feed_id", feedId);
+      }
+      if (pageParam) {
+        params.set("cursor", pageParam as string);
+      }
+      return apiClient.get<ItemSearchResponse>(
+        `/api/items/search?${params.toString()}`
+      );
+    },
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) =>
+      lastPage.has_more && lastPage.next_cursor
+        ? lastPage.next_cursor
+        : undefined,
+    enabled: isEnabled,
+  });
+}

--- a/web/src/types/item.ts
+++ b/web/src/types/item.ts
@@ -44,3 +44,62 @@ export interface ItemStateRequest {
   is_read?: boolean | null;
   is_starred?: boolean | null;
 }
+
+/**
+ * 検索スコープ。
+ *
+ * - `'global'`: 横断検索（購読中の全フィードを対象）
+ * - `'feed'`: フィード内検索（現在開いているフィードを対象）
+ *
+ * AppState 内の `searchScope` フィールドおよび `useItemSearch` の引数として利用する。
+ * 型の真の定義源は `@/contexts/app-state` 側にあり、types/item.ts では再エクスポートする
+ * （UI 状態側を canonical とし、types/item.ts は API レスポンス型と一緒に閲覧できるよう
+ * 利便のため re-export する）。
+ */
+export type { SearchScope } from "@/contexts/app-state";
+
+/**
+ * 検索結果 1 件（横断 / フィード内検索共通）。
+ *
+ * ItemSummary 相当のフィールドに加え、横断検索で「どのフィード由来か」を識別するための
+ * `feed_title` と `favicon_url` を併記する。`favicon_url` はサーバー側で生成された
+ * `data:<mime>;base64,...` 形式の data URL、または favicon 未取得時は null。
+ *
+ * 既存 ItemSummary との差分:
+ * - 追加: `feed_title`, `favicon_url`
+ * - 省略: `hatebu_fetched_at`（検索 API レスポンスに含まれないため）
+ */
+export interface ItemSearchHit {
+  id: string;
+  feed_id: string;
+  title: string;
+  link: string;
+  /** サニタイズ済みの概要テキスト（空の場合は空文字列） */
+  summary: string;
+  /** RFC3339 形式の公開日時。NULL の場合のみ null */
+  published_at: string | null;
+  is_date_estimated: boolean;
+  hatebu_count: number;
+  /** 記事が属するフィードのタイトル（横断検索結果のバッジ表示で使用） */
+  feed_title: string;
+  /**
+   * 記事が属するフィードの favicon URL（`data:<mime>;base64,...` 形式）。
+   * favicon 未取得時は null（API レスポンスでは `omitempty` のため未送信）。
+   */
+  favicon_url: string | null;
+  is_read: boolean;
+  is_starred: boolean;
+}
+
+/**
+ * 検索 API（GET /api/items/search）のレスポンス。
+ *
+ * カーソルベースページネーション形式で、`next_cursor` は `<RFC3339Nano>|<uuid>` 形式の
+ * 文字列または null。`has_more` が false のとき、または `next_cursor` が null / 空文字の
+ * ときは次ページなしとして扱う（impl-notes Task 4 / 5 の判断と整合）。
+ */
+export interface ItemSearchResponse {
+  items: ItemSearchHit[];
+  next_cursor: string | null;
+  has_more: boolean;
+}


### PR DESCRIPTION
## 概要

RSS フィードリーダー Feedman に記事検索機能を追加します。ヘッダーからの横断検索（全購読フィード対象）と、フィード選択中のフィード内検索の 2 モードをサポートします。Go バックエンド（DB マイグレーション / Repository / Service / Handler）と Next.js フロントエンド（状態管理 / UI コンポーネント / データフック）の両レイヤーを実装しました。

## 対応 Issue

Closes #120

## 関連 PR

- 設計 PR: #127（merged）

## 実装内容

- (Task 1) `pg_trgm` 拡張と GIN インデックス（`idx_items_title_trgm` / `idx_items_content_trgm`）を追加する DB マイグレーション
- (Task 2) `model.ItemSearchHit` 構造体・`ErrCodeInvalidSearchQuery` / `ErrCodeFeedNotSubscribed` エラーコードと生成関数を追加
- (Task 3) `ItemSearchRepository` インターフェースと `PostgresItemRepo.SearchByUserAndKeyword` 実装（`ILIKE` + `$3::uuid IS NULL` ガード + タプル比較ページング）、DB 結合テスト 10 ケース
- (Task 4) `internal/itemsearch.SearchService`（クエリ正規化 / LIKE メタ文字エスケープ / 購読確認 / cursor 解析 / HasMore 判定）、テーブル駆動テスト 30+ ケース
- (Task 5) `GET /api/items/search` ハンドラ・ルーター登録・`ItemSearchServiceAdapter`・`app.go` wiring、ハンドラテスト（200 / 401 / 400 / 403）
- (Task 6) `AppState` に検索状態 4 フィールド（`searchQuery` / `isSearching` / `searchScope` / `searchFeedId`）と `SET_SEARCH_QUERY` / `CLEAR_SEARCH` アクションを追加
- (Task 7) `useItemSearch` フック（`useInfiniteQuery`）・`HeaderSearchBar` / `FeedSearchBar` / `SearchResults` コンポーネントを新規作成（各テスト付き）
- (Task 8) `AppShell` ヘッダーへの `HeaderSearchBar` 統合・右ペインを `isSearching ? SearchResults : ItemList` で切替・`ItemList` に `FeedSearchBar` を配置

## 受入基準チェック

- [x] Req 1.1: ヘッダーに横断検索バーを常設 ← `header-search-bar.test.tsx` / `app-shell.test.tsx`
- [x] Req 1.2: フィード内検索バーをフィルタ同列に配置 ← `feed-search-bar.test.tsx` / `item-list.test.tsx`
- [x] Req 1.3-1.4: 横断 / フィード内それぞれ `SET_SEARCH_QUERY(scope)` dispatch ← 両バーテスト
- [x] Req 1.5: 空入力では検索発火しない ← バーテスト + `service_test.go`
- [x] Req 1.6: クリアボタンで `CLEAR_SEARCH`、`selectedFeedId` / `filter` 保持 ← `app-state.test.tsx`
- [x] Req 2.1-2.6: 横断 / フィード内・タイトル+本文 ILIKE・ILIKE による大小文字無視 ← `postgres_item_repo_search_test.go`
- [x] Req 3.1-3.4: ユーザー隔離・未購読フィード除外 ← DB 結合テスト
- [x] Req 3.5: 未購読 feed_id に 403 FEED_NOT_SUBSCRIBED ← `service_test.go` / `item_search_handler_test.go`
- [x] Req 4.1: `ORDER BY published_at DESC NULLS LAST, id DESC` + カーソルページング ← DB 結合テスト
- [x] Req 4.2: `feed_title` / `favicon_url` を含むレスポンス・global スコープ時バッジ表示 ← `search-results.test.tsx`
- [x] Req 4.3-4.5: 空・ローディング・エラー状態出し分け ← `search-results.test.tsx`
- [x] Req 4.6-4.7: 本文展開・検索 / 通常モード切替 ← `app-shell.test.tsx`
- [x] Req 5.1-5.2: `useMarkAsRead` / `useToggleStar` を SearchResults から再利用
- [x] Req 5.3: 検索 SQL は SELECT 専用・スナップショット不変テスト ← DB 結合テスト
- [x] NFR 1.1: TanStack Query `isLoading` 即時 true によるローディング表示 ← `search-results.test.tsx`
- [x] NFR 2.1-2.3: 既存 ItemList 経路を破壊しない / CLEAR_SEARCH で状態復元 / FeedSearchBar の null ガード
- [x] NFR 3.1: `slog.Info("item search request", ...)` 構造化ログ ← `item_search_handler.go`

## テスト結果

```
Go: go test ./... — 全 21 パッケージ green、go vet clean（impl-notes Task 5 / Task 7 記録）
Web: npm test     — 30 ファイル 276 ケース全 pass、ESLint errors 0（impl-notes Task 7 記録）
```

DB 結合テスト（`postgres_item_repo_search_test.go` 10 ケース）は `TEST_DATABASE_URL` 未設定環境では skip され、CI の PostgreSQL サービスコンテナ上で実行されます。

## 実装上の判断

主要な設計判断は `docs/specs/120-issue/impl-notes.md` の各 Task 節を参照してください。以下はレビュワーが特に注意すべき差分です。

- **`SET_SEARCH_QUERY` の `searchFeedId` 計算**: `action.feedId ?? null`（`design.md` は `action.feedId ?? state.selectedFeedId`）。`FeedSearchBar` が `feedId` を明示 dispatch するため `state` 依存を削除したが、意図が異なる場合は修正が必要です（impl-notes Task 6）
- **`CLEAR_SEARCH` で `expandedItemId` を保持**: `design.md` は `expandedItemId = null` を含めると記述しているが、UX 上の理由で保持。違和感が出れば揃え戻しが必要です（impl-notes Task 6 / 8）
- **`ItemSearchSummary` に `FaviconData` / `FaviconMime` を pass-through**: `design.md` の `FaviconURL *string` のみのフィールド一覧から拡張。Adapter 層で data URL 化する責務分離（impl-notes Task 4）

## 確認事項 / レビュワーへの依頼

- Reviewer の approve 済み判定: `docs/specs/120-issue/review-notes.md` 参照（RESULT: approve、Findings なし）
- Reviewer 補足: develop には #117（StarredItemList 等）が merge 済みで、本ブランチの base commit には含まれない。`git diff develop..HEAD` では関連コードが「削除」に見えるが本ブランチの変更ではない。develop への merge 前に rebase が推奨される
- base: develop / baseRefName: develop / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #120 のコメントを参照してください。