### PR TITLE
test(db): cleanup に user_cross_feed_views を追加し migrate テストの冪等性を回復 (#143)

### DIFF
--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -38,6 +38,7 @@ func setupTestDB(t *testing.T) (*sql.DB, string) {
 
 	// クリーンアップ: 既存のテーブルとマイグレーション履歴を削除
 	cleanupSQL := `
+		DROP TABLE IF EXISTS user_cross_feed_views CASCADE;
 		DROP TABLE IF EXISTS sessions CASCADE;
 		DROP TABLE IF EXISTS user_settings CASCADE;
 		DROP TABLE IF EXISTS item_states CASCADE;

--- a/internal/repository/postgres_feed_repo_test.go
+++ b/internal/repository/postgres_feed_repo_test.go
@@ -103,6 +103,7 @@ func setupListDueTestDB(t *testing.T) *sql.DB {
 	}
 
 	cleanupSQL := `
+		DROP TABLE IF EXISTS user_cross_feed_views CASCADE;
 		DROP TABLE IF EXISTS sessions CASCADE;
 		DROP TABLE IF EXISTS user_settings CASCADE;
 		DROP TABLE IF EXISTS item_states CASCADE;

--- a/internal/repository/postgres_item_repo_search_test.go
+++ b/internal/repository/postgres_item_repo_search_test.go
@@ -44,6 +44,7 @@ func setupItemSearchTestDB(t *testing.T) *sql.DB {
 	}
 
 	cleanupSQL := `
+		DROP TABLE IF EXISTS user_cross_feed_views CASCADE;
 		DROP TABLE IF EXISTS sessions CASCADE;
 		DROP TABLE IF EXISTS user_settings CASCADE;
 		DROP TABLE IF EXISTS item_states CASCADE;

--- a/internal/repository/postgres_subscription_repo_db_test.go
+++ b/internal/repository/postgres_subscription_repo_db_test.go
@@ -44,6 +44,7 @@ func setupSubscriptionTestDB(t *testing.T) *sql.DB {
 
 	// クリーンアップ: 既存のテーブルとマイグレーション履歴を削除してクリーンな状態にする
 	cleanupSQL := `
+		DROP TABLE IF EXISTS user_cross_feed_views CASCADE;
 		DROP TABLE IF EXISTS sessions CASCADE;
 		DROP TABLE IF EXISTS user_settings CASCADE;
 		DROP TABLE IF EXISTS item_states CASCADE;


### PR DESCRIPTION
## 概要

Fixes #143

`internal/database/migrate_test.go` の `TestRunMigrations_Idempotent` が実テスト DB に対して `relation "user_cross_feed_views" already exists (42P07)` で失敗する不具合を修正する。

## 原因

`setupTestDB` の `cleanupSQL` が、#121 で追加された `user_cross_feed_views`（マイグレーション `20260528130000_add_user_cross_feed_views`）を DROP していなかった。`DROP TABLE IF EXISTS users CASCADE;` は `user_cross_feed_views.user_id` の外部キー制約を落とすだけで、`user_cross_feed_views` テーブル本体は残存する。そのため実 DB を使い回すと 2 回目以降のマイグレーション適用で `CREATE TABLE user_cross_feed_views`（`IF NOT EXISTS` なし）が衝突していた。

CI は `go test` に test DB を渡さず該当テストが skip されるため検知されていなかった（#141 の version 衝突修正で `TestRunMigrations_Up` が通るようになり顕在化）。

repository 層の同種ヘルパー（`setupListDueTestDB` / `setupItemSearchTestDB` / `setupSubscriptionTestDB`）も同じく drop し忘れていたため併せて補った。`setupCrossFeedViewTestDB`（#121 で追加）は既に drop 済みのため対象外。

## 変更内容

以下 4 つの cleanup ブロック先頭に `DROP TABLE IF EXISTS user_cross_feed_views CASCADE;` を追加（既存の正しい記法 `postgres_user_cross_feed_view_repo_test.go` に揃える）。

- `internal/database/migrate_test.go`（`setupTestDB`）
- `internal/repository/postgres_feed_repo_test.go`（`setupListDueTestDB` — `cross_feed` / `starred` テストも経由）
- `internal/repository/postgres_item_repo_search_test.go`（`setupItemSearchTestDB`）
- `internal/repository/postgres_subscription_repo_db_test.go`（`setupSubscriptionTestDB`）

cleanup の追加のみで、assert やテスト観点は一切弱めていない。

## 検証

使い捨て PostgreSQL 16 を立て `TEST_DATABASE_URL` を指定して実 DB で確認:

```
go test ./internal/database/... -run TestRunMigrations -v   # Up / Idempotent ともに PASS
go test ./internal/database/... ./internal/repository/...    # 両パッケージ ok / トップレベル 55 件 PASS・SKIP 0・FAIL 0
go vet ./internal/database/... ./internal/repository/...     # clean
gofmt -l <対象 4 ファイル>                                    # 差分なし
```

- 修正前: `TestRunMigrations_Idempotent` が 42P07 で FAIL することを再現確認済み
- 修正後: 上記すべて green

## 確認事項

- **base ブランチ**: 本 PR は `origin/develop`（6ac52fb、#121/#141 マージ済み）起点で作成し `develop` 向けに出している。ローカルの `develop` チェックアウトは #121/#130/#141/#142 を含まない stale な状態（issue-120 のローカルマージ）だったため、それとは独立に origin/develop を base とした。
- **drop 位置**: `user_cross_feed_views` は `users` を参照する子テーブルのため、CASCADE 前提でも drop 順序の先頭に配置した（#121 既存ヘルパーと同一順序）。
- **CI 検知漏れ**: 本質的には CI が test DB を与えていない点が盲点。test DB を CI へ組み込むかは本 PR のスコープ外（別 Issue 化が望ましい）。

## 関連

- Related: #121 #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)
