### PR TITLE
fix(ci): serialize package test execution to prevent shared DB race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,11 @@ jobs:
         # 静的バイナリ構成（CGO_ENABLED=0）と同条件でビルドできることを確認する。
         run: CGO_ENABLED=0 go build -o /tmp/feedman ./cmd/feedman
 
+      # go test ./... はパッケージを並列実行するため、同一のテスト DB (feedman_test) を
+      # 共有する internal/database / internal/repository / internal/app がスキーマを
+      # 同時に作り替えて衝突する（issue #158）。 -p 1 でパッケージ直列化により回避する。
       - name: Run tests
-        run: go test ./...
+        run: go test -p 1 ./...
 
   go-vet:
     name: Go Static Analysis (go vet)


### PR DESCRIPTION
## Summary

Change 'go test ./...' to 'go test -p 1 ./...' in CI to serialize package-level test execution.

## Problem

'go test ./...' runs package tests in parallel. The DB integration tests in internal/database, internal/repository, and internal/app all share the same feedman_test database. When two packages run their test setup simultaneously, they race on schema creation/destruction.

This made Backend Tests flaky (observed in PR #156: 2/2 failures, not recoverable on retry).

## Fix

Add '-p 1' to 'go test ./...' in CI to serialize package execution, eliminating the cross-package schema race while preserving t.Parallel() within each package.

Closes #158