### PR TITLE
ci: backend ジョブに postgres service と TEST_DATABASE_URL を追加し DB 連動テストを実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,30 @@ jobs:
   backend:
     name: Backend Tests
     runs-on: ubuntu-latest
+    services:
+      # DB 連動テスト（internal/database / internal/repository）が t.Skipf で silently skip
+      # されず実際に RUN されるよう、テスト側 default と同じ接続情報の PostgreSQL を service
+      # container として起動する（#146 / Related #143）。これが無いと migrate 冪等性・
+      # repository 層の回帰を CI で検知できない。
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: feedman
+          POSTGRES_PASSWORD: feedman
+          POSTGRES_DB: feedman_test
+        # job は runner 上で直接実行されるため、localhost:5432 で到達できるようポートを公開する。
+        ports:
+          - 5432:5432
+        # healthcheck が healthy になるまで GitHub Actions が steps の開始を待機する。
+        options: >-
+          --health-cmd "pg_isready -U feedman -d feedman_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      # internal/database/migrate_test.go の testDatabaseURL と同一の接続情報。
+      # 未設定だと各 setup ヘルパーが DB へ接続できず DB 連動テストを skip する。
+      TEST_DATABASE_URL: postgres://feedman:feedman@localhost:5432/feedman_test?sslmode=disable
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## 概要

`.github/workflows/ci.yml` の `backend` ジョブは `go test ./...` のみで PostgreSQL service も
`TEST_DATABASE_URL` も与えていなかった。そのため DB 連動テスト（`internal/database` /
`internal/repository`）は各 setup ヘルパー（`setupTestDB` / `setupListDueTestDB` /
`setupItemSearchTestDB` / `setupSubscriptionTestDB` / `setupCrossFeedViewTestDB`）の `t.Skipf`
ガードで **すべて silently skip** されていた。この盲点により migrate 冪等性・repository 層の
回帰を CI で検知できず、#143 の不具合（PR #144 で修正済み）が長期間 CI を通過していた。

## 変更内容

- `backend` ジョブに `postgres:16` の service container を追加
  - `POSTGRES_USER=feedman` / `POSTGRES_PASSWORD=feedman` / `POSTGRES_DB=feedman_test`
  - `ports: 5432:5432`（job は runner 上で直接実行されるため localhost で到達できるよう公開）
  - `--health-cmd "pg_isready -U feedman -d feedman_test"` healthcheck を付与し、healthy に
    なるまで steps 開始を待機
- `backend` ジョブ env に `TEST_DATABASE_URL=postgres://feedman:feedman@localhost:5432/feedman_test?sslmode=disable`
  を追加（`internal/database/migrate_test.go` の `testDatabaseURL` default と同一接続情報）

変更は `backend` ジョブのみに閉じており、他ジョブ（go-vet / govulncheck / frontend /
frontend-lint / frontend-audit / trivy）は無変更（diff は +24 行のみ）。

## 検証

ローカルで使い捨て `postgres:16`（127.0.0.1:5433）を立て、`TEST_DATABASE_URL` を設定して検証:

- **DB 有り**: `go test ./internal/database/... ./internal/repository/...` が **PASS=118 / SKIP=0 / FAIL=0**
  （DB 連動テストが skip されず RUN される）
- **DB 無し（到達不能ポート）**: 同テストが **43 件 SKIP / 0 FAIL**（現行 CI と同じ盲点を再現）
- **CI と同じ `go test ./...` 全体**を **7 回連続実行**し、全て green（22 パッケージ ok / FAIL 0）。
  共有 DB への並列パッケージ実行による flaky は観測されなかった
- `actionlint` で workflow 構文チェック済み（NO ISSUES）

## 確認事項

- service container 由来で `backend` ジョブのウォールクロックが増えるが（postgres 起動待ち数秒程度）、
  許容範囲かご確認ください。
- 現状 `internal/database` と `internal/repository` の 2 パッケージは **同一 DB（feedman_test）を共有**
  します。ローカル 7 回連続では flaky は出ませんでしたが、将来テストが増えた場合に並列実行で競合する
  潜在リスクが残ります。必要なら別 Issue で「DB テストの分離（`-p 1` 化 or パッケージ別 DB）」を
  検討する余地があります（本 PR スコープ外）。

## 関連

- Closes #146
- Related: #143
