### PR TITLE
feat(#145): フィード内検索バーを結果表示中も残し再検索を容易にする

### DIFF
--- a/docs/specs/145--120/impl-notes.md
+++ b/docs/specs/145--120/impl-notes.md
@@ -45,6 +45,21 @@
   - **AppShell 統合テスト（`app-shell.test.tsx`）の 7 件が transient に失敗する状態**: 旧 `ItemList` が描画していたフィルタタブを `getByRole("tab", { name: "全て" })` で「ItemList が表示されたか」の proxy assertion として使っていたテストが 7 件あり、本 task の責務縮退で当該タブが ItemList 側に存在しなくなったため失敗する。これらは **Task 4 で AppShell が `FeedPaneHeader` を統合して再びフィルタタブを描画するようになると自動的に green に戻る** 想定（Task 2 の impl-notes で「task 4 で `AppShell` が `FeedPaneHeader` を呼び出す」と明記されている設計上の transient state。per-task 分割設計の意図された中間状態）。
   - **Task 4 で AppShell が `filter` props を `ItemList` に明示渡しする必要**: 本 task で `filter?` を optional にしたため、Task 4 で AppShell が `<ItemList ... filter={state.filter} />` を渡すことで design.md / tasks.md L62-63 の「props 経由で受け取る」が完全に成立する。
 
+### Task 4
+
+- **採用方針**: `web/src/components/app-shell.tsx` の右ペイン分岐を design.md「`app-shell.tsx`（修正）」節の擬似コードに従って書き換え、`FeedPaneHeader` を `SearchResults` / `ItemList` の上に挿入する責務統合のみを行う。タスク本体は AppShell の分岐ロジック変更に限定し、子コンポーネント（`FeedPaneHeader` / `ItemList` / `FeedSearchBar`）の中身は Task 1 / 2 / 3 で完成済みのため触らない。
+- **重要な判断**:
+  - **5 分岐 + ネスト 1 段の優先順位設計**: `isSearching` を最優先、その中で `searchScope === 'feed' && searchFeedId !== null` をネスト判定する 2 段構造を採用（design.md 擬似コードのフラット if-else を JSX の三項演算ネストで表現）。`searchScope === 'global'` 枝は `FeedPaneHeader` を挿入せず `<SearchResults />` のみ（Req 2.1）、`searchScope === 'feed' && searchFeedId !== null` 枝は `<FeedPaneHeader mode="search-feed" /> + <SearchResults />` を render（Req 1.1）。`searchFeedId === null` の例外ケース（理論上 `searchScope='feed'` だが feedId 未指定）は global 検索と同等扱いで `<SearchResults />` のみとする（防御的）。
+  - **「フィードを選択してください」メッセージの所有権移譲**: 旧構造では `ItemList` 側が `feedId === null` のときに当該メッセージを描画していたが、Task 3 で `ItemList` から責務を縮退した結果、AppShell が `selectedFeedId === null` 枝で直接描画する設計に変更（design.md「`app-shell.tsx`（修正）」節の擬似コード `// フィード未選択（Req 2.3 の前提状態）` 行に整合）。`ItemList` は `feedId !== null` を前提として呼び出される。これは `ItemList` 側に「フィードを選択してください」描画ロジックが残っている（item-list.tsx L114-121）が、AppShell が `feedId={state.selectedFeedId}` を渡すのは `selectedFeedId !== null` の枝のみなので到達不能コードになる（残置自体は仕様変更ではないため削除しない / Task 3 のスコープ）。
+  - **`filter` props 明示渡し（Task 3 で optional 化した橋渡しの確定）**: AppShell は `<ItemList ... filter={state.filter} />` と明示渡しすることで Task 3 の `filter?: ItemFilter` + `filter = "all"` fallback が defacto unused になる（design.md / tasks.md L62-63 の「props 経由で受け取る」が完全成立）。`FeedPaneHeader` には `filter={state.filter}` + `onFilterChange={(filter) => dispatch({ type: 'SET_FILTER', filter })}` を渡し、AppState の reducer 既存挙動（L218-222 `SET_FILTER` / L173 `SELECT_FEED` 時の `filter: "all"` リセット）を介してフィード切替時のリセットを担保する（design.md 確認事項 3 採用方針と整合）。
+  - **import 追加は `FeedPaneHeader` 1 件のみ**: 既存の `SearchResults` / `ItemList` / `StarredItemList` / `CrossFeedItemList` / `HeaderSearchBar` の import 配置を変更せず、`FeedPaneHeader` を `ItemList` の隣に追加。新規 `dispatch({ type: 'SET_FILTER', filter })` 呼び出しは既存 `useAppDispatch` hook をそのまま使用（AppState の reducer に既存実装あり / app-state.tsx L218-222）。
+  - **DOM 構造の維持**: `<main data-testid="right-pane" className="flex-1 overflow-hidden">` の内側 `<div className="flex flex-col h-full">` 構造は手付かずで、その flex-col の **直接の子**として `FeedPaneHeader` + リスト本体を fragment（`<>...</>`）で並べる形に変更した。`FeedPaneHeader` の `flex-shrink-0` ヘッダ DOM + リスト本体の `flex-1 overflow-y-auto` の組合せで flex-col layout が成立する（Task 2 で `FeedPaneHeader` 内部の `flex flex-shrink-0` div は実装済み / `ItemList` 内部の `flex-1 overflow-y-auto` も Task 3 縮退後も保持されている）。
+  - **Task 3 transient 失敗 7 件の自動解消確認**: Task 3 impl-notes 残存課題で記載されていた `app-shell.test.tsx` の 7 件 transient 失敗（旧 ItemList が描画していたフィルタタブを ItemList 表示判定の proxy として使用していたケース）は、Task 4 で AppShell が `<FeedPaneHeader mode="normal" .../>` を統合して再びフィルタタブを描画するようになったため、本 task 単独で全 19 件 green に復帰（per-task 分割設計の意図された中間状態が解消）。
+- **残存課題**:
+  - **Task 5（AppShell 統合テスト追加）が次タスク**: tasks.md Task 5 は「フィード内検索の連続操作（フィード選択 → キーワード入力 → Enter → 検索結果中に input 編集 → 再検索 / 空入力 / クリア）」を 9 ケースの統合テストで検証する追加スコープ。本 task では既存 19 件の transient 失敗を解消する以上の新規テストは追加しなかった（Task 5 のスコープ）。
+  - **横断検索結果中の FeedSearchBar 非表示の構造的担保**: AppShell の分岐で `searchScope === 'global'` 枝に `<FeedPaneHeader />` を挿入しない実装は完了しているが、回帰防止の専用テスト（Req 2.1 の「横断検索結果表示中に `feed-search-bar` testid が存在しない」）は Task 5 の統合テスト追加スコープに含まれる。
+  - **`ItemList` の `feedId === null` 到達不能化**: AppShell が `selectedFeedId !== null` の枝でのみ `<ItemList />` を呼ぶようになったため、`item-list.tsx` L114-121 の「フィード未選択時」分岐が defacto unreachable code となる。これは Task 3 のスコープで明示削除されておらず（Task 3 は最小差分の優先で当該分岐を残置）、本 task でも仕様変更を避けるため削除しない。将来の cleanup PR でデッドコードとして整理する余地あり。
+
 ## 受入基準カバレッジ
 
 | Requirement | Test |
@@ -75,6 +90,13 @@
   - 7 件失敗の内訳: 全件「フィルタタブが ItemList 経由で描画されること」を ItemList 表示判定の proxy として使用していたケース（`expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument()`）。Task 4 で AppShell が `FeedPaneHeader` を統合し再びフィルタタブを描画するため、それらは Task 4 完了時点で自動的に green に戻る。本 task で `ItemList` のテストを通すこと自体は完全に成功している（28 / 28）
 - `cd web && npm run lint`: 0 errors / 5 warnings（warnings は全て既存のもので本 task とは無関係。Task 2 時点 6 warnings → Task 3 で 5 warnings に減少した理由は、撤去された `useState<ItemFilter>` 関連の暗黙警告ではなく、テストヘルパーの未使用 import 整理に伴う副次的な減少）
 - `cd web && npm run build`: ✓ success（standalone build 5 routes prerendered）
+
+### Task 4 検証結果
+
+- `cd web && npm test -- app-shell`: 19 / 19 pass（Task 3 完了時点で transient 失敗していた 7 件が全て自動 green 復帰。新規追加テストは Task 5 のスコープのため本 task では 0 件）
+- `cd web && npm test`: 365 / 365 pass（全 web スイート / 既存 358 件 + Task 3 transient 失敗解消の 7 件）
+- `cd web && npm run lint`: 0 errors / 5 warnings（warnings は全て既存のもので本 task とは無関係。Task 3 時点と同件数 / 同一内容）
+- `cd web && npm run build`: ✓ success（standalone build 5 routes prerendered / Task 3 時点と同一の build output）
 
 ## 確認事項
 

--- a/docs/specs/145--120/impl-notes.md
+++ b/docs/specs/145--120/impl-notes.md
@@ -60,15 +60,36 @@
   - **横断検索結果中の FeedSearchBar 非表示の構造的担保**: AppShell の分岐で `searchScope === 'global'` 枝に `<FeedPaneHeader />` を挿入しない実装は完了しているが、回帰防止の専用テスト（Req 2.1 の「横断検索結果表示中に `feed-search-bar` testid が存在しない」）は Task 5 の統合テスト追加スコープに含まれる。
   - **`ItemList` の `feedId === null` 到達不能化**: AppShell が `selectedFeedId !== null` の枝でのみ `<ItemList />` を呼ぶようになったため、`item-list.tsx` L114-121 の「フィード未選択時」分岐が defacto unreachable code となる。これは Task 3 のスコープで明示削除されておらず（Task 3 は最小差分の優先で当該分岐を残置）、本 task でも仕様変更を避けるため削除しない。将来の cleanup PR でデッドコードとして整理する余地あり。
 
+### Task 5
+
+- **採用方針**: `web/src/components/app-shell.test.tsx` の既存 `describe("AppShell コンポーネント")` 内に、`describe("フィード内検索の連続操作（Task 5 / Issue #145）")` ネスト describe を追加し、tasks.md L102-119 に列挙された 9 ケースを 1:1 で対応する個別 `it` として実装。fetch モックは既存 `setupMockFetch`（`/api/feeds`, `/api/items/search`, `/api/feeds/:id/items` を全て空応答）をそのまま再利用し、テスト個別の上書きは行わなかった（空 SearchResults / 空 ItemList 状態の組合せで 9 ケース全 AC を判定可能なため）。
+- **重要な判断**:
+  - **判定戦略の選択**: 「feed-search-bar testid の有無」「feed-search-input の value 比較」「mockFetch.mock.calls 履歴の `q=` クエリパラメータ抽出」「`role="tab"` 全て / 未読 の存在 + `data-state` 属性」「`data-selected="true"` 属性」の 5 軸で判定。queryKey 更新の検証（Req 1.4）は `useItemSearch` の内部 state を直接見るのではなく、mockFetch の最新 `/api/items/search?q=...` の `q` 値を抽出する `lastSearchQuery()` ヘルパで間接的に検証する形を採用（黒箱テスト / 既存 SearchResults テストパターンと整合 / TanStack Query の内部 queryKey 更新は fetch 発火の必要条件のため十分）。
+  - **fetch モック共有方針**: 既存 `setupMockFetch` は `/api/items/search` を `{ items: [], next_cursor: null, has_more: false }` で常に空応答するため、9 ケース全てで「SearchResults 空状態 → `search-results-empty` testid 出現」を観測でき、テスト個別の mock 上書き不要だった。`search-results.test.tsx` のような検索結果データ ありの mock も検討したが、Task 5 の重点は「右ペイン分岐の組合せが意図通り」であり、検索結果の中身は SearchResults 単体テストで担保済み（NFR 1.2 の DOM 構造同一性確認はケース 9 で testid + tagName + 隣接 testid 不在の構造比較で行うため、データ ありモックは不要）。
+  - **ケース 3（再検索 input 編集）の上書き手段**: 初実装で `user.tripleClick(input)` + `user.type` を採用したが、`<input type="search">` で jsdom + radix-ui ベース Input のテキスト全選択挙動が安定せず "typescriptkubernetes" のように文字列連結された。`user.clear(input)` → `user.type(input, "kubernetes")` の組合せに修正し、value=="kubernetes" + lastSearchQuery()=="kubernetes" の両方が green に。`user.clear()` は内部的に `input.setSelectionRange + fireEvent('change', '')` を行うため Controlled component の `localQuery` state も同期的に "" にリセットされる。
+  - **ケース 5（filter 保持確認）の補強**: NFR 1.1 の「通常利用の非回帰」の一環として、フィード内検索 →クリア の往復で `filter` も保持されることを確認するため、検索前に「未読」タブをクリックして filter=="unread" に切替えてから検索 → クリア後に再び `getByRole("tab", { name: "未読" })` の `data-state="active"` を確認する形にした。AppState reducer の `CLEAR_SEARCH` は searchQuery のみリセットし filter は保持するため（contexts/app-state.tsx L232-239）、本検証は reducer 仕様と整合。
+  - **ケース 9（NFR 1.2 構造比較）の判定粒度**: snapshot 比較は導入していない（snapshot は本変更外の DOM 変動で false-fail しやすいため）。代わりに「テキスト文言 "検索結果はありません" の一致」「empty 要素 tagName === "DIV"」「`search-results` testid 不在」「ローディング / エラー testid 不在」「FeedPaneHeader の feed-search-bar testid との同居」の 5 観点で構造同一性を担保した。`search-results.tsx` L130-138 の空状態 DOM 構造（`<div data-testid="search-results-empty" className="flex items-center justify-center h-full ...">検索結果はありません</div>`）が変わると本検証が落ちる。
+- **残存課題**: なし（per-task ループ最終 task / Task 1〜4 の実装が全て統合された状態で 9 ケース 全 pass を確認。Task 5 完了で Issue #145 の全 AC（Req 1.1〜1.6 / Req 2.1〜2.3 / Req 3.1〜3.4 / NFR 1.1〜1.2 / NFR 2.1）が単体テスト + 統合テストでカバーされた）。
+
 ## 受入基準カバレッジ
 
 | Requirement | Test |
 |---|---|
-| Req 1.2 (初期描画) | `feed-search-bar.test.tsx` 新規ケース「初期 mount 時に検索結果表示中... `state.searchQuery` を反映すること」/ 既存「クリアボタン...」ケースでも暗黙的にカバー |
+| Req 1.1 (検索結果表示中の feed-search-bar 残置) | `app-shell.test.tsx` 統合テスト Task 5 ケース (1)「フィード選択 → キーワード入力 → Enter で SearchResults と feed-search-bar が同時に表示されること」 |
+| Req 1.2 (初期描画) | `feed-search-bar.test.tsx` 新規ケース「初期 mount 時に検索結果表示中... `state.searchQuery` を反映すること」/ 既存「クリアボタン...」ケースでも暗黙的にカバー / `app-shell.test.tsx` Task 5 ケース (2)「検索結果表示中に feed-search-input の value が現在の検索キーワードを反映していること」 |
 | Req 1.2 (mount 後の外部 dispatch 同期 / 一般化) | `feed-search-bar.test.tsx` 新規ケース「mount 後に外部から SET_SEARCH_QUERY を dispatch すると input の value が新キーワードに同期されること」 |
-| Req 1.3 (入力編集追随) | 既存「キーワード入力 + Enter で SET_SEARCH_QUERY...」「入力に前後空白がある場合は trim された値で dispatch」で onChange の追随を検証済み |
+| Req 1.3 (入力編集追随) | 既存「キーワード入力 + Enter で SET_SEARCH_QUERY...」「入力に前後空白がある場合は trim された値で dispatch」で onChange の追随を検証済み / `app-shell.test.tsx` Task 5 ケース (3) で再検索時の input 編集追随も確認 |
+| Req 1.4 (新キーワードで新検索開始) | `app-shell.test.tsx` Task 5 ケース (3)「検索結果表示中に input を編集 → Enter で useItemSearch の queryKey が更新され新キーワードで fetch される」 |
+| Req 1.5 (空入力で検索結果維持) | `app-shell.test.tsx` Task 5 ケース (4)「検索結果表示中に input を空にして Enter → 検索結果表示が維持されること」 |
+| Req 1.6 (クリアで通常一覧復帰) | `app-shell.test.tsx` Task 5 ケース (5)「検索結果表示中にクリアボタン押下 → 通常一覧（ItemList）に戻り選択フィードと filter が保持されること」 |
+| Req 2.1 (横断検索中は feed-search-bar 非表示) | `app-shell.test.tsx` Task 5 ケース (6)「横断検索結果表示中（HeaderSearchBar から submit）に feed-search-bar testid が画面上に存在しないこと」 |
+| Req 2.2 (別フィード選択で検索解除) | `app-shell.test.tsx` Task 5 ケース (7)「フィード内検索結果表示中に左ペインで別フィードを選択 → 検索解除 → 選択先フィードの通常一覧が表示されること」 |
+| Req 2.3 (フィード未選択時 feed-search-bar 非表示) | `app-shell.test.tsx` Task 5 ケース (8)「初期状態（フィード未選択）で feed-search-bar testid が存在しないこと」 |
+| Req 3.1 (HeaderSearchBar 常設の非回帰) | 既存「ヘッダー領域に横断検索バー（HeaderSearchBar）が常設されること」/ `app-shell.test.tsx` Task 5 ケース (8) で HeaderSearchBar の継続表示も再確認 |
 | Req 3.3 (検索結果画面の非回帰 / 記事リスト挙動の非回帰 part) | `item-list.test.tsx`「filter props で渡された値が API リクエストの filter パラメータに反映されること」+ 記事描画 / 詳細展開 / 既読化 / スター切替 / 無限スクロールの既存ケース群（全 28 件 pass）で `ItemList` 記事リスト本体の挙動非回帰を担保 |
-| NFR 1.1 (通常利用の非回帰 part) | `item-list.test.tsx`「ItemList 単体ではフィードヘッダ要素を描画しないこと」+ 「filter props 未指定時の `"all"` fallback ケース」で責務縮退後も既存挙動と等価動作することを構造的に担保 |
+| Req 3.4 (通常一覧モードのフィードヘッダ要素) | `feed-pane-header.test.tsx`「mode='normal' で FilterTabs / FeedSearchBar / ManualRefreshButton が描画されること」+ `app-shell.test.tsx` Task 5 ケース (1)(5)(7) で AppShell 統合下でも従来要素群が描画されることを確認 |
+| NFR 1.1 (通常利用の非回帰 part) | `item-list.test.tsx`「ItemList 単体ではフィードヘッダ要素を描画しないこと」+ 「filter props 未指定時の `"all"` fallback ケース」で責務縮退後も既存挙動と等価動作することを構造的に担保 / `app-shell.test.tsx` Task 5 ケース (5) でフィード内検索 → クリア後の filter "未読" 保持を確認 |
+| NFR 1.2 (検索結果画面の DOM 構造同一性) | `app-shell.test.tsx` Task 5 ケース (9)「検索結果表示中の SearchResults 空状態 DOM 構造が本変更導入前と同一であることを構造比較で確認」（テキスト "検索結果はありません" / tagName "DIV" / `search-results` testid 不在 / ローディング・エラー testid 不在 / feed-search-bar との同居の 5 観点） |
 | NFR 2.1 (即応性) | React の同期 state update に依存。Req 1.3 の既存 user.type ベーステストで間接的に担保 |
 
 ## 検証
@@ -97,6 +118,13 @@
 - `cd web && npm test`: 365 / 365 pass（全 web スイート / 既存 358 件 + Task 3 transient 失敗解消の 7 件）
 - `cd web && npm run lint`: 0 errors / 5 warnings（warnings は全て既存のもので本 task とは無関係。Task 3 時点と同件数 / 同一内容）
 - `cd web && npm run build`: ✓ success（standalone build 5 routes prerendered / Task 3 時点と同一の build output）
+
+### Task 5 検証結果
+
+- `cd web && npx vitest run src/components/app-shell.test.tsx`: 28 / 28 pass（既存 19 + Task 5 新規 9）
+- `cd web && npm test`: 374 / 374 pass（全 web スイート / Task 4 時点 365 + Task 5 新規 9）
+- `cd web && npm run lint`: 0 errors / 5 warnings（warnings は全て既存のもので Task 5 とは無関係。Task 4 時点と同件数 / 同一内容。新規追加 `app-shell.test.tsx` 内のテストブロックで追加 warning なし）
+- `cd web && npm run build`: ✓ success（standalone build 5 routes prerendered / Task 4 時点と同一の build output）
 
 ## 確認事項
 

--- a/docs/specs/145--120/impl-notes.md
+++ b/docs/specs/145--120/impl-notes.md
@@ -26,6 +26,25 @@
   - **task 4 で `AppShell` が `FeedPaneHeader` を呼び出す**: 本 task で `FeedPaneHeader` 単体は完成したが、現状 `AppShell` の右ペイン分岐は旧構造のままで `FeedPaneHeader` をまだ使っていない。task 4 で `<FeedPaneHeader mode="normal/search-feed" ... />` を挿入する。
   - **`filter` props の AppState 持ち上げ**: design.md「`item-list.tsx`（修正）」節および「確認事項 3」で「`AppState.filter` 直接読み書き / `ItemList` 内部 `useState<ItemFilter>` 撤去」を暫定採用としているが、本 task では `FeedPaneHeader` の `filter` / `onFilterChange` を props として受け取る形まで実装した（実体の AppState 接続は task 3 / 4 で完成）。
 
+### Task 3
+
+- **採用方針**: `web/src/components/item-list.tsx` からフィードヘッダ責務（フィルタタブ + FeedSearchBar + ManualRefreshButton + ManualRefreshBanner + 関連 wiring）を完全撤去し、`ItemList` を記事リスト本体のみに縮退（tasks.md L54-75 / design.md「`item-list.tsx`（修正）」節に準拠）。Task 2 で `FeedPaneHeader` 側に移譲済みの責務を `ItemList` 側からも削除して重複解消。
+- **重要な判断**:
+  - **`ItemListProps.filter` の optional 化（ビルド非破壊の橋渡し）**: design.md / tasks.md は「`ItemList` 内部の useState の代わりに props 経由で受け取る」と記述しており、required にする読み方も可能だが、AppShell（呼び出し側）の修正は **Task 4 のスコープ**で確定している。本 Task 単独で required にすると AppShell の `<ItemList feedId=... onSelectItem=... expandedItemId=... />` 呼び出しが TypeScript 型エラーとなり build が壊れる。これは Task 2 の `FeedPaneHeader.filter?` を optional にしている設計と整合する（Task 2 / 3 / 4 を順に通すための per-task 設計）。本 task では `filter?: ItemFilter` + `filter = "all"` の destructuring default fallback を採用し、AppShell が Task 4 で props を明示渡しするまでの間も従来挙動（filter="all" 初期値）と等価に動作させる。
+  - **`useState<ItemFilter>` および filter リセット useEffect の撤去方針**: 旧 `useState<ItemFilter>("all")`（L37）と `useEffect(() => setFilter("all"), [feedId])`（L84-86）は両方撤去。fallback の destructuring default `filter = "all"` は **render ごとに評価される即値の局所変数**であり、feedId 変更時の状態リセットを行う必要が無い（前者は React state で、後者は props 駆動で挙動が変わるため）。これにより design.md 確認事項 3 で言及されている「AppState.filter を直接読み書き / `useEffect(L84-86)` 撤去」と整合する状態を本 task 単独で達成できる。
+  - **`useFeeds` / `useManualRefresh` の撤去**: Task 2 で `FeedPaneHeader` 内部へ完全移譲済み（subscriptionId 解決ロジックも含む）のため、`ItemList` 側から無条件に撤去。`manual-refresh-banner` import / `ManualRefreshBanner` 描画も撤去（FeedPaneHeader 側に移譲済み）。
+  - **`ManualRefreshButton` の export 維持**: Task 2 で `FeedPaneHeader` が `import { ManualRefreshButton } from "@/components/item-list"` 経由で再利用しているため、本 task でも `export function ManualRefreshButton` のままにする（移動・別ファイル切り出しは行わない。tasks.md L64-66 が「設計簡素化のため `item-list.tsx` 内で export 化」を採用する旨を明記）。`ItemRow` / `ItemDetailArea` の export も維持（`CrossFeedItemList` / `StarredItemList` が import 経由で再利用しているため）。
+  - **テストの `AppStateProvider` 削除と新規ケース追加**:
+    - 旧 `item-list.test.tsx` は `ItemList` 内部の `FeedSearchBar` が `useAppState` を参照するため `AppStateProvider` 必須だった。本 task で `FeedSearchBar` 配線を撤去したため `AppStateProvider` は不要になり、テストヘルパー `createWrapper` を `QueryClientProvider` のみに簡素化。`renderWithInitialDispatch` / `useDispatchOnce` 系ヘルパーも不要になり削除。
+    - 「フィルタタブ表示」「フィルタ切替で API パラメータ送信」「FeedSearchBar 表示制御」「ManualRefreshButton クリック / 進行中表示」「ManualRefreshBanner エラー表示（429 / 409 / 401 / 5xx / networkError）」のテスト群は `FeedPaneHeader` 側のテスト（Task 2.2）に既に移管済みのため撤去。テストヘルパー `mockSubscriptions` / `setupMockFetchForManualRefresh` / 関連 `Subscription` 型 import も削除。
+    - 新規ケース 3 件を追加:
+      1. `filter="unread"` props が API リクエストの `filter=unread` パラメータに反映される（Req 3.3 + props 駆動の検証）
+      2. `filter` props 省略時は `"all"` fallback として動作（Task 4 までのビルド非破壊橋渡しの動作確認）
+      3. ItemList 単体ではフィードヘッダ要素（フィルタタブ / FeedSearchBar / ManualRefreshButton / ManualRefreshBanner）を描画しない（責務縮退の構造的担保 / NFR 1.1 の同時実装でフィードヘッダが二重描画されないことの保証）
+- **残存課題**:
+  - **AppShell 統合テスト（`app-shell.test.tsx`）の 7 件が transient に失敗する状態**: 旧 `ItemList` が描画していたフィルタタブを `getByRole("tab", { name: "全て" })` で「ItemList が表示されたか」の proxy assertion として使っていたテストが 7 件あり、本 task の責務縮退で当該タブが ItemList 側に存在しなくなったため失敗する。これらは **Task 4 で AppShell が `FeedPaneHeader` を統合して再びフィルタタブを描画するようになると自動的に green に戻る** 想定（Task 2 の impl-notes で「task 4 で `AppShell` が `FeedPaneHeader` を呼び出す」と明記されている設計上の transient state。per-task 分割設計の意図された中間状態）。
+  - **Task 4 で AppShell が `filter` props を `ItemList` に明示渡しする必要**: 本 task で `filter?` を optional にしたため、Task 4 で AppShell が `<ItemList ... filter={state.filter} />` を渡すことで design.md / tasks.md L62-63 の「props 経由で受け取る」が完全に成立する。
+
 ## 受入基準カバレッジ
 
 | Requirement | Test |
@@ -33,6 +52,8 @@
 | Req 1.2 (初期描画) | `feed-search-bar.test.tsx` 新規ケース「初期 mount 時に検索結果表示中... `state.searchQuery` を反映すること」/ 既存「クリアボタン...」ケースでも暗黙的にカバー |
 | Req 1.2 (mount 後の外部 dispatch 同期 / 一般化) | `feed-search-bar.test.tsx` 新規ケース「mount 後に外部から SET_SEARCH_QUERY を dispatch すると input の value が新キーワードに同期されること」 |
 | Req 1.3 (入力編集追随) | 既存「キーワード入力 + Enter で SET_SEARCH_QUERY...」「入力に前後空白がある場合は trim された値で dispatch」で onChange の追随を検証済み |
+| Req 3.3 (検索結果画面の非回帰 / 記事リスト挙動の非回帰 part) | `item-list.test.tsx`「filter props で渡された値が API リクエストの filter パラメータに反映されること」+ 記事描画 / 詳細展開 / 既読化 / スター切替 / 無限スクロールの既存ケース群（全 28 件 pass）で `ItemList` 記事リスト本体の挙動非回帰を担保 |
+| NFR 1.1 (通常利用の非回帰 part) | `item-list.test.tsx`「ItemList 単体ではフィードヘッダ要素を描画しないこと」+ 「filter props 未指定時の `"all"` fallback ケース」で責務縮退後も既存挙動と等価動作することを構造的に担保 |
 | NFR 2.1 (即応性) | React の同期 state update に依存。Req 1.3 の既存 user.type ベーステストで間接的に担保 |
 
 ## 検証
@@ -47,8 +68,16 @@
 - `cd web && npm test`: 377 / 377 pass（既存 373 + Task 2 新規 4）
 - `cd web && npm run lint`: 0 errors / 6 warnings（warnings は全て既存のもので Task 2 とは無関係。新規ファイル `feed-pane-header.tsx` / `feed-pane-header.test.tsx` で追加 warning なし）
 
+### Task 3 検証結果
+
+- `cd web && npm test -- item-list`: 28 / 28 pass（旧 32 件から、`FeedPaneHeader` 側に移管した 7 件 + 関連 `useDispatchOnce` ヘルパーが消費していた合計 7 件を削除し、新規 3 件を追加した結果。記事リスト本体・記事詳細展開・無限スクロール・empty/loading/error・タイトルリンク・date estimated マーカー等の従来テストは全て保持して回帰なし）
+- `cd web && npm test`: 358 / 365 pass（**7 件 transient 失敗 / すべて `app-shell.test.tsx` 内 / Task 4 完了で自動 green 化見込み**）
+  - 7 件失敗の内訳: 全件「フィルタタブが ItemList 経由で描画されること」を ItemList 表示判定の proxy として使用していたケース（`expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument()`）。Task 4 で AppShell が `FeedPaneHeader` を統合し再びフィルタタブを描画するため、それらは Task 4 完了時点で自動的に green に戻る。本 task で `ItemList` のテストを通すこと自体は完全に成功している（28 / 28）
+- `cd web && npm run lint`: 0 errors / 5 warnings（warnings は全て既存のもので本 task とは無関係。Task 2 時点 6 warnings → Task 3 で 5 warnings に減少した理由は、撤去された `useState<ItemFilter>` 関連の暗黙警告ではなく、テストヘルパーの未使用 import 整理に伴う副次的な減少）
+- `cd web && npm run build`: ✓ success（standalone build 5 routes prerendered）
+
 ## 確認事項
 
-- なし。design.md の疑似コードどおりに実装し、既存テストの破壊なし。
+- **Task 3 単独での `app-shell.test.tsx` 7 件 transient 失敗**: 既存 `ItemList` が描画していたフィルタタブ（`role="tab"` name="全て"）を AppShell 統合テストが「ItemList の表示有無」の proxy として使っていたため、本 task でフィードヘッダ責務を `FeedPaneHeader` へ移譲したことで一時的に失敗する。これは tasks.md の Task 3 → Task 4 の責務分割と Task 4 の `_Depends: 1, 2.1, 3_` に従う設計上の意図された中間状態であり、Task 4 で AppShell の右ペイン分岐に `<FeedPaneHeader mode="normal" ... />` を挿入することで自動的に解消される（Task 2 の impl-notes でもこの順序が明記されている）。Task 4 完了後の Reviewer 段階では全テスト green を期待する。
 
 STATUS: complete

--- a/docs/specs/145--120/impl-notes.md
+++ b/docs/specs/145--120/impl-notes.md
@@ -12,6 +12,20 @@
   - 新規テストは既存 8 ケースの **末尾に追加**（既存ケースは変更しない）。ケース A（初期 mount）は既存「クリアボタン...」テストで暗黙にカバーされていたが、Req 1.2 単独の検証として独立化。ケース B（mount 後の外部 dispatch）は `renderWithInitialDispatch` が initial dispatch しか扱えないため、テスト内で `ExternalDispatcher` 小コンポーネントを並列 mount してボタン経由で追加 dispatch を発火する形にした。
 - **残存課題**: なし（後続 task 2.x / 3 / 4 / 5 に影響する変更はない。`FeedSearchBar` の public 振る舞いは追加のみで既存 API は不変）。
 
+### Task 2
+
+- **採用方針**: `web/src/components/feed-pane-header.tsx` を新規作成し、design.md の Components and Interfaces / tasks.md L21-52 に従って `FeedPaneHeaderProps = { mode, feedId, filter?, onFilterChange? }` を実装。`mode==='normal'` で FilterTabs + FeedSearchBar + ManualRefreshButton（+ ManualRefreshBanner）を、`mode==='search-feed'` で FeedSearchBar のみを描画する暫定方針を採用。`useFeeds` / `useManualRefresh` の wiring は本コンポーネント内部で完結。
+- **重要な判断**:
+  - **`FeedSearchBar` の mount 維持構造（Req 1.1）**: 両モードで「左スロット div + 右スロット div + (任意) ManualRefreshBanner」という固定構造を持たせ、`<FeedSearchBar />` は常に右スロット div 内の最初の子として配置した。さらに各スロット div に `key="feed-pane-header-left"` / `"feed-pane-header-right"` を付与し、mode 切替に伴う兄弟要素数変化があっても React reconciliation が同一インスタンスを維持するようにした。テスト（mount 維持テスト）で `expect(inputAfter).toBe(inputBefore)` の Element identity 比較が pass することを確認済み。
+  - **`ManualRefreshButton` の export 化方針（tasks.md L36-37 案 A）**: `item-list.tsx` の既存 `function ManualRefreshButton` を `export function ManualRefreshButton` に変更（1 行修正 + doc コメントに再利用理由を追記）。別ファイル切り出しは task 3 で `item-list.tsx` を縮退する際に整理する余地があるため、本 task では最小差分の export 化に留めた。
+  - **`useFeeds` / `useManualRefresh` wiring の移譲方針**: `item-list.tsx` から `FeedPaneHeader` 内部へ完全移譲（subscriptionId 解決ロジックも含む）。`item-list.tsx` 側の wiring 撤去は task 3 のスコープのため、現状は両者にロジックが重複している状態だが、task 3 で重複が解消される設計（仕様通り）。
+  - **テストヘルパー `renderWithInitialDispatch` の `rerenderUi` 追加**: React Testing Library の `rerender` は `render` 時の wrapper を保持しないため、mount 維持テストで `rerender` を素で使うと `QueryClientProvider` が消失し `useFeeds` が失敗する。これを避けるため、Probe 内で `currentUi` を mutable 参照経由で差し替える `rerenderUi` を追加し、`QueryClientProvider` / `AppStateProvider` / 初期 dispatch を再構築せず内側 ui だけ差し替えられるようにした。
+  - **act warning 対策**: `mode='search-feed'` のテストで `setTimeout` で待つ代わりに `waitFor(() => expect(mockFetch).toHaveBeenCalledWith('/api/subscriptions', ...))` で `useFeeds` の resolve を明示的に待つ形に修正し、act warning を解消。
+- **残存課題**:
+  - **task 3 で `item-list.tsx` から重複ロジック撤去が必要**: `useFeeds` / `useManualRefresh` / `subscriptionId` 解決 / `ManualRefreshBanner` 描画 / フィードヘッダ DOM（L143-169）は task 3 のスコープで撤去する。本 task 完了時点では両ファイルに重複コードがある状態だが、これは tasks.md の段階分割設計どおり。
+  - **task 4 で `AppShell` が `FeedPaneHeader` を呼び出す**: 本 task で `FeedPaneHeader` 単体は完成したが、現状 `AppShell` の右ペイン分岐は旧構造のままで `FeedPaneHeader` をまだ使っていない。task 4 で `<FeedPaneHeader mode="normal/search-feed" ... />` を挿入する。
+  - **`filter` props の AppState 持ち上げ**: design.md「`item-list.tsx`（修正）」節および「確認事項 3」で「`AppState.filter` 直接読み書き / `ItemList` 内部 `useState<ItemFilter>` 撤去」を暫定採用としているが、本 task では `FeedPaneHeader` の `filter` / `onFilterChange` を props として受け取る形まで実装した（実体の AppState 接続は task 3 / 4 で完成）。
+
 ## 受入基準カバレッジ
 
 | Requirement | Test |
@@ -26,6 +40,12 @@
 - `cd web && npm test -- feed-search-bar`: 10 / 10 pass（既存 8 + 新規 2）
 - `cd web && npm test`: 373 / 373 pass（全 web スイート）
 - `cd web && npm run lint`: 0 errors / 6 warnings（warnings は全て既存のもので本変更とは無関係）
+
+### Task 2 検証結果
+
+- `cd web && npm test -- feed-pane-header`: 4 / 4 pass（新規追加分）
+- `cd web && npm test`: 377 / 377 pass（既存 373 + Task 2 新規 4）
+- `cd web && npm run lint`: 0 errors / 6 warnings（warnings は全て既存のもので Task 2 とは無関係。新規ファイル `feed-pane-header.tsx` / `feed-pane-header.test.tsx` で追加 warning なし）
 
 ## 確認事項
 

--- a/docs/specs/145--120/impl-notes.md
+++ b/docs/specs/145--120/impl-notes.md
@@ -1,0 +1,34 @@
+# Implementation Notes
+
+## Implementation Notes
+
+### Task 1
+
+- **採用方針**: `FeedSearchBar` に `useEffect` を追加し、検索結果表示中（`isSearching && scope==='feed' && searchFeedId===selectedFeedId`）に AppState の `searchQuery` 外部変更を `localQuery` へ同期する（design.md「`feed-search-bar.tsx`（修正）」節の疑似コードに準拠）。
+- **重要な判断**:
+  - `useEffect` は `useState(initialLocalQuery)` の **直後**・`if (selectedFeedId === null) return null;` の **前** に配置した。React hooks は条件付き呼び出しを許さないため、early return より前で全 hook を評価しておく必要がある（既存 `useState` も同じ位置にあり、設計と整合）。
+  - `useEffect` の deps は `[state.isSearching, state.searchScope, state.searchFeedId, state.searchQuery, selectedFeedId]`。`setLocalQuery` は安定参照のため deps に含めない（react-hooks/exhaustive-deps は満たす）。
+  - 既存 `useState(initialLocalQuery)` の初期化ロジック（クリアボタンテスト等で暗黙利用）と handleSubmit / handleClear / 描画 JSX は **一切変更せず**、初期描画の同期は既存の `useState` 初期値経路で、mount 後の外部変更同期は今回追加した `useEffect` 経路で担保する二段構えとした（既存テストの後方互換確保）。
+  - 新規テストは既存 8 ケースの **末尾に追加**（既存ケースは変更しない）。ケース A（初期 mount）は既存「クリアボタン...」テストで暗黙にカバーされていたが、Req 1.2 単独の検証として独立化。ケース B（mount 後の外部 dispatch）は `renderWithInitialDispatch` が initial dispatch しか扱えないため、テスト内で `ExternalDispatcher` 小コンポーネントを並列 mount してボタン経由で追加 dispatch を発火する形にした。
+- **残存課題**: なし（後続 task 2.x / 3 / 4 / 5 に影響する変更はない。`FeedSearchBar` の public 振る舞いは追加のみで既存 API は不変）。
+
+## 受入基準カバレッジ
+
+| Requirement | Test |
+|---|---|
+| Req 1.2 (初期描画) | `feed-search-bar.test.tsx` 新規ケース「初期 mount 時に検索結果表示中... `state.searchQuery` を反映すること」/ 既存「クリアボタン...」ケースでも暗黙的にカバー |
+| Req 1.2 (mount 後の外部 dispatch 同期 / 一般化) | `feed-search-bar.test.tsx` 新規ケース「mount 後に外部から SET_SEARCH_QUERY を dispatch すると input の value が新キーワードに同期されること」 |
+| Req 1.3 (入力編集追随) | 既存「キーワード入力 + Enter で SET_SEARCH_QUERY...」「入力に前後空白がある場合は trim された値で dispatch」で onChange の追随を検証済み |
+| NFR 2.1 (即応性) | React の同期 state update に依存。Req 1.3 の既存 user.type ベーステストで間接的に担保 |
+
+## 検証
+
+- `cd web && npm test -- feed-search-bar`: 10 / 10 pass（既存 8 + 新規 2）
+- `cd web && npm test`: 373 / 373 pass（全 web スイート）
+- `cd web && npm run lint`: 0 errors / 6 warnings（warnings は全て既存のもので本変更とは無関係）
+
+## 確認事項
+
+- なし。design.md の疑似コードどおりに実装し、既存テストの破壊なし。
+
+STATUS: complete

--- a/docs/specs/145--120/review-notes.md
+++ b/docs/specs/145--120/review-notes.md
@@ -1,0 +1,79 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-29T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-145-impl--120
+- HEAD commit: 6a1a584e5f9727ac9b55f1cbc6516874c06db640
+- Compared to: develop..HEAD（merge-base 75c9014 起点。`git diff --stat develop..HEAD` 上に
+  `internal/feed/favicon*.go` / `docs/specs/148-*` の削除が含まれるが、これらは PR #150
+  （Issue #148）が develop に merge された後の base 側追加であり本ブランチ側での意図的削除
+  ではない。本 PR で実際に変更/追加されたファイルは `web/src/components/*` と
+  `docs/specs/145--120/*` の 10 ファイル）
+
+## Verified Requirements
+
+- 1.1 — `app-shell.tsx` L156-164 で `isSearching && searchScope==='feed' && searchFeedId!==null`
+  枝に `<FeedPaneHeader mode="search-feed">` を `<SearchResults />` の上に挿入。
+  `app-shell.test.tsx` ケース (1)「フィード選択→Enter で SearchResults と feed-search-bar が同時表示」
+  / `feed-pane-header.test.tsx`「mode 切替で feed-search-input が同一 DOM 要素として保持」で構造担保
+- 1.2 — `feed-search-bar.tsx` L48-62 の `useEffect` で `state.searchQuery` の外部変更を
+  `localQuery` に sync + L36-42 の初期化ロジック。`feed-search-bar.test.tsx` の
+  「初期 mount 時に input.value が state.searchQuery を反映」/「外部 dispatch で input.value 同期」
+  および `app-shell.test.tsx` ケース (2) で検証
+- 1.3 — `feed-search-bar.tsx` L105 の `onChange` 既存挙動 + `app-shell.test.tsx` ケース (3)
+  「input を編集 → value が "kubernetes" に追随」
+- 1.4 — `feed-search-bar.tsx` L68-81 `handleSubmit` で `SET_SEARCH_QUERY` dispatch。
+  `feed-search-bar.test.tsx`「Enter で SET_SEARCH_QUERY dispatch」+ `app-shell.test.tsx`
+  ケース (3)「Enter 後に `/api/items/search?q=kubernetes` が呼ばれる（`lastSearchQuery()=="kubernetes"`）」
+- 1.5 — `feed-search-bar.tsx` L70-73 の `trimmed.length===0` ガード。
+  `feed-search-bar.test.tsx`「空入力 Enter で dispatch されない」/「空白のみ Enter で dispatch されない」+
+  `app-shell.test.tsx` ケース (4)「input 空にして Enter 後も search-results-empty が維持」
+- 1.6 — `feed-search-bar.tsx` L83-87 `handleClear` で `CLEAR_SEARCH` dispatch。
+  `feed-search-bar.test.tsx`「クリアボタン押下で CLEAR_SEARCH」+ `app-shell.test.tsx`
+  ケース (5)「クリアで通常一覧（フィルタタブ）に戻り `feed-item-sub-1` の `data-selected="true"` 保持」
+- 2.1 — `app-shell.tsx` L165-167 で `searchScope==='global'` 枝は `<SearchResults />` のみ。
+  `app-shell.test.tsx` ケース (6)「HeaderSearchBar から submit 後に `feed-search-bar` testid が存在しない」
+- 2.2 — 既存 AppState reducer の `SELECT_FEED` が検索状態をリセット。`app-shell.test.tsx`
+  ケース (7)「別フィード選択で search-results-empty が消え、選択先 feed-item-sub-2 が選択中」
+- 2.3 — `feed-search-bar.tsx` L64-66 の早期 return + `app-shell.tsx` L189-193 の
+  「フィードを選択してください」枝。`app-shell.test.tsx` ケース (8)「フィード未選択時に
+  feed-search-bar testid が存在しない」+ `feed-search-bar.test.tsx`「フィード未選択時は描画しない」
+- 3.1 — `app-shell.tsx` L96 `<HeaderSearchBar />` 配置を維持。`app-shell.test.tsx`
+  ケース (8) 末で `header-search-bar` testid 継続表示を確認
+- 3.2 — バックエンド API / `useItemSearch` の `feed_id` 任意付与ロジックは変更なし
+  （diff に backend ファイル変更なし。`web/src/components/*` のみ）
+- 3.3 — `search-results.tsx` 変更なし（diff に含まれない）+ `item-list.test.tsx` の記事描画/
+  ローディング/エラー/空状態/詳細展開/無限スクロール/タイトルリンクテスト群（28 件）保持で
+  記事リスト本体の挙動非回帰を担保
+- 3.4 — `feed-pane-header.tsx` `mode==='normal'` で FilterTabs + FeedSearchBar +
+  ManualRefreshButton の 3 要素を描画。`feed-pane-header.test.tsx`「mode='normal' で
+  3 要素が描画」+「タブ切替で onFilterChange 呼出」
+- NFR 1.1 — `item-list.test.tsx`「ItemList 単体ではフィードヘッダ要素を描画しない」+
+  「filter props 未指定時の 'all' fallback ケース」+ `app-shell.test.tsx` ケース (5)
+  でフィード内検索 → クリア後の filter "未読" 保持を確認
+- NFR 1.2 — `search-results.tsx` 無変更により表示領域・カード構造・空状態・ローディング/
+  エラー出し分けは自動的に同一性維持。`app-shell.test.tsx` ケース (9) で 5 観点
+  （文言 "検索結果はありません" / tagName "DIV" / `search-results` testid 不在 / ローディング
+  / エラー testid 不在 / `feed-search-bar` との同居）構造比較
+- NFR 2.1 — React の同期 state update に依存（`feed-search-bar.tsx` の controlled component
+  `value={localQuery}` + `onChange` 即時 `setLocalQuery`）。`feed-search-bar.test.tsx` の
+  `user.type` ベース既存テスト群で間接的に担保
+
+## Findings
+
+なし
+
+## Summary
+
+Issue #145 の全 AC（Req 1.1-1.6 / 2.1-2.3 / 3.1-3.4 / NFR 1.1-1.2 / NFR 2.1）が
+impl コード（`feed-search-bar.tsx` / `feed-pane-header.tsx`（新規）/ `app-shell.tsx` /
+`item-list.tsx`）と単体・統合テスト（`feed-search-bar.test.tsx` +2 ケース /
+`feed-pane-header.test.tsx` 新規 4 ケース / `app-shell.test.tsx` 新規 9 ケース）で
+カバーされている。Developer 報告では `cd web && npm test` 374/374 pass、`npm run lint` 0 errors、
+`npm run build` 成功。`_Boundary:_` 違反は検出されず（変更は `web/src/components/*` の 5 ファイル
++ spec ファイルのみで backend `internal/*` への変更は無し）。CLAUDE.md の Feature Flag Protocol は
+`**採否**: opt-out` のため flag 観点の追加判定は適用外。
+
+RESULT: approve

--- a/docs/specs/145--120/tasks.md
+++ b/docs/specs/145--120/tasks.md
@@ -98,7 +98,7 @@
   - _Requirements: 1.1, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 3.4, NFR 1.2_
   - _Depends: 1, 2.1, 3_
 
-- [ ] 5. `AppShell` 統合テストでフィード内検索の連続操作を検証する
+- [x] 5. `AppShell` 統合テストでフィード内検索の連続操作を検証する
   - `web/src/components/app-shell.test.tsx` に統合テストを追加する。fetch モックは既存パターン
     を踏襲し、`/api/feeds`, `/api/items/search`, `/api/items` のレスポンスを差し替える:
     1. フィード選択 → キーワード入力 → Enter で `SearchResults` が表示され、同時に

--- a/docs/specs/145--120/tasks.md
+++ b/docs/specs/145--120/tasks.md
@@ -74,7 +74,7 @@
     - 記事リスト描画・ローディング/エラー/空状態・無限スクロール sentinel のテストは保持する
   - _Requirements: 3.3, 3.4, NFR 1.1_
 
-- [ ] 4. `AppShell` の右ペイン分岐に `FeedPaneHeader` 挿入ロジックを統合する
+- [x] 4. `AppShell` の右ペイン分岐に `FeedPaneHeader` 挿入ロジックを統合する
   - `web/src/components/app-shell.tsx` の右ペイン分岐（L147-159 付近）を design.md
     「`app-shell.tsx`（修正）」節の擬似コードに従って書き換える:
     - `isSearching && searchScope === 'feed' && searchFeedId !== null` の枝で

--- a/docs/specs/145--120/tasks.md
+++ b/docs/specs/145--120/tasks.md
@@ -17,7 +17,7 @@
       （新規ケース、Req 1.2 の一般化）
   - _Requirements: 1.2, 1.3, NFR 2.1_
 
-- [ ] 2. `FeedPaneHeader` コンポーネントを新規作成する
+- [x] 2. `FeedPaneHeader` コンポーネントを新規作成する
 - [x] 2.1 `web/src/components/feed-pane-header.tsx` を新規作成する
   - design.md の `FeedPaneHeaderProps` 型に従ったコンポーネントを実装する
     （`mode: 'normal' | 'search-feed'`, `feedId: string`, `filter?: ItemFilter`,

--- a/docs/specs/145--120/tasks.md
+++ b/docs/specs/145--120/tasks.md
@@ -51,7 +51,7 @@
   - _Boundary: web/components/feed-pane-header.tsx_
   - _Depends: 2.1_
 
-- [ ] 3. `ItemList` から責務を縮退してフィードヘッダ要素を撤去する
+- [x] 3. `ItemList` から責務を縮退してフィードヘッダ要素を撤去する
   - `web/src/components/item-list.tsx` の以下を撤去する:
     - フィードヘッダ DOM（L143-169 の `<div className="flex flex-shrink-0 ...">` 配下）
     - `FeedSearchBar` import / 配置

--- a/docs/specs/145--120/tasks.md
+++ b/docs/specs/145--120/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. `FeedSearchBar` の外部 searchQuery 同期 useEffect を追加する
+- [x] 1. `FeedSearchBar` の外部 searchQuery 同期 useEffect を追加する
   - `web/src/components/feed-search-bar.tsx` に `useEffect` を追加し、
     `state.isSearching && state.searchScope === 'feed' && state.searchFeedId === selectedFeedId`
     のとき `state.searchQuery` を `localQuery` に setLocalQuery で反映する（design.md

--- a/docs/specs/145--120/tasks.md
+++ b/docs/specs/145--120/tasks.md
@@ -38,7 +38,7 @@
   - `useFeeds` / `useManualRefresh` の wiring は `FeedPaneHeader` 内部で完結する
     （`item-list.tsx` から移譲。`feedId` 経由で `subscriptionId` を解決する）
   - _Requirements: 1.1, 2.1, 2.3, 3.4_
-- [ ] 2.2 `web/src/components/feed-pane-header.test.tsx` を新規作成する (P)
+- [x] 2.2 `web/src/components/feed-pane-header.test.tsx` を新規作成する (P)
   - `mode="normal"` で FilterTabs / FeedSearchBar / ManualRefreshButton が描画されること
   - `mode="normal"` で `onFilterChange` がタブ切替で呼ばれること
   - `mode="search-feed"` で FeedSearchBar のみ描画され、FilterTabs / ManualRefreshButton が

--- a/docs/specs/145--120/tasks.md
+++ b/docs/specs/145--120/tasks.md
@@ -18,7 +18,7 @@
   - _Requirements: 1.2, 1.3, NFR 2.1_
 
 - [ ] 2. `FeedPaneHeader` コンポーネントを新規作成する
-- [ ] 2.1 `web/src/components/feed-pane-header.tsx` を新規作成する
+- [x] 2.1 `web/src/components/feed-pane-header.tsx` を新規作成する
   - design.md の `FeedPaneHeaderProps` 型に従ったコンポーネントを実装する
     （`mode: 'normal' | 'search-feed'`, `feedId: string`, `filter?: ItemFilter`,
     `onFilterChange?: (filter: ItemFilter) => void`）

--- a/web/src/components/app-shell.test.tsx
+++ b/web/src/components/app-shell.test.tsx
@@ -737,6 +737,378 @@ describe("AppShell コンポーネント", () => {
     ).not.toBeInTheDocument();
   });
 
+  // -----------------------------------------------------------------------
+  // フィード内検索の連続操作統合テスト（Task 5 / Issue #145）
+  //
+  // フィード内検索の結果表示中もフィード内検索バーが画面に残り、再編集 → 再検索の
+  // 連続操作が単一画面で完結することを 9 ケースで検証する。fetch モックは既存
+  // `setupMockFetch` を踏襲し、`/api/feeds/:id/items` / `/api/items/search` は空応答を
+  // 返す前提（描画されるリスト本体は空状態 / 空 SearchResults）。
+  //
+  // テスト戦略:
+  // - `feed-search-bar` testid の有無で「フィード内検索バーが画面上にあるか」を判定
+  //   （Req 1.1 / 2.1 / 2.3）
+  // - `feed-search-input` の DOM value で「現在の検索キーワード反映」を判定（Req 1.2）
+  // - mockFetch.mock.calls の URL 引数の `q=<キーワード>` 有無で「新しい検索が発火されたか」
+  //   を判定（Req 1.3, 1.4）
+  // - クリアボタン押下後に `search-results-empty` が消えて「全て」タブが復活することで
+  //   「通常一覧に戻った」を判定（Req 1.6, NFR 1.1）
+  // -----------------------------------------------------------------------
+  describe("フィード内検索の連続操作（Task 5 / Issue #145）", () => {
+    /**
+     * 直近の `/api/items/search` リクエスト URL から `q=` パラメータを抽出する。
+     * fetch モックの呼び出し履歴から検索キーワード遷移を観測するヘルパ。
+     */
+    function lastSearchQuery(): string | null {
+      const calls = mockFetch.mock.calls
+        .map(([url]) => url as string)
+        .filter(
+          (url) =>
+            typeof url === "string" && url.startsWith("/api/items/search")
+        );
+      if (calls.length === 0) return null;
+      const last = calls[calls.length - 1];
+      const queryString = last.substring(last.indexOf("?") + 1);
+      const params = new URLSearchParams(queryString);
+      return params.get("q");
+    }
+
+    it("(1) フィード選択 → キーワード入力 → Enter で SearchResults と feed-search-bar が同時に表示されること（Req 1.1）", async () => {
+      const user = userEvent.setup();
+      render(<AppShell />, { wrapper: createWrapper() });
+
+      // フィード Tech Blog を選択
+      await waitFor(() => {
+        expect(screen.getByText("Tech Blog")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Tech Blog"));
+
+      // 通常一覧（FeedPaneHeader normal モード）が描画される
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
+      });
+
+      // フィード内検索バーで「typescript」を入力 → Enter で検索実行
+      const feedSearchInput = screen.getByTestId("feed-search-input");
+      await user.type(feedSearchInput, "typescript");
+      await user.keyboard("{Enter}");
+
+      // SearchResults が表示される（空結果なので空状態 testid）
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("search-results-empty")
+        ).toBeInTheDocument();
+      });
+
+      // 同時に feed-search-bar testid も画面上に残っている（Req 1.1）
+      expect(screen.getByTestId("feed-search-bar")).toBeInTheDocument();
+    });
+
+    it("(2) 検索結果表示中に feed-search-input の value が現在の検索キーワードを反映していること（Req 1.2）", async () => {
+      const user = userEvent.setup();
+      render(<AppShell />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByText("Tech Blog")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Tech Blog"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
+      });
+
+      const feedSearchInput = screen.getByTestId("feed-search-input");
+      await user.type(feedSearchInput, "kubernetes");
+      await user.keyboard("{Enter}");
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("search-results-empty")
+        ).toBeInTheDocument();
+      });
+
+      // 検索結果表示中に再度 input を取得し、value が "kubernetes" を反映している
+      const inputAfter = screen.getByTestId(
+        "feed-search-input"
+      ) as HTMLInputElement;
+      expect(inputAfter.value).toBe("kubernetes");
+    });
+
+    it("(3) 検索結果表示中に input を編集 → Enter で useItemSearch の queryKey が更新され新キーワードで fetch される（Req 1.3, 1.4）", async () => {
+      const user = userEvent.setup();
+      render(<AppShell />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByText("Tech Blog")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Tech Blog"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
+      });
+
+      // 初回検索: "typescript"
+      const feedSearchInput = screen.getByTestId("feed-search-input");
+      await user.type(feedSearchInput, "typescript");
+      await user.keyboard("{Enter}");
+
+      await waitFor(() => {
+        expect(lastSearchQuery()).toBe("typescript");
+      });
+
+      // 検索結果表示中に input を編集（既存値を一旦クリアしてから上書き）
+      const inputDuringSearch = screen.getByTestId(
+        "feed-search-input"
+      ) as HTMLInputElement;
+      await user.clear(inputDuringSearch);
+      await user.type(inputDuringSearch, "kubernetes");
+
+      // onChange が追随していること（Req 1.3）
+      expect(inputDuringSearch.value).toBe("kubernetes");
+
+      // Enter で新しい検索を実行
+      await user.keyboard("{Enter}");
+
+      // mockFetch の最新 search 呼び出しが新キーワード "kubernetes" を含む（Req 1.4）
+      await waitFor(() => {
+        expect(lastSearchQuery()).toBe("kubernetes");
+      });
+    });
+
+    it("(4) 検索結果表示中に input を空にして Enter → 検索結果表示が維持されること（Req 1.5）", async () => {
+      const user = userEvent.setup();
+      render(<AppShell />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByText("Tech Blog")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Tech Blog"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
+      });
+
+      // 検索を実行 → SearchResults 表示
+      const feedSearchInput = screen.getByTestId("feed-search-input");
+      await user.type(feedSearchInput, "typescript");
+      await user.keyboard("{Enter}");
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("search-results-empty")
+        ).toBeInTheDocument();
+      });
+
+      // 入力欄を空にして Enter（空入力 submit は dispatch されない / Req 1.5）
+      const inputDuringSearch = screen.getByTestId(
+        "feed-search-input"
+      ) as HTMLInputElement;
+      await user.clear(inputDuringSearch);
+      expect(inputDuringSearch.value).toBe("");
+
+      await user.keyboard("{Enter}");
+
+      // 検索結果表示は維持される（SearchResults 空状態が依然として表示されている）
+      // 通常一覧のフィルタタブは再表示されない（モードが切り替わっていないことの裏付け）
+      expect(screen.getByTestId("search-results-empty")).toBeInTheDocument();
+      expect(screen.queryByRole("tab", { name: "全て" })).not.toBeInTheDocument();
+      // feed-search-bar 自体は引き続き存在
+      expect(screen.getByTestId("feed-search-bar")).toBeInTheDocument();
+    });
+
+    it("(5) 検索結果表示中にクリアボタン押下 → 通常一覧（ItemList）に戻り選択フィードと filter が保持されること（Req 1.6, NFR 1.1）", async () => {
+      const user = userEvent.setup();
+      render(<AppShell />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByText("Tech Blog")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Tech Blog"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
+      });
+
+      // 通常一覧で filter を "未読" に切替（filter 保持の検証準備）
+      await user.click(screen.getByRole("tab", { name: "未読" }));
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: "未読" })).toHaveAttribute(
+          "data-state",
+          "active"
+        );
+      });
+
+      // フィード内検索を実行
+      const feedSearchInput = screen.getByTestId("feed-search-input");
+      await user.type(feedSearchInput, "typescript");
+      await user.keyboard("{Enter}");
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("search-results-empty")
+        ).toBeInTheDocument();
+      });
+
+      // クリアボタン押下（× アイコン）→ 通常一覧へ戻る（Req 1.6）
+      await user.click(screen.getByTestId("feed-search-clear"));
+
+      await waitFor(() => {
+        // フィルタタブが再表示される = ItemList（通常一覧）に戻った
+        expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
+      });
+
+      // SearchResults は撤去された
+      expect(
+        screen.queryByTestId("search-results-empty")
+      ).not.toBeInTheDocument();
+
+      // 選択フィードが保持されている（feed-1 = Tech Blog / sub-1）
+      expect(screen.getByTestId("feed-item-sub-1")).toHaveAttribute(
+        "data-selected",
+        "true"
+      );
+
+      // filter "未読" が保持されている（NFR 1.1 の通常利用挙動の非回帰）
+      expect(screen.getByRole("tab", { name: "未読" })).toHaveAttribute(
+        "data-state",
+        "active"
+      );
+    });
+
+    it("(6) 横断検索結果表示中（HeaderSearchBar から submit）に feed-search-bar testid が画面上に存在しないこと（Req 2.1）", async () => {
+      const user = userEvent.setup();
+      render(<AppShell />, { wrapper: createWrapper() });
+
+      // フィード未選択のままヘッダー横断検索バーから submit
+      await waitFor(() => {
+        expect(screen.getByTestId("header-search-input")).toBeInTheDocument();
+      });
+
+      const headerInput = screen.getByTestId("header-search-input");
+      await user.type(headerInput, "typescript");
+      await user.keyboard("{Enter}");
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("search-results-empty")
+        ).toBeInTheDocument();
+      });
+
+      // フィード内検索バーは表示されない（横断検索結果中なので Req 2.1）
+      expect(
+        screen.queryByTestId("feed-search-bar")
+      ).not.toBeInTheDocument();
+    });
+
+    it("(7) フィード内検索結果表示中に左ペインで別フィードを選択 → 検索解除 → 選択先フィードの通常一覧が表示されること（Req 2.2）", async () => {
+      const user = userEvent.setup();
+      render(<AppShell />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByText("Tech Blog")).toBeInTheDocument();
+        expect(screen.getByText("News Feed")).toBeInTheDocument();
+      });
+
+      // フィード A (Tech Blog) を選択し、フィード内検索を実行
+      await user.click(screen.getByText("Tech Blog"));
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
+      });
+
+      const feedSearchInput = screen.getByTestId("feed-search-input");
+      await user.type(feedSearchInput, "typescript");
+      await user.keyboard("{Enter}");
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("search-results-empty")
+        ).toBeInTheDocument();
+      });
+      expect(screen.getByTestId("feed-search-bar")).toBeInTheDocument();
+
+      // 左ペインで別フィード (News Feed / feed-2) を選択 → SELECT_FEED で検索状態は解除される
+      await user.click(screen.getByText("News Feed"));
+
+      // 選択先フィードの通常一覧（フィルタタブ + feed-search-bar）が再表示される
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
+      });
+      expect(screen.getByTestId("feed-search-bar")).toBeInTheDocument();
+
+      // 検索結果表示は解除される
+      expect(
+        screen.queryByTestId("search-results-empty")
+      ).not.toBeInTheDocument();
+
+      // 選択先フィード（sub-2）が選択中になっている
+      expect(screen.getByTestId("feed-item-sub-2")).toHaveAttribute(
+        "data-selected",
+        "true"
+      );
+    });
+
+    it("(8) 初期状態（フィード未選択）で feed-search-bar testid が存在しないこと（Req 2.3）", async () => {
+      render(<AppShell />, { wrapper: createWrapper() });
+
+      // 初期状態の右ペインが描画されるのを待つ
+      await waitFor(() => {
+        expect(
+          screen.getByText("フィードを選択してください")
+        ).toBeInTheDocument();
+      });
+
+      // フィード未選択時はフィード内検索バーが画面に存在しない（Req 2.3）
+      expect(
+        screen.queryByTestId("feed-search-bar")
+      ).not.toBeInTheDocument();
+
+      // ヘッダー横断検索バーは別物なので引き続き存在する（既存 Req 3.1 の非回帰確認）
+      expect(screen.getByTestId("header-search-bar")).toBeInTheDocument();
+    });
+
+    it("(9) フィード内検索結果表示中の SearchResults 空状態 DOM 構造が本変更導入前と同一であること（NFR 1.2）", async () => {
+      const user = userEvent.setup();
+      render(<AppShell />, { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(screen.getByText("Tech Blog")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("Tech Blog"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
+      });
+
+      // フィード内検索を実行
+      const feedSearchInput = screen.getByTestId("feed-search-input");
+      await user.type(feedSearchInput, "typescript");
+      await user.keyboard("{Enter}");
+
+      // SearchResults 空状態の DOM 構造を確認（NFR 1.2: 検索結果画面の本変更導入前との同一性）
+      const empty = await screen.findByTestId("search-results-empty");
+
+      // 1. 空状態のメッセージ文言が変更されていない（search-results.tsx L135 と一致）
+      expect(empty).toHaveTextContent("検索結果はありません");
+
+      // 2. 空状態は SearchResults の代替表示として div ノードで描画される
+      //    （カード一覧の data-testid="search-results" は出現しない）
+      expect(empty.tagName).toBe("DIV");
+      expect(screen.queryByTestId("search-results")).not.toBeInTheDocument();
+
+      // 3. ローディング / エラー表示の testid は同時に出現しない（出し分けが排他）
+      expect(
+        screen.queryByTestId("search-results-loading")
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("search-results-error")
+      ).not.toBeInTheDocument();
+
+      // 4. SearchResults の親 DOM 構造（FeedPaneHeader + SearchResults が右ペイン内に同居）は
+      //    feed-search-bar testid と search-results-empty testid が同時に存在することで担保
+      expect(screen.getByTestId("feed-search-bar")).toBeInTheDocument();
+    });
+  });
+
   it("横断 → 個別 → 横断 の遷移後に crossFeedSessionSince が保持され同一 baseline で fetch されること（Req 4.7）", async () => {
     const user = userEvent.setup();
     render(<AppShell />, { wrapper: createWrapper() });

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -7,6 +7,7 @@ import { FeedList } from "@/components/feed-list";
 import { FeedRegisterDialog } from "@/components/feed-register-dialog";
 import { HeaderSearchBar } from "@/components/header-search-bar";
 import { ItemList } from "@/components/item-list";
+import { FeedPaneHeader } from "@/components/feed-pane-header";
 import { CrossFeedItemList } from "@/components/cross-feed-item-list";
 import { StarredItemList } from "@/components/starred-item-list";
 import { StarredNavItem } from "@/components/starred-nav-item";
@@ -140,22 +141,55 @@ export function AppShell() {
         {/* 右ペイン: 記事一覧 + 記事詳細（検索モード時は SearchResults に切り替わり、通常時は selectedView で切替 / Req 1.3 / 2.x / 4.7） */}
         <main data-testid="right-pane" className="flex-1 overflow-hidden">
           <div className="flex flex-col h-full">
-            {/* 右ペイン分岐の優先順位（Issue #121 / impl-notes Task 6 確認事項に従う）:
+            {/* 右ペイン分岐の優先順位（Issue #145 / design.md「`app-shell.tsx`（修正）」節）:
                 isSearching > selectedView==='starred' > viewMode==='cross-feed' > 既存 ItemList
                 viewMode==='cross-feed' は SELECT_ALL_NEW_ITEMS によって selectedView='feed' に
-                倒されているため、本分岐は selectedView==='feed' 文脈で評価される。 */}
+                倒されているため、本分岐は selectedView==='feed' 文脈で評価される。
+
+                Issue #145 追加: isSearching && searchScope === 'feed' && searchFeedId !== null
+                の枝で <FeedPaneHeader mode="search-feed" ...> を <SearchResults /> の上に挿入し、
+                フィード内検索結果表示中もフィード内検索バーを画面に残す（Req 1.1）。
+                isSearching && searchScope === 'global' は従来どおり <SearchResults /> のみ（Req 2.1）。
+                selectedFeedId !== null の通常一覧枝では <FeedPaneHeader mode="normal" ...> を
+                <ItemList /> の上に挿入し、従来 ItemList 内部にあったフィードヘッダ要素群を
+                FeedPaneHeader に移譲した責務に対応する（Req 3.4 / NFR 1.2）。 */}
             {state.isSearching ? (
-              <SearchResults />
+              state.searchScope === "feed" && state.searchFeedId !== null ? (
+                <>
+                  <FeedPaneHeader
+                    mode="search-feed"
+                    feedId={state.searchFeedId}
+                  />
+                  <SearchResults />
+                </>
+              ) : (
+                <SearchResults />
+              )
             ) : state.selectedView === "starred" ? (
               <StarredItemList />
             ) : state.viewMode === "cross-feed" ? (
               <CrossFeedItemList />
+            ) : state.selectedFeedId !== null ? (
+              <>
+                <FeedPaneHeader
+                  mode="normal"
+                  feedId={state.selectedFeedId}
+                  filter={state.filter}
+                  onFilterChange={(filter) =>
+                    dispatch({ type: "SET_FILTER", filter })
+                  }
+                />
+                <ItemList
+                  feedId={state.selectedFeedId}
+                  onSelectItem={handleSelectItem}
+                  expandedItemId={state.expandedItemId}
+                  filter={state.filter}
+                />
+              </>
             ) : (
-              <ItemList
-                feedId={state.selectedFeedId}
-                onSelectItem={handleSelectItem}
-                expandedItemId={state.expandedItemId}
-              />
+              <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+                フィードを選択してください
+              </div>
             )}
             {/* 記事詳細は ItemList / StarredItemList / SearchResults 内の展開で表示する。
                 展開記事の詳細表示はItemDetailコンポーネントとして

--- a/web/src/components/feed-pane-header.test.tsx
+++ b/web/src/components/feed-pane-header.test.tsx
@@ -1,0 +1,256 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect, useState, type ReactNode } from "react";
+import { FeedPaneHeader } from "./feed-pane-header";
+import {
+  AppStateProvider,
+  useAppDispatch,
+  type AppAction,
+} from "@/contexts/app-state";
+import type { Subscription } from "@/types/feed";
+
+/**
+ * テスト用の購読一覧。
+ * `FeedPaneHeader` 内部の `useFeeds` が解決する `subscription.id` のソースとなり、
+ * `ManualRefreshButton` の描画条件を満たすために用いる。
+ */
+const mockSubscriptions: Subscription[] = [
+  {
+    id: "sub-1",
+    user_id: "user-1",
+    feed_id: "feed-1",
+    feed_title: "テストフィード",
+    feed_url: "https://example.com/feed.xml",
+    favicon_url: null,
+    fetch_interval_minutes: 60,
+    feed_status: "active",
+    error_message: null,
+    unread_count: 1,
+    created_at: "2026-02-27T00:00:00Z",
+  },
+];
+
+// グローバル fetch のモック（useFeeds の `/api/subscriptions` を満たすため）。
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+/**
+ * `/api/subscriptions` を返すだけのシンプルな fetch モックセットアップ。
+ * 他の API は使わない（FeedPaneHeader は記事一覧 fetch を呼ばない）。
+ */
+function setupMockFetch() {
+  mockFetch.mockImplementation((url: string) => {
+    if (typeof url === "string" && url === "/api/subscriptions") {
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockSubscriptions,
+      });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+}
+
+/**
+ * `AppStateProvider` 配下で対象 UI を render し、初回 mount で 1 度だけ
+ * `initialDispatch` を実行するヘルパー（`FeedSearchBar` 内部の `selectedFeedId`
+ * 連動を成立させるため、フィード選択を初期 dispatch で行う）。
+ */
+function renderWithInitialDispatch(
+  ui: ReactNode,
+  initialDispatch?: (dispatch: (action: AppAction) => void) => void
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  // Probe 内で current ui を ref 経由で参照することで、render 後の rerender でも
+  // initialDispatch / AppStateProvider / QueryClientProvider を再構築せず、AppState と
+  // 内部マウント済みコンポーネントの identity を維持したまま children だけ差し替える。
+  let currentUi: ReactNode = ui;
+  function Probe() {
+    const dispatch = useAppDispatch();
+    const ready = useDispatchOnce(() => {
+      if (initialDispatch) initialDispatch(dispatch);
+    });
+    return ready ? <>{currentUi}</> : null;
+  }
+  const Wrappers = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <AppStateProvider>{children}</AppStateProvider>
+    </QueryClientProvider>
+  );
+  const utils = render(
+    <Wrappers>
+      <Probe />
+    </Wrappers>
+  );
+  return {
+    ...utils,
+    /** 同じ QueryClient / AppState ツリーを維持したまま、Probe 配下の ui だけ差し替える */
+    rerenderUi(nextUi: ReactNode) {
+      currentUi = nextUi;
+      utils.rerender(
+        <Wrappers>
+          <Probe />
+        </Wrappers>
+      );
+    },
+  };
+}
+
+/** 初回 mount でのみ effect を 1 度発火するテスト専用ヘルパー */
+function useDispatchOnce(fn: () => void): boolean {
+  const [done, setDone] = useState(false);
+  useEffect(() => {
+    fn();
+    setDone(true);
+    // 初回 mount のみ発火 / deps は意図的に空配列
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return done;
+}
+
+describe("FeedPaneHeader コンポーネント", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMockFetch();
+  });
+
+  // --- mode="normal" (Req 3.4) ---
+
+  describe("mode='normal'", () => {
+    it("FilterTabs / FeedSearchBar / ManualRefreshButton の 3 要素が描画されること", async () => {
+      // Arrange / Act: selectedFeedId を feed-1 にして、FeedPaneHeader を mode='normal' で render
+      renderWithInitialDispatch(
+        <FeedPaneHeader mode="normal" feedId="feed-1" filter="all" onFilterChange={() => {}} />,
+        (dispatch) => {
+          dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
+        }
+      );
+
+      // Assert: FilterTabs (全て / 未読 / スター)
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
+      });
+      expect(screen.getByRole("tab", { name: "未読" })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "スター" })).toBeInTheDocument();
+
+      // Assert: FeedSearchBar
+      expect(screen.getByTestId("feed-search-bar")).toBeInTheDocument();
+      expect(screen.getByTestId("feed-search-input")).toBeInTheDocument();
+
+      // Assert: ManualRefreshButton（subscription.id 解決後に描画される）
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "フィードを更新" })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("タブ切替で onFilterChange が選択値とともに呼ばれること", async () => {
+      // Arrange
+      const onFilterChange = vi.fn();
+      const user = userEvent.setup();
+      renderWithInitialDispatch(
+        <FeedPaneHeader
+          mode="normal"
+          feedId="feed-1"
+          filter="all"
+          onFilterChange={onFilterChange}
+        />,
+        (dispatch) => {
+          dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: "未読" })).toBeInTheDocument();
+      });
+
+      // Act: 「未読」タブをクリック
+      await user.click(screen.getByRole("tab", { name: "未読" }));
+
+      // Assert
+      expect(onFilterChange).toHaveBeenCalledWith("unread");
+    });
+  });
+
+  // --- mode="search-feed" (Req 1.1, 2.3) ---
+
+  describe("mode='search-feed'", () => {
+    it("FeedSearchBar のみ描画され、FilterTabs / ManualRefreshButton は描画されないこと", async () => {
+      // Arrange / Act
+      renderWithInitialDispatch(
+        <FeedPaneHeader mode="search-feed" feedId="feed-1" />,
+        (dispatch) => {
+          dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
+        }
+      );
+
+      // Assert: FeedSearchBar は描画される
+      await waitFor(() => {
+        expect(screen.getByTestId("feed-search-bar")).toBeInTheDocument();
+      });
+      expect(screen.getByTestId("feed-search-input")).toBeInTheDocument();
+
+      // Assert: FilterTabs は描画されない
+      expect(screen.queryByRole("tab", { name: "全て" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("tab", { name: "未読" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("tab", { name: "スター" })).not.toBeInTheDocument();
+
+      // Assert: ManualRefreshButton は描画されない
+      // useFeeds（/api/subscriptions）の解決が走り終わるまで waitFor で安定状態を待ち、
+      // その上で ManualRefreshButton が一切現れていないことを確認する。
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/subscriptions",
+          expect.any(Object)
+        );
+      });
+      expect(
+        screen.queryByRole("button", { name: "フィードを更新" })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // --- mode 切替時の FeedSearchBar mount 維持 (Req 1.1) ---
+
+  it("mode が 'normal' → 'search-feed' に切り替わっても feed-search-input が同一 DOM 要素として保持されること", async () => {
+    // Arrange: 最初は mode='normal' で render
+    const { rerenderUi } = renderWithInitialDispatch(
+      <FeedPaneHeader
+        mode="normal"
+        feedId="feed-1"
+        filter="all"
+        onFilterChange={() => {}}
+      />,
+      (dispatch) => {
+        dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("feed-search-input")).toBeInTheDocument();
+    });
+    const inputBefore = screen.getByTestId("feed-search-input");
+
+    // Act: mode を 'search-feed' に切り替える
+    rerenderUi(<FeedPaneHeader mode="search-feed" feedId="feed-1" />);
+
+    // Assert: 同じ testid の input 要素が DOM 上に存在し、かつ
+    // Element identity が切替前後で一致する（= React reconciliation で同一インスタンスとして
+    // 保持されている。Req 1.1 の構造的担保）
+    const inputAfter = screen.getByTestId("feed-search-input");
+    expect(inputAfter).toBe(inputBefore);
+
+    // 副次確認: 切替後は FilterTabs / ManualRefreshButton が消えていること
+    expect(screen.queryByRole("tab", { name: "全て" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "フィードを更新" })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/feed-pane-header.tsx
+++ b/web/src/components/feed-pane-header.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { FeedSearchBar } from "@/components/feed-search-bar";
+import { ManualRefreshBanner } from "@/components/manual-refresh-banner";
+import { ManualRefreshButton } from "@/components/item-list";
+import { useFeeds } from "@/hooks/use-feeds";
+import { useManualRefresh } from "@/hooks/use-manual-refresh";
+import type { ItemFilter } from "@/types/item";
+
+/**
+ * `FeedPaneHeader` の表示モード。
+ * - `"normal"`: 通常の記事一覧表示（FilterTabs + FeedSearchBar + ManualRefreshButton の 3 要素を描画）
+ * - `"search-feed"`: フィード内検索結果表示中（FeedSearchBar のみ描画。FilterTabs / ManualRefresh は撤去）
+ */
+export type FeedPaneHeaderMode = "normal" | "search-feed";
+
+/** FeedPaneHeader のプロパティ */
+export interface FeedPaneHeaderProps {
+  /** 表示モード（"normal" = 通常一覧、"search-feed" = フィード内検索結果表示中） */
+  mode: FeedPaneHeaderMode;
+  /**
+   * 対象フィードID。
+   * `"normal"` / `"search-feed"` のいずれでも非 null を期待する
+   * （呼び出し側で `selectedFeedId` / `searchFeedId` を解決して渡す）。
+   */
+  feedId: string;
+  /** `"normal"` モードでのフィルタ値（`"search-feed"` モードでは未使用） */
+  filter?: ItemFilter;
+  /** `"normal"` モードでのフィルタ変更ハンドラ（`"search-feed"` モードでは未使用） */
+  onFilterChange?: (filter: ItemFilter) => void;
+}
+
+/**
+ * フィードペイン上部のヘッダ領域レイアウトコンポーネント。
+ *
+ * 通常一覧と検索結果表示の双方で「フィードを開いている文脈の上部ヘッダ」という同一意味論を
+ * 共有しつつ、内部要素の出し分けを行う（design.md Components and Interfaces / Issue #145）。
+ *
+ * - `mode === "normal"`: `FilterTabs` + `<FeedSearchBar />` + `<ManualRefreshButton />` の 3 要素を、
+ *   従来 `item-list.tsx` のフィードヘッダ DOM 構造と同等のレイアウトで描画する（Req 3.4）。
+ *   `ManualRefreshBanner` もヘッダ直下に描画する。
+ * - `mode === "search-feed"`: 同じ外側コンテナ div を用い、内部は `<FeedSearchBar />` のみを
+ *   描画する（暫定方針。design.md 確認事項 1, 2 を参照）。
+ *
+ * `<FeedSearchBar />` は両モードで同一の React tree 位置（同じ親 div の同じ index 兄弟要素）に
+ * 配置するため、mode 切替時に unmount されず DOM 上で同一要素として保持される（Req 1.1）。
+ */
+export function FeedPaneHeader({
+  mode,
+  feedId,
+  filter,
+  onFilterChange,
+}: FeedPaneHeaderProps) {
+  // 手動更新ボタン用に subscription.id を解決する（旧 item-list.tsx L62-67 の責務を移譲）。
+  const { data: feeds } = useFeeds();
+  const subscriptionId = Array.isArray(feeds)
+    ? feeds.find((f) => f.feed_id === feedId)?.id ?? null
+    : null;
+  const manualRefresh = useManualRefresh(feedId);
+
+  const isNormal = mode === "normal";
+
+  // React の reconciliation で `<FeedSearchBar />` を mode 切替時にも同一インスタンスとして
+  // 保持する（Req 1.1 の構造的担保）。兄弟要素の有無で position が変わると key 無しでは remount
+  // されうるため、左スロット（FilterTabs 用）と右スロット（FeedSearchBar + ManualRefreshButton 用）の
+  // ラッパ div を常に同じ位置・同じ key で描画し、中身だけ条件分岐する。`<FeedSearchBar />` は
+  // 右スロット div 内の常に最初の子として固定される。
+  return (
+    <>
+      <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b px-4 py-2">
+        <div key="feed-pane-header-left">
+          {isNormal ? (
+            <Tabs
+              value={filter}
+              onValueChange={(value) => onFilterChange?.(value as ItemFilter)}
+            >
+              <TabsList>
+                <TabsTrigger value="all">全て</TabsTrigger>
+                <TabsTrigger value="unread">未読</TabsTrigger>
+                <TabsTrigger value="starred">スター</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          ) : null}
+        </div>
+        <div key="feed-pane-header-right" className="flex items-center gap-2">
+          <FeedSearchBar />
+          {isNormal && subscriptionId !== null ? (
+            <ManualRefreshButton
+              subscriptionId={subscriptionId}
+              isPending={manualRefresh.isPending}
+              onClick={() => manualRefresh.mutate(subscriptionId)}
+            />
+          ) : null}
+        </div>
+      </div>
+
+      {/* 手動更新エラー表示（normal モードのみ。検索結果表示中は手動更新自体を撤去するため非表示） */}
+      {isNormal && <ManualRefreshBanner error={manualRefresh.error ?? null} />}
+    </>
+  );
+}

--- a/web/src/components/feed-search-bar.test.tsx
+++ b/web/src/components/feed-search-bar.test.tsx
@@ -183,4 +183,69 @@ describe("FeedSearchBar", () => {
     });
     expect(screen.queryByTestId("feed-search-clear")).toBeNull();
   });
+
+  it("初期 mount 時に検索結果表示中（scope='feed' かつ searchFeedId が一致）のとき、input の value が state.searchQuery を反映すること（Req 1.2 / 初期描画）", () => {
+    renderWithInitialDispatch(<FeedSearchBar />, (dispatch) => {
+      dispatch({ type: "SELECT_FEED", feedId: "feed-X" });
+      dispatch({
+        type: "SET_SEARCH_QUERY",
+        query: "rust",
+        scope: "feed",
+        feedId: "feed-X",
+      });
+    });
+
+    const input = screen.getByTestId(
+      "feed-search-input"
+    ) as HTMLInputElement;
+    expect(input.value).toBe("rust");
+  });
+
+  it("mount 後に外部から SET_SEARCH_QUERY を dispatch すると input の value が新キーワードに同期されること（Req 1.2 / 一般化）", async () => {
+    const user = userEvent.setup();
+
+    // 別の dispatcher コンポーネントを描画し、ボタン押下で SET_SEARCH_QUERY を発火させる。
+    // renderWithInitialDispatch は initial dispatch しか扱えないため、本ケースでは
+    // FeedSearchBar と並列に dispatcher を mount してテスト中に追加 dispatch を実行する。
+    function ExternalDispatcher() {
+      const dispatch = useAppDispatch();
+      return (
+        <button
+          type="button"
+          data-testid="external-set-search"
+          onClick={() =>
+            dispatch({
+              type: "SET_SEARCH_QUERY",
+              query: "typescript",
+              scope: "feed",
+              feedId: "feed-Y",
+            })
+          }
+        >
+          fire
+        </button>
+      );
+    }
+
+    renderWithInitialDispatch(
+      <>
+        <FeedSearchBar />
+        <ExternalDispatcher />
+      </>,
+      (dispatch) => {
+        dispatch({ type: "SELECT_FEED", feedId: "feed-Y" });
+      }
+    );
+
+    // 初期状態では検索未開始のため input は空
+    const input = screen.getByTestId(
+      "feed-search-input"
+    ) as HTMLInputElement;
+    expect(input.value).toBe("");
+
+    // 外部 dispatch で SET_SEARCH_QUERY を発火 → useEffect により input.value が同期される
+    await user.click(screen.getByTestId("external-set-search"));
+
+    expect(input.value).toBe("typescript");
+  });
 });

--- a/web/src/components/feed-search-bar.tsx
+++ b/web/src/components/feed-search-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { Search, X } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -40,6 +40,26 @@ export function FeedSearchBar() {
       ? state.searchQuery
       : "";
   const [localQuery, setLocalQuery] = useState(initialLocalQuery);
+
+  // Req 1.2 一般化: 検索結果表示中に AppState の searchQuery が外部変更（例: ProgrammaticallyDispatched
+  // からの再検索キーワード変更）されたとき、localQuery にも反映して入力欄表示を同期する。
+  // useState の直後・early return の前に配置することで、React の hooks 順序制約を満たす。
+  // 注: setLocalQuery は安定参照のため deps には含めない（react-hooks/exhaustive-deps は満たす）。
+  useEffect(() => {
+    if (
+      state.isSearching &&
+      state.searchScope === "feed" &&
+      state.searchFeedId === selectedFeedId
+    ) {
+      setLocalQuery(state.searchQuery);
+    }
+  }, [
+    state.isSearching,
+    state.searchScope,
+    state.searchFeedId,
+    state.searchQuery,
+    selectedFeedId,
+  ]);
 
   if (selectedFeedId === null) {
     return null;

--- a/web/src/components/item-list.test.tsx
+++ b/web/src/components/item-list.test.tsx
@@ -2,33 +2,9 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
 import { ItemList } from "./item-list";
-import {
-  AppStateProvider,
-  useAppDispatch,
-  type AppAction,
-} from "@/contexts/app-state";
 import type { ItemDetail, ItemListResponse } from "@/types/item";
-import type { Subscription } from "@/types/feed";
 import type { ReactNode } from "react";
-
-/** テスト用の購読一覧（手動更新ボタン用 subscription.id 解決のため） */
-const mockSubscriptions: Subscription[] = [
-  {
-    id: "sub-1",
-    user_id: "user-1",
-    feed_id: "feed-1",
-    feed_title: "テストフィード",
-    feed_url: "https://example.com/feed.xml",
-    favicon_url: null,
-    fetch_interval_minutes: 60,
-    feed_status: "active",
-    error_message: null,
-    unread_count: 1,
-    created_at: "2026-02-27T00:00:00Z",
-  },
-];
 
 // グローバルfetchのモック
 const mockFetch = vi.fn();
@@ -36,7 +12,7 @@ global.fetch = mockFetch;
 
 // IntersectionObserverのモック
 const mockIntersectionObserver = vi.fn();
-mockIntersectionObserver.mockImplementation((callback: IntersectionObserverCallback) => ({
+mockIntersectionObserver.mockImplementation(() => ({
   observe: vi.fn(),
   unobserve: vi.fn(),
   disconnect: vi.fn(),
@@ -45,8 +21,9 @@ global.IntersectionObserver = mockIntersectionObserver;
 
 /** テスト用ラッパー
  *
- * ItemList は FeedSearchBar（useAppState 経由で AppState を参照）を内包するため、
- * AppStateProvider 配下でレンダする必要がある。
+ * Issue #145 / Task 3 で `ItemList` からフィードヘッダ責務（FeedSearchBar / ManualRefreshButton
+ * / フィルタタブ等）を切り出したため、AppStateProvider は本テストでは不要になった
+ * （`useItems` は内部で React Query を使うため QueryClientProvider のみ提供する）。
  */
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -57,53 +34,9 @@ function createWrapper() {
   });
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
-      <QueryClientProvider client={queryClient}>
-        <AppStateProvider>{children}</AppStateProvider>
-      </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
   };
-}
-
-/**
- * AppStateProvider に初期 dispatch（例: SELECT_FEED）を流してから ItemList をマウントする
- * ヘルパー。FeedSearchBar の selectedFeedId 連動を検証する場合に使用する。
- */
-function renderWithInitialDispatch(
-  ui: ReactNode,
-  initialDispatch?: (dispatch: (action: AppAction) => void) => void
-) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  });
-  function Probe() {
-    const dispatch = useAppDispatch();
-    const ready = useDispatchOnce(() => {
-      if (initialDispatch) initialDispatch(dispatch);
-    });
-    return ready ? <>{ui}</> : null;
-  }
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <AppStateProvider>
-        <Probe />
-      </AppStateProvider>
-    </QueryClientProvider>
-  );
-}
-
-/** 初回 mount でのみ effect を 1 度発火するテスト専用ヘルパー */
-function useDispatchOnce(fn: () => void): boolean {
-  const [done, setDone] = useState(false);
-  useEffect(() => {
-    fn();
-    setDone(true);
-    // 初回 mount のみ発火 / deps は意図的に空配列
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  return done;
 }
 
 /** テスト用の記事一覧レスポンス */
@@ -151,12 +84,6 @@ function setupMockFetch(response: ItemListResponse = mockItemsResponse) {
         json: async () => response,
       });
     }
-    if (typeof url === "string" && url === "/api/subscriptions") {
-      return Promise.resolve({
-        ok: true,
-        json: async () => mockSubscriptions,
-      });
-    }
     return Promise.resolve({
       ok: true,
       json: async () => ({}),
@@ -202,9 +129,6 @@ function setupMockFetchWithDetail(options?: {
     if (typeof url === "string" && url.includes("/api/feeds/feed-1/items")) {
       return Promise.resolve({ ok: true, json: async () => mockItemsResponse });
     }
-    if (typeof url === "string" && url === "/api/subscriptions") {
-      return Promise.resolve({ ok: true, json: async () => mockSubscriptions });
-    }
     if (typeof url === "string" && url === `/api/items/${detailItemId}`) {
       if (options?.detailFails) {
         return Promise.resolve({
@@ -239,6 +163,7 @@ describe("ItemList コンポーネント", () => {
         feedId={null}
         onSelectItem={() => {}}
         expandedItemId={null}
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -252,6 +177,7 @@ describe("ItemList コンポーネント", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId={null}
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -275,6 +201,7 @@ describe("ItemList コンポーネント", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId={null}
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -288,43 +215,19 @@ describe("ItemList コンポーネント", () => {
     expect(within(estimatedItem).getByTestId("date-estimated")).toBeInTheDocument();
   });
 
-  it("フィルタ切替UI（全て/未読/スター）が表示されること", async () => {
+  it("filter props で渡された値が API リクエストの filter パラメータに反映されること（Req 3.3）", async () => {
+    // Arrange / Act: filter="unread" を渡してマウント
     render(
       <ItemList
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId={null}
+        filter="unread"
       />,
       { wrapper: createWrapper() }
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
-    });
-
-    expect(screen.getByRole("tab", { name: "未読" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "スター" })).toBeInTheDocument();
-  });
-
-  it("フィルタを切り替えるとAPIにフィルタパラメータが送信されること", async () => {
-    const user = userEvent.setup();
-
-    render(
-      <ItemList
-        feedId="feed-1"
-        onSelectItem={() => {}}
-        expandedItemId={null}
-      />,
-      { wrapper: createWrapper() }
-    );
-
-    await waitFor(() => {
-      expect(screen.getByRole("tab", { name: "未読" })).toBeInTheDocument();
-    });
-
-    // 「未読」フィルタをクリック
-    await user.click(screen.getByRole("tab", { name: "未読" }));
-
+    // Assert: API リクエストが filter=unread を含む
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("filter=unread"),
@@ -342,6 +245,7 @@ describe("ItemList コンポーネント", () => {
         feedId="feed-1"
         onSelectItem={onSelectItem}
         expandedItemId={null}
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -361,6 +265,7 @@ describe("ItemList コンポーネント", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId={null}
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -384,6 +289,7 @@ describe("ItemList コンポーネント", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId={null}
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -408,6 +314,7 @@ describe("ItemList コンポーネント", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId={null}
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -423,6 +330,7 @@ describe("ItemList コンポーネント", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId={null}
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -446,6 +354,7 @@ describe("ItemList コンポーネント", () => {
         feedId="feed-1"
         onSelectItem={onSelectItem}
         expandedItemId={null}
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -461,12 +370,38 @@ describe("ItemList コンポーネント", () => {
     expect(onSelectItem).not.toHaveBeenCalled();
   });
 
+  it("filter props が未指定の場合は 'all' fallback として動作すること（Task 4 までのビルド非破壊橋渡し）", async () => {
+    // Arrange / Act: filter を省略してマウント
+    render(
+      <ItemList
+        feedId="feed-1"
+        onSelectItem={() => {}}
+        expandedItemId={null}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    // Assert: 一覧描画が成功し、API リクエストが filter=all で発火する（既存挙動の非回帰担保）
+    await waitFor(() => {
+      expect(screen.getByText("最新の記事タイトル")).toBeInTheDocument();
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("filter=all"),
+      expect.any(Object)
+    );
+  });
+
   // --- 概要表示 (Requirement 2) ---
 
   it("概要があるとき記事行のタイトル直下に概要が表示されること", async () => {
     // Arrange / Act
     render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
+      <ItemList
+        feedId="feed-1"
+        onSelectItem={() => {}}
+        expandedItemId={null}
+        filter="all"
+      />,
       { wrapper: createWrapper() }
     );
 
@@ -483,7 +418,12 @@ describe("ItemList コンポーネント", () => {
   it("概要が空のとき概要領域を描画しないこと", async () => {
     // Arrange / Act
     render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
+      <ItemList
+        feedId="feed-1"
+        onSelectItem={() => {}}
+        expandedItemId={null}
+        filter="all"
+      />,
       { wrapper: createWrapper() }
     );
 
@@ -499,7 +439,12 @@ describe("ItemList コンポーネント", () => {
   it("概要テキストがタイトルより小さく薄い配色で表示されること", async () => {
     // Arrange / Act
     render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
+      <ItemList
+        feedId="feed-1"
+        onSelectItem={() => {}}
+        expandedItemId={null}
+        filter="all"
+      />,
       { wrapper: createWrapper() }
     );
 
@@ -519,7 +464,12 @@ describe("ItemList コンポーネント", () => {
   it("概要が最大2行で省略されるよう line-clamp-2 が適用されること", async () => {
     // Arrange / Act
     render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
+      <ItemList
+        feedId="feed-1"
+        onSelectItem={() => {}}
+        expandedItemId={null}
+        filter="all"
+      />,
       { wrapper: createWrapper() }
     );
 
@@ -537,7 +487,12 @@ describe("ItemList コンポーネント", () => {
   it("公開日時がタイトルと同一行の右側に配置されること", async () => {
     // Arrange / Act
     render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
+      <ItemList
+        feedId="feed-1"
+        onSelectItem={() => {}}
+        expandedItemId={null}
+        filter="all"
+      />,
       { wrapper: createWrapper() }
     );
 
@@ -560,7 +515,12 @@ describe("ItemList コンポーネント", () => {
   it("推定日付の記事では推定フラグが日時に隣接して表示されること", async () => {
     // Arrange / Act
     render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
+      <ItemList
+        feedId="feed-1"
+        onSelectItem={() => {}}
+        expandedItemId={null}
+        filter="all"
+      />,
       { wrapper: createWrapper() }
     );
 
@@ -576,37 +536,34 @@ describe("ItemList コンポーネント", () => {
     expect(titleRow).toContainElement(estimated as HTMLElement);
   });
 
-  // --- フィード内検索バーの表示制御 (Req 1.2 / NFR 2.3) ---
+  // --- フィードヘッダ責務移譲後の非描画確認 (Issue #145 / Task 3 / Req 3.3 / NFR 1.1) ---
 
-  it("フィード選択時はフィルタ群と同列に FeedSearchBar が表示されること（Req 1.2）", async () => {
-    // Arrange: AppState で feed-1 を選択した状態にして ItemList を render
-    renderWithInitialDispatch(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
-      (dispatch) => {
-        dispatch({ type: "SELECT_FEED", feedId: "feed-1" });
-      }
-    );
-
-    // Assert: FeedSearchBar が描画される（フィルタタブと同じ領域に併設）
-    await waitFor(() => {
-      expect(screen.getByTestId("feed-search-bar")).toBeInTheDocument();
-    });
-    expect(screen.getByTestId("feed-search-input")).toBeInTheDocument();
-    // フィルタタブも引き続き表示される（同列の隣接）
-    expect(screen.getByRole("tab", { name: "全て" })).toBeInTheDocument();
-  });
-
-  it("フィード未選択時（feedId === null）は FeedSearchBar が描画されないこと（NFR 2.3）", () => {
-    // Arrange / Act: feedId を null で render（AppState の selectedFeedId も初期値 null）
+  it("ItemList 単体ではフィードヘッダ要素（フィルタタブ / FeedSearchBar / ManualRefreshButton）を描画しないこと", async () => {
+    // Arrange / Act: 通常マウント
     render(
-      <ItemList feedId={null} onSelectItem={() => {}} expandedItemId={null} />,
+      <ItemList
+        feedId="feed-1"
+        onSelectItem={() => {}}
+        expandedItemId={null}
+        filter="all"
+      />,
       { wrapper: createWrapper() }
     );
 
-    // Assert: ItemList 自体が案内メッセージのみで FeedSearchBar に到達しない
-    expect(screen.getByText("フィードを選択してください")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("最新の記事タイトル")).toBeInTheDocument();
+    });
+
+    // Assert: フィードヘッダ要素は `FeedPaneHeader` 側に移譲済みで ItemList 単体では描画されない
+    expect(screen.queryByRole("tab", { name: "全て" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "未読" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "スター" })).not.toBeInTheDocument();
     expect(screen.queryByTestId("feed-search-bar")).not.toBeInTheDocument();
     expect(screen.queryByTestId("feed-search-input")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "フィードを更新" })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("manual-refresh-banner")).not.toBeInTheDocument();
   });
 });
 
@@ -625,6 +582,7 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId="item-1"
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -654,6 +612,7 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId="item-1"
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -676,6 +635,7 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId={null}
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -703,6 +663,7 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId="item-1"
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -724,6 +685,7 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId="item-1"
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -745,6 +707,7 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId="item-1"
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -777,6 +740,7 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId="item-2"
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -803,6 +767,7 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId="item-1"
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -841,9 +806,6 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
           json: async () => mockItemsResponse,
         });
       }
-      if (typeof url === "string" && url === "/api/subscriptions") {
-        return Promise.resolve({ ok: true, json: async () => mockSubscriptions });
-      }
       if (url === "/api/items/item-1") {
         return Promise.resolve({ ok: true, json: async () => mockItemDetail });
       }
@@ -859,6 +821,7 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId="item-1"
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -873,6 +836,7 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId="item-2"
+        filter="all"
       />
     );
 
@@ -894,6 +858,7 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId="item-1"
+        filter="all"
       />,
       { wrapper: createWrapper() }
     );
@@ -908,6 +873,7 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
         feedId="feed-1"
         onSelectItem={() => {}}
         expandedItemId={null}
+        filter="all"
       />
     );
 
@@ -915,356 +881,5 @@ describe("ItemList コンポーネント: 記事詳細の展開表示", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("item-content")).not.toBeInTheDocument();
     });
-  });
-});
-
-/**
- * 手動更新ボタン / バナー専用の mockFetch セットアップヘルパー。
- *
- * @param options.manualFetch - POST /api/subscriptions/sub-1/fetch のレスポンス制御
- *   - `success`: 200 OK
- *   - `cooldown`: 429 + FEED_COOLDOWN（details.retry_after_seconds=480）
- *   - `inProgress`: 409 + FEED_FETCH_IN_PROGRESS
- *   - `unauthorized`: 401 + UNAUTHORIZED
- *   - `serverError`: 503 + INTERNAL_ERROR
- *   - `networkError`: fetch reject（ネットワーク到達不能）
- *   - `pending`: 永久 pending（isPending 検証用）
- */
-function setupMockFetchForManualRefresh(options?: {
-  manualFetch?:
-    | "success"
-    | "cooldown"
-    | "inProgress"
-    | "unauthorized"
-    | "serverError"
-    | "networkError"
-    | "pending";
-}) {
-  const manualFetchKind = options?.manualFetch ?? "success";
-
-  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
-    if (
-      typeof url === "string" &&
-      url === "/api/subscriptions/sub-1/fetch" &&
-      init?.method === "POST"
-    ) {
-      switch (manualFetchKind) {
-        case "success":
-          return Promise.resolve({ ok: true, json: async () => ({ id: "sub-1" }) });
-        case "cooldown":
-          return Promise.resolve({
-            ok: false,
-            status: 429,
-            json: async () => ({
-              error: {
-                code: "FEED_COOLDOWN",
-                message: "cooldown",
-                category: "feed",
-                action: "wait",
-                details: { retry_after_seconds: 480 },
-              },
-            }),
-          });
-        case "inProgress":
-          return Promise.resolve({
-            ok: false,
-            status: 409,
-            json: async () => ({
-              error: {
-                code: "FEED_FETCH_IN_PROGRESS",
-                message: "in progress",
-                category: "feed",
-                action: "wait",
-              },
-            }),
-          });
-        case "unauthorized":
-          return Promise.resolve({
-            ok: false,
-            status: 401,
-            json: async () => ({
-              error: {
-                code: "UNAUTHORIZED",
-                message: "session expired",
-                category: "auth",
-                action: "login",
-              },
-            }),
-          });
-        case "serverError":
-          return Promise.resolve({
-            ok: false,
-            status: 503,
-            json: async () => ({
-              error: {
-                code: "INTERNAL_ERROR",
-                message: "internal",
-                category: "system",
-                action: "retry",
-              },
-            }),
-          });
-        case "networkError":
-          return Promise.reject(new TypeError("Failed to fetch"));
-        case "pending":
-          return new Promise(() => {
-            /* never resolve */
-          });
-      }
-    }
-    if (typeof url === "string" && url.includes("/api/feeds/feed-1/items")) {
-      return Promise.resolve({ ok: true, json: async () => mockItemsResponse });
-    }
-    if (typeof url === "string" && url === "/api/subscriptions") {
-      return Promise.resolve({ ok: true, json: async () => mockSubscriptions });
-    }
-    return Promise.resolve({ ok: true, json: async () => ({}) });
-  });
-}
-
-describe("ItemList コンポーネント: 手動更新ボタン", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("フィード選択時に「フィードを更新」ボタンが表示されること（Req 5.1）", async () => {
-    // Arrange
-    setupMockFetchForManualRefresh();
-
-    // Act
-    render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
-      { wrapper: createWrapper() }
-    );
-
-    // Assert: subscription 解決待ちの後、ボタンが描画される
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "フィードを更新" })
-      ).toBeInTheDocument();
-    });
-  });
-
-  it("ボタンクリックで POST /api/subscriptions/:id/fetch が発火すること（Req 5.3）", async () => {
-    // Arrange
-    setupMockFetchForManualRefresh();
-    const user = userEvent.setup();
-
-    render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
-      { wrapper: createWrapper() }
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "フィードを更新" })
-      ).toBeInTheDocument();
-    });
-
-    // Act
-    await user.click(screen.getByRole("button", { name: "フィードを更新" }));
-
-    // Assert
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith(
-        "/api/subscriptions/sub-1/fetch",
-        expect.objectContaining({ method: "POST" })
-      );
-    });
-  });
-
-  it("mutation 進行中はボタンが disabled + animate-spin になること（Req 5.4 / 5.6）", async () => {
-    // Arrange: 永久 pending で進行中状態を維持する
-    setupMockFetchForManualRefresh({ manualFetch: "pending" });
-    const user = userEvent.setup();
-
-    render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
-      { wrapper: createWrapper() }
-    );
-
-    const button = await waitFor(() =>
-      screen.getByRole("button", { name: "フィードを更新" })
-    );
-
-    // Act
-    await user.click(button);
-
-    // Assert: disabled になり、内部の RotateCw アイコンに animate-spin が付く
-    await waitFor(() => {
-      expect(button).toBeDisabled();
-    });
-    expect(button).toHaveAttribute("aria-busy", "true");
-    const icon = button.querySelector("svg");
-    expect(icon).not.toBeNull();
-    expect(icon?.getAttribute("class") ?? "").toContain("animate-spin");
-  });
-
-  it("初期状態（mutation 未発火）ではバナーが表示されないこと", async () => {
-    // Arrange
-    setupMockFetchForManualRefresh();
-
-    // Act
-    render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
-      { wrapper: createWrapper() }
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText("最新の記事タイトル")).toBeInTheDocument();
-    });
-
-    // Assert
-    expect(screen.queryByTestId("manual-refresh-banner")).not.toBeInTheDocument();
-  });
-
-  it("成功時にバナーが表示されないこと", async () => {
-    // Arrange
-    setupMockFetchForManualRefresh({ manualFetch: "success" });
-    const user = userEvent.setup();
-
-    render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
-      { wrapper: createWrapper() }
-    );
-
-    const button = await waitFor(() =>
-      screen.getByRole("button", { name: "フィードを更新" })
-    );
-
-    // Act
-    await user.click(button);
-    await waitFor(() => expect(button).not.toBeDisabled());
-
-    // Assert
-    expect(screen.queryByTestId("manual-refresh-banner")).not.toBeInTheDocument();
-  });
-
-  it("429 エラー時にクールダウン残り秒数を含むバナーが表示されること（Req 7.1）", async () => {
-    // Arrange
-    setupMockFetchForManualRefresh({ manualFetch: "cooldown" });
-    const user = userEvent.setup();
-
-    render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
-      { wrapper: createWrapper() }
-    );
-
-    const button = await waitFor(() =>
-      screen.getByRole("button", { name: "フィードを更新" })
-    );
-
-    // Act
-    await user.click(button);
-
-    // Assert
-    await waitFor(() => {
-      expect(screen.getByTestId("manual-refresh-banner")).toBeInTheDocument();
-    });
-    expect(screen.getByTestId("manual-refresh-banner")).toHaveTextContent(
-      /480 秒以内のため再試行できません/
-    );
-  });
-
-  it("409 エラー時に「現在フェッチ中です」バナーが表示されること（Req 7.2）", async () => {
-    setupMockFetchForManualRefresh({ manualFetch: "inProgress" });
-    const user = userEvent.setup();
-
-    render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
-      { wrapper: createWrapper() }
-    );
-
-    const button = await waitFor(() =>
-      screen.getByRole("button", { name: "フィードを更新" })
-    );
-
-    await user.click(button);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("manual-refresh-banner")).toHaveTextContent(
-        /現在フェッチ中です/
-      );
-    });
-  });
-
-  it("401 エラー時にセッション切れバナーが表示されること（Req 7.3）", async () => {
-    setupMockFetchForManualRefresh({ manualFetch: "unauthorized" });
-    const user = userEvent.setup();
-
-    render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
-      { wrapper: createWrapper() }
-    );
-
-    const button = await waitFor(() =>
-      screen.getByRole("button", { name: "フィードを更新" })
-    );
-
-    await user.click(button);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("manual-refresh-banner")).toHaveTextContent(
-        /セッションが切れました/
-      );
-    });
-  });
-
-  it("5xx エラー時に一時的失敗バナーが表示されること（Req 7.4）", async () => {
-    setupMockFetchForManualRefresh({ manualFetch: "serverError" });
-    const user = userEvent.setup();
-
-    render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
-      { wrapper: createWrapper() }
-    );
-
-    const button = await waitFor(() =>
-      screen.getByRole("button", { name: "フィードを更新" })
-    );
-
-    await user.click(button);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("manual-refresh-banner")).toHaveTextContent(
-        /一時的なエラーが発生しました/
-      );
-    });
-  });
-
-  it("ネットワークエラー時に一時的失敗バナーが表示されること（Req 7.4）", async () => {
-    setupMockFetchForManualRefresh({ manualFetch: "networkError" });
-    const user = userEvent.setup();
-
-    render(
-      <ItemList feedId="feed-1" onSelectItem={() => {}} expandedItemId={null} />,
-      { wrapper: createWrapper() }
-    );
-
-    const button = await waitFor(() =>
-      screen.getByRole("button", { name: "フィードを更新" })
-    );
-
-    await user.click(button);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("manual-refresh-banner")).toHaveTextContent(
-        /一時的なエラーが発生しました/
-      );
-    });
-  });
-
-  it("feedId=null のときはボタンを描画しないこと（Req 5.2）", () => {
-    // Arrange / Act: ItemList は feedId=null で早期 return するため、ボタンは構造的に存在しない
-    setupMockFetchForManualRefresh();
-    render(
-      <ItemList feedId={null} onSelectItem={() => {}} expandedItemId={null} />,
-      { wrapper: createWrapper() }
-    );
-
-    // Assert
-    expect(
-      screen.queryByRole("button", { name: "フィードを更新" })
-    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/item-list.tsx
+++ b/web/src/components/item-list.tsx
@@ -234,8 +234,10 @@ interface ManualRefreshButtonProps {
  *
  * 進行中は `aria-busy=true` / `disabled` で重複起動を防止し、Lucide `RotateCw`
  * アイコンに `animate-spin` を当てて視覚的なローディングを継続する（Req 5.4 / 5.5 / 5.6）。
+ *
+ * `FeedPaneHeader`（フィードペイン上部ヘッダ）から再利用するため export する（Issue #145 / Task 2.1）。
  */
-function ManualRefreshButton({
+export function ManualRefreshButton({
   subscriptionId,
   isPending,
   onClick,

--- a/web/src/components/item-list.tsx
+++ b/web/src/components/item-list.tsx
@@ -1,16 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useCallback, useEffect, useRef } from "react";
 import { RotateCw, Star } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useItems, useItemDetail } from "@/hooks/use-items";
 import { useMarkAsRead, useToggleStar } from "@/hooks/use-item-state";
-import { useManualRefresh } from "@/hooks/use-manual-refresh";
-import { useFeeds } from "@/hooks/use-feeds";
-import { FeedSearchBar } from "@/components/feed-search-bar";
 import { ItemDetail } from "@/components/item-detail";
-import { ManualRefreshBanner } from "@/components/manual-refresh-banner";
 import type {
   ItemDetail as ItemDetailType,
   ItemFilter,
@@ -25,16 +20,36 @@ interface ItemListProps {
   onSelectItem: (itemId: string) => void;
   /** 現在展開中の記事ID（null = 未展開） */
   expandedItemId: string | null;
+  /**
+   * 現在のフィルタ値（"all" | "unread" | "starred"）。
+   *
+   * Issue #145 / Task 3 でフィードヘッダ領域（フィルタタブを含む）の責務を
+   * `FeedPaneHeader` へ移譲したため、フィルタ値は呼び出し側（`AppShell`）で
+   * 保持し props 経由で受け取る形に変更した。
+   *
+   * 後方互換のため optional とし、未指定時は `"all"` を fallback として用いる
+   * （`AppShell` 側で本 props を渡す改修が Task 4 で完了するまでのビルド非破壊の橋渡し）。
+   */
+  filter?: ItemFilter;
 }
 
 /**
  * 記事一覧パネル（右ペイン）
  *
  * フィード選択に応じた記事一覧をpublished_at降順で表示する。
- * 推定フラグ付き日付の表示、無限スクロール、フィルタ切替UIを提供する。
+ * 推定フラグ付き日付の表示、無限スクロール、記事詳細展開を提供する。
+ *
+ * Issue #145 / Task 3: フィードヘッダ領域（フィルタタブ / FeedSearchBar /
+ * ManualRefreshButton / ManualRefreshBanner）の描画責務は `FeedPaneHeader` へ
+ * 移譲した。本コンポーネントは記事リスト本体（取得・ローディング/エラー/空状態・
+ * 無限スクロール・詳細展開）のみを担う（Req 3.3 / NFR 1.1 の非回帰担保）。
  */
-export function ItemList({ feedId, onSelectItem, expandedItemId }: ItemListProps) {
-  const [filter, setFilter] = useState<ItemFilter>("all");
+export function ItemList({
+  feedId,
+  onSelectItem,
+  expandedItemId,
+  filter = "all",
+}: ItemListProps) {
   const sentinelRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -57,15 +72,6 @@ export function ItemList({ feedId, onSelectItem, expandedItemId }: ItemListProps
   const markAsRead = useMarkAsRead();
   const toggleStar = useToggleStar();
 
-  // 手動更新ボタン用: 現在表示中のフィードに対応する subscription.id を解決する。
-  // useFeeds は購読一覧（feed_id → subscription.id 対応表）を提供する。
-  const { data: feeds } = useFeeds();
-  const subscriptionId =
-    feedId !== null && Array.isArray(feeds)
-      ? feeds.find((f) => f.feed_id === feedId)?.id ?? null
-      : null;
-  const manualRefresh = useManualRefresh(feedId);
-
   const handleMarkAsRead = useCallback(
     (itemId: string) => {
       markAsRead.mutate(itemId);
@@ -79,11 +85,6 @@ export function ItemList({ feedId, onSelectItem, expandedItemId }: ItemListProps
     },
     [toggleStar]
   );
-
-  // フィード切替時にフィルタをリセット
-  useEffect(() => {
-    setFilter("all");
-  }, [feedId]);
 
   // Intersection Observerによる無限スクロール
   const handleObserver = useCallback(
@@ -141,37 +142,10 @@ export function ItemList({ feedId, onSelectItem, expandedItemId }: ItemListProps
 
   return (
     <div className="flex flex-col h-full">
-      {/* フィルタタブ + フィード内検索バー + 手動更新ボタン
-          FeedSearchBar は selectedFeedId === null のとき内部で null を返すため、
-          本領域に到達する時点（feedId !== null）では常に描画される（Req 1.2 / NFR 2.3）。
-          ManualRefreshButton は subscriptionId 解決時のみ描画する（Issue #115 Req 5.x）。 */}
-      <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b px-4 py-2">
-        <Tabs
-          value={filter}
-          onValueChange={(value) => setFilter(value as ItemFilter)}
-        >
-          <TabsList>
-            <TabsTrigger value="all">全て</TabsTrigger>
-            <TabsTrigger value="unread">未読</TabsTrigger>
-            <TabsTrigger value="starred">スター</TabsTrigger>
-          </TabsList>
-        </Tabs>
-        <div className="flex items-center gap-2">
-          <FeedSearchBar />
-          {subscriptionId !== null && (
-            <ManualRefreshButton
-              subscriptionId={subscriptionId}
-              isPending={manualRefresh.isPending}
-              onClick={() => manualRefresh.mutate(subscriptionId)}
-            />
-          )}
-        </div>
-      </div>
-
-      {/* 手動更新エラー表示（成功時は描画しない） */}
-      <ManualRefreshBanner error={manualRefresh.error ?? null} />
-
-      {/* 記事一覧 */}
+      {/* 記事一覧
+          Issue #145 / Task 3: フィードヘッダ領域（フィルタタブ / FeedSearchBar /
+          ManualRefreshButton / ManualRefreshBanner）は `FeedPaneHeader` 側に移譲済み。
+          本領域は記事リスト本体のみを担う。 */}
       <div className="flex-1 overflow-y-auto">
         {allItems.length === 0 ? (
           <div className="flex items-center justify-center h-32 text-sm text-muted-foreground">


### PR DESCRIPTION
## 概要

Issue #145 の仕様変更（#120 の後続）として、フィード内検索の結果表示中もフィードヘッダ領域に
フィード内検索バーを残置し、現在の検索キーワードが入力欄に反映された状態で再編集・再検索
できるようにしました。

主な変更は `web/src/components/` 配下の 5 ファイルです。`FeedSearchBar` に外部 state 同期の
`useEffect` を追加し、新規コンポーネント `FeedPaneHeader`（mode='normal' / 'search-feed' 切替）
を作成して `ItemList` からフィードヘッダ責務を移譲、`AppShell` の右ペイン分岐を再整理して
`FeedPaneHeader` を検索結果表示中も描画するよう統合しました。横断検索（HeaderSearchBar）の
挙動は変更していません。

## 対応 Issue

Closes #145

## 関連 PR

- 設計 PR: #149（merged）

## 実装内容

- (Req 1.1 / Task 1) `feed-search-bar.tsx` に `useEffect` を追加し、検索結果表示中の外部 state 変化（`SET_SEARCH_QUERY`）を `localQuery` に同期
- (Req 1.1 / Task 2) `feed-pane-header.tsx` を新規作成。`mode='normal'` で FilterTabs + FeedSearchBar + ManualRefreshButton、`mode='search-feed'` で FeedSearchBar のみ描画。React reconciliation で mode 切替時も同一 DOM インスタンスを維持する `key` 設計を採用
- (Task 3) `item-list.tsx` からフィードヘッダ責務（FilterTabs / FeedSearchBar / ManualRefreshButton / ManualRefreshBanner + 関連 wiring）を撤去し、`ItemList` を記事リスト本体のみに縮退
- (Req 1.1, 2.1 / Task 4) `app-shell.tsx` の右ペイン分岐を再整理。`isSearching && searchScope==='feed' && searchFeedId!==null` 枝で `<FeedPaneHeader mode="search-feed" />` を `<SearchResults />` の上に挿入。横断検索枝（Req 2.1）は `<SearchResults />` のみ
- (Task 5) `app-shell.test.tsx` にフィード内検索の連続操作シナリオ 9 ケースの統合テストを追加

## 受入基準チェック

- [x] Req 1.1: 検索結果表示中に `feed-search-bar` testid が存在すること ← `app-shell.test.tsx` Task 5 ケース (1)
- [x] Req 1.2: 結果表示中の input.value が `state.searchQuery` を反映すること ← `feed-search-bar.test.tsx` 新規ケース 2 件 + `app-shell.test.tsx` ケース (2)
- [x] Req 1.3: 入力編集に input.value が追随すること ← `feed-search-bar.test.tsx` 既存ケース + `app-shell.test.tsx` ケース (3)
- [x] Req 1.4: 編集後 Enter で新キーワードの fetch が発火すること ← `app-shell.test.tsx` ケース (3) `lastSearchQuery()`
- [x] Req 1.5: 空入力 Enter で直前の検索結果が維持されること ← `app-shell.test.tsx` ケース (4)
- [x] Req 1.6: クリア操作で通常一覧に戻ること ← `feed-search-bar.test.tsx` + `app-shell.test.tsx` ケース (5)
- [x] Req 2.1: 横断検索結果表示中に `feed-search-bar` が非表示であること ← `app-shell.test.tsx` ケース (6)
- [x] Req 2.2: 別フィード選択で検索解除されること ← `app-shell.test.tsx` ケース (7)
- [x] Req 2.3: フィード未選択時に `feed-search-bar` が非表示であること ← `app-shell.test.tsx` ケース (8)
- [x] Req 3.1〜3.4, NFR 1.1〜1.2, NFR 2.1: 詳細は `docs/specs/145--120/review-notes.md` を参照

## テスト結果

```
Task 5 完了時点（Developer 最終報告）:
cd web && npm test: 374 / 374 pass（全 web スイート）
cd web && npm run lint: 0 errors / 5 warnings（warnings は全て既存のもので本変更とは無関係）
cd web && npm run build: ✓ success（standalone build 5 routes prerendered）
```

## 実装上の判断

- `FeedPaneHeader` で両 mode に共通の「左スロット div + 右スロット div」固定構造を持たせ、`key="feed-pane-header-right"` を付与することで mode 切替時も React が `FeedSearchBar` を同一インスタンスとして再利用するよう設計（Req 1.1 の DOM 継続性を担保）
- `ItemList` の `filter` prop を `filter?: ItemFilter` + destructuring default `filter = "all"` として optional 化し、Task 3 → Task 4 の順次統合でビルドを壊さない橋渡し設計を採用
- `AppState.filter` は AppShell が `<ItemList ... filter={state.filter} />` / `<FeedPaneHeader ... filter={state.filter} onFilterChange={...} />` で明示渡しすることで、reducer 既存の `SELECT_FEED` 時フィルタリセット（app-state.tsx L173）が自動的に機能する
- 詳細は `docs/specs/145--120/impl-notes.md` を参照

## 確認事項 / レビュワーへの依頼

- Reviewer（Reviewer Round 1）は `docs/specs/145--120/review-notes.md` で全 AC を確認済みです（`RESULT: approve`）。詳細な Verified Requirements と Findings は同ファイルを参照してください
- `ItemList` の `feedId === null` 時の「フィード未選択」描画分岐（item-list.tsx L114 付近）が AppShell 統合後に defacto unreachable code になっています。本変更のスコープ外として残置していますが、将来の cleanup PR で整理できます
- base: develop / baseRefName: develop / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #145 のコメントを参照してください。
