### PR TITLE
test(app): goroutine 起動確認をポーリング待ちにして flaky テストを解消

### DIFF
--- a/internal/app/shutdown_test.go
+++ b/internal/app/shutdown_test.go
@@ -24,6 +24,21 @@ func waitGoroutineCount(target int, timeout time.Duration) int {
 	}
 }
 
+// waitGoroutineCountAbove は goroutine 数が target を上回るのを最大 timeout 待つ。
+// go 文で起動した goroutine のスケジューリングは非同期のため、起動直後の即時比較では
+// 未スケジュールのまま比較に達して偽陰性になりうる（CI 環境で観測）。ポーリングで増加を待つ。
+func waitGoroutineCountAbove(target int, timeout time.Duration) int {
+	deadline := time.Now().Add(timeout)
+	for {
+		runtime.Gosched()
+		n := runtime.NumGoroutine()
+		if n > target || time.Now().After(deadline) {
+			return n
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func newTestRateLimiter() *middleware.RateLimiter {
 	return middleware.NewRateLimiter(middleware.RateLimiterConfig{
 		GeneralRate:     2,
@@ -42,8 +57,8 @@ func TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine(t *testing.T) {
 
 	rl := newTestRateLimiter()
 
-	// goroutine が起動したことを確認
-	afterStart := runtime.NumGoroutine()
+	// goroutine が起動したことを確認（スケジュール完了をポーリングで待つ）
+	afterStart := waitGoroutineCountAbove(before, 2*time.Second)
 	if afterStart <= before {
 		t.Fatalf("expected goroutine count to increase after NewRateLimiter, before=%d after=%d", before, afterStart)
 	}
@@ -70,7 +85,8 @@ func TestShutdownCoordinator_StopsIPRateLimiterCleanupGoroutine(t *testing.T) {
 
 	ipRL := middleware.NewIPRateLimiter(middleware.DefaultIPRateLimiterConfig(30))
 
-	afterStart := runtime.NumGoroutine()
+	// goroutine が起動したことを確認（スケジュール完了をポーリングで待つ）
+	afterStart := waitGoroutineCountAbove(before, 2*time.Second)
 	if afterStart <= before {
 		t.Fatalf("expected goroutine count to increase after NewIPRateLimiter, before=%d after=%d", before, afterStart)
 	}


### PR DESCRIPTION
## 概要

`internal/app/shutdown_test.go` の `TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine` / `TestShutdownCoordinator_StopsIPRateLimiterCleanupGoroutine` が CI で間欠的に失敗する flaky テストになっていたため修正します。

PR #181 の CI（Backend Tests）で実際に失敗を観測:

```
--- FAIL: TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine (0.00s)
    shutdown_test.go:48: expected goroutine count to increase after NewRateLimiter, before=3 after=3
```

## 原因

`NewRateLimiter` / `NewIPRateLimiter` が `go` 文で起動する cleanup goroutine のスケジューリングは非同期のため、直後の `runtime.NumGoroutine()` 即時比較では未スケジュールのまま比較に達して偽陰性になりうる（CI のような低スペック環境で顕在化）。

## 修正

既存の収束待ちヘルパー `waitGoroutineCount`（減少側）と対になる **増加待ちヘルパー `waitGoroutineCountAbove`** を追加し、起動確認もポーリング（最大 2 秒）で待つように変更。テストの検証意図（cleanup goroutine が起動し、shutdown で停止する）は不変です。

## テスト

- `go test ./internal/app/ -run TestShutdownCoordinator -count=5` で 5 回連続 pass
- `gofmt` / `go vet` green

## 確認事項（レビュワー判断ポイント）

- プロジェクト規約「flaky テストは quarantine せず原因を特定して修正する」に基づく対応です
- タイムアウト 2 秒は既存の収束待ち側と同じ値に揃えています

🤖 Generated with [Claude Code](https://claude.com/claude-code)