### PR TITLE
fix(item): 記事詳細・状態更新の購読チェック追加で IDOR を防ぐ (#175)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -132,7 +132,10 @@ func runServe(cfg *config.Config) error {
 	faviconFetcher := feed.NewFaviconFetcher(ssrfGuard)
 	feedService := feed.NewFeedService(feedRepo, subRepo, feedDetector, faviconFetcher)
 
-	itemService := item.NewItemService(itemRepo, itemStateRepo)
+	// itemService / itemStateService は subRepo を SubscriptionChecker として注入し、
+	// 記事詳細取得・状態更新時に購読外フィードへの越境アクセスを拒否する（#175）。
+	itemService := item.NewItemService(itemRepo, itemStateRepo, subRepo)
+	itemStateService := item.NewItemStateService(itemRepo, itemStateRepo, subRepo)
 
 	// 横断新着一覧サービス（Issue #121）。itemRepo の ListNewAcrossFeeds と
 	// userCrossFeedViewRepo の Get / Upsert を利用する。
@@ -175,7 +178,7 @@ func runServe(cfg *config.Config) error {
 	subServiceAdapter := handler.NewSubscriptionServiceAdapter(subService)
 	userServiceAdapter := handler.NewUserServiceAdapter(userService)
 	itemServiceAdapter := handler.NewItemServiceAdapter(itemService)
-	itemStateServiceAdapter := handler.NewItemStateServiceAdapter(itemStateRepo)
+	itemStateServiceAdapter := handler.NewItemStateServiceAdapter(itemStateService)
 	itemSearchServiceAdapter := handler.NewItemSearchServiceAdapter(itemSearchService)
 	crossFeedServiceAdapter := handler.NewCrossFeedServiceAdapter(crossFeedService)
 

--- a/internal/handler/service_adapter.go
+++ b/internal/handler/service_adapter.go
@@ -210,19 +210,20 @@ func (a *ItemServiceAdapterFromDomain) GetItem(ctx context.Context, userID, item
 	}, nil
 }
 
-// ItemStateServiceAdapterFromRepo は repository.ItemStateRepository を ItemStateServiceInterface に適合させるアダプタ。
-type ItemStateServiceAdapterFromRepo struct {
-	repo repository.ItemStateRepository
+// ItemStateServiceAdapterFromDomain は item.ItemStateService を ItemStateServiceInterface に適合させるアダプタ。
+type ItemStateServiceAdapterFromDomain struct {
+	svc *item.ItemStateService
 }
 
-// NewItemStateServiceAdapter は repository.ItemStateRepository から ItemStateServiceInterface を生成する。
-func NewItemStateServiceAdapter(repo repository.ItemStateRepository) ItemStateServiceInterface {
-	return &ItemStateServiceAdapterFromRepo{repo: repo}
+// NewItemStateServiceAdapter は item.ItemStateService から ItemStateServiceInterface を生成する。
+// 状態更新の認可（購読チェック）はサービス層（item.ItemStateService.UpdateState）が担う。
+func NewItemStateServiceAdapter(svc *item.ItemStateService) ItemStateServiceInterface {
+	return &ItemStateServiceAdapterFromDomain{svc: svc}
 }
 
 // UpdateState は記事の既読・スター状態を冪等に更新する。
-func (a *ItemStateServiceAdapterFromRepo) UpdateState(ctx context.Context, userID, itemID string, isRead *bool, isStarred *bool) (*model.ItemState, error) {
-	return a.repo.Upsert(ctx, userID, itemID, isRead, isStarred)
+func (a *ItemStateServiceAdapterFromDomain) UpdateState(ctx context.Context, userID, itemID string, isRead *bool, isStarred *bool) (*model.ItemState, error) {
+	return a.svc.UpdateState(ctx, userID, itemID, isRead, isStarred)
 }
 
 // SubscriptionDeleterAdapter はリポジトリ層を SubscriptionDeleter に適合させるアダプタ。
@@ -385,7 +386,7 @@ func (a *CrossFeedServiceAdapter) TouchLastSeen(ctx context.Context, userID stri
 var _ SubscriptionServiceInterface = (*SubscriptionServiceAdapter)(nil)
 var _ UserServiceInterface = (*UserServiceAdapter)(nil)
 var _ ItemServiceInterface = (*ItemServiceAdapterFromDomain)(nil)
-var _ ItemStateServiceInterface = (*ItemStateServiceAdapterFromRepo)(nil)
+var _ ItemStateServiceInterface = (*ItemStateServiceAdapterFromDomain)(nil)
 var _ ItemSearchServiceInterface = (*ItemSearchServiceAdapter)(nil)
 var _ SubscriptionDeleter = (*SubscriptionDeleterAdapter)(nil)
 var _ CrossFeedServiceInterface = (*CrossFeedServiceAdapter)(nil)

--- a/internal/item/service.go
+++ b/internal/item/service.go
@@ -9,20 +9,33 @@ import (
 	"github.com/hitoshi/feedman/internal/repository"
 )
 
+// SubscriptionChecker は記事アクセスの認可に必要な購読確認の最小インターフェース。
+// repository.SubscriptionRepository がこれを満たす（インターフェース分離のため
+// 全 SubscriptionRepository ではなく必要メソッドのみに依存する）。
+type SubscriptionChecker interface {
+	// FindByUserAndFeed はユーザーとフィードの購読を返す。未購読なら nil を返す。
+	FindByUserAndFeed(ctx context.Context, userID, feedID string) (*model.Subscription, error)
+}
+
 // ItemService は記事取得・フィルタリングのサービス。
 type ItemService struct {
 	itemRepo      repository.ItemRepository
 	itemStateRepo repository.ItemStateRepository
+	subChecker    SubscriptionChecker
 }
 
 // NewItemService はItemServiceの新しいインスタンスを生成する。
+// subChecker は記事詳細取得時に呼び出しユーザーが当該フィードを購読しているかを
+// 確認するために使用する（購読外フィードの記事本文への越境アクセスを防ぐ）。
 func NewItemService(
 	itemRepo repository.ItemRepository,
 	itemStateRepo repository.ItemStateRepository,
+	subChecker SubscriptionChecker,
 ) *ItemService {
 	return &ItemService{
 		itemRepo:      itemRepo,
 		itemStateRepo: itemStateRepo,
+		subChecker:    subChecker,
 	}
 }
 
@@ -233,6 +246,17 @@ func (s *ItemService) GetItem(
 		return nil, err
 	}
 	if item == nil {
+		return nil, model.NewItemNotFoundError(itemID)
+	}
+
+	// 認可: 呼び出しユーザーが当該記事のフィードを購読していることを確認する。
+	// 一覧系は subscriptions JOIN で user_id を強制しているため、詳細取得でも同じ
+	// 購読境界を守る。未購読なら存在を秘匿するため ITEM_NOT_FOUND を返す。
+	sub, err := s.subChecker.FindByUserAndFeed(ctx, userID, item.FeedID)
+	if err != nil {
+		return nil, err
+	}
+	if sub == nil {
 		return nil, model.NewItemNotFoundError(itemID)
 	}
 

--- a/internal/item/service_test.go
+++ b/internal/item/service_test.go
@@ -96,6 +96,33 @@ func (m *mockItemStateRepoForService) DeleteByUserID(_ context.Context, _ string
 	return nil
 }
 
+// mockSubCheckerForService は購読確認の最小インターフェース（SubscriptionChecker）の
+// テスト用モック。findFn 未設定時は subscribed フラグに従って購読有無を返す。
+type mockSubCheckerForService struct {
+	subscribed bool
+	findFn     func(ctx context.Context, userID, feedID string) (*model.Subscription, error)
+}
+
+func (m *mockSubCheckerForService) FindByUserAndFeed(ctx context.Context, userID, feedID string) (*model.Subscription, error) {
+	if m.findFn != nil {
+		return m.findFn(ctx, userID, feedID)
+	}
+	if m.subscribed {
+		return &model.Subscription{UserID: userID, FeedID: feedID}, nil
+	}
+	return nil, nil
+}
+
+// subscribedChecker は「購読済み」を返す checker を生成するテストヘルパー。
+func subscribedChecker() *mockSubCheckerForService {
+	return &mockSubCheckerForService{subscribed: true}
+}
+
+// unsubscribedChecker は「未購読」を返す checker を生成するテストヘルパー。
+func unsubscribedChecker() *mockSubCheckerForService {
+	return &mockSubCheckerForService{subscribed: false}
+}
+
 // --- ItemService ListItems テスト ---
 
 // TestItemService_ListItems_ReturnsItems はフィードの記事一覧がpublished_at降順で返されることをテストする。
@@ -132,7 +159,7 @@ func TestItemService_ListItems_ReturnsItems(t *testing.T) {
 		}, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 	result, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterAll, "", 50)
 	if err != nil {
 		t.Fatalf("ListItems returned error: %v", err)
@@ -186,7 +213,7 @@ func TestItemService_ListItems_IncludesSummary(t *testing.T) {
 					},
 				}, nil
 			}
-			svc := NewItemService(repo, newMockItemStateRepoForService())
+			svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 
 			// Act
 			result, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterAll, "", 50)
@@ -229,7 +256,7 @@ func TestItemService_SummaryConsistentBetweenListAndDetail(t *testing.T) {
 		itemCopy := srcItem
 		return &itemCopy, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 
 	listResult, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterAll, "", 50)
 	if err != nil {
@@ -275,7 +302,7 @@ func TestItemService_ListItems_HasMore(t *testing.T) {
 		return items, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 	result, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterAll, "", 50)
 	if err != nil {
 		t.Fatalf("ListItems returned error: %v", err)
@@ -298,7 +325,7 @@ func TestItemService_ListItems_HasMore(t *testing.T) {
 // TestItemService_ListItems_InvalidFilter は無効なフィルタでエラーが返されることをテストする。
 func TestItemService_ListItems_InvalidFilter(t *testing.T) {
 	repo := newMockItemRepoForService()
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 
 	_, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilter("invalid"), "", 50)
 	if err == nil {
@@ -323,7 +350,7 @@ func TestItemService_ListItems_CursorParsing(t *testing.T) {
 		return nil, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 	cursorStr := "2026-02-27T10:00:00Z"
 	_, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterAll, cursorStr, 50)
 	if err != nil {
@@ -345,7 +372,7 @@ func TestItemService_ListItems_EmptyCursor(t *testing.T) {
 		return nil, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 	_, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterAll, "", 50)
 	if err != nil {
 		t.Fatalf("ListItems returned error: %v", err)
@@ -365,7 +392,7 @@ func TestItemService_ListItems_UnreadFilter(t *testing.T) {
 		return nil, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 	_, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterUnread, "", 50)
 	if err != nil {
 		t.Fatalf("ListItems returned error: %v", err)
@@ -385,7 +412,7 @@ func TestItemService_ListItems_StarredFilter(t *testing.T) {
 		return nil, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 	_, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterStarred, "", 50)
 	if err != nil {
 		t.Fatalf("ListItems returned error: %v", err)
@@ -435,7 +462,7 @@ func TestItemService_ListStarredItems_EmptyCursor(t *testing.T) {
 			makeStarredRow("item-1", "feed-1", "Feed A", now),
 		}, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 
 	// Act
 	result, err := svc.ListStarredItems(context.Background(), "user-123", "", 50)
@@ -481,7 +508,7 @@ func TestItemService_ListStarredItems_InvalidCursor(t *testing.T) {
 		repoCalled = true
 		return nil, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 
 	// Act
 	_, err := svc.ListStarredItems(context.Background(), "user-123", "not-a-timestamp", 50)
@@ -524,7 +551,7 @@ func TestItemService_ListStarredItems_HasMoreTrue(t *testing.T) {
 		}
 		return rows, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 
 	// Act
 	result, err := svc.ListStarredItems(context.Background(), "user-123", "", 50)
@@ -566,7 +593,7 @@ func TestItemService_ListStarredItems_HasMoreFalse(t *testing.T) {
 			makeStarredRow("item-2", "feed-2", "Feed B", now.Add(-time.Hour)),
 		}, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 
 	// Act
 	result, err := svc.ListStarredItems(context.Background(), "user-123", "", 50)
@@ -617,7 +644,7 @@ func TestItemService_ListStarredItems_NextCursorRFC3339NanoFormat(t *testing.T) 
 		rows[outerLimit] = makeStarredRow("item-overflow", "feed-1", "Feed A", tailTime.Add(-time.Hour))
 		return rows, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 
 	// Act
 	result, err := svc.ListStarredItems(context.Background(), "user-123", "", outerLimit)
@@ -654,7 +681,7 @@ func TestItemService_ListStarredItems_CursorPassedToRepo(t *testing.T) {
 		receivedCursor = cursor
 		return nil, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 	cursorStr := "2026-02-27T10:00:00Z"
 
 	// Act
@@ -702,7 +729,7 @@ func TestItemService_GetItem_ReturnsDetail(t *testing.T) {
 		IsStarred: true,
 	}
 
-	svc := NewItemService(repo, stateRepo)
+	svc := NewItemService(repo, stateRepo, subscribedChecker())
 	detail, err := svc.GetItem(context.Background(), "user-123", "item-1")
 	if err != nil {
 		t.Fatalf("GetItem returned error: %v", err)
@@ -731,6 +758,48 @@ func TestItemService_GetItem_ReturnsDetail(t *testing.T) {
 	}
 }
 
+// TestItemService_GetItem_Unsubscribed_ReturnsNotFound は、記事が存在しても
+// 呼び出しユーザーが当該フィードを未購読の場合に ITEM_NOT_FOUND を返し、本文を
+// 漏えいしないことを検証する（#175 IDOR 対策）。
+func TestItemService_GetItem_Unsubscribed_ReturnsNotFound(t *testing.T) {
+	// Arrange: 記事は存在する（他ユーザー専用フィードの記事を想定）
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := newMockItemRepoForService()
+	repo.findByIDFn = func(ctx context.Context, id string) (*model.Item, error) {
+		return &model.Item{
+			ID:          "item-1",
+			FeedID:      "feed-foreign",
+			Title:       "他人のフィードの記事",
+			Content:     "<p>秘密の本文</p>",
+			PublishedAt: &now,
+		}, nil
+	}
+	// 購読チェックは「未購読」を返す。FeedID が渡ることも確認する。
+	checker := unsubscribedChecker()
+	checker.findFn = func(_ context.Context, userID, feedID string) (*model.Subscription, error) {
+		if feedID != "feed-foreign" {
+			t.Errorf("feedID = %q, want %q", feedID, "feed-foreign")
+		}
+		return nil, nil
+	}
+
+	// Act
+	svc := NewItemService(repo, newMockItemStateRepoForService(), checker)
+	detail, err := svc.GetItem(context.Background(), "user-123", "item-1")
+
+	// Assert: 存在を秘匿して ITEM_NOT_FOUND、本文は返さない
+	if detail != nil {
+		t.Errorf("expected nil detail for unsubscribed access, got %+v", detail)
+	}
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("expected *model.APIError, got %T (%v)", err, err)
+	}
+	if apiErr.Code != model.ErrCodeItemNotFound {
+		t.Errorf("error code = %q, want %q", apiErr.Code, model.ErrCodeItemNotFound)
+	}
+}
+
 // TestItemService_GetItem_NotFound は存在しない記事でエラーが返されることをテストする。
 func TestItemService_GetItem_NotFound(t *testing.T) {
 	repo := newMockItemRepoForService()
@@ -738,7 +807,7 @@ func TestItemService_GetItem_NotFound(t *testing.T) {
 		return nil, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 	_, err := svc.GetItem(context.Background(), "user-123", "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for non-existent item")
@@ -767,7 +836,7 @@ func TestItemService_GetItem_NoState(t *testing.T) {
 	}
 
 	// item_statesにレコードなし
-	svc := NewItemService(repo, newMockItemStateRepoForService())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
 	detail, err := svc.GetItem(context.Background(), "user-123", "item-1")
 	if err != nil {
 		t.Fatalf("GetItem returned error: %v", err)
@@ -813,7 +882,7 @@ func TestItemStateService_UpdateState_SetRead(t *testing.T) {
 		return &model.Item{ID: "item-1"}, nil
 	}
 
-	svc := NewItemStateService(itemRepo, stateRepo)
+	svc := NewItemStateService(itemRepo, stateRepo, subscribedChecker())
 	isRead := true
 	state, err := svc.UpdateState(context.Background(), "user-123", "item-1", &isRead, nil)
 	if err != nil {
@@ -845,7 +914,7 @@ func TestItemStateService_UpdateState_SetStarred(t *testing.T) {
 		return &model.Item{ID: "item-1"}, nil
 	}
 
-	svc := NewItemStateService(itemRepo, stateRepo)
+	svc := NewItemStateService(itemRepo, stateRepo, subscribedChecker())
 	isStarred := true
 	state, err := svc.UpdateState(context.Background(), "user-123", "item-1", nil, &isStarred)
 	if err != nil {
@@ -882,7 +951,7 @@ func TestItemStateService_UpdateState_NilFieldsNotChanged(t *testing.T) {
 		return &model.Item{ID: "item-1"}, nil
 	}
 
-	svc := NewItemStateService(itemRepo, stateRepo)
+	svc := NewItemStateService(itemRepo, stateRepo, subscribedChecker())
 	isRead := false
 	state, err := svc.UpdateState(context.Background(), "user-123", "item-1", &isRead, nil)
 	if err != nil {
@@ -904,7 +973,7 @@ func TestItemStateService_UpdateState_ItemNotFound(t *testing.T) {
 		return nil, nil // 記事が存在しない
 	}
 
-	svc := NewItemStateService(itemRepo, newMockItemStateRepoForService())
+	svc := NewItemStateService(itemRepo, newMockItemStateRepoForService(), subscribedChecker())
 	isRead := true
 	_, err := svc.UpdateState(context.Background(), "user-123", "nonexistent", &isRead, nil)
 	if err == nil {
@@ -914,6 +983,40 @@ func TestItemStateService_UpdateState_ItemNotFound(t *testing.T) {
 	apiErr, ok := err.(*model.APIError)
 	if !ok {
 		t.Fatalf("expected *model.APIError, got %T", err)
+	}
+	if apiErr.Code != model.ErrCodeItemNotFound {
+		t.Errorf("error code = %q, want %q", apiErr.Code, model.ErrCodeItemNotFound)
+	}
+}
+
+// TestItemStateService_UpdateState_Unsubscribed_ReturnsNotFound は、記事が存在しても
+// 呼び出しユーザーが当該フィードを未購読の場合に ITEM_NOT_FOUND を返し、状態の
+// 書き込み（Upsert）を行わないことを検証する（#175 越境書き込み対策）。
+func TestItemStateService_UpdateState_Unsubscribed_ReturnsNotFound(t *testing.T) {
+	// Arrange: 記事は存在する
+	itemRepo := newMockItemRepoForService()
+	itemRepo.findByIDFn = func(ctx context.Context, id string) (*model.Item, error) {
+		return &model.Item{ID: "item-1", FeedID: "feed-foreign"}, nil
+	}
+	// Upsert が呼ばれたら失敗（越境書き込みが起きていないことを保証）
+	stateRepo := newMockItemStateRepoForService()
+	stateRepo.upsertFn = func(_ context.Context, _, _ string, _, _ *bool) (*model.ItemState, error) {
+		t.Fatal("Upsert must not be called for unsubscribed access")
+		return nil, nil
+	}
+
+	// Act: 未購読
+	svc := NewItemStateService(itemRepo, stateRepo, unsubscribedChecker())
+	isRead := true
+	state, err := svc.UpdateState(context.Background(), "user-123", "item-1", &isRead, nil)
+
+	// Assert
+	if state != nil {
+		t.Errorf("expected nil state for unsubscribed access, got %+v", state)
+	}
+	apiErr, ok := err.(*model.APIError)
+	if !ok {
+		t.Fatalf("expected *model.APIError, got %T (%v)", err, err)
 	}
 	if apiErr.Code != model.ErrCodeItemNotFound {
 		t.Errorf("error code = %q, want %q", apiErr.Code, model.ErrCodeItemNotFound)
@@ -939,7 +1042,7 @@ func TestItemStateService_UpdateState_UserDataIsolation(t *testing.T) {
 		return &model.Item{ID: "item-1"}, nil
 	}
 
-	svc := NewItemStateService(itemRepo, stateRepo)
+	svc := NewItemStateService(itemRepo, stateRepo, subscribedChecker())
 	isRead := true
 	_, err := svc.UpdateState(context.Background(), "user-456", "item-1", &isRead, nil)
 	if err != nil {

--- a/internal/item/state_service.go
+++ b/internal/item/state_service.go
@@ -12,22 +12,28 @@ import (
 type ItemStateService struct {
 	itemRepo      repository.ItemRepository
 	itemStateRepo repository.ItemStateRepository
+	subChecker    SubscriptionChecker
 }
 
 // NewItemStateService はItemStateServiceの新しいインスタンスを生成する。
+// subChecker は状態更新時に呼び出しユーザーが当該フィードを購読しているかを
+// 確認するために使用する（購読外フィードの記事への越境書き込みを防ぐ）。
 func NewItemStateService(
 	itemRepo repository.ItemRepository,
 	itemStateRepo repository.ItemStateRepository,
+	subChecker SubscriptionChecker,
 ) *ItemStateService {
 	return &ItemStateService{
 		itemRepo:      itemRepo,
 		itemStateRepo: itemStateRepo,
+		subChecker:    subChecker,
 	}
 }
 
 // UpdateState は記事の既読・スター状態を冪等に更新する。
 // nilフィールドは変更せず、既存の値を維持する部分更新を行う。
-// 記事が存在しない場合はITEM_NOT_FOUNDエラーを返す。
+// 記事が存在しない、または呼び出しユーザーが当該フィードを未購読の場合は
+// ITEM_NOT_FOUND エラーを返す（越境書き込みを防ぐため存在を秘匿する）。
 // ユーザーデータ分離（全クエリにuser_id条件付与）をRepository層で強制する。
 func (s *ItemStateService) UpdateState(
 	ctx context.Context,
@@ -41,6 +47,16 @@ func (s *ItemStateService) UpdateState(
 		return nil, err
 	}
 	if item == nil {
+		return nil, model.NewItemNotFoundError(itemID)
+	}
+
+	// 認可: 呼び出しユーザーが当該記事のフィードを購読していることを確認する。
+	// 未購読フィードの記事に対する状態書き込み・ID 列挙を防ぐ。
+	sub, err := s.subChecker.FindByUserAndFeed(ctx, userID, item.FeedID)
+	if err != nil {
+		return nil, err
+	}
+	if sub == nil {
 		return nil, model.NewItemNotFoundError(itemID)
 	}
 


### PR DESCRIPTION
## 概要

`GET /api/items/{id}`（記事詳細）と `PUT /api/items/{id}/state`（既読/スター更新）に**購読チェック**を追加し、購読外フィードの記事への越境アクセス（IDOR）を防ぎます。Issue #175 の修正です。

監査で、一覧系（`ListByFeed` / `ListStarredByUser` / 検索）は `subscriptions` を JOIN して `user_id` で絞っているのに、**詳細・状態更新だけがこの購読境界を越えている**ことを確認しました。

## 変更内容

- `item.SubscriptionChecker`（`FindByUserAndFeed` のみの最小インターフェース）を導入。`repository.SubscriptionRepository` が構造的に充足（インターフェース分離）
- `ItemService.GetItem`: 記事取得後に `subChecker.FindByUserAndFeed(userID, item.FeedID)` を確認。未購読なら存在を秘匿するため `ITEM_NOT_FOUND` を返す（`FeedService.GetFeed` と同パターン）
- **dead code だった `ItemStateService` を正規実装として配線し直し**、`UpdateState` に同じ購読チェックを追加
  - 状態更新パスは従来 `NewItemStateServiceAdapter(itemStateRepo)` が `repo.Upsert` を直叩きしており、サービス層の認可ロジックを通っていなかった
  - 新たに adapter は `item.ItemStateService` をラップする
- `app.go` で `subRepo` を両サービスへ `SubscriptionChecker` として注入

## テスト

- `TestItemService_GetItem_Unsubscribed_ReturnsNotFound`: 記事が存在しても未購読なら `ITEM_NOT_FOUND`、本文を返さない
- `TestItemStateService_UpdateState_Unsubscribed_ReturnsNotFound`: 未購読時は `Upsert` を呼ばず `ITEM_NOT_FOUND`（越境書き込みが起きないことを `t.Fatal` で保証）
- 既存テストは購読済み checker を注入して挙動不変
- `go build ./...` / `go vet ./...` / `go test ./...` / `gofmt` すべて green

## 確認事項（レビュワー判断ポイント）

- **存在秘匿の方針**: 未購読アクセスを `403 FORBIDDEN` ではなく `404 ITEM_NOT_FOUND` にしています。記事の存在有無を漏らさないための選択です（列挙対策）。403 を好む場合は指摘ください
- **`ItemStateService` の復活**: これまで未配線（dead code）だった `state_service.go` を正規パスに戻しました。adapter の責務（認可をサービス層へ移譲）も合わせて変更しています
- **緩和要因**: 記事 ID は UUIDv4（122bit）で総当たりは非現実的ですが、認可を推測困難性に依存させない方針で修正しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)