### PR TITLE
spec(#167): POST /api/auth/refresh の要件定義・設計・タスク分割

### DIFF
--- a/docs/specs/167-auth-refresh-rotation/design.md
+++ b/docs/specs/167-auth-refresh-rotation/design.md
@@ -1,0 +1,249 @@
+# Design Document
+
+## Overview
+
+**Purpose**: 本 spec は `POST /api/auth/refresh` を追加し、有効な refresh token を rotation
+（旧 token の使用不可化 + 同一 family での新 token 発行）したうえで、新しい access token /
+refresh token を `POST /api/auth/token`（Issue #166）と同形の JSON で返せるようにする。
+
+**Users**: Feedman iOS アプリが access token（900 秒）の失効前後に本エンドポイントを呼び、
+セッションを維持する。既存 Web ユーザー・既存 API には影響しない。
+
+**Impact**: #166 で導入済みの `TokenService` / `NativeAuthHandler` / router 配線に
+rotation 操作と 1 ルートを**追加**する。永続化は #164 の `RefreshTokenRepository`
+（FindByHash / MarkRotated / CreateToken）をそのまま使用し、新規 migration は追加しない。
+署名鍵 env 未設定環境では #166 と同一の fail-closed（`NativeAuthHandler` 自体が nil で
+未登録）に乗るため、追加の縮退制御は不要。
+
+### Goals
+
+- `{refresh_token}` → 新 `{access_token, refresh_token, token_type, expires_in}`（Req 1.1, 1.6）
+- `MarkRotated`（#164 の atomic UPDATE）を単回確定ゲートとした race-safe rotation（Req 1.2, 3.1）
+- スライディング 30 日 TTL の新 token を同一 family に発行（Req 1.3, 1.4）
+- 拒否理由を区別させない uniform な 401 応答（Req 2.6）
+
+### Non-Goals
+
+- rotated 済み token 再利用時の **family 全体失効**（Issue #168。本 spec は
+  `ErrInvalidRefreshToken` での単純拒否。#168 が本 spec の拒否分岐を失効昇格に拡張する）
+- `POST /api/auth/revoke`（#168）/ Bearer middleware（#169）/ IP レート制限（#171）
+- 期限切れ refresh_tokens の定期削除 worker
+
+## Architecture Pattern & Boundary Map
+
+```mermaid
+flowchart TD
+  A[Feedman iOS] -->|"POST /api/auth/refresh {refresh_token}"| H
+
+  subgraph Handler["internal/handler"]
+    H["NativeAuthHandler.Refresh<br/>(native_auth_handler.go へ追加)"]
+  end
+
+  subgraph Auth["internal/auth"]
+    TS["TokenService.RotateRefreshToken<br/>(token_service.go へ追加)"]
+    JI["JWTIssuer (#166 導入済み)"]
+    HN["HashNativeSecret (#165 導入済み)"]
+  end
+
+  subgraph Repo["internal/repository (#164 導入済み)"]
+    RTR["RefreshTokenRepository<br/>FindByHash / MarkRotated / CreateToken"]
+  end
+
+  H --> TS
+  TS --> HN
+  TS --> JI
+  TS --> RTR
+  RTR --> DB[(refresh_tokens)]
+```
+
+### Rotation フロー（正常系）
+
+```
+1. handler: JSON decode（refresh_token 必須）→ 不正なら 400 INVALID_REQUEST
+2. service: HashNativeSecret(refresh_token) → RefreshTokenStore.FindByHash
+   → nil なら ErrInvalidRefreshToken
+3. service: 状態検証（いずれかに該当なら ErrInvalidRefreshToken）
+   - RevokedAt != nil（失効済み。family 単位 revoke でも token 行に set される #164 設計）
+   - ExpiresAt <= now（期限切れ）
+   - RotatedAt != nil（rotation 済み = 再利用。#168 が family 失効へ昇格するまでは単純拒否）
+4. service: MarkRotated(id, now)
+   → ErrRefreshTokenAlreadyRotated なら ErrInvalidRefreshToken
+   ※ UPDATE ... WHERE rotated_at IS NULL の atomic 判定により、並行 rotation でも
+     高々 1 件のみ成功（Req 3.1。手順 3 の RotatedAt 検査は高速拒否のための事前判定で、
+     正本のゲートは本手順）
+5. service: 新 refresh token（crypto/rand 32 byte）を同一 FamilyID で hash 保存
+   （ExpiresAt = now + RefreshTokenTTL（30 日）= スライディング延長）
+6. service: JWTIssuer.IssueAccessToken(token.UserID)
+7. handler: 200 {access_token, refresh_token, token_type: "Bearer", expires_in: 900}
+```
+
+**部分失敗の扱い**: 手順 5〜6 の失敗時は旧 token が rotation 済みのまま 500 を返す
+（クライアントは再ログイン）。#166 の auth_code と同じ「安全側に倒して燃やす」方針
+（requirements.md Open Questions）。
+
+## Technology Stack
+
+#166 と完全に同一（新規依存なし）。JWT 発行は導入済み `JWTIssuer`、hash は
+`HashNativeSecret`、エラー応答は `middleware.WriteErrorResponse` + `model.APIError`。
+
+## File Structure Plan
+
+```
+internal/
+├── auth/
+│   ├── token_service.go       # 変更: ErrInvalidRefreshToken sentinel /
+│   │                          #       RefreshTokenStore IF に FindByHash・MarkRotated を拡張 /
+│   │                          #       RotateRefreshToken を追加
+│   └── token_service_test.go  # 変更: rotation の成功 / 拒否 / 並行ゲートのケースを追加
+├── handler/
+│   ├── native_auth_handler.go      # 変更: Refresh handler（401 INVALID_REFRESH_TOKEN 応答）
+│   ├── native_auth_handler_test.go # 変更: Refresh の 200 / 401 / 400 / 500 ケース
+│   ├── router.go              # 変更: 認証不要グループに POST /api/auth/refresh を登録
+│   │                          #       （NativeAuthHandler nil ガードは #166 と共通）
+│   ├── router_test.go         # 変更: refresh ルートの到達 / nil 時 404 ケース
+│   └── integration_test.go    # 変更: token 交換 → refresh → 旧 token 拒否の通しケース
+```
+
+## Requirements Traceability
+
+| Req | 設計要素 |
+|---|---|
+| 1.1, 1.6 | `NativeAuthHandler.Refresh` が `TokenPair` を #166 と同一の `tokenResponse` 形式で応答 |
+| 1.2 | フロー手順 4（`MarkRotated` による rotation 確定） |
+| 1.3 | フロー手順 5（`CreateToken`、`FamilyID` は旧 token と同一、`TokenHash = HashNativeSecret(新平文)`） |
+| 1.4 | 手順 5 の `ExpiresAt = now + RefreshTokenTTL`（#166 で定義済みの 30 日定数を再利用） |
+| 1.5 | router の認証不要グループに登録（Session / Bearer を通らない） |
+| 2.1 | 手順 2（FindByHash nil → `ErrInvalidRefreshToken`） |
+| 2.2, 2.3, 2.4 | 手順 3（ExpiresAt / RevokedAt / RotatedAt の状態検証） |
+| 2.5 | handler の JSON decode / 必須フィールド検査 → 400 `INVALID_REQUEST` |
+| 2.6 | service は全拒否を単一 sentinel `ErrInvalidRefreshToken` に正規化し、handler は単一の 401 `INVALID_REFRESH_TOKEN` を返す |
+| 2.7 | 拒否パスは手順 5（新 token 永続化）に到達しない処理順序 + 手順 4 失敗時は状態変更なし（UPDATE 0 行） |
+| 3.1 | `MarkRotated` の `WHERE rotated_at IS NULL` atomic 判定（#164 の race-safe 設計） |
+| NFR 1.1 | 新 token は crypto/rand 32 byte → base64.RawURLEncoding（#166 の生成ヘルパーを共用） |
+| NFR 1.2, NFR 1.3 | hash のみ永続化。ログは hash 先頭 8 文字。固定メッセージ応答 |
+| NFR 2.1 | 追加ルート・追加メソッドのみで既存経路不変 |
+| NFR 2.2 | `NativeAuthHandler` nil 時は token / refresh とも未登録（#166 の fail-closed に同乗） |
+| NFR 3.1 | `RefreshTokenStore` のモックで service を単体検証。issue AC の 6 ケースを Testing Strategy に対応付け |
+
+## Components and Interfaces
+
+### auth.TokenService（変更 / token_service.go）
+
+```go
+// ErrInvalidRefreshToken は refresh token の不明・期限切れ・失効・rotation 済みを
+// 区別せず表す sentinel error。
+var ErrInvalidRefreshToken = errors.New("invalid refresh token")
+
+// RefreshTokenStore（#166 導入）を rotation 操作まで拡張する。
+// repository.RefreshTokenRepository が引き続き構造的に充足する。
+type RefreshTokenStore interface {
+	CreateFamily(ctx context.Context, family *model.RefreshTokenFamily) error
+	CreateToken(ctx context.Context, token *model.RefreshToken) error
+	FindByHash(ctx context.Context, tokenHash string) (*model.RefreshToken, error)
+	MarkRotated(ctx context.Context, id string, rotatedAt time.Time) error
+}
+
+// RotateRefreshToken は rotation フロー（design.md 参照）を実行する。
+// 拒否はすべて ErrInvalidRefreshToken を返す（errors.Is で判別可能）。
+func (s *TokenService) RotateRefreshToken(ctx context.Context, refreshToken string) (*TokenPair, error)
+```
+
+- 新 refresh token の生成・hash 保存は #166 の内部ヘルパー（乱数生成 +
+  `HashNativeSecret`）を共用する
+- `now` の参照は `TokenService` 既存の時刻取得方法に合わせる（#166 実装でテスト注入可能に
+  している場合はそれを共用）
+
+### handler.NativeAuthHandler（変更 / native_auth_handler.go）
+
+```go
+// TokenExchangeService（#166 導入）に Refresh 用メソッドを追加拡張する。
+type TokenExchangeService interface {
+	ExchangeAuthCode(ctx context.Context, authCode, codeVerifier string) (*auth.TokenPair, error)
+	RotateRefreshToken(ctx context.Context, refreshToken string) (*auth.TokenPair, error)
+}
+
+// Refresh は POST /api/auth/refresh を処理する。
+// 200: token 交換と同形の tokenResponse
+// 400 INVALID_REQUEST:        JSON 不正 / refresh_token 欠落（category: validation）
+// 401 INVALID_REFRESH_TOKEN:  ErrInvalidRefreshToken（category: auth、理由は細分しない）
+// 500 INTERNAL_ERROR:         上記以外（category: system）
+func (h *NativeAuthHandler) Refresh(w http.ResponseWriter, r *http.Request)
+```
+
+- 401 は SERVER.md §1.3 の契約（`errors: 401 INVALID_REFRESH_TOKEN`）。token 交換の
+  400 INVALID_GRANT とはステータス・コードが異なる点に注意
+
+### router（変更）
+
+```go
+if deps.NativeAuthHandler != nil {
+	r.With(middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
+		Post("/api/auth/token", deps.NativeAuthHandler.Token)
+	r.With(middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
+		Post("/api/auth/refresh", deps.NativeAuthHandler.Refresh)
+}
+```
+
+- `RouterDeps` の変更は不要（#166 の `NativeAuthHandler` フィールドに同乗）
+- app.go の wiring 変更も不要（`TokenService` のメソッド追加のみで成立）
+
+## Data Models
+
+新規モデル・migration なし。rotation 時の値設定:
+
+| フィールド | 旧 token（更新） | 新 token（作成） |
+|---|---|---|
+| `RotatedAt` | `now`（MarkRotated） | nil |
+| `FamilyID` | 不変 | 旧 token と同一 |
+| `UserID` | 不変 | 旧 token と同一 |
+| `TokenHash` | 不変 | `HashNativeSecret(新平文)` |
+| `ExpiresAt` | 不変 | `now + RefreshTokenTTL`（30 日スライディング） |
+
+## Error Handling
+
+| 状況 | HTTP | APIError | 備考 |
+|---|---|---|---|
+| JSON 不正 / `refresh_token` 欠落 | 400 | code `INVALID_REQUEST`, category `validation` | #166 と同一ヘルパーを共用 |
+| token 不明 / 期限切れ / 失効済み / rotation 済み | 401 | code `INVALID_REFRESH_TOKEN`, category `auth` | 理由を区別しない（Req 2.6）。SERVER.md §1.3 |
+| JWT 発行失敗 / 新 token 永続化失敗 | 500 | code `INTERNAL_ERROR`, category `system` | 旧 token は消費済み（Open Questions 参照） |
+
+## Testing Strategy
+
+### 単体テスト（auth / token_service_test.go 追加分）
+
+1. rotation 成功: TokenPair 3 値 / MarkRotated が旧 ID で呼ばれる / CreateToken の
+   FamilyID・UserID が旧 token と同一 / ExpiresAt ≈ now+30d / TokenHash が新平文の hash
+2. FindByHash nil → ErrInvalidRefreshToken（MarkRotated 未呼び出し）
+3. 期限切れ token → ErrInvalidRefreshToken（MarkRotated 未呼び出し）
+4. RevokedAt set 済み token → ErrInvalidRefreshToken
+5. RotatedAt set 済み token（再利用）→ ErrInvalidRefreshToken（新 token 未作成）
+6. MarkRotated が ErrRefreshTokenAlreadyRotated（並行 race の敗者）→ ErrInvalidRefreshToken
+   （新 token 未作成 = Req 3.1 の高々 1 件成功）
+7. CreateToken 失敗 → 非 InvalidRefreshToken エラー（500 系へ）
+
+### 単体テスト（handler / native_auth_handler_test.go 追加分）
+
+8. 正常 200 と JSON フィールド名 / ErrInvalidRefreshToken → 401 INVALID_REFRESH_TOKEN /
+   不正 JSON・フィールド欠落 → 400 INVALID_REQUEST / 内部エラー → 500
+
+### ルーティング・統合テスト
+
+9. `router_test.go`: POST /api/auth/refresh が NativeAuthHandler 注入時にセッション無しで
+   到達 / nil 時 404
+10. `integration_test.go`: token 交換 → refresh 成功（新 pair 取得）→ **旧 refresh token で
+    再 refresh → 401** の通しケース（issue AC「old token after rotation」）
+
+## Security Considerations
+
+- rotation の正本ゲートは `MarkRotated` の atomic UPDATE（#164）。事前の状態検査は
+  応答高速化のためで、TOCTOU は手順 4 が防ぐ
+- 拒否は 401 単一応答で token の存在・状態を列挙できない
+- 新旧 token とも平文はレスポンス JSON のみ。ログは hash 先頭 8 文字
+- 再利用（rotated 済み提示)は本 spec では拒否のみ。盗難対応の family 失効は #168 で
+  本フローの手順 3〜4 の拒否分岐を昇格させる設計とする（拡張点を局所化済み）
+
+## Supporting References
+
+- feedman-ios `design/SERVER.md` §1.3（/api/auth/refresh 契約・401 INVALID_REFRESH_TOKEN）/
+  §1.4（rotation・30 日スライディング）
+- Issue #164 spec（MarkRotated の atomic 設計）/ #166 spec（TokenService / handler / 配線）

--- a/docs/specs/167-auth-refresh-rotation/requirements.md
+++ b/docs/specs/167-auth-refresh-rotation/requirements.md
@@ -1,0 +1,91 @@
+# Requirements Document
+
+## Introduction
+
+access token は 900 秒で失効するため、Feedman iOS（親 Issue #163）は refresh token を使って
+access token を更新し続ける必要がある。SERVER.md §1.4 はローテーション方式（refresh のたびに
+新 refresh token を発行し旧 token を失効）を要求している。
+
+本 spec は **`POST /api/auth/refresh` の rotation 付き再発行**のみを対象とする。具体的には
+(1) 有効な refresh token の検証と新 access / refresh token の発行、(2) 旧 token の rotation
+確定（以後の通常 refresh で使用不可）、(3) 並行 rotation の安全性、を要件化する。
+rotated 済み token の**再利用検知による family 全体失効**は Issue #168 の領分であり、本 spec
+では再利用を単に拒否するに留める。`POST /api/auth/revoke`（#168）、Bearer middleware（#169）、
+IP レート制限（#171）はスコープ外。
+
+## Requirements
+
+### Requirement 1: Rotation 付き再発行の成功パス
+
+**Objective:** As a Feedman iOS アプリ, I want refresh token で access token を更新したい,
+so that 再ログインなしに API 呼び出しを継続できる
+
+#### Acceptance Criteria
+
+1. When refresh エンドポイントが有効な refresh token を受け取ったとき, the Refresh Endpoint shall 新しい `access_token`・新しい `refresh_token`・`token_type: "Bearer"`・`expires_in: 900` を JSON で返す
+2. When rotation が成功したとき, the Refresh Endpoint shall 旧 refresh token を rotation 済みとして確定し、以後の通常 refresh で使用不可にする
+3. When rotation が成功したとき, the Refresh Endpoint shall 新 refresh token を hash 値でのみ永続化し、旧 token と同一の rotation family に紐付ける
+4. When 新 refresh token を発行するとき, the Refresh Endpoint shall 有効期限を発行時点から 30 日に再設定する（スライディング延長）
+5. The Refresh Endpoint shall Cookie セッション・Bearer 認証のいずれも無しで呼び出し可能とする
+6. The Refresh Endpoint shall 成功応答の JSON 形式を token 交換エンドポイント（Issue #166）と同一フィールド名（`access_token` / `refresh_token` / `token_type` / `expires_in`）とする
+
+### Requirement 2: 再発行の拒否パス
+
+**Objective:** As a Feedman 運用者, I want 無効な refresh token による再発行が確実に拒否されて
+ほしい, so that 漏えい・失効済み token がアクセス継続につながらない
+
+#### Acceptance Criteria
+
+1. If 提示された refresh token が存在しないとき, the Refresh Endpoint shall 新 token を発行せず要求を拒否する
+2. If 提示された refresh token が期限切れのとき, the Refresh Endpoint shall 新 token を発行せず要求を拒否する
+3. If 提示された refresh token が失効（revoke）済みのとき, the Refresh Endpoint shall 新 token を発行せず要求を拒否する
+4. If 提示された refresh token が既に rotation 済みのとき, the Refresh Endpoint shall 新 token を発行せず要求を拒否する
+5. If リクエストボディが不正な JSON、または必須フィールド（`refresh_token`）が欠落しているとき, the Refresh Endpoint shall 入力不正として要求を拒否する
+6. The Refresh Endpoint shall 拒否応答において token の存在有無・期限切れ・失効済み・rotation 済みを区別できる情報を返さない（同一のエラー応答とする）
+7. If 再発行が拒否されたとき, the Refresh Endpoint shall 新 refresh token を永続化せず、既存 token の状態も変更しない
+
+### Requirement 3: 並行 rotation の安全性
+
+**Objective:** As a Feedman 運用者, I want 同一 refresh token への並行要求が二重発行に
+つながらないでほしい, so that ネットワーク再送や攻撃による token 増殖を防げる
+
+#### Acceptance Criteria
+
+1. While 同一の refresh token に対する複数の rotation 要求が並行して処理されているとき, the Refresh Endpoint shall 高々 1 件の要求のみを成功させ、他の要求を拒否する
+
+## Non-Functional Requirements
+
+### NFR 1: セキュリティ
+
+1. The Refresh Endpoint shall 新 refresh token を暗号論的乱数源から 256bit 以上のエントロピーで生成する
+2. The Refresh Endpoint shall refresh token の平文を永続化領域・ログ・エラーメッセージのいずれにも残さない
+3. The Refresh Endpoint shall エラー応答にクライアント入力値・内部詳細を反射しない
+
+### NFR 2: 後方互換性
+
+1. The API Server shall 既存のすべてのルート（Web ログイン・既存 API・token 交換）の挙動を変更しない
+2. The API Server shall 署名鍵未設定の環境では refresh エンドポイントも公開しない（token 交換と同一の fail-closed 縮退）
+
+### NFR 3: テスト容易性
+
+1. The Refresh Module shall 成功・期限切れ・失効済み・不明 token・不正 JSON・rotation 後の旧 token 再利用の各ケースを外部ネットワーク依存なしで検証可能にする
+
+## Out of Scope
+
+- rotated 済み token 再利用検知による **family 全体失効**（Issue #168 — 本 spec は単純拒否のみ）
+- `POST /api/auth/revoke`（Issue #168）
+- Bearer middleware（Issue #169）/ IP レート制限（Issue #171）/ contract tests 全体整備（Issue #172）
+- device_label 等の任意メタデータ
+- refresh token family の上限管理・世代数制限
+
+## Open Questions
+
+- rotation 確定後・新 token 永続化前にインフラ障害が起きた場合、旧 token は消費済みのまま
+  新 token が返らない（クライアントは再ログイン）。#166 の auth_code と同じ「安全側に倒して
+  燃やす」方針を踏襲する（rollback 機構は導入しない）
+
+## 関連
+
+- Parent: #163
+- Depends on: #164 #166
+- Sibling: #165 #168 #169 #170 #171 #172

--- a/docs/specs/167-auth-refresh-rotation/tasks.md
+++ b/docs/specs/167-auth-refresh-rotation/tasks.md
@@ -1,0 +1,44 @@
+# Implementation Plan
+
+- [ ] 1. auth: TokenService.RotateRefreshToken を追加
+  - `internal/auth/token_service.go` に `ErrInvalidRefreshToken` sentinel を追加し、
+    `RefreshTokenStore` interface を `FindByHash` / `MarkRotated` まで拡張
+    （`repository.RefreshTokenRepository` が引き続き構造的に充足することを compile-time
+    check で確認）
+  - `RotateRefreshToken(ctx, refreshToken string) (*TokenPair, error)` を design.md の
+    rotation フロー手順 2〜6 どおり実装（拒否は全て `ErrInvalidRefreshToken` に正規化。
+    新 token は同一 FamilyID・`now + RefreshTokenTTL` のスライディング 30 日。
+    乱数生成・hash は #166 の内部ヘルパーを共用）
+  - `internal/auth/token_service_test.go` に design.md Testing Strategy 1〜7 のケースを追加
+    （既存 #166 ケースは変更しない。モックの interface 拡張追従は可）
+  - _Requirements: 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 2.6, 2.7, 3.1, NFR 1.1, NFR 1.2, NFR 3.1_
+
+- [ ] 2. handler: Refresh エンドポイントと router 登録
+  - `internal/handler/native_auth_handler.go`: `TokenExchangeService` interface に
+    `RotateRefreshToken` を追加し、`Refresh` handler を実装（200 / 400 INVALID_REQUEST /
+    401 INVALID_REFRESH_TOKEN / 500 を `middleware.WriteErrorResponse` で応答。
+    成功応答は Token と同一の tokenResponse 形式を共用）
+  - `internal/handler/router.go`: 認証不要グループの `NativeAuthHandler != nil` ガード内に
+    `POST /api/auth/refresh` を登録（ボディ上限 middleware 付き）
+  - `internal/handler/native_auth_handler_test.go` に design.md Testing Strategy 8 を、
+    `internal/handler/router_test.go` に Testing Strategy 9 を追加
+  - _Requirements: 1.1, 1.5, 1.6, 2.5, 2.6, NFR 1.3, NFR 2.1, NFR 2.2_
+  - _Depends: 1_
+
+- [ ] 3. 統合テスト: token 交換 → refresh → 旧 token 拒否
+  - `internal/handler/integration_test.go` に「token 交換で pair 取得 → refresh 成功で
+    新 pair 取得 → 旧 refresh token による再 refresh が 401」の通しケースを追加
+    （issue AC「old token after rotation」に対応）
+  - 既存の統合テスト・既存ルートが無変更で green であることを確認
+  - _Requirements: 1.1, 1.2, 2.4, NFR 2.1, NFR 3.1_
+  - _Depends: 2_
+
+## Verify
+
+本 spec の実装後、watcher（stage-a-verify gate）が再実行すべき verify コマンドを以下の
+構造化ブロックで宣言する。
+
+<!-- stage-a-verify -->
+```sh
+go build ./... && go vet ./... && go test ./...
+```


### PR DESCRIPTION
## 概要

Issue #167（POST /api/auth/refresh で refresh token をローテーションする）の設計 PR です。`docs/specs/167-auth-refresh-rotation/` に requirements.md（EARS）/ design.md / tasks.md を追加します。実装は本 PR マージ後に別 PR で行います。

## 設計の要点

- **rotation フロー**: FindByHash → 状態検証（revoked / expired / rotated）→ `MarkRotated`（#164 の `WHERE rotated_at IS NULL` atomic 判定が正本ゲート。並行 rotation は高々 1 件成功）→ 同一 family に新 token（30 日スライディング）→ 新 JWT
- **uniform な拒否**: 不明 / 期限切れ / 失効 / rotation 済みを区別しない単一の `401 INVALID_REFRESH_TOKEN`（SERVER.md §1.3 の契約。token 交換の 400 INVALID_GRANT とは別コード）
- **#166 への追加のみ**: `TokenService` にメソッド追加・`RefreshTokenStore` interface の拡張・router 1 ルート追加。RouterDeps / app.go の wiring 変更なし（fail-closed も #166 に同乗）
- **#168 への拡張点を局所化**: rotated 済み token の再利用は本 spec では単純拒否。family 全体失効への昇格は #168 が拒否分岐を拡張する設計
- **タスク分割**: 3 タスク（service → handler/router → 統合テスト）

## 確認事項（レビュワー判断ポイント）

- **部分失敗**: MarkRotated 後の新 token 永続化失敗時は旧 token 消費済みのまま 500（再ログインで回復。#166 と同方針）
- **再利用の扱い**: 本 spec では拒否のみで family 失効しません（#168 のスコープ。Issue 本文のスコープ外宣言どおり）

## Mechanical Checks（design-review-gate）

- [x] Requirements traceability 全 ID / File Structure Plan 具体化 / orphan なし
- [x] Budget overflow check: 最上位タスク 3 件（≤10）
- [x] checkbox enforcement / verify block well-formed

## 関連

- Parent: #163
- Depends on: #164 #166（#166 実装は別 PR で進行中）

🤖 Generated with [Claude Code](https://claude.com/claude-code)