### PR TITLE
spec(#168): refresh token 再利用検知と POST /api/auth/revoke の要件定義・設計・タスク分割

### DIFF
--- a/docs/specs/168-reuse-detection-revoke/design.md
+++ b/docs/specs/168-reuse-detection-revoke/design.md
@@ -1,0 +1,238 @@
+# Design Document
+
+## Overview
+
+**Purpose**: 本 spec は (1) rotation 済み refresh token の再利用検知を **family 全体失効**へ
+昇格させ（盗難対策、SERVER.md §1.4）、(2) ログアウト用の **`POST /api/auth/revoke`** を追加する。
+
+**Users**: Feedman iOS アプリ（ログアウト時の revoke 呼び出し）と Feedman 運用者
+（漏えい token 系列の自動遮断）。既存 Web ユーザーには影響しない。
+
+**Impact**: #167 で導入済みの `TokenService.RotateRefreshToken` の拒否分岐 2 箇所
+（RotatedAt 検出 / MarkRotated 競合敗北）を family 失効に昇格させ、`RevokeRefreshToken` と
+handler / route を追加する。永続化は #164 の `RevokeFamily`（冪等設計済み）をそのまま使用し、
+新規 migration は追加しない。
+
+### Goals
+
+- 再利用検知（rotated 済み提示・並行競合敗北）→ `RevokeFamily` → 通常拒否と同一の 401（Req 1）
+- `POST /api/auth/revoke`: family 失効 + 常に 204（冪等・列挙オラクルなし）（Req 2）
+- revoke 後・再利用検知後の family 全 token が refresh 不能であること（Req 1.3, 2.3）
+
+### Non-Goals
+
+- Bearer middleware（#169）/ IP レート制限（#171）/ contract tests 全体整備（#172）
+- access token（JWT）の即時失効（短命 900 秒で吸収）
+- 再利用検知イベントの外部通知（slog の warn 出力まで）
+
+## Architecture Pattern & Boundary Map
+
+```mermaid
+flowchart TD
+  A[Feedman iOS] -->|"POST /api/auth/refresh（再利用提示）"| HR
+  A -->|"POST /api/auth/revoke {refresh_token}"| HV
+
+  subgraph Handler["internal/handler"]
+    HR["NativeAuthHandler.Refresh (#167 導入済み)"]
+    HV["NativeAuthHandler.Revoke<br/>(native_auth_handler.go へ追加)"]
+  end
+
+  subgraph Auth["internal/auth"]
+    TS["TokenService.RotateRefreshToken<br/>拒否分岐を family 失効へ昇格"]
+    RV["TokenService.RevokeRefreshToken<br/>(token_service.go へ追加)"]
+  end
+
+  subgraph Repo["internal/repository (#164 導入済み)"]
+    RTR["RefreshTokenRepository<br/>FindByHash / RevokeFamily（冪等）"]
+  end
+
+  HR --> TS
+  HV --> RV
+  TS --> RTR
+  RV --> RTR
+  RTR --> DB[(refresh_token_families / refresh_tokens)]
+```
+
+### 再利用検知の昇格（RotateRefreshToken の変更点）
+
+#167 の rotation フロー手順 3〜4 の拒否分岐を以下のとおり拡張する（他の手順は不変）:
+
+```
+3. 状態検証:
+   - RevokedAt != nil → ErrInvalidRefreshToken（変更なし: 失効済みは再利用ではない）
+   - ExpiresAt <= now → ErrInvalidRefreshToken（変更なし）
+   - RotatedAt != nil → 【昇格】RevokeFamily(FamilyID, now) を実行してから
+                        ErrInvalidRefreshToken（再利用検知。slog.Warn で記録）
+4. MarkRotated:
+   - ErrRefreshTokenAlreadyRotated → 【昇格】RevokeFamily(FamilyID, now) を実行してから
+                        ErrInvalidRefreshToken（並行競合 = 検知漏れ防止、Req 1.2）
+   - RevokeFamily 自体が失敗した場合も ErrInvalidRefreshToken ではなく内部エラーを返さず、
+     【安全側】失効を諦めず拒否は維持する（新 token は発行しない。Req 1.5。
+     実装は「RevokeFamily の error を slog.Error で記録しつつ ErrInvalidRefreshToken を返す」）
+```
+
+- strict 方針（正規クライアントの再送も失効対象）の根拠と回復手段は requirements.md
+  Open Questions を参照
+- 検知ログ: `slog.Warn("refresh token reuse detected", family_id, token_hash 先頭 8 文字)`
+
+### Revoke フロー
+
+```
+1. handler: JSON decode（refresh_token 必須）→ 不正なら 400 INVALID_REQUEST
+2. service: HashNativeSecret(refresh_token) → FindByHash
+   → nil なら【何もせず】nil を返す（handler は 204。存在オラクルを作らない）
+3. service: RevokeFamily(token.FamilyID, now)（#164 設計により二重 revoke 冪等）
+4. handler: 204 No Content（ボディなし）
+```
+
+- token の状態（期限切れ・rotation 済み・失効済み）に関わらず family を失効する
+  （クライアントが古い世代の token しか保持していなくてもログアウトを成立させる）
+- infra エラー（FindByHash / RevokeFamily の DB 障害）のみ 500
+
+## Technology Stack
+
+#166 / #167 と完全に同一（新規依存なし）。
+
+## File Structure Plan
+
+```
+internal/
+├── auth/
+│   ├── token_service.go       # 変更: RefreshTokenStore IF に RevokeFamily を追加 /
+│   │                          #       RotateRefreshToken の拒否分岐 2 箇所を失効昇格 /
+│   │                          #       RevokeRefreshToken を追加
+│   └── token_service_test.go  # 変更: 再利用昇格 / 競合昇格 / revoke 成功・冪等のケース追加
+├── handler/
+│   ├── native_auth_handler.go      # 変更: Revoke handler（204 / 400 / 500）
+│   ├── native_auth_handler_test.go # 変更: Revoke の 204 / 400 / 500 ケース
+│   ├── router.go              # 変更: 認証不要グループに POST /api/auth/revoke を登録
+│   ├── router_test.go         # 変更: revoke ルートの到達 / nil 時 404 ケース
+│   └── integration_test.go    # 変更: 再利用 → family 全滅 / revoke → refresh 拒否の通しケース
+```
+
+## Requirements Traceability
+
+| Req | 設計要素 |
+|---|---|
+| 1.1 | RotateRefreshToken 手順 3 の RotatedAt 分岐で `RevokeFamily` 実行後に `ErrInvalidRefreshToken` |
+| 1.2 | 手順 4 の `ErrRefreshTokenAlreadyRotated` 分岐で同様に昇格 |
+| 1.3 | `RevokeFamily` が family 配下全 token の `RevokedAt` を set（#164）→ 手順 3 の RevokedAt 検証で拒否 |
+| 1.4 | 昇格後も返すのは同一 sentinel `ErrInvalidRefreshToken` → handler は #167 と同じ 401 単一応答 |
+| 1.5 | RevokeFamily 失敗時も `ErrInvalidRefreshToken` を返し新 token を発行しない（slog.Error 記録） |
+| 2.1 | `RevokeRefreshToken` 手順 2〜3 + handler `Revoke` の 204 |
+| 2.2 | FindByHash nil → 何もせず nil（204）。`RevokeFamily` は二重 revoke 冪等（#164） |
+| 2.3 | family 失効後の refresh は RotateRefreshToken 手順 3 の RevokedAt 検証で拒否（#167 既存） |
+| 2.4 | router の認証不要グループに登録（Req 2.4 の境界判断は requirements.md Open Questions） |
+| 2.5 | handler の JSON decode / 必須フィールド検査 → 400 `INVALID_REQUEST` |
+| 2.6 | 既存 `POST /auth/logout` のコード経路に変更なし |
+| NFR 1.1 | 平文は hash 化後に破棄。ログは hash 先頭 8 文字 |
+| NFR 1.2 | 不明 token でも既知 token でも同一の 204（タイミング差は FindByHash 1 回で同等） |
+| NFR 1.3 | 固定メッセージの APIError（入力反射なし） |
+| NFR 2.1 | 既存経路の変更は RotateRefreshToken の拒否分岐内部のみ（応答契約は不変） |
+| NFR 2.2 | `NativeAuthHandler` nil 時は revoke も未登録（#166 の fail-closed に同乗） |
+| NFR 3.1 | RefreshTokenStore モックで service を単体検証。Testing Strategy が issue AC 5 観点を網羅 |
+
+## Components and Interfaces
+
+### auth.TokenService（変更 / token_service.go）
+
+```go
+// RefreshTokenStore（#166/#167 導入）に family 失効を追加拡張する。
+// repository.RefreshTokenRepository が引き続き構造的に充足する。
+type RefreshTokenStore interface {
+	CreateFamily(ctx context.Context, family *model.RefreshTokenFamily) error
+	CreateToken(ctx context.Context, token *model.RefreshToken) error
+	FindByHash(ctx context.Context, tokenHash string) (*model.RefreshToken, error)
+	MarkRotated(ctx context.Context, id string, rotatedAt time.Time) error
+	RevokeFamily(ctx context.Context, familyID string, revokedAt time.Time) error
+}
+
+// RevokeRefreshToken は提示された refresh token の family 全体を失効する。
+// token が見つからない場合は何もせず nil を返す（冪等・存在オラクルなし）。
+// infra エラーのみ error を返す。
+func (s *TokenService) RevokeRefreshToken(ctx context.Context, refreshToken string) error
+```
+
+### handler.NativeAuthHandler（変更 / native_auth_handler.go）
+
+```go
+// TokenExchangeService に Revoke 用メソッドを追加拡張する。
+type TokenExchangeService interface {
+	ExchangeAuthCode(ctx context.Context, authCode, codeVerifier string) (*auth.TokenPair, error)
+	RotateRefreshToken(ctx context.Context, refreshToken string) (*auth.TokenPair, error)
+	RevokeRefreshToken(ctx context.Context, refreshToken string) error
+}
+
+// Revoke は POST /api/auth/revoke を処理する。
+// 204: 失効成功または対象不明（区別しない・ボディなし）
+// 400 INVALID_REQUEST: JSON 不正 / refresh_token 欠落
+// 500 INTERNAL_ERROR:  infra エラー
+func (h *NativeAuthHandler) Revoke(w http.ResponseWriter, r *http.Request)
+```
+
+### router（変更）
+
+```go
+if deps.NativeAuthHandler != nil {
+	// （既存）POST /api/auth/token / POST /api/auth/refresh
+	r.With(middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
+		Post("/api/auth/revoke", deps.NativeAuthHandler.Revoke)
+}
+```
+
+- `RouterDeps` / app.go の wiring 変更は不要（#166 の配線に同乗）
+
+## Data Models
+
+新規モデル・migration なし。`RevokeFamily` は `refresh_token_families.revoked_at` と
+配下 `refresh_tokens.revoked_at` を一括 set する（#164 実装済み・二重 revoke 冪等）。
+
+## Error Handling
+
+| 状況 | HTTP | APIError | 備考 |
+|---|---|---|---|
+| revoke: JSON 不正 / フィールド欠落 | 400 | `INVALID_REQUEST` / validation | |
+| revoke: token 不明 / 失効済み / 何であれ処理完了 | 204 | （ボディなし） | 区別しない（Req 2.2 / NFR 1.2） |
+| revoke: DB 障害 | 500 | `INTERNAL_ERROR` / system | |
+| refresh: 再利用検知（昇格後） | 401 | `INVALID_REFRESH_TOKEN` / auth | 通常拒否と同一応答（Req 1.4） |
+
+## Testing Strategy
+
+### 単体テスト（auth / token_service_test.go 追加分）
+
+1. RotatedAt 済み token 提示 → `RevokeFamily` が当該 FamilyID で呼ばれ、`ErrInvalidRefreshToken`
+   が返り、新 token 未作成（Req 1.1）
+2. MarkRotated が `ErrRefreshTokenAlreadyRotated` → 同様に昇格（Req 1.2）
+3. 昇格時の RevokeFamily が失敗 → それでも `ErrInvalidRefreshToken`（新 token 未発行、Req 1.5）
+4. RevokeRefreshToken: 既知 token → RevokeFamily 呼び出し + nil（Req 2.1）
+5. RevokeRefreshToken: FindByHash nil → RevokeFamily 未呼び出し + nil（Req 2.2 冪等）
+6. RevokeRefreshToken: DB 障害 → error（500 系）
+7. 失効済み（RevokedAt set）token の refresh は引き続き昇格なしの単純拒否（#167 既存挙動の回帰）
+
+### 単体テスト（handler）
+
+8. Revoke: 正常 204（ボディ空）/ 不明 token でも 204 / 不正 JSON・欠落 → 400 / service エラー → 500
+
+### ルーティング・統合テスト
+
+9. `router_test.go`: POST /api/auth/revoke の到達 / NativeAuthHandler nil 時 404
+10. `integration_test.go`:
+    - 再利用シナリオ: token 交換 → refresh（旧 A → 新 B）→ A を再提示 → 401 + 以後 B でも 401
+      （family 全滅、Req 1.1, 1.3）
+    - revoke シナリオ: token 交換 → revoke 204 → 同 token で refresh → 401 → 再 revoke → 204
+      （冪等、Req 2.1, 2.2, 2.3）
+
+## Security Considerations
+
+- 再利用検知は「漏えいの可能性がある系列を丸ごと止める」strict 方針（SERVER.md §1.4 準拠）。
+  誤検知（正規再送）でもユーザーは再ログインで回復でき、安全側に倒れる
+- revoke は破壊的操作のみで奪取に使えず、常に 204 のため列挙オラクルにならない。
+  token 所持ベースの認可は RFC 7009 §2.1 の public client 慣行に整合
+- family 失効は #164 の冪等 `RevokeFamily` に委譲し、二重実行・並行実行で壊れない
+
+## Supporting References
+
+- feedman-ios `design/SERVER.md` §1.3（/api/auth/revoke 契約）/ §1.4・§1.5（再利用検知 /
+  family 失効）
+- RFC 7009 (OAuth 2.0 Token Revocation) §2.1 <https://datatracker.ietf.org/doc/html/rfc7009>
+- Issue #164 spec（RevokeFamily の冪等設計）/ #167 spec（rotation フローの拒否分岐）

--- a/docs/specs/168-reuse-detection-revoke/requirements.md
+++ b/docs/specs/168-reuse-detection-revoke/requirements.md
@@ -1,0 +1,86 @@
+# Requirements Document
+
+## Introduction
+
+refresh token rotation（Issue #167）では、rotation 済みの旧 token が再び提示された場合、
+それは応答消失後のクライアント再送か token 漏えいのいずれかであり、安全側に倒して
+当該 rotation 系列（family）全体を失効させる必要がある（SERVER.md §1.4 の盗難対策）。
+また iOS アプリのログアウト時には、クライアントが refresh token を明示失効できる
+`POST /api/auth/revoke` が必要である（SERVER.md §1.3）。
+
+本 spec は (1) rotation 済み token 再利用検知時の **family 全体失効への昇格**（#167 の
+単純拒否分岐の拡張）、(2) **`POST /api/auth/revoke`** の追加、を対象とする。
+Bearer middleware（#169）、IP レート制限（#171）、contract tests 全体整備（#172）は
+スコープ外。
+
+## Requirements
+
+### Requirement 1: Rotation 済み token 再利用の検知と family 失効
+
+**Objective:** As a Feedman 運用者, I want 旧 refresh token の再利用を漏えいの兆候として
+扱いたい, so that 盗まれた token 系列によるアクセス継続を遮断できる
+
+#### Acceptance Criteria
+
+1. When rotation 済みの refresh token が refresh エンドポイントに提示されたとき, the Refresh Endpoint shall 当該 token が属する family 全体を失効させ、要求を拒否する
+2. When 並行 rotation の競合に敗れた要求（atomic な rotation 確定で先行された提示）が検知されたとき, the Refresh Endpoint shall 同様に family 全体を失効させ、要求を拒否する
+3. When family が失効されたとき, the Refresh Endpoint shall 当該 family に属するすべての refresh token による以後の再発行要求を拒否する
+4. The Refresh Endpoint shall 再利用検知時の拒否応答を、通常の無効 token 拒否（Issue #167 Req 2.6）と区別できない同一応答とする
+5. If family 失効の永続化が失敗したとき, the Refresh Endpoint shall 新 token を発行せず要求を拒否する
+
+### Requirement 2: Revoke エンドポイント
+
+**Objective:** As a Feedman iOS アプリ, I want ログアウト時に refresh token を明示失効したい,
+so that 端末から削除した token がサーバー側でも使用不能になる
+
+#### Acceptance Criteria
+
+1. When revoke エンドポイントが既知の refresh token を受け取ったとき, the Revoke Endpoint shall 当該 token が属する family 全体を失効させ、ボディなしの成功応答（204）を返す
+2. When 不明・失効済み・rotation 済み・期限切れの refresh token を受け取ったとき, the Revoke Endpoint shall token の存在有無を区別できない同一の成功応答（204）を返す（冪等）
+3. When family が revoke エンドポイント経由で失効されたとき, the Refresh Endpoint shall 当該 family の全 token による再発行要求を拒否する
+4. The Revoke Endpoint shall Cookie セッション・Bearer 認証のいずれも無しで呼び出し可能とする（refresh token の所持自体を失効権限とみなす）
+5. If リクエストボディが不正な JSON、または必須フィールド（`refresh_token`）が欠落しているとき, the Revoke Endpoint shall 入力不正として要求を拒否する
+6. The Revoke Endpoint shall 既存 Web ログアウト（Cookie セッション破棄）の挙動を変更しない
+
+## Non-Functional Requirements
+
+### NFR 1: セキュリティ
+
+1. The Refresh Endpoint and Revoke Endpoint shall refresh token の平文を永続化領域・ログ・エラーメッセージのいずれにも残さない
+2. The Revoke Endpoint shall 応答内容・ステータスから token の存在有無・状態を推測できないようにする
+3. The Refresh Endpoint and Revoke Endpoint shall エラー応答にクライアント入力値・内部詳細を反射しない
+
+### NFR 2: 後方互換性
+
+1. The API Server shall 既存のすべてのルート（Web ログイン / ログアウト・既存 API・token 交換・refresh の正常系）の挙動を変更しない
+2. The API Server shall 署名鍵未設定の環境では revoke エンドポイントも公開しない（token 交換・refresh と同一の fail-closed 縮退）
+
+### NFR 3: テスト容易性
+
+1. The Native Auth Module shall 再利用検知・family 失効・revoke 成功・revoke 冪等性・revoke 後の refresh 拒否の各ケースを外部ネットワーク依存なしで検証可能にする
+
+## Out of Scope
+
+- `POST /api/auth/token` の初回交換（#166）と refresh の基本 rotation（#167）
+- Bearer middleware による既存 API の Bearer 対応（#169）
+- 未認証 IP レート制限（#171）と contract tests 全体整備（#172）
+- iOS 側のログアウト UI / token 破棄処理
+- access token（JWT）の即時失効（jti ブラックリスト等）— 短命（900 秒）で吸収する設計（SERVER.md §1.4）
+- 再利用検知イベントの通知・アラート連携（ログ出力までを本 spec で行う）
+
+## Open Questions
+
+- 再利用検知の strict 方針（応答消失後の正規クライアント再送も family 失効になる）は
+  SERVER.md §1.4「失効済みトークンの提示時は当該ファミリ全失効」に従う。誤検知時も
+  ユーザーは再ログインで回復できる（データ損失なし）
+- `POST /api/auth/revoke` は SERVER.md §1.3 に「Bearer 認証下」と注記があるが、Bearer
+  middleware は後続 Issue #169 の領分であること、および RFC 7009（OAuth 2.0 Token
+  Revocation）が public client の revocation を token 所持ベースで許す慣行であることから、
+  本 spec では**未認証 + token 所持 = 権限**の境界を採用する（Issue 本文「仮案・判断を
+  委ねたい点」への回答。失効は破壊のみで奪取に使えず、冪等 204 で列挙オラクルも生じない）
+
+## 関連
+
+- Parent: #163
+- Depends on: #167
+- Sibling: #164 #165 #166 #169 #170 #171 #172

--- a/docs/specs/168-reuse-detection-revoke/tasks.md
+++ b/docs/specs/168-reuse-detection-revoke/tasks.md
@@ -1,0 +1,42 @@
+# Implementation Plan
+
+- [ ] 1. auth: 再利用検知の昇格と RevokeRefreshToken
+  - `internal/auth/token_service.go`: `RefreshTokenStore` interface に `RevokeFamily` を追加
+    （compile-time check で `repository.RefreshTokenRepository` 充足を確認）
+  - `RotateRefreshToken` の拒否分岐 2 箇所（手順 3 の RotatedAt 検出 / 手順 4 の
+    `ErrRefreshTokenAlreadyRotated`）を design.md「再利用検知の昇格」どおり
+    `RevokeFamily` 実行 + `ErrInvalidRefreshToken` に昇格（`slog.Warn` で family_id と
+    hash 先頭 8 文字を記録。RevokeFamily 失敗時も拒否は維持し `slog.Error` 記録）
+  - `RevokeRefreshToken(ctx, refreshToken string) error` を design.md「Revoke フロー」どおり
+    実装（不明 token は no-op nil / 状態に関わらず family 失効 / infra エラーのみ error）
+  - `internal/auth/token_service_test.go` に design.md Testing Strategy 1〜7 を追加
+    （#167 既存ケースの検証内容は変えない。モックの interface 追従は可）
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, NFR 1.1, NFR 1.3, NFR 3.1_
+
+- [ ] 2. handler: Revoke エンドポイントと router 登録
+  - `internal/handler/native_auth_handler.go`: `TokenExchangeService` interface に
+    `RevokeRefreshToken` を追加し、`Revoke` handler を実装（204 ボディなし /
+    400 INVALID_REQUEST / 500 INTERNAL_ERROR）
+  - `internal/handler/router.go`: 認証不要グループの `NativeAuthHandler != nil` ガード内に
+    `POST /api/auth/revoke` を登録（ボディ上限 middleware 付き）
+  - `internal/handler/native_auth_handler_test.go` に design.md Testing Strategy 8 を、
+    `internal/handler/router_test.go` に Testing Strategy 9 を追加
+  - _Requirements: 2.1, 2.2, 2.4, 2.5, 2.6, NFR 1.2, NFR 2.1, NFR 2.2_
+  - _Depends: 1_
+
+- [ ] 3. 統合テスト: 再利用 family 全滅と revoke 後拒否
+  - `internal/handler/integration_test.go` に design.md Testing Strategy 10 の 2 シナリオ
+    （再利用 → family 全滅 / revoke 204 → refresh 401 → 再 revoke 204 の冪等）を追加
+  - 既存の統合テスト・既存ルートが無変更で green であることを確認
+  - _Requirements: 1.1, 1.3, 2.1, 2.2, 2.3, NFR 2.1, NFR 3.1_
+  - _Depends: 2_
+
+## Verify
+
+本 spec の実装後、watcher（stage-a-verify gate）が再実行すべき verify コマンドを以下の
+構造化ブロックで宣言する。
+
+<!-- stage-a-verify -->
+```sh
+go build ./... && go vet ./... && go test ./...
+```


### PR DESCRIPTION
## 概要

Issue #168 の設計 PR です。`docs/specs/168-reuse-detection-revoke/` に requirements.md（EARS）/ design.md / tasks.md を追加します。実装は本 PR マージ後・#167 実装マージ後に別 PR で行います。

## 設計の要点

- **再利用検知の昇格**: #167 の rotation 拒否分岐 2 箇所（RotatedAt 検出 / MarkRotated 競合敗北）を `RevokeFamily`（#164 の冪等実装）実行 + 同一の 401 拒否へ昇格。応答は通常拒否と区別不能（検知をオラクル化しない）
- **strict 方針**: 応答消失後の正規再送も失効対象（SERVER.md §1.4「失効済みトークンの提示時は family 全失効」準拠。誤検知時は再ログインで回復）
- **POST /api/auth/revoke**: 常に 204（冪等・存在オラクルなし）。token の状態に関わらず family 全体を失効（古い世代しか持たないクライアントでもログアウト成立）
- **タスク分割**: 3 タスク（service → handler/router → 統合テスト）

## 確認事項（レビュワー判断ポイント）

- **revoke の認可境界**: SERVER.md §1.3 には「Bearer 認証下」と注記がありますが、Bearer middleware は後続 #169 の領分のため、本設計では **未認証 + refresh token 所持 = 失効権限**（RFC 7009 §2.1 の public client 慣行）を採用しました。失効は破壊のみで奪取に使えず、常に 204 のため列挙オラクルも生じません。Bearer 必須に変える場合は #169 マージ後に小改修で対応可能です
- **昇格時の RevokeFamily 失敗**: 失効に失敗しても拒否（新 token 非発行）は維持し、slog.Error 記録に留めます（Req 1.5）

## Mechanical Checks（design-review-gate）

- [x] Requirements traceability 全 ID / File Structure Plan 具体化 / orphan なし
- [x] Budget overflow check: 最上位タスク 3 件（≤10）
- [x] checkbox enforcement / verify block well-formed

## 関連

- Parent: #163
- Depends on: #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)