### PR TITLE
fix(security): フィード由来 URL(item.link) の scheme 検証で XSS を防ぐ (#176)

### DIFF
--- a/internal/item/upsert.go
+++ b/internal/item/upsert.go
@@ -247,7 +247,9 @@ func buildUpdatedItem(existing *model.Item, p preparedItem, now time.Time) *mode
 	updated := *existing
 	updated.GuidOrID = p.parsed.GuidOrID
 	updated.Title = p.parsed.Title
-	updated.Link = p.parsed.Link
+	// link は href として出力されるため、http/https 以外（javascript: 等）を無害化する。
+	// 同一性判定には生の parsed.Link を使うため dedup には影響しない。
+	updated.Link = security.SafeExternalURL(p.parsed.Link)
 	updated.Content = p.sanitizedContent
 	updated.Summary = p.sanitizedSummary
 	updated.Author = p.parsed.Author
@@ -267,11 +269,12 @@ func buildUpdatedItem(existing *model.Item, p preparedItem, now time.Time) *mode
 // published_at未設定の場合はfetched_atを代用し、推定フラグを付与する。
 func buildNewItem(feedID string, p preparedItem, now time.Time) *model.Item {
 	item := &model.Item{
-		ID:          uuid.New().String(),
-		FeedID:      feedID,
-		GuidOrID:    p.parsed.GuidOrID,
-		Title:       p.parsed.Title,
-		Link:        p.parsed.Link,
+		ID:       uuid.New().String(),
+		FeedID:   feedID,
+		GuidOrID: p.parsed.GuidOrID,
+		Title:    p.parsed.Title,
+		// link は href として出力されるため、http/https 以外（javascript: 等）を無害化する。
+		Link:        security.SafeExternalURL(p.parsed.Link),
 		Content:     p.sanitizedContent,
 		Summary:     p.sanitizedSummary,
 		Author:      p.parsed.Author,

--- a/internal/item/upsert_test.go
+++ b/internal/item/upsert_test.go
@@ -518,6 +518,68 @@ func TestUpsertItems_NewItem_Insert(t *testing.T) {
 	}
 }
 
+// TestUpsertItems_NewItem_UnsafeLinkSanitized は、フィード由来の link が javascript: 等の
+// 危険スキームのとき、保存される記事の Link が空に無害化されることを検証する（#176）。
+func TestUpsertItems_NewItem_UnsafeLinkSanitized(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	pubTime := time.Date(2026, 2, 15, 10, 0, 0, 0, time.UTC)
+	// 同一性は GUID で判定させ、危険スキームの link を持たせる。
+	parsedItems := []model.ParsedItem{
+		{
+			GuidOrID:    "guid-xss",
+			Title:       "悪意あるリンクの記事",
+			Link:        "javascript:alert(document.cookie)",
+			Content:     "<p>本文</p>",
+			PublishedAt: &pubTime,
+		},
+	}
+
+	if _, _, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems); err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+
+	created := repo.lastCreatedItem
+	if created == nil {
+		t.Fatal("lastCreatedItem should not be nil")
+	}
+	if created.Link != "" {
+		t.Errorf("created.Link = %q, want empty (javascript: must be sanitized)", created.Link)
+	}
+}
+
+// TestUpsertItems_NewItem_SafeLinkPreserved は http/https の link がそのまま保存される
+// ことを確認し、上の無害化テストとの差分等価を担保する（#176）。
+func TestUpsertItems_NewItem_SafeLinkPreserved(t *testing.T) {
+	repo := newMockItemRepo()
+	sanitizer := &mockSanitizer{}
+	svc := NewItemUpsertService(repo, sanitizer)
+
+	pubTime := time.Date(2026, 2, 15, 10, 0, 0, 0, time.UTC)
+	parsedItems := []model.ParsedItem{
+		{
+			GuidOrID:    "guid-safe",
+			Title:       "通常記事",
+			Link:        "https://example.com/article",
+			PublishedAt: &pubTime,
+		},
+	}
+
+	if _, _, err := svc.UpsertItems(context.Background(), "feed-1", parsedItems); err != nil {
+		t.Fatalf("UpsertItems returned error: %v", err)
+	}
+
+	created := repo.lastCreatedItem
+	if created == nil {
+		t.Fatal("lastCreatedItem should not be nil")
+	}
+	if created.Link != "https://example.com/article" {
+		t.Errorf("created.Link = %q, want %q", created.Link, "https://example.com/article")
+	}
+}
+
 // TestUpsertItems_NewItem_PublishedAtMissing_UsesFetchedAt はpublished_at未設定時にfetched_atを代用することをテストする。
 func TestUpsertItems_NewItem_PublishedAtMissing_UsesFetchedAt(t *testing.T) {
 	repo := newMockItemRepo()

--- a/internal/security/url_guard.go
+++ b/internal/security/url_guard.go
@@ -1,0 +1,35 @@
+package security
+
+import (
+	"net/url"
+	"strings"
+)
+
+// SafeExternalURL は外部リンク（フィード記事の link 等）として安全に href へ出力できる
+// URL のみを通すための scheme 検証を行う。
+//
+// 許可するのは絶対 URL の http / https スキームのみ（大文字小文字は無視）。それ以外
+// （javascript: / data: / vbscript: / file: などの実行可能・危険スキーム、相対 URL、
+// プロトコル相対 URL `//host`、パースできない値、空文字列）は空文字列を返す。
+//
+// フィード由来の URL は攻撃者が制御しうるため、bluemonday を通る記事本文 HTML とは別に、
+// 記事自身の link（gofeed が <link> から抽出する値）に対してもこの検証を適用し、
+// href に javascript: 等が出力される保存型 XSS を防ぐ。前後の空白は除去して返す。
+func SafeExternalURL(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return ""
+	}
+
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		return trimmed
+	default:
+		return ""
+	}
+}

--- a/internal/security/url_guard_test.go
+++ b/internal/security/url_guard_test.go
@@ -1,0 +1,43 @@
+package security
+
+import "testing"
+
+// TestSafeExternalURL は許可スキーム（http/https）のみを通し、危険・相対・不正な
+// URL を空文字列へ無害化することを検証する。
+func TestSafeExternalURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// 正常系（http/https を維持）
+		{name: "https を許可する", in: "https://example.com/article", want: "https://example.com/article"},
+		{name: "http を許可する", in: "http://example.com/article", want: "http://example.com/article"},
+		{name: "大文字スキームも許可する", in: "HTTPS://example.com", want: "HTTPS://example.com"},
+		{name: "クエリ付き URL を維持する", in: "https://example.com/a?b=c&d=e", want: "https://example.com/a?b=c&d=e"},
+		{name: "前後の空白を除去して維持する", in: "  https://example.com  ", want: "https://example.com"},
+
+		// 異常系（危険スキームを無害化）
+		{name: "javascript スキームを拒否する", in: "javascript:alert(1)", want: ""},
+		{name: "大文字混在の javascript を拒否する", in: "JaVaScRiPt:alert(1)", want: ""},
+		{name: "先頭空白付き javascript を拒否する", in: "   javascript:alert(1)", want: ""},
+		{name: "data スキームを拒否する", in: "data:text/html,<script>alert(1)</script>", want: ""},
+		{name: "vbscript スキームを拒否する", in: "vbscript:msgbox(1)", want: ""},
+		{name: "file スキームを拒否する", in: "file:///etc/passwd", want: ""},
+
+		// 境界値（相対・空・プロトコル相対）
+		{name: "相対 URL を拒否する", in: "/path/to/article", want: ""},
+		{name: "プロトコル相対 URL を拒否する", in: "//evil.example.com", want: ""},
+		{name: "空文字列は空文字列を返す", in: "", want: ""},
+		{name: "空白のみは空文字列を返す", in: "   ", want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SafeExternalURL(tc.in)
+			if got != tc.want {
+				t.Errorf("SafeExternalURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/web/src/components/item-detail.tsx
+++ b/web/src/components/item-detail.tsx
@@ -5,6 +5,7 @@ import { ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { sanitizeContentHtml } from "@/lib/sanitize";
+import { safeFeedUrl } from "@/lib/url";
 import type { ItemDetail as ItemDetailType } from "@/types/item";
 
 /**
@@ -90,7 +91,7 @@ export function ItemDetail({
           {/* タイトルリンク（長文時は折り返し）。 */}
           <h3 className="text-lg font-semibold leading-tight">
             <a
-              href={item.link}
+              href={safeFeedUrl(item.link)}
               target="_blank"
               rel="noopener noreferrer"
               className="hover:underline"
@@ -112,7 +113,7 @@ export function ItemDetail({
             </>
           )}
           <a
-            href={item.link}
+            href={safeFeedUrl(item.link)}
             target="_blank"
             rel="noopener noreferrer"
             data-testid="original-link"

--- a/web/src/components/item-list.tsx
+++ b/web/src/components/item-list.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { RotateCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { safeFeedUrl } from "@/lib/url";
 import { useItems, useItemDetail } from "@/hooks/use-items";
 import { useMarkAsRead, useToggleStar } from "@/hooks/use-item-state";
 import { ItemDetail } from "@/components/item-detail";
@@ -365,7 +366,7 @@ export function ItemRow({
       >
         {/* タイトルリンク */}
         <a
-          href={item.link}
+          href={safeFeedUrl(item.link)}
           target="_blank"
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}

--- a/web/src/components/search-results.tsx
+++ b/web/src/components/search-results.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
+import { safeFeedUrl } from "@/lib/url";
 import { useAppState, useAppDispatch } from "@/contexts/app-state";
 import { useItemSearch } from "@/hooks/use-item-search";
 import { useItemDetail } from "@/hooks/use-items";
@@ -310,7 +311,7 @@ function SearchResultRow({
         className="flex items-start gap-2"
       >
         <a
-          href={hit.link}
+          href={safeFeedUrl(hit.link)}
           target="_blank"
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}

--- a/web/src/lib/url.test.ts
+++ b/web/src/lib/url.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { safeFeedUrl } from "./url";
+
+describe("safeFeedUrl", () => {
+  // 正常系: http/https はそのまま維持する
+  it("https URL のときそのまま返すこと", () => {
+    expect(safeFeedUrl("https://example.com/article")).toBe("https://example.com/article");
+  });
+
+  it("http URL のときそのまま返すこと", () => {
+    expect(safeFeedUrl("http://example.com/article")).toBe("http://example.com/article");
+  });
+
+  it("大文字スキームの URL も許可すること", () => {
+    expect(safeFeedUrl("HTTPS://example.com")).toBe("HTTPS://example.com");
+  });
+
+  it("前後の空白を除去して返すこと", () => {
+    expect(safeFeedUrl("  https://example.com  ")).toBe("https://example.com");
+  });
+
+  // 異常系: 危険スキームを "#" へ無害化する
+  it("javascript スキームのとき # を返すこと", () => {
+    expect(safeFeedUrl("javascript:alert(1)")).toBe("#");
+  });
+
+  it("大文字混在の javascript スキームのとき # を返すこと", () => {
+    expect(safeFeedUrl("JaVaScRiPt:alert(1)")).toBe("#");
+  });
+
+  it("先頭空白付きの javascript スキームのとき # を返すこと", () => {
+    expect(safeFeedUrl("  javascript:alert(1)")).toBe("#");
+  });
+
+  it("data スキームのとき # を返すこと", () => {
+    expect(safeFeedUrl("data:text/html,<script>alert(1)</script>")).toBe("#");
+  });
+
+  // 境界値: 相対・プロトコル相対・空・null/undefined
+  it("相対 URL のとき # を返すこと", () => {
+    expect(safeFeedUrl("/path/to/article")).toBe("#");
+  });
+
+  it("プロトコル相対 URL のとき # を返すこと", () => {
+    expect(safeFeedUrl("//evil.example.com")).toBe("#");
+  });
+
+  it("空文字列のとき # を返すこと", () => {
+    expect(safeFeedUrl("")).toBe("#");
+  });
+
+  it("null のとき # を返すこと", () => {
+    expect(safeFeedUrl(null)).toBe("#");
+  });
+
+  it("undefined のとき # を返すこと", () => {
+    expect(safeFeedUrl(undefined)).toBe("#");
+  });
+});

--- a/web/src/lib/url.ts
+++ b/web/src/lib/url.ts
@@ -1,0 +1,33 @@
+/**
+ * フィード由来 URL を `href` に出力する前の scheme 検証ユーティリティ。
+ *
+ * 記事の `link` はフィード（攻撃者が制御しうる外部サイト）由来の値であり、バックエンドの
+ * bluemonday / DOMPurify による本文サニタイズの経路を通らない。`javascript:` や `data:` の
+ * URL を `<a href>` に出力するとクリック時に任意スクリプトが実行されうるため（保存型 XSS）、
+ * バックエンドの取り込み時検証（`internal/security/url_guard.go` の SafeExternalURL）に続く
+ * 多層防御の最終層として、描画直前にもフロントエンドで scheme を検証する。
+ *
+ * 許可するのは絶対 URL の http / https のみ。それ以外（危険スキーム・相対 URL・
+ * プロトコル相対 URL・空値）は安全な `"#"` に無害化する。
+ */
+
+/** http / https の絶対 URL のみを許可する正規表現（スキーム部のみ判定）。 */
+const SAFE_URL_SCHEME = /^https?:\/\//i;
+
+/**
+ * フィード由来 URL を href 用に検証する。http/https のみ許可し、危険・不正な URL は
+ * `"#"` を返す。
+ *
+ * @param url 検証対象の URL（null / undefined 許容）
+ * @returns 安全な URL、または無害化された `"#"`
+ */
+export function safeFeedUrl(url: string | null | undefined): string {
+  if (!url) {
+    return "#";
+  }
+  const trimmed = url.trim();
+  if (SAFE_URL_SCHEME.test(trimmed)) {
+    return trimmed;
+  }
+  return "#";
+}


### PR DESCRIPTION
## 概要

記事自身のリンク `item.link`（gofeed が `<link>` から抽出する値）の **scheme 検証**を追加し、`javascript:` / `data:` URL が `href` に出力される保存型 XSS を防ぎます。Issue #176 の修正です。

監査で、記事本文 HTML は bluemonday（バックエンド）+ DOMPurify（フロント）でサニタイズされる一方、**`item.link` はそのサニタイズ経路を通っていない**ことを確認しました。実測でも bluemonday は本文中の `javascript:` href を確実に除去しますが、`item.link` は生の値のまま `href={item.link}` で描画されていました。

## 変更内容（多層防御）

**バックエンド（取り込み時）**
- `internal/security/url_guard.go`: `SafeExternalURL` を新設。絶対 URL の `http`/`https` のみ許可し、`javascript:` / `data:` / `vbscript:` / `file:` / 相対 URL / プロトコル相対 URL / 空値は空文字列へ無害化
- `internal/item/upsert.go`: 記事保存時（`buildNewItem` / `buildUpdatedItem`）に `item.Link` へ適用。**同一性判定（dedup）は生の `parsed.Link` を使う**ため重複判定には影響しない

**フロントエンド（描画時・defense in depth）**
- `web/src/lib/url.ts`: `safeFeedUrl` を新設。許可外は `"#"` へ無害化
- `item-detail.tsx`（2 箇所）/ `item-list.tsx` / `search-results.tsx` の `href={item.link|hit.link}` に適用

## テスト

- `url_guard_test.go` / `url.test.ts`: 正常系（http/https・大文字・空白）、異常系（javascript/data/vbscript/file）、境界値（相対/プロトコル相対/空/null）を網羅
- `upsert_test.go`: `javascript:` link が空に無害化され、`https` link は保持されること（差分等価）を検証
- Go: `go build` / `go vet` / `go test` / `gofmt` green、Web: 既存 component テスト 69 件 green・eslint 0 error

## 確認事項（レビュワー判断ポイント）

- **無害化の戻り値**: バックエンドは許可外を `""`、フロントは `"#"` にしています。`""` の場合フロントの `safeFeedUrl("")` も `"#"` を返すため一貫します
- **`mailto:` は不許可**: 記事リンクは http/https を想定し、`mailto:` 等は許可していません。許可が必要なら指摘ください
- **既存データ**: 既存の保存済み `item.link` は次回フェッチ更新時に正規化されます。即時の遡及更新は本 PR の scope 外です

🤖 Generated with [Claude Code](https://claude.com/claude-code)