### PR TITLE
fix: #117/#120 並行 merge による develop CI 赤を修正

### DIFF
--- a/internal/repository/postgres_item_repo_starred_test.go
+++ b/internal/repository/postgres_item_repo_starred_test.go
@@ -10,9 +10,9 @@ import (
 	_ "github.com/lib/pq"
 )
 
-// insertTestItem はテスト用記事を items テーブルに挿入し、生成された ID を返す。
+// insertStarredTestItem はテスト用記事を items テーブルに挿入し、生成された ID を返す。
 // title / published_at を指定でき、スター記事一覧の並び順検証に利用する。
-func insertTestItem(t *testing.T, db *sql.DB, feedID, title string, publishedAt time.Time) string {
+func insertStarredTestItem(t *testing.T, db *sql.DB, feedID, title string, publishedAt time.Time) string {
 	t.Helper()
 	var itemID string
 	err := db.QueryRow(
@@ -26,9 +26,9 @@ func insertTestItem(t *testing.T, db *sql.DB, feedID, title string, publishedAt 
 	return itemID
 }
 
-// insertTestItemState はテスト用 item_states 行を挿入する。
+// insertStarredTestItemState はテスト用 item_states 行を挿入する。
 // is_read / is_starred を指定でき、スター解除済み・既読既スター記事等の状態組合せを表現できる。
-func insertTestItemState(t *testing.T, db *sql.DB, userID, itemID string, isRead, isStarred bool) {
+func insertStarredTestItemState(t *testing.T, db *sql.DB, userID, itemID string, isRead, isStarred bool) {
 	t.Helper()
 	_, err := db.Exec(
 		`INSERT INTO item_states (user_id, item_id, is_read, is_starred)
@@ -69,13 +69,13 @@ func TestPostgresItemRepo_ListStarredByUser(t *testing.T) {
 		feedB := insertTestFeedWithTitle(t, db, "https://example.com/feed-b.xml", "Feed B", "https://example.com/b", model.FetchStatusActive)
 
 		// 公開日時を 3 段階に分けて並び順を検証可能にする。
-		olderItem := insertTestItem(t, db, feedA, "old-article", base.Add(-2*time.Hour))
-		middleItem := insertTestItem(t, db, feedB, "mid-article", base.Add(-1*time.Hour))
-		newerItem := insertTestItem(t, db, feedA, "new-article", base)
+		olderItem := insertStarredTestItem(t, db, feedA, "old-article", base.Add(-2*time.Hour))
+		middleItem := insertStarredTestItem(t, db, feedB, "mid-article", base.Add(-1*time.Hour))
+		newerItem := insertStarredTestItem(t, db, feedA, "new-article", base)
 
-		insertTestItemState(t, db, user, olderItem, false, true)
-		insertTestItemState(t, db, user, middleItem, true, true) // is_read=true でもスターなら返る
-		insertTestItemState(t, db, user, newerItem, false, true)
+		insertStarredTestItemState(t, db, user, olderItem, false, true)
+		insertStarredTestItemState(t, db, user, middleItem, true, true) // is_read=true でもスターなら返る
+		insertStarredTestItemState(t, db, user, newerItem, false, true)
 
 		// Act
 		rows, err := repo.ListStarredByUser(ctx, user, time.Time{}, 50)
@@ -123,12 +123,12 @@ func TestPostgresItemRepo_ListStarredByUser(t *testing.T) {
 		userB := insertTestUser(t, db, "user-b@example.com")
 		feed := insertTestFeedWithTitle(t, db, "https://example.com/shared.xml", "Shared Feed", "", model.FetchStatusActive)
 
-		itemA := insertTestItem(t, db, feed, "article-a", base.Add(-1*time.Hour))
-		itemB := insertTestItem(t, db, feed, "article-b", base)
+		itemA := insertStarredTestItem(t, db, feed, "article-a", base.Add(-1*time.Hour))
+		itemB := insertStarredTestItem(t, db, feed, "article-b", base)
 
 		// userA は itemA のみスター、userB は itemB のみスター。
-		insertTestItemState(t, db, userA, itemA, false, true)
-		insertTestItemState(t, db, userB, itemB, false, true)
+		insertStarredTestItemState(t, db, userA, itemA, false, true)
+		insertStarredTestItemState(t, db, userB, itemB, false, true)
 
 		// Act: userA の一覧を取得する。
 		rows, err := repo.ListStarredByUser(ctx, userA, time.Time{}, 50)
@@ -153,11 +153,11 @@ func TestPostgresItemRepo_ListStarredByUser(t *testing.T) {
 		// Arrange: スター付き 1 件 + スター解除済み 1 件。
 		user := insertTestUser(t, db, "unstarred@example.com")
 		feed := insertTestFeedWithTitle(t, db, "https://example.com/mixed.xml", "Mixed Feed", "", model.FetchStatusActive)
-		starred := insertTestItem(t, db, feed, "starred-article", base)
-		unstarred := insertTestItem(t, db, feed, "unstarred-article", base.Add(-1*time.Hour))
+		starred := insertStarredTestItem(t, db, feed, "starred-article", base)
+		unstarred := insertStarredTestItem(t, db, feed, "unstarred-article", base.Add(-1*time.Hour))
 
-		insertTestItemState(t, db, user, starred, false, true)
-		insertTestItemState(t, db, user, unstarred, false, false) // 既読/スター無しの状態行
+		insertStarredTestItemState(t, db, user, starred, false, true)
+		insertStarredTestItemState(t, db, user, unstarred, false, false) // 既読/スター無しの状態行
 
 		// Act
 		rows, err := repo.ListStarredByUser(ctx, user, time.Time{}, 50)
@@ -187,12 +187,12 @@ func TestPostgresItemRepo_ListStarredByUser(t *testing.T) {
 		pubAtMid := base.Add(-1 * time.Hour)
 		pubAtFuture := base
 
-		past := insertTestItem(t, db, feed, "past", pubAtPast)
-		mid := insertTestItem(t, db, feed, "mid", pubAtMid)
-		future := insertTestItem(t, db, feed, "future", pubAtFuture)
-		insertTestItemState(t, db, user, past, false, true)
-		insertTestItemState(t, db, user, mid, false, true)
-		insertTestItemState(t, db, user, future, false, true)
+		past := insertStarredTestItem(t, db, feed, "past", pubAtPast)
+		mid := insertStarredTestItem(t, db, feed, "mid", pubAtMid)
+		future := insertStarredTestItem(t, db, feed, "future", pubAtFuture)
+		insertStarredTestItemState(t, db, user, past, false, true)
+		insertStarredTestItemState(t, db, user, mid, false, true)
+		insertStarredTestItemState(t, db, user, future, false, true)
 
 		// Act: cursor = pubAtMid を指定（境界条件: i.published_at < pubAtMid のみ返る）
 		rows, err := repo.ListStarredByUser(ctx, user, pubAtMid, 50)
@@ -228,9 +228,9 @@ func TestPostgresItemRepo_ListStarredByUser(t *testing.T) {
 		// Arrange: ユーザーとフィードはあるが、当該ユーザーはスターを付与していない。
 		user := insertTestUser(t, db, "no-star@example.com")
 		feed := insertTestFeedWithTitle(t, db, "https://example.com/no-star.xml", "No Star Feed", "", model.FetchStatusActive)
-		item := insertTestItem(t, db, feed, "article", base)
+		item := insertStarredTestItem(t, db, feed, "article", base)
 		// スターを付与しない（item_states を挿入しない or is_starred=false を挿入する）。
-		insertTestItemState(t, db, user, item, false, false)
+		insertStarredTestItemState(t, db, user, item, false, false)
 
 		// Act
 		rows, err := repo.ListStarredByUser(ctx, user, time.Time{}, 50)
@@ -251,12 +251,12 @@ func TestPostgresItemRepo_ListStarredByUser(t *testing.T) {
 
 		user := insertTestUser(t, db, "limit@example.com")
 		feed := insertTestFeedWithTitle(t, db, "https://example.com/limit.xml", "Limit Feed", "", model.FetchStatusActive)
-		item1 := insertTestItem(t, db, feed, "limit-item1", base)
-		item2 := insertTestItem(t, db, feed, "limit-item2", base.Add(-1*time.Hour))
-		item3 := insertTestItem(t, db, feed, "limit-item3", base.Add(-2*time.Hour))
-		insertTestItemState(t, db, user, item1, false, true)
-		insertTestItemState(t, db, user, item2, false, true)
-		insertTestItemState(t, db, user, item3, false, true)
+		item1 := insertStarredTestItem(t, db, feed, "limit-item1", base)
+		item2 := insertStarredTestItem(t, db, feed, "limit-item2", base.Add(-1*time.Hour))
+		item3 := insertStarredTestItem(t, db, feed, "limit-item3", base.Add(-2*time.Hour))
+		insertStarredTestItemState(t, db, user, item1, false, true)
+		insertStarredTestItemState(t, db, user, item2, false, true)
+		insertStarredTestItemState(t, db, user, item3, false, true)
 
 		// Act: limit=2 を指定
 		rows, err := repo.ListStarredByUser(ctx, user, time.Time{}, 2)

--- a/web/src/components/app-shell.test.tsx
+++ b/web/src/components/app-shell.test.tsx
@@ -97,6 +97,20 @@ function setupMockFetch() {
         }),
       });
     }
+    // 横断検索 API（GET /api/items/search）を空結果で返す。
+    // ItemSearchResponse の形（items / next_cursor / has_more）を満たさないと
+    // SearchResults の allHits 構築で undefined 要素が混入しクラッシュするため、
+    // 検索モードの空状態表示を検証するには正しい空レスポンス形が必要。
+    if (typeof url === "string" && url.includes("/api/items/search")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          items: [],
+          next_cursor: null,
+          has_more: false,
+        }),
+      });
+    }
     return Promise.resolve({
       ok: true,
       json: async () => ({}),


### PR DESCRIPTION
## Summary

- #117（横断お気に入り）と #120（記事検索）が develop に並行 merge された結果、テキスト conflict として検出されない**意味的な破綻**が develop HEAD（b606211）に持ち込まれ、CI（Backend Tests / Frontend Tests）が赤になっていた。本 PR はこれを解消する（#115 / PR #136 とは独立した develop 既存不具合）。
- **Backend**: `postgres_item_repo_starred_test.go`（#117 由来）と `postgres_item_repo_search_test.go`（#120 由来）が同名ヘルパー `insertTestItem` / `insertTestItemState` を異なるシグネチャで重複定義 → コンパイルエラー。starred 側を `insertStarredTestItem` / `insertStarredTestItemState` にリネームして解消。
- **Frontend**: `app-shell.test.tsx` の `setupMockFetch` に `/api/items/search`（#120 で追加）の分岐が無く catch-all の `{}` を返していた。`ItemSearchResponse` 契約を満たさず `SearchResults` の `allHits` 構築で undefined 要素が混入しクラッシュ。空レスポンス形（`items: [] / next_cursor: null / has_more: false`）を返す分岐を追加。

いずれも「テストを通すための実装/テスト弱体化」ではなく、並行 merge が持ち込んだ破綻の修正（backend は重複定義解消、frontend は API 契約に沿ったモック形の付与）。

## Test plan

- [x] Backend: `go vet ./...` clean
- [x] Backend: `go test ./...` 全パッケージ ok
- [x] Frontend: `vitest run` 302 passed（`app-shell.test.tsx` 3 failed → 11 passed）
- [x] Frontend: `npm run lint` 0 errors（既存 warning 6 件のみ）
- [x] Frontend: `npm run build` success
- [ ] CI（Backend Tests / Frontend Tests）green を確認

## 確認事項

- 本 PR は手動修正（auto-dev パイプライン非経由）のため Issue #137 に `auto-dev` ラベルは付与していない。
- フロントの修正は production コードへの防御コード追加ではなく、テストモックを実 API 契約（`ItemSearchResponse`）に揃える方針を採用した（CLAUDE.md「起こり得ないシナリオに防御コードを足さない」「テストを弱めない」に整合）。production の `search-results.tsx` は契約準拠レスポンス前提のまま据え置き。
- backend のヘルパーリネームは starred 側のみ実施し、search 側（`content` 引数付きシグネチャ）は据え置いた。

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)