### PR TITLE
test(app): shutdown テストの goroutine 判定を関数名ベースの計数に変更

### DIFF
--- a/internal/app/shutdown_test.go
+++ b/internal/app/shutdown_test.go
@@ -4,36 +4,56 @@ import (
 	"context"
 	"net/http"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/hitoshi/feedman/internal/middleware"
 )
 
-// waitGoroutineCount は goroutine 数が target 以下に収束するのを最大 timeout 待つ。
-// goroutine の停止は非同期に行われるため、即時比較ではなくポーリングで収束を待つ。
-func waitGoroutineCount(target int, timeout time.Duration) int {
+// cleanup goroutine の関数名（goroutine スタックダンプ上の表記）。
+// `middleware.(*` まで含めることで RateLimiter / IPRateLimiter が substring 衝突しない。
+const (
+	rateLimiterCleanupFn   = "middleware.(*RateLimiter).cleanupLoop"
+	ipRateLimiterCleanupFn = "middleware.(*IPRateLimiter).cleanupLoop"
+)
+
+// countGoroutinesContaining は全 goroutine のスタックダンプから、関数名 fn を含む
+// goroutine 数を数える。
+//
+// runtime.NumGoroutine() のグローバル総数比較は、同一テストバイナリ内の先行テストが
+// 残した goroutine の起動・終了とレースして flaky になる（CI で before=after の偽陰性を
+// 2 度観測）。対象 goroutine の関数名を直接数えることで、無関係な goroutine の増減に
+// 影響されず決定論的に判定する。
+func countGoroutinesContaining(fn string) int {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), fn)
+}
+
+// waitGoroutineRunning は fn を含む goroutine が現れるのを最大 timeout 待ち、最終観測数を返す。
+// go 文によるgoroutine 起動は非同期のため、起動直後の即時観測ではなくポーリングで待つ。
+func waitGoroutineRunning(fn string, timeout time.Duration) int {
 	deadline := time.Now().Add(timeout)
 	for {
 		runtime.Gosched()
-		n := runtime.NumGoroutine()
-		if n <= target || time.Now().After(deadline) {
-			return n
+		c := countGoroutinesContaining(fn)
+		if c > 0 || time.Now().After(deadline) {
+			return c
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
 }
 
-// waitGoroutineCountAbove は goroutine 数が target を上回るのを最大 timeout 待つ。
-// go 文で起動した goroutine のスケジューリングは非同期のため、起動直後の即時比較では
-// 未スケジュールのまま比較に達して偽陰性になりうる（CI 環境で観測）。ポーリングで増加を待つ。
-func waitGoroutineCountAbove(target int, timeout time.Duration) int {
+// waitGoroutineGone は fn を含む goroutine が消えるのを最大 timeout 待ち、最終観測数を返す。
+// goroutine の停止は非同期に行われるため、ポーリングで収束を待つ。
+func waitGoroutineGone(fn string, timeout time.Duration) int {
 	deadline := time.Now().Add(timeout)
 	for {
 		runtime.Gosched()
-		n := runtime.NumGoroutine()
-		if n > target || time.Now().After(deadline) {
-			return n
+		c := countGoroutinesContaining(fn)
+		if c == 0 || time.Now().After(deadline) {
+			return c
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
@@ -53,14 +73,11 @@ func newTestRateLimiter() *middleware.RateLimiter {
 // RateLimiter のクリーンアップ goroutine が停止し、リークしないことを検証する（NFR 1.1, AC 1.3）。
 func TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine(t *testing.T) {
 	// Arrange: クリーンアップ goroutine を起動した RateLimiter と即時 Shutdown 可能なサーバー
-	before := runtime.NumGoroutine()
-
 	rl := newTestRateLimiter()
 
 	// goroutine が起動したことを確認（スケジュール完了をポーリングで待つ）
-	afterStart := waitGoroutineCountAbove(before, 2*time.Second)
-	if afterStart <= before {
-		t.Fatalf("expected goroutine count to increase after NewRateLimiter, before=%d after=%d", before, afterStart)
+	if c := waitGoroutineRunning(rateLimiterCleanupFn, 2*time.Second); c == 0 {
+		t.Fatal("expected RateLimiter cleanup goroutine to start after NewRateLimiter")
 	}
 
 	sc := newShutdownCoordinator(&http.Server{Addr: ":0"}, rl, nil)
@@ -70,10 +87,9 @@ func TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine(t *testing.T) {
 		t.Fatalf("shutdown returned error: %v", err)
 	}
 
-	// Assert: goroutine 数が起動前の水準に戻る（クリーンアップ goroutine が残存しない）
-	after := waitGoroutineCount(before, 2*time.Second)
-	if after > before {
-		t.Errorf("goroutine leaked: before=%d after=%d (cleanup goroutine not stopped)", before, after)
+	// Assert: クリーンアップ goroutine が残存しない
+	if c := waitGoroutineGone(rateLimiterCleanupFn, 2*time.Second); c > 0 {
+		t.Errorf("cleanup goroutine leaked: %d goroutine(s) still running after shutdown", c)
 	}
 }
 
@@ -81,14 +97,11 @@ func TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine(t *testing.T) {
 // IPRateLimiter のクリーンアップ goroutine も停止し、リークしないことを検証する（NFR 3.1）。
 func TestShutdownCoordinator_StopsIPRateLimiterCleanupGoroutine(t *testing.T) {
 	// Arrange: クリーンアップ goroutine を起動した IPRateLimiter（userID 側は nil）。
-	before := runtime.NumGoroutine()
-
 	ipRL := middleware.NewIPRateLimiter(middleware.DefaultIPRateLimiterConfig(30))
 
 	// goroutine が起動したことを確認（スケジュール完了をポーリングで待つ）
-	afterStart := waitGoroutineCountAbove(before, 2*time.Second)
-	if afterStart <= before {
-		t.Fatalf("expected goroutine count to increase after NewIPRateLimiter, before=%d after=%d", before, afterStart)
+	if c := waitGoroutineRunning(ipRateLimiterCleanupFn, 2*time.Second); c == 0 {
+		t.Fatal("expected IPRateLimiter cleanup goroutine to start after NewIPRateLimiter")
 	}
 
 	sc := newShutdownCoordinator(&http.Server{Addr: ":0"}, nil, ipRL)
@@ -98,10 +111,9 @@ func TestShutdownCoordinator_StopsIPRateLimiterCleanupGoroutine(t *testing.T) {
 		t.Fatalf("shutdown returned error: %v", err)
 	}
 
-	// Assert: goroutine 数が起動前の水準に戻る。
-	after := waitGoroutineCount(before, 2*time.Second)
-	if after > before {
-		t.Errorf("goroutine leaked: before=%d after=%d (IP cleanup goroutine not stopped)", before, after)
+	// Assert: クリーンアップ goroutine が残存しない
+	if c := waitGoroutineGone(ipRateLimiterCleanupFn, 2*time.Second); c > 0 {
+		t.Errorf("IP cleanup goroutine leaked: %d goroutine(s) still running after shutdown", c)
 	}
 }
 
@@ -109,7 +121,6 @@ func TestShutdownCoordinator_StopsIPRateLimiterCleanupGoroutine(t *testing.T) {
 // 二重 close panic が起きず goroutine が収束することを検証する。
 func TestShutdownCoordinator_StopsBothLimiters(t *testing.T) {
 	// Arrange
-	before := runtime.NumGoroutine()
 	rl := newTestRateLimiter()
 	ipRL := middleware.NewIPRateLimiter(middleware.DefaultIPRateLimiterConfig(30))
 	sc := newShutdownCoordinator(&http.Server{Addr: ":0"}, rl, ipRL)
@@ -122,10 +133,12 @@ func TestShutdownCoordinator_StopsBothLimiters(t *testing.T) {
 		t.Fatalf("second shutdown returned error: %v", err)
 	}
 
-	// Assert
-	after := waitGoroutineCount(before, 2*time.Second)
-	if after > before {
-		t.Errorf("goroutine leaked: before=%d after=%d", before, after)
+	// Assert: 両リミッターのクリーンアップ goroutine が残存しない
+	if c := waitGoroutineGone(rateLimiterCleanupFn, 2*time.Second); c > 0 {
+		t.Errorf("RateLimiter cleanup goroutine leaked: %d goroutine(s) still running", c)
+	}
+	if c := waitGoroutineGone(ipRateLimiterCleanupFn, 2*time.Second); c > 0 {
+		t.Errorf("IPRateLimiter cleanup goroutine leaked: %d goroutine(s) still running", c)
 	}
 }
 
@@ -148,7 +161,6 @@ func TestShutdownCoordinator_DoesNotPanic(t *testing.T) {
 // 2 回呼んでも二重 close panic を起こさない。
 func TestShutdownCoordinator_DoubleInvocationDoesNotPanic(t *testing.T) {
 	// Arrange
-	before := runtime.NumGoroutine()
 	rl := newTestRateLimiter()
 	sc := newShutdownCoordinator(&http.Server{Addr: ":0"}, rl, nil)
 
@@ -160,9 +172,8 @@ func TestShutdownCoordinator_DoubleInvocationDoesNotPanic(t *testing.T) {
 		t.Fatalf("second shutdown returned error: %v", err)
 	}
 
-	// Assert: panic せず、goroutine も収束する
-	after := waitGoroutineCount(before, 2*time.Second)
-	if after > before {
-		t.Errorf("goroutine leaked: before=%d after=%d", before, after)
+	// Assert: panic せず、クリーンアップ goroutine も収束する
+	if c := waitGoroutineGone(rateLimiterCleanupFn, 2*time.Second); c > 0 {
+		t.Errorf("cleanup goroutine leaked: %d goroutine(s) still running", c)
 	}
 }


### PR DESCRIPTION
## 概要

PR #186 のポーリング化（増加待ち）後も、PR #184 の CI で同じ flaky 失敗が再発しました:

```
--- FAIL: TestShutdownCoordinator_StopsRateLimiterCleanupGoroutine (2.00s)
    shutdown_test.go:63: expected goroutine count to increase after NewRateLimiter, before=3 after=3
```

2 秒ポーリングしても増加が観測されないため、起動遅延ではなく **`runtime.NumGoroutine()` のグローバル総数比較自体の構造的レース**が原因です。

## 原因

`internal/app` のテストバイナリには metrics_listener / run などサーバーを起動するテストが同居しており、先行テストが残した goroutine の**終了**と cleanup goroutine の**起動**が `before` 〜ポーリングの間で相殺すると、総数が増えないまま 2 秒経過して偽陰性になります。総数比較はこのレースを原理的に排除できません。

## 修正

`runtime.Stack` の全 goroutine ダンプから cleanup goroutine の**関数名を直接数える**方式（goleak と同系のアプローチ）に変更:

- `middleware.(*RateLimiter).cleanupLoop` / `middleware.(*IPRateLimiter).cleanupLoop` の出現数を計数
- 起動確認は「対象関数の goroutine が現れるまで」、リーク確認は「消えるまで」をポーリング
- 無関係な goroutine の増減に影響されない決定論的な判定になり、検証意図（cleanup goroutine が起動し shutdown で停止する）は不変

## テスト

- `go test ./internal/app/ -run TestShutdownCoordinator -count=10` で 10 回連続 pass
- `go test ./internal/app/ -count=2`（パッケージ全体、先行テストの残骸 goroutine がある状態）でも pass
- `gofmt` / `go vet` green

## 確認事項（レビュワー判断ポイント）

- 関数名定数は `middleware.(*` プレフィックスまで含めており、`RateLimiter` / `IPRateLimiter` の substring 衝突はありません
- 両リミッター同時停止テスト・二重 shutdown テストの総数ベース検証も同方式に揃えています

🤖 Generated with [Claude Code](https://claude.com/claude-code)