### PR TITLE
feat(#153): フィード検出時の HTTP エラーをユーザー向けエラーとして返す

### DIFF
--- a/docs/specs/153--rss/impl-notes.md
+++ b/docs/specs/153--rss/impl-notes.md
@@ -1,0 +1,162 @@
+# 実装ノート: Issue #153「登録できないRSSがある」
+
+## 概要
+
+Feed Detector がフィード URL の HTTP レスポンスのステータスコードを判定せず、
+非 2xx 応答（ボット保護による 429 やサーバーエラー）でも HTML として
+パースしていたため「フィード未検出」として誤って失敗していた問題を修正した。
+
+本実装では `internal/feed/detector.go` の `DetectFeedURL` に HTTP ステータスコード
+判定を追加し、非 2xx（< 200 || >= 300）の場合は新しいエラー `FEED_HTTP_ERROR`
+を返すようにした。これにより UI 側がユーザーに「サイト側のブロック / URL 間違い
+/ 一時的にサーバが応答しない」可能性を示唆できるようになる。
+
+## 設計判断
+
+### 1. エラー粒度（Open Question への対応）
+
+要件 Open Questions では「4xx と 5xx で別エラーコードを持つか、まとめて 1 つの
+カテゴリにするか」が論点として挙げられていた。本実装では **1 つのエラーコード
+`FEED_HTTP_ERROR` + `Details["status_code"]` でステータスコードを付帯情報として
+表現する** 方針を採った。
+
+理由:
+
+- Req 2.4 が「ステータスコードを付記する」ことを要求しており、`Details` の
+  メカニズムで満たせる（既存 `FEED_COOLDOWN` の `retry_after_seconds` と同パターン）
+- 4xx / 5xx の区別はユーザー向けメッセージ上では同一の対処（別 URL を試す /
+  時間を置いて再試行）に集約できるため、コード分割の実益が低い
+- 将来 403 / 404 / 429 などをカテゴリ細分化する必要が生じても、`Details` を拡張
+  すれば対応可能（後方互換性を保ちながら拡張できる）
+
+### 2. HTTP ステータスコードマッピング（handler 層）
+
+`mapAPIErrorToHTTPStatus` で `FEED_HTTP_ERROR` を **`502 Bad Gateway`** にマップした
+（既存 `FETCH_FAILED` と同じステータス）。理由:
+
+- 「上流サイトが応答を返したがエラー応答だった」状況は、API として見れば
+  上流ゲートウェイのエラーを通知する 502 が semantically 適切
+- `FETCH_FAILED`（レスポンス取得前の失敗）と HTTP ステータスは同じだが、
+  エラーコード / メッセージ / Details は別系統で UI が区別表示できる
+- 422 Unprocessable Entity（`FEED_NOT_DETECTED` のマッピング）と区別することで、
+  「ユーザー入力の URL は正常だが上流側で問題」という意味を表現できる
+
+### 3. 3xx 最終応答の扱い
+
+Go の `http.Client` は既定でリダイレクトを最大 10 回追跡するため、最終応答に
+3xx が残るのは Location ヘッダ欠落等の限定ケースであることを確認した。
+本実装では Req 1.4 に従い、`resp.StatusCode < 200 || resp.StatusCode >= 300` で
+判定する 1 つの分岐に統合し、3xx も同様に `FEED_HTTP_ERROR` として扱う。
+テスト `TestDetectFeedURL_HTTPError_3xxFinalResponse` で Location なしの 302 を
+返すケースを検証している。
+
+### 4. ボディ読み込みのスキップ
+
+非 2xx 応答時は `io.ReadAll` を呼ばずに即座にエラーを返す実装にした。
+
+- Req 4.4「4xx 応答内のリンクは信頼しない」の意図に沿っている
+- 不要な I/O / メモリ確保を回避（NFR 1.2 とは別軸だが運用負荷を下げる）
+- テスト `TestDetectFeedURL_HTTPError_4xx_DoesNotParseHTMLFeedLink` で
+  4xx + HTML 内 RSS リンクのケースを検証
+
+### 5. ログ出力（NFR 2.1）
+
+`slog.Warn` で `url` と `status` を出力。既存 `internal/feed/favicon.go` の
+`FetchFavicon` での非 2xx ログ出力（"favicon取得: HTTPステータス異常"）と同じ
+パターンを採用した。これにより運用者が頻発するブロッキング先を grep で特定できる。
+
+## 確認事項
+
+### 解決済み
+
+- **3xx 最終応答の発生頻度**: Go `http.Client` の既定挙動を確認した上で、
+  Location ヘッダ欠落等の限定ケースとして同一分岐で扱うと決定（Req 1.4）
+- **HTTP ステータスコードマッピング**: handler 層 `mapAPIErrorToHTTPStatus` で
+  `FEED_HTTP_ERROR` を `StatusBadGateway` (502) にマップ済み（既存 `FETCH_FAILED`
+  と同じ）
+
+### 未解決（PR レビュワー / 運用判断に委ねる）
+
+- **UI 側のメッセージ表示**: Req 2.1 / 2.2 は「Feed Registration UI shall ...」と
+  記述されているが、本 PR は backend のエラー仕様までを対象とし、Next.js 側の
+  メッセージ表示は別途確認が必要。UI 側は既存の APIError 表示機構（Code /
+  Message / Action / Details）を経由して新エラーコードを受け取れる
+- **Worker 側のフィード取得**: Out of Scope に明記されている通り、定期フェッチ処理
+  （`internal/worker/fetch/`）の同様の HTTP エラー扱い改善は本 Issue 対象外。
+  必要なら別 Issue で扱う
+
+## テスト追加内容
+
+### `internal/feed/detector_test.go`
+
+| テスト名 | 観点 | 対応 AC |
+|---|---|---|
+| `TestDetectFeedURL_HTTPError_4xx` | 404 / 429 / 403 で `FEED_HTTP_ERROR` 返却、`Details["status_code"]` に int でステータス載せる | Req 1.3, 1.5, 2.4 |
+| `TestDetectFeedURL_HTTPError_5xx` | 500 / 503 で `FEED_HTTP_ERROR` 返却、Category=feed、Action 非空 | Req 1.3, 1.5, 2.1, 2.4 |
+| `TestDetectFeedURL_HTTPError_4xx_DoesNotParseHTMLFeedLink` | 4xx 応答ボディに HTML feed link があっても HTML パースせず HTTP エラー返却 | Req 4.4 |
+| `TestDetectFeedURL_HTTPError_3xxFinalResponse` | Location なし 302 を 3xx 最終応答として HTTP エラー処理 | Req 1.4 |
+| `TestDetectFeedURL_2xxStillWorks` | 200 応答の従来の検出フローが継続動作 | Req 3.1, NFR 1.1 |
+
+### `internal/model/errors_test.go`
+
+| テスト名 | 観点 | 対応 AC |
+|---|---|---|
+| `TestNewFeedHTTPError` | 4 種のステータスコード（429/404/503/500）で Code / Category / Details["status_code"] / Action 構造を検証 | Req 1.5, 2.1, 2.3, 2.4 |
+
+### 既存テストの回帰確認
+
+- `TestDetectFeedURL_DirectRSSFeed` / `TestDetectFeedURL_DirectAtomFeed` /
+  `TestDetectFeedURL_HTMLWithFeedLink` 等の 200 応答系既存テストは無修正で
+  全件 pass（Req 3.1, 3.2, NFR 1.1 を担保）
+
+## 受入基準達成確認
+
+| AC ID | 担保するテスト |
+|---|---|
+| Req 1.1 (HTTP レスポンス受信時にステータスコードを判定対象に) | `TestDetectFeedURL_HTTPError_4xx/5xx` （ステータスコード分岐を経由して FEED_HTTP_ERROR を返す）|
+| Req 1.2 (2xx は既存フロー継続) | `TestDetectFeedURL_2xxStillWorks` + 既存 `TestDetectFeedURL_DirectRSSFeed` 等 |
+| Req 1.3 (4xx/5xx は HTML パースせず固有エラー) | `TestDetectFeedURL_HTTPError_4xx` / `TestDetectFeedURL_HTTPError_5xx` / `TestDetectFeedURL_HTTPError_4xx_DoesNotParseHTMLFeedLink` |
+| Req 1.4 (3xx 最終応答も HTTP エラー扱い) | `TestDetectFeedURL_HTTPError_3xxFinalResponse` |
+| Req 1.5 (HTTP エラーと FEED_NOT_DETECTED を別コード) | `TestDetectFeedURL_HTTPError_4xx/5xx` （Code != FEED_NOT_DETECTED を assert）+ `TestNewFeedHTTPError` |
+| Req 2.1 (原因示唆 + 対処) | `TestNewFeedHTTPError`（Action 非空）+ Message テンプレ（「ブロック / URL 間違い / 一時的にサーバが応答しない」を含む） |
+| Req 2.2 (2xx 未検出は既存メッセージ継続) | 既存 `TestDetectFeedURL_HTMLNoFeedLink` |
+| Req 2.3 (内部詳細を露出しない) | `NewFeedHTTPError` は固定テンプレ Message でレスポンス body を含まない |
+| Req 2.4 (ステータスコード付記) | `TestDetectFeedURL_HTTPError_4xx` / `TestNewFeedHTTPError`（`Details["status_code"]` int 検証 + Message に "HTTP" 含む） |
+| Req 3.1 (2xx + フィード Content-Type の従来結果) | `TestDetectFeedURL_2xxStillWorks` |
+| Req 3.2 (2xx + HTML + フィードリンクの従来優先順位) | 既存 `TestDetectFeedURL_HTMLWithFeedLink` / `TestDetectFeedURL_HTMLWithMultipleFeedLinks_PrioritySelection` |
+| Req 3.3 (ネットワーク失敗は既存 FETCH_FAILED) | 既存 `client.Do(req)` の err 分岐を変更せず維持（コード review で確認可） |
+| Req 3.4 (新たな外部依存追加なし) | `go.mod` 変更なし |
+| Req 4.1 (200 + 空ボディ → FEED_NOT_DETECTED) | 既存 `IsDirectFeed` / `ParseFeedLinksFromHTML` の挙動を維持 |
+| Req 4.2 (200 + Content-Type 欠落 + XML 有効 → 検出成功) | 既存 `TestIsDirectFeed_XMLContentTypeWithRSSBody` 等 |
+| Req 4.3 (200 + 非 HTML/XML → FEED_NOT_DETECTED) | 既存挙動を維持（detector.go の `!strings.Contains(strings.ToLower(mediaType), "html")` 分岐は HTTP 判定後に位置） |
+| Req 4.4 (4xx + HTML link でも HTTP エラー) | `TestDetectFeedURL_HTTPError_4xx_DoesNotParseHTMLFeedLink` |
+| NFR 1.1 (2xx の挙動同一) | `TestDetectFeedURL_2xxStillWorks` + 既存テスト全件 pass |
+| NFR 1.2 (5MB 上限維持) | `io.LimitReader(resp.Body, detectorMaxResponseSize)` を変更せず |
+| NFR 1.3 (10 秒タイムアウト維持) | `detectorTimeout` を変更せず（`TestFeedDetector_GetHTTPClient_TimeoutPreserved` が引き続き pass）|
+| NFR 2.1 (URL + status をログ出力) | `slog.Warn("フィード検出: HTTPステータス異常", "url", inputURL, "status", resp.StatusCode)` を追加 |
+| NFR 3.1 (ボット保護回避コードを追加しない) | User-Agent / Cookie 永続化 / JS 評価などは一切追加せず |
+
+## 動作確認方法
+
+```bash
+# 単体テスト
+cd /home/hitoshi/.issue-watcher/worktrees/hitoshiichikawa-feedman/slot-1
+go test ./internal/feed/... ./internal/model/...
+
+# 全パッケージテスト
+go test ./internal/...
+
+# 静的解析
+go vet ./...
+gofmt -l internal/feed/ internal/model/ internal/handler/
+```
+
+実機検証手順（手動）:
+
+1. API サーバを起動し、フィード登録エンドポイントに `https://www.wtwco.com/ja-jp/search/getsearchrssfeed?type=Insight`
+   を POST する
+2. レスポンスとして `502 Bad Gateway` + `{"code":"FEED_HTTP_ERROR","message":"...HTTP 429...","details":{"status_code":429}}`
+   が返ることを確認
+3. 通常のフィード URL（例: `https://blog.golang.org/feed.atom`）が引き続き登録できることを回帰確認
+
+STATUS: complete

--- a/docs/specs/153--rss/requirements.md
+++ b/docs/specs/153--rss/requirements.md
@@ -1,0 +1,94 @@
+# Requirements Document
+
+## Introduction
+
+ユーザーがフィード URL を登録しようとした際、対象サイト側がボット保護や一時的なサーバ
+エラーで非 2xx レスポンスを返したケースで、現状の Feed Detector はステータスコードを
+確認せずにレスポンスボディを HTML としてパースしている。その結果、エラー画面の HTML
+に `<link rel="alternate" type="application/rss+xml">` が含まれないため「指定された URL
+から RSS/Atom フィードを検出できませんでした」というメッセージが返り、ユーザーには
+「フィードが存在しない」と誤認させる UX 不良が発生している（例: Issue #153 の
+`https://www.wtwco.com/ja-jp/search/getsearchrssfeed?type=Insight` は Vercel の
+ボット保護で HTTP 429 を返すが、現状は「フィード未検出」として失敗する）。
+
+本仕様はボット保護の回避を目的とせず、検出処理が HTTP レスポンスのステータスコードを
+正しく解釈し、HTTP エラー時には「フィードが存在しない」とは別の原因カテゴリで失敗を
+返して、ユーザーが次の手（別 URL を試す・時間をおいて再試行する・サイト側の制約を
+理解する）を打てるようにすることをスコープとする。
+
+## Requirements
+
+### Requirement 1: HTTP エラーレスポンスの正しい識別
+
+**Objective:** As a フィードを登録しようとするユーザー, I want 検出処理が HTTP エラーレスポンスを「フィード未検出」と区別して扱うこと, so that 失敗の原因が「サイトがアクセスを拒否した」のか「サイトはアクセスできたがフィードが存在しない」のかを判別できる
+
+#### Acceptance Criteria
+
+1. When the Feed Detector が検出対象 URL に対する HTTP レスポンスを受信した時, the Feed Detector shall レスポンスのステータスコードを判定対象として扱う
+2. When the Feed Detector が 2xx 系のステータスコードを受信した時, the Feed Detector shall 既存の Content-Type / ボディ解析フローを継続する
+3. If the Feed Detector が 4xx 系または 5xx 系のステータスコードを受信した場合, the Feed Detector shall レスポンスボディを HTML としてパースせず、HTTP エラー由来の固有エラーとして失敗を返す
+4. If the Feed Detector が 3xx 系のステータスコードを最終応答として受信した場合（HTTP クライアントのリダイレクト追跡後にも 3xx が残る場合）, the Feed Detector shall HTTP エラー由来の固有エラーとして失敗を返す
+5. The Feed Detector shall HTTP エラー由来の失敗と「2xx だが HTML 内にフィードリンクが無い失敗」を別エラーコードで区別する
+
+### Requirement 2: ユーザーが次に取るべきアクションを示すエラーメッセージ
+
+**Objective:** As a フィードを登録しようとするユーザー, I want 失敗時のエラーメッセージから次の手が読み取れること, so that 不要な再試行や問い合わせを避けて自力で解決できる
+
+#### Acceptance Criteria
+
+1. When 検出処理が HTTP エラー由来の失敗を返す時, the Feed Registration UI shall 「サイトがアクセスをブロックしている可能性がある」「URL が間違っている可能性がある」「一時的にサーバが応答しない可能性がある」のいずれか該当する原因示唆と、ユーザーが取れる対処（別 URL を試す / 時間を置いて再試行する 等）を含むメッセージを表示する
+2. When 検出処理が「2xx 応答だが HTML 内にフィードリンクが見つからなかった」失敗を返す時, the Feed Registration UI shall 既存の「フィード未検出」相当のメッセージ（フィードが存在しない可能性を示唆する内容）を継続して表示する
+3. The エラーメッセージ shall 内部スタックトレースや HTTP レスポンスボディの抜粋などユーザーが対処に使えない情報を露出しない
+4. Where 失敗原因に紐付く受信ステータスコードが利用可能な場合, the エラーメッセージ shall ステータスコード（例: 429, 404, 503）をユーザー向けに付記する
+
+### Requirement 3: 既存の正常系・既存エラー分類との互換性維持
+
+**Objective:** As a 既に Feedman を運用している運用者, I want 本変更によって今まで成功していた登録フローが壊れないこと, so that 既存ユーザーの登録済みフィードや今後の新規登録が回帰しない
+
+#### Acceptance Criteria
+
+1. When 検出対象 URL が 200 で RSS/Atom 固有 Content-Type を返す時, the Feed Detector shall 本変更前と同じ結果（当該 URL をフィード URL として返す）を返す
+2. When 検出対象 URL が 200 で HTML を返し、HTML 内に有効な `rel="alternate"` フィードリンクを含む時, the Feed Detector shall 本変更前と同じ優先順位ロジックで最適なフィード URL を返す
+3. If 検出処理中に HTTP クライアント自体がネットワーク到達不能・タイムアウト・SSRF 拒否などでレスポンスを取得できなかった場合, the Feed Detector shall HTTP エラー由来の固有エラーではなく、既存のネットワーク失敗系エラー（ステータスコード受信前の失敗）として扱う
+4. The Feed Detector shall 本変更によって新たな外部依存（ヘッドレスブラウザ・ボット保護回避ライブラリ等）を追加しない
+
+### Requirement 4: 境界・異常系の確定的な扱い
+
+**Objective:** As a 本機能を保守する開発者, I want ステータスコード境界・空ボディ・Content-Type 欠落などの異常系挙動が一意に決まること, so that 将来の変更で挙動が暗黙に崩れない
+
+#### Acceptance Criteria
+
+1. When 検出対象 URL が 200 だがレスポンスボディが空の時, the Feed Detector shall 「2xx 応答だが HTML 内にフィードリンクが見つからなかった」失敗として扱う
+2. When 検出対象 URL が 200 で Content-Type ヘッダが欠落しているがボディが RSS/Atom XML として有効な時, the Feed Detector shall 当該 URL をフィード URL として返す（既存の XML 判定ロジックを継続適用する）
+3. If 検出対象 URL が 200 で Content-Type も HTML でなく XML でもなく、ボディからもフィードと判定できない場合, the Feed Detector shall 「2xx 応答だが HTML 内にフィードリンクが見つからなかった」失敗として扱う
+4. When 検出対象 URL が 4xx でレスポンスボディに HTML 形式のフィードリンクが含まれている時, the Feed Detector shall HTML パースを実行せず HTTP エラー由来の固有エラーとして失敗を返す（4xx 応答内のリンクは信頼しない）
+
+## Non-Functional Requirements
+
+### NFR 1: 互換性・既存挙動の温存
+
+1. The Feed Detector shall 2xx 応答に対する既存の検出結果（成功 URL / 失敗エラーコード）を本変更前と同一に保つ
+2. The Feed Detector shall 本変更後も 1 リクエストあたりの読み込みサイズ上限（既存の 5 MB 制限）を超えないこと
+3. The Feed Detector shall 本変更後も 1 リクエストあたりのタイムアウト（既存の 10 秒）を延長しないこと
+
+### NFR 2: 観測性
+
+1. When 検出処理が HTTP エラー由来の失敗を返す時, the Feed Detector shall 受信したステータスコードと対象 URL（PII を含まない範囲）をログ出力し、運用者が頻発するブロッキング先を特定できるようにする
+
+### NFR 3: セキュリティ
+
+1. The Feed Detector shall 本変更を理由にユーザーエージェント偽装・JS チャレンジ解決・Cookie 永続化などボット保護を回避する挙動を追加しないこと
+
+## Out of Scope
+
+- Vercel / Cloudflare 等のボット保護を回避してフィードを取得すること（技術的・倫理的に対象外）
+- HTML のメタタグや `<link>` 以外のヒューリスティクス（サイトマップ走査・推測 URL `/feed`・`/rss` の試行など）による検出強化
+- フィード取得（Worker 側の定期フェッチ処理）に対する同様の HTTP エラー扱い改善（本 Issue は登録時の検出フローのみが対象。Worker 側の変更は別 Issue で扱う想定）
+- 5xx 系の一過性エラーに対する自動リトライ（必要なら別 Issue で検討）
+- Issue #153 で報告された特定 URL（`wtwco.com`）を登録可能にすること自体
+
+## Open Questions
+
+- HTTP エラー応答の細分化粒度: 4xx と 5xx で別エラーコード（さらに 403 / 404 / 429 を個別カテゴリ化するか）を持つか、まとめて 1 つの「HTTP エラー応答」カテゴリとしてステータスコードを付帯情報で表現するか。ユーザー向けメッセージの出し分け要件（Req 2.1）を実現できる粒度であれば実装は自由としてよいか
+- 既存の「ネットワーク到達不能（レスポンス取得前の失敗）」と新カテゴリ「HTTP エラー応答（レスポンス取得後の非 2xx）」の境界をユーザー向けメッセージ上でも区別する必要があるか、内部分類のみで十分か
+- 3xx 最終応答が実運用上どの程度発生するか（HTTP クライアントが既定でリダイレクトを追跡する場合、最終応答に 3xx が残るのは Location ヘッダ欠落など限定ケース）。Req 1.4 を独立 AC として扱うか、HTTP エラー応答に統合するかの判断材料

--- a/docs/specs/153--rss/review-notes.md
+++ b/docs/specs/153--rss/review-notes.md
@@ -1,0 +1,58 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-30T00:10:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-153-impl--rss
+- HEAD commit: 0e0d2213e848b48e3ac273b7654f7c34cab22fdf
+- Compared to: develop..HEAD
+- Mode: design-less impl（`tasks.md` / `design.md` 不在のため、AC カバレッジと missing test の 2 軸で評価。`_Boundary:_` 注釈は存在しないため、boundary 逸脱は CLAUDE.md の禁止事項のみで判定）
+
+## Verified Requirements
+
+- 1.1 — `internal/feed/detector.go:333-343` で `resp.StatusCode` を判定対象として扱う分岐を追加。`TestDetectFeedURL_HTTPError_4xx/5xx/3xxFinalResponse` が判定通過を検証
+- 1.2 — 上記分岐は 2xx で false 評価され既存フローを継続。`TestDetectFeedURL_2xxStillWorks` および既存 `TestDetectFeedURL_DirectRSSFeed` / `TestDetectFeedURL_HTMLWithFeedLink` 等で回帰確認
+- 1.3 — 4xx / 5xx で `io.ReadAll` を呼ばず `model.NewFeedHTTPError` を返す（`detector.go:340-342`）。`TestDetectFeedURL_HTTPError_4xx`（404/429/403）/ `TestDetectFeedURL_HTTPError_5xx`（500/503）でカバー
+- 1.4 — 同一分岐条件 `< 200 || >= 300` で 3xx 最終応答も同経路。`TestDetectFeedURL_HTTPError_3xxFinalResponse`（Location なし 302）で検証
+- 1.5 — `ErrCodeFeedHTTPError = "FEED_HTTP_ERROR"` を `internal/model/errors.go:42` に新設し、`FEED_NOT_DETECTED` と別 code。各テストで `Code != ErrCodeFeedNotDetected` を assert
+- 2.1 — `NewFeedHTTPError` の Message が「ブロックしている / URL が間違っている / 一時的にサーバが応答していない」3 原因を含み、Action が「別のURLを試す / 時間を置いて再試行」を含む（`internal/model/errors.go:236-243`）。`TestNewFeedHTTPError` が Action 非空を検証
+- 2.2 — 2xx 経路の `FEED_NOT_DETECTED` 返却ロジックは未変更。既存 `TestDetectFeedURL_HTMLNoFeedLink` 等が引き続き pass
+- 2.3 — Message は `fmt.Sprintf` で受信ステータスコードのみを差し込む固定テンプレ。レスポンスボディや stacktrace を含めない（`errors.go:237`）
+- 2.4 — Message に `HTTP %d` を埋め込み、`Details["status_code"]` に int で添付。`TestNewFeedHTTPError` で Message に "HTTP" 含有、`Details["status_code"].(int)` 型・値を検証
+- 3.1 — 200 + RSS Content-Type の検出パスを変更せず。`TestDetectFeedURL_2xxStillWorks` + 既存 `TestDetectFeedURL_DirectRSSFeed` で担保
+- 3.2 — HTML 内 feed link 優先順位ロジックは未変更。既存 `TestDetectFeedURL_HTMLWithFeedLink` / `TestDetectFeedURL_HTMLWithMultipleFeedLinks_PrioritySelection` で担保
+- 3.3 — `client.Do(req)` の err 分岐（`detector.go:316-328`）は未変更で、レスポンス取得前の失敗は引き続き `FETCH_FAILED`。本変更の HTTP ステータス判定は `client.Do` 成功後にのみ実行される
+- 3.4 — `go.mod` に変更なし。新規 import は標準ライブラリ `log/slog` のみで外部依存追加なし
+- 4.1 — 200 + 空ボディの分岐は未変更。既存の `ParseFeedLinksFromHTML` 経路で `FEED_NOT_DETECTED` を返す挙動を温存
+- 4.2 — 200 + Content-Type 欠落 + XML 有効の判定（`IsDirectFeed` の body sniff 経路）は未変更
+- 4.3 — 200 + 非 HTML/XML の経路は未変更
+- 4.4 — `TestDetectFeedURL_HTTPError_4xx_DoesNotParseHTMLFeedLink`: 429 応答ボディに `<link rel="alternate" type="application/rss+xml">` を含む HTML を返しても HTML パース実行されず `FEED_HTTP_ERROR` 返却を assert
+- NFR 1.1 — 既存 200 系テスト群が無修正で全件 pass（`go test ./internal/feed/... ./internal/model/... ./internal/handler/...` green を確認）
+- NFR 1.2 — `io.LimitReader(resp.Body, detectorMaxResponseSize)`（5MB）の呼び出しは温存。非 2xx 時は LimitReader 自体も実行されない
+- NFR 1.3 — `detectorTimeout`（10 秒）は変更なし
+- NFR 2.1 — `slog.Warn("フィード検出: HTTPステータス異常", "url", inputURL, "status", resp.StatusCode)` を非 2xx 分岐で出力（`detector.go:336-339`）。`favicon.go` の既存パターンと整合
+- NFR 3.1 — User-Agent / Cookie 永続化 / JS 評価などボット保護回避コードは一切追加されていない
+
+## handler 層の整合
+
+- `internal/handler/feed_handler.go:277-283` で `ErrCodeFeedHTTPError` → `http.StatusBadGateway` (502) にマップ。Req 1〜4 には HTTP ステータスのマップ自体を直接規定する AC は無いが、impl-notes.md 設計判断 2 に基づき `FETCH_FAILED` と同じ 502 を選択。FEED_NOT_DETECTED が 422 のままなので UI 側はエラーコードで区別可能（Req 1.5, 2.1 のスコープと整合）
+
+## design-less impl の取り扱い
+
+- `tasks.md` / `design.md` が不在のため `_Boundary:_` / `_Requirements:_` アノテーションによる境界判定は行えない。代わりに CLAUDE.md「禁止事項」に照らして検査:
+  - base ブランチ（develop）への直接 push: 無し
+  - 機密情報のコミット: 無し
+  - 外部 API キー埋め込み: 無し
+  - SSRF/サニタイズ機構の迂回: `safeurl` / SSRF ガードは経由されたまま、新規分岐は判定後の処理のみ追加
+- 変更ファイルはすべて Issue スコープ（feed 検出 + handler マッピング + model エラー定義 + テスト + impl-notes）に閉じており、無関係領域への波及なし
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric AC（Req 1.1〜4.4 / NFR 1.1〜3.1）に対応する実装またはテストが diff または既存コードのいずれかに確認できた。Req 1.3 / 1.4 / 1.5 / 2.4 / 4.4 はそれぞれ専用テストが追加され、2xx 系の互換性も `TestDetectFeedURL_2xxStillWorks` および既存テスト群で担保されている。`go test ./internal/feed/... ./internal/model/... ./internal/handler/...` を独立再実行し全件 green を確認。新規外部依存は無く、ボット保護回避コードも追加されていない。
+
+RESULT: approve

--- a/internal/feed/detector.go
+++ b/internal/feed/detector.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime"
 	"net/http"
 	"net/url"
@@ -328,6 +329,19 @@ func (d *FeedDetector) DetectFeedURL(ctx context.Context, inputURL string) (stri
 		return "", model.NewFetchFailedError(err.Error())
 	}
 	defer resp.Body.Close()
+
+	// HTTP ステータスコードの判定（Issue #153 / Req 1.1〜1.5）。
+	// 非 2xx（3xx 最終応答 / 4xx / 5xx）はレスポンスボディを HTML/XML としてパースせず、
+	// 「フィード未検出」とは別の HTTP エラー由来エラーとして失敗を返す。
+	// Go の http.Client は既定でリダイレクトを最大 10 回追跡するため、最終応答に
+	// 3xx が残るのは Location ヘッダ欠落など限定ケース。それも本分岐で同様に扱う。
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		slog.Warn("フィード検出: HTTPステータス異常",
+			"url", inputURL,
+			"status", resp.StatusCode,
+		)
+		return "", model.NewFeedHTTPError(resp.StatusCode)
+	}
 
 	// レスポンスボディを読み込み（最大5MB）
 	body, err := io.ReadAll(io.LimitReader(resp.Body, detectorMaxResponseSize))

--- a/internal/feed/detector_test.go
+++ b/internal/feed/detector_test.go
@@ -516,6 +516,215 @@ func TestDetectFeedURL_HTMLWithMultipleFeedLinks_PrioritySelection(t *testing.T)
 	}
 }
 
+// --- HTTP エラーレスポンスの判定テスト（Issue #153 / Req 1.3, 1.4, 1.5, 2.4, 4.4） ---
+
+// TestDetectFeedURL_HTTPError_4xx は 4xx 系ステータスコード（404 / 429）受信時に
+// FEED_HTTP_ERROR を返すことをテストする（Req 1.3, 1.5, 2.4）。
+func TestDetectFeedURL_HTTPError_4xx(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+	}{
+		{name: "404 Not Found", status: http.StatusNotFound},
+		{name: "429 Too Many Requests", status: http.StatusTooManyRequests},
+		{name: "403 Forbidden", status: http.StatusForbidden},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				w.WriteHeader(tc.status)
+				fmt.Fprint(w, `<html><body>Error</body></html>`)
+			}))
+			defer server.Close()
+
+			guard := &mockSSRFGuard{}
+			d := NewFeedDetector(guard)
+
+			// Act
+			_, err := d.DetectFeedURL(context.Background(), server.URL+"/")
+
+			// Assert
+			if err == nil {
+				t.Fatalf("HTTP %d 受信時はエラーを返すべき", tc.status)
+			}
+			apiErr, ok := err.(*model.APIError)
+			if !ok {
+				t.Fatalf("APIError型が期待されるが、%T が返された", err)
+			}
+			if apiErr.Code != model.ErrCodeFeedHTTPError {
+				t.Errorf("期待エラーコード: %s, 結果: %s", model.ErrCodeFeedHTTPError, apiErr.Code)
+			}
+			if apiErr.Code == model.ErrCodeFeedNotDetected {
+				t.Errorf("HTTP エラーは FEED_NOT_DETECTED と区別されるべき（Req 1.5）")
+			}
+			// Details["status_code"] にステータスコードが載っていること（Req 2.4）
+			if apiErr.Details == nil {
+				t.Fatal("Details が nil。status_code を載せるべき")
+			}
+			gotStatus, ok := apiErr.Details["status_code"].(int)
+			if !ok {
+				t.Fatalf("Details[\"status_code\"] は int であるべき。実型: %T", apiErr.Details["status_code"])
+			}
+			if gotStatus != tc.status {
+				t.Errorf("期待ステータスコード: %d, 結果: %d", tc.status, gotStatus)
+			}
+		})
+	}
+}
+
+// TestDetectFeedURL_HTTPError_5xx は 5xx 系ステータスコード（500 / 503）受信時に
+// FEED_HTTP_ERROR を返すことをテストする（Req 1.3, 1.5, 2.4）。
+func TestDetectFeedURL_HTTPError_5xx(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+	}{
+		{name: "500 Internal Server Error", status: http.StatusInternalServerError},
+		{name: "503 Service Unavailable", status: http.StatusServiceUnavailable},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				w.WriteHeader(tc.status)
+				fmt.Fprint(w, `<html><body>Server Error</body></html>`)
+			}))
+			defer server.Close()
+
+			guard := &mockSSRFGuard{}
+			d := NewFeedDetector(guard)
+
+			// Act
+			_, err := d.DetectFeedURL(context.Background(), server.URL+"/")
+
+			// Assert
+			if err == nil {
+				t.Fatalf("HTTP %d 受信時はエラーを返すべき", tc.status)
+			}
+			apiErr, ok := err.(*model.APIError)
+			if !ok {
+				t.Fatalf("APIError型が期待されるが、%T が返された", err)
+			}
+			if apiErr.Code != model.ErrCodeFeedHTTPError {
+				t.Errorf("期待エラーコード: %s, 結果: %s", model.ErrCodeFeedHTTPError, apiErr.Code)
+			}
+			if apiErr.Category != "feed" {
+				t.Errorf("期待カテゴリ: feed, 結果: %s", apiErr.Category)
+			}
+			if apiErr.Action == "" {
+				t.Error("ユーザー向け対処方法が空であるべきではない（Req 2.1）")
+			}
+			gotStatus, _ := apiErr.Details["status_code"].(int)
+			if gotStatus != tc.status {
+				t.Errorf("期待ステータスコード: %d, 結果: %d", tc.status, gotStatus)
+			}
+		})
+	}
+}
+
+// TestDetectFeedURL_HTTPError_4xx_DoesNotParseHTMLFeedLink は 4xx 応答ボディに
+// HTML 形式の <link rel="alternate" type="application/rss+xml"> が含まれていても
+// HTML パースを実行せず HTTP エラー由来の固有エラーとして失敗を返すことを
+// テストする（Req 4.4）。
+func TestDetectFeedURL_HTTPError_4xx_DoesNotParseHTMLFeedLink(t *testing.T) {
+	// Arrange: 429 でフィードリンクを持つ HTML を返すサーバ
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusTooManyRequests)
+		fmt.Fprint(w, `<html><head>
+			<link rel="alternate" type="application/rss+xml" href="https://example.com/feed.xml">
+		</head><body>Rate limited</body></html>`)
+	}))
+	defer server.Close()
+
+	guard := &mockSSRFGuard{}
+	d := NewFeedDetector(guard)
+
+	// Act
+	feedURL, err := d.DetectFeedURL(context.Background(), server.URL+"/")
+
+	// Assert: HTML 内の feed link を信頼せず FEED_HTTP_ERROR を返す
+	if err == nil {
+		t.Fatalf("4xx 応答内の HTML フィードリンクを信頼してはならない。返却URL: %s", feedURL)
+	}
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("APIError型が期待されるが、%T が返された", err)
+	}
+	if apiErr.Code != model.ErrCodeFeedHTTPError {
+		t.Errorf("期待エラーコード: %s, 結果: %s", model.ErrCodeFeedHTTPError, apiErr.Code)
+	}
+	if feedURL != "" {
+		t.Errorf("HTTP エラー時はフィードURLを返してはならない。結果: %s", feedURL)
+	}
+}
+
+// TestDetectFeedURL_HTTPError_3xxFinalResponse は最終応答が 3xx だった場合
+// （HTTP クライアントのリダイレクト追跡後にも 3xx が残るケース）にも HTTP エラー
+// として扱うことをテストする（Req 1.4）。
+//
+// 通常、Go の http.Client は Location ヘッダがあれば 3xx を自動追跡するため、
+// 最終応答に 3xx が残るのは Location ヘッダ欠落等の限定ケース。本テストでは
+// Location なしの 302 を返してその挙動を再現する。
+func TestDetectFeedURL_HTTPError_3xxFinalResponse(t *testing.T) {
+	// Arrange: Location なしの 302
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Location ヘッダを設定せずに 302 を返す
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer server.Close()
+
+	guard := &mockSSRFGuard{}
+	d := NewFeedDetector(guard)
+
+	// Act
+	_, err := d.DetectFeedURL(context.Background(), server.URL+"/")
+
+	// Assert: 3xx 最終応答も HTTP エラーとして処理される
+	if err == nil {
+		t.Fatal("3xx 最終応答はエラーを返すべき")
+	}
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("APIError型が期待されるが、%T が返された", err)
+	}
+	if apiErr.Code != model.ErrCodeFeedHTTPError {
+		t.Errorf("期待エラーコード: %s, 結果: %s", model.ErrCodeFeedHTTPError, apiErr.Code)
+	}
+}
+
+// TestDetectFeedURL_2xxStillWorks は 200 応答の既存の検出フローが本変更後も
+// 引き続き動作することを明示的にテストする（Req 3.1, NFR 1.1）。
+func TestDetectFeedURL_2xxStillWorks(t *testing.T) {
+	// Arrange
+	rssXML := `<?xml version="1.0"?><rss version="2.0"><channel><title>Test</title></channel></rss>`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, rssXML)
+	}))
+	defer server.Close()
+
+	guard := &mockSSRFGuard{}
+	d := NewFeedDetector(guard)
+
+	// Act
+	feedURL, err := d.DetectFeedURL(context.Background(), server.URL+"/feed.xml")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("200 応答時はエラーを返してはならない: %v", err)
+	}
+	if feedURL != server.URL+"/feed.xml" {
+		t.Errorf("期待URL: %s/feed.xml, 結果: %s", server.URL, feedURL)
+	}
+}
+
 // --- HTTP クライアント再利用のテスト（Requirement 1 / 5 / 6） ---
 
 // TestFeedDetector_GetHTTPClient_ReusesSameInstanceWithGuard はSSRFガード有効時に

--- a/internal/handler/feed_handler.go
+++ b/internal/handler/feed_handler.go
@@ -274,6 +274,13 @@ func mapAPIErrorToHTTPStatus(apiErr *model.APIError) int {
 		return http.StatusForbidden
 	case model.ErrCodeFetchFailed:
 		return http.StatusBadGateway
+	case model.ErrCodeFeedHTTPError:
+		// 検出対象 URL から非 2xx HTTP 応答を受信した場合（Issue #153）。
+		// 上流サイトが応答を返したがエラー応答（4xx/5xx 等）だったため、
+		// プロキシ的に上流エラーを通知する 502 Bad Gateway にマップする。
+		// FETCH_FAILED（レスポンス取得前の失敗）と同じ 502 だが、エラーコードと
+		// メッセージは別系統で UI 側がユーザー向けに区別表示できる。
+		return http.StatusBadGateway
 	case model.ErrCodeParseFailed:
 		return http.StatusUnprocessableEntity
 	case model.ErrCodeSubscriptionLimit:

--- a/internal/model/errors.go
+++ b/internal/model/errors.go
@@ -39,6 +39,7 @@ const (
 	ErrCodeFeedCooldown         = "FEED_COOLDOWN"
 	ErrCodeInvalidSearchQuery   = "INVALID_SEARCH_QUERY"
 	ErrCodeFeedNotSubscribed    = "FEED_NOT_SUBSCRIBED"
+	ErrCodeFeedHTTPError        = "FEED_HTTP_ERROR"
 )
 
 // NewItemNotFoundError は記事未検出エラーを生成する。
@@ -218,5 +219,25 @@ func NewFeedNotSubscribedError(feedID string) *APIError {
 		Message:  fmt.Sprintf("指定されたフィードを購読していません: %s", feedID),
 		Category: "authorization",
 		Action:   "購読中のフィードを指定するか、横断検索を利用してください。",
+	}
+}
+
+// NewFeedHTTPError は検出対象 URL から非 2xx の HTTP ステータスを受信した場合の
+// エラーを生成する（Issue #153）。FETCH_FAILED（レスポンス取得前の失敗）とは
+// 区別され、レスポンス取得には成功したが HTTP エラー応答だったことを示す。
+// Details["status_code"] に受信したステータスコード（int）を載せる。
+//
+// ユーザー向けメッセージには受信ステータスコードを付記し（Req 2.4）、
+// 「サイト側のブロック / URL 間違い / 一時的にサーバが応答しない」といった
+// 原因示唆と、ユーザーが取れる対処（別 URL を試す / 時間を置いて再試行する）を含める（Req 2.1）。
+func NewFeedHTTPError(statusCode int) *APIError {
+	return &APIError{
+		Code:     ErrCodeFeedHTTPError,
+		Message:  fmt.Sprintf("URLにアクセスしたところ HTTP %d が返されました。サイト側がアクセスをブロックしている、URL が間違っている、もしくは一時的にサーバが応答していない可能性があります。", statusCode),
+		Category: "feed",
+		Action:   "別のURL（フィード本体のURLや異なるページ）を試すか、時間を置いてから再度お試しください。",
+		Details: map[string]any{
+			"status_code": statusCode,
+		},
 	}
 }

--- a/internal/model/errors_test.go
+++ b/internal/model/errors_test.go
@@ -171,3 +171,64 @@ func TestNewFeedNotSubscribedError(t *testing.T) {
 		}
 	})
 }
+
+// TestNewFeedHTTPError は HTTP エラー由来のフィード検出エラーが
+// 期待する Code / Category / Details["status_code"] を持つことを検証する
+// （Issue #153 Req 1.5, 2.1, 2.3, 2.4）。
+func TestNewFeedHTTPError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"429 Too Many Requests", 429},
+		{"404 Not Found", 404},
+		{"503 Service Unavailable", 503},
+		{"500 Internal Server Error", 500},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange & Act
+			err := NewFeedHTTPError(tt.statusCode)
+
+			// Assert
+			if err == nil {
+				t.Fatal("NewFeedHTTPError が nil を返した")
+			}
+			if err.Code != ErrCodeFeedHTTPError {
+				t.Errorf("Code = %q, want %q", err.Code, ErrCodeFeedHTTPError)
+			}
+			if err.Code != "FEED_HTTP_ERROR" {
+				t.Errorf("Code リテラル = %q, want %q", err.Code, "FEED_HTTP_ERROR")
+			}
+			if err.Category != "feed" {
+				t.Errorf("Category = %q, want %q", err.Category, "feed")
+			}
+			// FEED_NOT_DETECTED と区別されること（Req 1.5）
+			if err.Code == ErrCodeFeedNotDetected {
+				t.Errorf("FEED_HTTP_ERROR は FEED_NOT_DETECTED と区別されるべき")
+			}
+			// Details["status_code"] に int で載っていること（Req 2.4）
+			if err.Details == nil {
+				t.Fatal("Details が nil。status_code を載せるべき")
+			}
+			gotStatus, ok := err.Details["status_code"].(int)
+			if !ok {
+				t.Fatalf("Details[\"status_code\"] は int であるべき。実型: %T", err.Details["status_code"])
+			}
+			if gotStatus != tt.statusCode {
+				t.Errorf("Details[\"status_code\"] = %d, want %d", gotStatus, tt.statusCode)
+			}
+			// Message にステータスコードが付記されていること（Req 2.4）
+			if !strings.Contains(err.Message, "HTTP") {
+				t.Errorf("Message に HTTP が含まれていない: %q", err.Message)
+			}
+			// Action が空でないこと（Req 2.1）
+			if err.Action == "" {
+				t.Error("Action が空である（ユーザー向け対処方法が必要）")
+			}
+			// 内部スタックトレース等がレスポンスボディに含まれていないこと（Req 2.3）
+			// ここではフォーマット文字列の制御で担保される（Message は固定テンプレ）。
+		})
+	}
+}


### PR DESCRIPTION
## 概要

フィード URL の登録時、対象サイトが HTTP 4xx/5xx でアクセスをブロックしている場合でも
「フィード未検出」として失敗していた UX 不良を修正する。

本実装では `internal/feed/detector.go` の検出処理に HTTP ステータスコード判定を追加し、
非 2xx 応答（4xx / 5xx / 3xx 最終応答）を新エラー型 `FEED_HTTP_ERROR` として返すようにした。
UI 側は `Details["status_code"]` の付帯情報を通じてステータスコードを取得でき、
「サイト側のブロック・URL 間違い・一時的にサーバが応答しない」可能性をユーザーに示唆できる。
2xx 応答に対する既存の検出フロー（Content-Type 判定・HTML フィードリンク解析）は無変更。

## 対応 Issue

Closes #153

## 関連 PR

なし

## 実装内容

- (Req 1.1〜1.3 / Task) `internal/feed/detector.go`: レスポンス受信後にステータスコード判定を追加。非 2xx の場合は `FEED_HTTP_ERROR` を返し、HTML パースを実行しない
- (Req 1.4) 3xx 最終応答（Location ヘッダ欠落など Go `http.Client` がリダイレクト追跡できなかったケース）も同一分岐で `FEED_HTTP_ERROR` として処理
- (Req 1.5) `FEED_HTTP_ERROR` と既存の `FEED_NOT_DETECTED` を別エラーコードで区別
- (Req 2.1 / 2.4) `internal/model/errors.go`: `NewFeedHTTPError` を新設し、`Details["status_code"]` にステータスコードを格納、Message にはコード番号を含む原因示唆メッセージを設定
- (NFR 2.1) 非 2xx 受信時に `slog.Warn` で url / status をログ出力
- (handler) `mapAPIErrorToHTTPStatus` に `FEED_HTTP_ERROR` → `502 Bad Gateway` マッピングを追加

## 受入基準チェック

- [x] Req 1.1: ステータスコードを判定対象として扱う ← `TestDetectFeedURL_HTTPError_4xx/5xx`
- [x] Req 1.2: 2xx は既存フロー継続 ← `TestDetectFeedURL_2xxStillWorks` + 既存テスト全件
- [x] Req 1.3: 4xx/5xx で HTML パースせず固有エラー ← `TestDetectFeedURL_HTTPError_4xx/5xx`, `TestDetectFeedURL_HTTPError_4xx_DoesNotParseHTMLFeedLink`
- [x] Req 1.4: 3xx 最終応答も HTTP エラー ← `TestDetectFeedURL_HTTPError_3xxFinalResponse`
- [x] Req 1.5: FEED_HTTP_ERROR と FEED_NOT_DETECTED を別コードで区別 ← `TestNewFeedHTTPError`
- [x] Req 2.1: 原因示唆 + 対処を Message に含む ← `TestNewFeedHTTPError`（Action 非空）
- [x] Req 2.3: 内部詳細を露出しない ← `NewFeedHTTPError` は固定テンプレ Message のみ
- [x] Req 2.4: ステータスコード付記 ← `Details["status_code"]` + Message に HTTP ステータス含む
- [x] Req 3.1〜3.4: 2xx 正常系の既存挙動維持 / 新外部依存なし ← `go.mod` 変更なし、既存テスト全件 pass
- [x] Req 4.4: 4xx + HTML link でも HTTP エラー ← `TestDetectFeedURL_HTTPError_4xx_DoesNotParseHTMLFeedLink`
- [x] NFR 1.1〜1.3: 既存挙動同一 / 5MB 上限維持 / 10 秒タイムアウト維持 ← 関連定数・LimitReader 変更なし
- [x] NFR 2.1: URL + status をログ出力 ← `slog.Warn("フィード検出: HTTPステータス異常", ...)`
- [x] NFR 3.1: ボット保護回避コードを追加しない ← UA 偽装・Cookie 永続化等なし

## テスト結果

```
全テスト pass（`go test ./internal/feed/... ./internal/model/...` / `go test ./internal/...`）

追加したテスト（internal/feed/detector_test.go）:
- TestDetectFeedURL_HTTPError_4xx
- TestDetectFeedURL_HTTPError_5xx
- TestDetectFeedURL_HTTPError_4xx_DoesNotParseHTMLFeedLink
- TestDetectFeedURL_HTTPError_3xxFinalResponse
- TestDetectFeedURL_2xxStillWorks

追加したテスト（internal/model/errors_test.go）:
- TestNewFeedHTTPError（4 ケース: 429/404/503/500）

既存テスト（200 応答系）は無修正で全件 pass
```

## 実装上の判断

- **エラー粒度**: 4xx / 5xx を 1 つのコード `FEED_HTTP_ERROR` にまとめ、ステータスコードを `Details["status_code"]` で付帯情報として表現（既存 `FEED_COOLDOWN` の `retry_after_seconds` と同パターン）。将来的な細分化が必要な場合も `Details` 拡張で後方互換を保てる
- **handler マッピング**: `FEED_HTTP_ERROR` → `502 Bad Gateway`。「上流サイトがエラー応答を返した」状況を API として表現する上で semantically 適切と判断
- **非 2xx 時のボディ読み込みスキップ**: `io.ReadAll` を呼ばず即座にエラー返却。Req 4.4（4xx 内 HTML リンクを信頼しない）の意図にも沿い、不要な I/O を回避
- 詳細は `docs/specs/153--rss/impl-notes.md` を参照

## 確認事項 / レビュワーへの依頼

- `docs/specs/153--rss/review-notes.md` にて Reviewer による独立レビューが完了し、`RESULT: approve` 判定済み
- **UI 側の表示未対応**: Req 2.1 / 2.2「Feed Registration UI shall ...」は本 PR 対象外。Next.js 側は既存の APIError 表示機構（Code / Message / Action / Details）を通じて `FEED_HTTP_ERROR` を受け取れる状態になっており、UI 表示は別途対応が必要
- **Worker 側フェッチの同様改善**: Out of Scope（別 Issue で扱う）
- base ブランチ検証結果: `base: develop / baseRefName: develop / OK`

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #153 のコメントを参照してください。
