### PR TITLE
spec(#171): native auth endpoint の IP rate limit 要件定義・設計・タスク分割

### DIFF
--- a/docs/specs/171-native-auth-ip-ratelimit/design.md
+++ b/docs/specs/171-native-auth-ip-ratelimit/design.md
@@ -1,0 +1,189 @@
+# Design Document
+
+## Overview
+
+**Purpose**: 本 spec は #166〜#168 が導入する native auth の 3 エンドポイント
+（`POST /api/auth/token` / `POST /api/auth/refresh` / `POST /api/auth/revoke`）に、
+#38 導入済みの未認証 IP 単位レート制限（`middleware.IPRateLimiter`、router 上の
+`unauthIPMW`）を適用する（SERVER.md §1.7）。
+
+**Users**: サービス運用者（未認証 token 系エンドポイントへのフラッディング・総当たりの
+入口を制限したい）。正常な Feedman iOS クライアントの利用頻度（token 交換 ≈ ログイン毎 1 回・
+refresh ≈ 15 分毎 1 回・revoke ≈ ログアウト毎 1 回）は閾値に対して十分小さく、影響しない。
+
+**Impact**: 変更は `router.go` の native auth ルート登録 3 行に `unauthIPMW` を重ねるのみ。
+`IPRateLimiter` 本体・config・app.go の wiring・既存ルートはすべて不変。
+`NativeAuthHandler` nil（署名鍵 `NATIVE_AUTH_JWT_SECRET` 未設定）の環境では 3 ルート自体が
+未登録のため、**本 spec の変更は no-op**（#166 の fail-closed に同乗）。
+
+### Goals
+
+- native auth 3 ルートへの IP 単位レート制限の適用（Req 1.1〜1.4, 1.6）
+- 閾値超過時は handler / service に到達する前に既存共通の 429 応答（Retry-After 付き）で
+  遮断する（Req 1.1〜1.3, 1.5, 2.3）
+- 既存未認証 3 ルート・認証済み API・縮退環境（native auth 無効）の完全な後方互換
+  （Req 2.1, 2.2, 2.4）
+
+### Non-Goals
+
+- `IPRateLimiter` の実装・IP 判定方針・資源管理・閾値設定機構の変更（#38 設計のまま）
+- native auth 専用の制限値・設定ノブの新設（後述「制限値の設計判断」で共用を採用）
+- Bearer middleware（#169）/ contract tests（#172）/ 認証済み API の制限変更
+
+## 前提（#166〜#168 design への依存）
+
+本 spec の実装は #166〜#168 の実装 PR が merge 済みであることを前提とする（requirements.md
+の `Depends on:` どおり）。本 design が参照する router 上のルート登録は、#166 / #167 / #168
+各 design の「router（変更）」節で確定済みの内容（認証不要グループ内・
+`NativeAuthHandler != nil` ガード・ボディ上限ミドルウェア付き）である。#166 design は
+「IP レート制限（`unauthIPMW`）の適用は Issue #171 の領分」と明記しており、本 spec が
+その残置部分を埋める。
+
+## Architecture Pattern & Boundary Map
+
+認証不要グループのミドルウェアチェーンに、既存未認証ルートと同じ位置づけで `unauthIPMW` を
+挿入する。
+
+```
+（認証不要グループ共通: Recovery → SecurityHeaders → CORS → Logging）
+  /health               : unauthIPMW → handler                               （既存・不変）
+  /auth/google/login    : unauthIPMW → handler                               （既存・不変）
+  /auth/google/callback : unauthIPMW → handler                               （既存・不変）
+  /api/auth/token       : unauthIPMW → MaxBodyBytes → NativeAuthHandler.Token   （unauthIPMW を追加）
+  /api/auth/refresh     : unauthIPMW → MaxBodyBytes → NativeAuthHandler.Refresh （unauthIPMW を追加）
+  /api/auth/revoke      : unauthIPMW → MaxBodyBytes → NativeAuthHandler.Revoke  （unauthIPMW を追加）
+```
+
+- `unauthIPMW` は route 単位チェーンの最外（Logging の内側）に置く。閾値超過時はボディ上限の
+  wrap・JSON decode・永続化層参照のいずれにも到達せずに遮断され（Req 1.1〜1.3 の
+  「処理を試行せずに」）、既存ルートの「Logging の内側に IP 制限」という順序規約とも一致する
+  （NFR 2.2）
+- 429 応答も既存ルート同様にアクセスログへ記録される（可観測性の一貫性）
+
+## 制限値の設計判断（共用 vs 分離）
+
+**判断: 既存の `IPRateLimiter` インスタンスと閾値（env `RATE_LIMIT_UNAUTH_IP`、
+既定 30 req/min/IP）をそのまま共用する。native auth 専用の制限値・インスタンスは新設しない。**
+
+| 観点 | 共用（採用） | 分離（不採用） |
+|---|---|---|
+| 設定構造 | 既存ノブ（`RateLimitUnauthIP`）1 個のまま | 新 env + config フィールド + 第 2 `IPRateLimiter` インスタンス + cleanup goroutine + shutdown coordinator 配線が増える |
+| 正常トラフィック | token 交換 ≈ ログイン毎 / refresh ≈ 15 分毎 / revoke ≈ ログアウト毎。30 req/min/IP は NAT 配下の多数台でも余裕（refresh 定常で約 450 台/IP 相当） | 専用値を必要とするトラフィック特性が現状存在しない |
+| 防御の位置づけ | auth_code / refresh token は 256bit 乱数 + hash 永続化（#164〜#168）で列挙は計算量的に不可能。制限は多層防御 + 資源保護であり、OAuth 入口（/auth/google/*）と同強度で釣り合う | 攻撃面の差が薄く、強度を変える根拠が立たない |
+| 既存意味論との整合 | 「IP あたりの未認証リクエスト予算」という #38 の意味論（login / callback / health は既に IP ごとの単一バケットを共有）に native auth が加わるだけ | エンドポイント別バケットは #38 意味論からの逸脱になる |
+
+**共用に伴う既知の性質**: 同一 IP が native auth エンドポイントへ大量リクエストすると、
+その IP からの `/auth/google/*`・`/health` も同じバケットで 429 になる（逆も同様）。これは
+「同一の攻撃元を全未認証入口で一括制限する」安全側の性質であり、既存 3 ルート間で既に
+成立している挙動と同種である（既存ルートの閾値・適用範囲・429 形式は不変のため Req 2.1 の
+後方互換と矛盾しない）。将来 native auth に独立した閾値が必要になった場合は、config に
+値を追加して別インスタンスを配線するだけで本設計を変えずに分離できる（拡張点の記録のみ。
+本 spec では実装しない）。
+
+## Technology Stack
+
+新規依存なし。`internal/middleware` の既存 `IPRateLimiter`（`golang.org/x/time/rate`）と
+共通 429 応答ヘルパー `writeRateLimitResponse`（Retry-After ヘッダー + 固定 JSON）を
+変更なしで使用する。
+
+## File Structure Plan
+
+```
+internal/
+├── handler/
+│   ├── router.go        # 変更: NativeAuthHandler != nil ガード内の 3 ルート登録に
+│   │                    #       unauthIPMW を追加（既存 unauthIPMW 変数を共用）
+│   └── router_test.go   # 変更: native auth 3 ルートの within/over limit・IP 独立・
+│                        #       429 形式・縮退（nil handler / nil limiter）ケースを追加
+```
+
+config / app.go / middleware / 既存テストファイルの変更なし。
+
+## Requirements Traceability
+
+| Req | 設計要素 |
+|---|---|
+| 1.1, 1.2, 1.3 | 3 ルートの route チェーン最外に `unauthIPMW`。超過時は handler 到達前に 429（モック service 未呼び出しで検証） |
+| 1.4 | 閾値以内は素通しで後続（MaxBodyBytes → handler）へ。既存 `IPRateLimiter.Middleware` の挙動を共用 |
+| 1.5 | 共通 `writeRateLimitResponse` の Retry-After ヘッダー（変更なしで共用） |
+| 1.6 | `IPRateLimiter` の IP 別バケット（#38 実装。本 spec は適用のみで変更しない） |
+| 2.1 | 既存 3 ルートの登録・`RATE_LIMIT_UNAUTH_IP` 閾値・単一インスタンス構成は無変更（「制限値の設計判断」参照） |
+| 2.2 | 認証必須グループ（Session → RateLimit(General) → Logging）に変更なし |
+| 2.3 | 既存と同一の `writeRateLimitResponse`（429 + Retry-After + 固定 JSON）を共用 |
+| 2.4 | `NativeAuthHandler` nil 時は 3 ルート未登録のため本変更は no-op（#166 fail-closed に同乗） |
+| NFR 1.1 | 既存 `IPRateLimiter` の拒否ログ（`slog.Warn("rate limit exceeded", limit_type=unauth_ip)`）を共用 |
+| NFR 1.2 | 同上（ログは limit 種別のみで token・セッション情報・IP 以外の個人情報なし。#38 設計） |
+| NFR 2.1 | 設定・wiring 不変。既定 30 req/min/IP がそのまま native auth ルートにも効く |
+| NFR 2.2 | 既存ルートのミドルウェア種類・順序は無変更（native auth ルートへの route 単位 `With` 追加のみ） |
+| NFR 3.1 | `router_test.go` で httptest + モック service による within/over の検証（Testing Strategy 1〜4） |
+
+## Components and Interfaces
+
+### router（変更 / router.go のみ）
+
+```go
+// 認証不要グループ内（#166〜#168 で確定済みの登録に unauthIPMW を追加）
+if deps.NativeAuthHandler != nil {
+	r.With(unauthIPMW, middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
+		Post("/api/auth/token", deps.NativeAuthHandler.Token)
+	r.With(unauthIPMW, middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
+		Post("/api/auth/refresh", deps.NativeAuthHandler.Refresh)
+	r.With(unauthIPMW, middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
+		Post("/api/auth/revoke", deps.NativeAuthHandler.Revoke)
+}
+```
+
+- `unauthIPMW` は既存定義（`deps.UnauthIPRateLimiter` nil なら素通しの no-op closure）を
+  そのまま参照する。`UnauthIPRateLimiter` nil + `NativeAuthHandler` 非 nil の組合せでは
+  native auth ルートは制限なしで到達可能（既存未認証ルートと同一の縮退規約）
+- `RouterDeps` / app.go / config の変更は不要（双方とも #38 / #166 の配線に同乗）
+
+## Data Models
+
+なし（新規モデル・migration・設定フィールドの追加なし）。
+
+## Error Handling
+
+| 状況 | HTTP | 応答 | 備考 |
+|---|---|---|---|
+| 閾値超過 | 429 | `Retry-After: <秒>` ヘッダー + JSON `{"code": "rate_limit_exceeded", "message": ..., "category": "system", "action": ...}` | 既存 `writeRateLimitResponse` を共用（Req 2.3）。handler 未到達のため `INVALID_GRANT` / `INVALID_REFRESH_TOKEN` 等の native auth エラー契約（#166〜#168）とは独立 |
+| 閾値以内 | - | 各 handler の既存契約（#166〜#168）どおり | 本 spec では変更しない |
+
+## Testing Strategy
+
+### ルーティングテスト（router_test.go 追加分）
+
+1. 閾値超過: 小さい burst の `IPRateLimiter` を注入し、burst を使い切った後の
+   `POST /api/auth/token` が 429 + Retry-After ヘッダー付きで応答し、モック service が
+   呼ばれないこと（Req 1.1, 1.5）
+2. 同様に `/api/auth/refresh`（Req 1.2）・`/api/auth/revoke`（Req 1.3）の超過 429 +
+   モック service 未呼び出し
+3. 閾値以内: 3 ルートとも通常応答（モック service への到達）が維持されること（Req 1.4）
+4. IP 独立: 別 IP（RemoteAddr 差し替え）からの要求は超過 IP の影響を受けないこと（Req 1.6）
+5. 429 応答 JSON・ヘッダーが既存未認証ルート（例: /health）の 429 と同一形式であること
+   （Req 2.3）
+
+### 縮退・後方互換 regression
+
+6. `NativeAuthHandler` nil なら 3 ルートは 404 のまま（= 本変更は no-op。Req 2.4）。
+   `UnauthIPRateLimiter` nil なら 3 ルートは制限なしで到達（既存縮退規約の維持）
+7. 既存未認証 3 ルート（/health・/auth/google/login・/auth/google/callback）の IP 制限挙動と
+   既存テストが無変更で green（Req 2.1, NFR 2.2）
+8. 認証必須グループ（/api/*）の既存テストが無変更で green（Req 2.2）
+
+## Security Considerations
+
+- 本制限は多層防御: auth_code / refresh token 自体が 256bit 乱数 + hash 永続化
+  （#164〜#168）であり、レート制限は列挙対策の主防御ではなく資源保護・フラッディング抑止
+- クライアント IP 判定は接続元アドレスのみ（X-Forwarded-For 非信頼）・判定不能時は固定キーの
+  単一バケットで安全側 — いずれも #38 設計を変更なしで継承
+- 署名鍵未設定環境では 3 ルート未登録（fail-closed）のため、本変更による新たな露出はゼロ
+  （no-op）
+
+## Supporting References
+
+- feedman-ios `design/SERVER.md` §1.7（未認証エンドポイントへの IP rate limit 要求）
+- `docs/specs/38--auth-google-health-ip/`（IPRateLimiter の要件・IP 判定方針・既定閾値の正本）
+- `docs/specs/166-auth-token-exchange/design.md` / `docs/specs/167-auth-refresh-rotation/design.md` /
+  `docs/specs/168-reuse-detection-revoke/design.md`（router 節 = 本 spec が前提とするルート登録。
+  #166 design が IP レート制限を #171 の領分として明示）

--- a/docs/specs/171-native-auth-ip-ratelimit/requirements.md
+++ b/docs/specs/171-native-auth-ip-ratelimit/requirements.md
@@ -1,0 +1,86 @@
+# Requirements Document
+
+## Introduction
+
+native auth エンドポイント群（親 Issue #163）のうち `POST /api/auth/token`（#166）・
+`POST /api/auth/refresh`（#167）・`POST /api/auth/revoke`（#168）は、Cookie セッションも
+Bearer 認証も持たない未認証状態から呼び出される。これらは token 試行・フラッディングの
+入口になりうるため、SERVER.md §1.7 が要求する未認証 IP rate limit による保護が必要になる。
+
+Feedman には Issue #38 で導入済みの未認証エンドポイント向け IP 単位レート制限
+（`/auth/google/login`・`/auth/google/callback`・`/health` に適用、閾値超過時に
+HTTP 429 を返す）が存在する。本 spec は **この既存保護を native auth の 3 エンドポイントへ
+拡張適用すること**のみを対象とする。制限方式そのもの（クライアント IP の判定方針・閾値の
+設定可能性・内部状態の資源管理）は #38 で要件化済みであり、本 spec では再定義しない。
+
+なお Issue 本文の仮案は「`/api/auth/revoke` は Bearer 認証下想定のため対象外」としていたが、
+#168 の要件定義で revoke は「未認証 + token 所持 = 権限」の境界が採用され、未認証で
+公開されることが確定した（`docs/specs/168-reuse-detection-revoke/requirements.md` の
+Open Questions）。このため本 spec は revoke も保護対象に含める。
+
+## Requirements
+
+### Requirement 1: native auth エンドポイントへの IP 単位レート制限
+
+**Objective:** As a サービス運用者, I want native auth エンドポイントを同一 IP 単位で
+レート制限したい, so that 未認証で公開される token 系エンドポイントへの総当たり・
+フラッディングからサービスを保護できる
+
+#### Acceptance Criteria
+
+1. When 同一クライアント IP から token 交換エンドポイントへの単位時間あたりリクエスト数が閾値を超過したとき, the IP レート制限 shall token 交換処理を試行せずに HTTP 429 Too Many Requests を返す
+2. When 同一クライアント IP から refresh エンドポイントへの単位時間あたりリクエスト数が閾値を超過したとき, the IP レート制限 shall refresh 処理を試行せずに HTTP 429 Too Many Requests を返す
+3. When 同一クライアント IP から revoke エンドポイントへの単位時間あたりリクエスト数が閾値を超過したとき, the IP レート制限 shall 失効処理を試行せずに HTTP 429 Too Many Requests を返す
+4. While 同一クライアント IP からのリクエスト数が閾値以内であるとき, the IP レート制限 shall token 交換・refresh・revoke の各要求を後続処理へ通常どおり通過させる
+5. When 閾値超過により拒否したとき, the IP レート制限 shall 再試行可能になるまでの待機時間をレスポンスヘッダーで通知する
+6. When 異なるクライアント IP から native auth エンドポイントへリクエストが到達したとき, the IP レート制限 shall 各 IP のリクエスト数を独立にカウントする
+
+### Requirement 2: 既存挙動の後方互換
+
+**Objective:** As a 既存利用者・運用者, I want 既存エンドポイントのレート制限挙動と
+エラー応答契約が変わらないでほしい, so that 本変更を既存環境へ無調整で導入できる
+
+#### Acceptance Criteria
+
+1. The システム shall 既存未認証エンドポイント（Google ログイン入口・コールバック・ヘルスチェック）への IP 単位レート制限の適用範囲・閾値を本変更導入前と同一に維持する
+2. The システム shall 認証済みエンドポイントの userID 単位レート制限挙動を本変更導入前と同一に維持する
+3. The IP レート制限 shall native auth エンドポイントでの閾値超過応答を既存未認証エンドポイントの閾値超過応答と同一形式とする
+4. While native auth 機能が無効な環境（native auth エンドポイントが公開されない環境）であるとき, the システム shall 本変更導入前と同一の挙動を維持する
+
+## Non-Functional Requirements
+
+### NFR 1: 可観測性
+
+1. When native auth エンドポイントで IP 単位レート制限による拒否が発生したとき, the IP レート制限 shall 拒否事象を運用ログとして記録する
+2. The IP レート制限 shall 拒否ログに token・セッション情報・個人を特定しうる情報を含めない
+
+### NFR 2: 互換性・運用
+
+1. While IP 単位レート制限の設定値が未指定であるとき, the システム shall 設定追加なしに native auth エンドポイントへの制限を既定値で有効化する
+2. The システム shall 既存ルートに適用されているミドルウェアの種類・順序を変更しない
+
+### NFR 3: テスト容易性
+
+1. The レート制限テスト shall token 交換・refresh・revoke の各エンドポイントについて、閾値以内の通過と閾値超過の拒否を外部ネットワーク依存なしで検証可能にする
+
+## Out of Scope
+
+- グローバル rate limit 設計の置き換え・制限方式（IP 判定・資源管理・閾値設定機構）の再設計（#38 で要件化済み）
+- 認証済み既存 API（`/api/*` の userID 単位制限）のレート制限変更
+- push notification 等、v1 スコープ外エンドポイントの保護
+- 分散環境で複数インスタンス間にレート制限状態を共有する外部ストアの導入
+- Bearer middleware（#169）/ contract tests 全体整備（#172）
+
+## Open Questions
+
+- `/api/auth/revoke` の包含: Issue 仮案（Bearer 認証下想定で対象外）に対し、#168 で
+  「未認証 + token 所持 = 権限」の境界が確定したため対象に含める（Introduction 参照）。
+  revoke は破壊操作のみで token 奪取には使えないが、未認証で永続化層の参照を伴うため、
+  資源保護として他 2 エンドポイントと同一の制限を適用する
+
+## 関連
+
+- Parent: #163
+- Depends on: #166 #167 #168
+- Related: #38
+- Sibling: #164 #165 #169 #170 #172

--- a/docs/specs/171-native-auth-ip-ratelimit/tasks.md
+++ b/docs/specs/171-native-auth-ip-ratelimit/tasks.md
@@ -1,0 +1,32 @@
+# Implementation Plan
+
+- [ ] 1. router: native auth 3 ルートへ unauthIPMW を適用しレート制限テストを追加
+  - `internal/handler/router.go`: `NativeAuthHandler != nil` ガード内の
+    `POST /api/auth/token` / `POST /api/auth/refresh` / `POST /api/auth/revoke` の
+    route 単位チェーン最外（MaxBodyBytes より外側）に既存 `unauthIPMW` を追加する
+    （design.md「Components and Interfaces > router」のとおり。`IPRateLimiter` 本体・
+    `RouterDeps`・app.go・config は変更しない）
+  - `internal/handler/router_test.go` に design.md Testing Strategy 1〜5 を追加
+    （超過 429 + Retry-After + モック service 未呼び出し × 3 ルート / 閾値以内の通常応答 /
+    IP 独立カウント / 429 応答が既存未認証ルートと同一形式）
+  - 拒否ログ（NFR 1.1, 1.2）は既存 `IPRateLimiter` の共用で充足（実装変更なし）
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 2.3, NFR 1.1, NFR 1.2, NFR 3.1_
+
+- [ ] 2. 縮退・後方互換の regression テスト
+  - `internal/handler/router_test.go` に design.md Testing Strategy 6 を追加
+    （`NativeAuthHandler` nil で 3 ルートが 404 のまま = 本変更 no-op /
+    `UnauthIPRateLimiter` nil で 3 ルートが制限なしで到達する縮退規約）
+  - 既存テスト（既存未認証 3 ルートの IP 制限・認証必須グループ・middleware）が無変更で
+    green であることを確認（design.md Testing Strategy 7〜8。既存テストの書き換えは行わない）
+  - _Requirements: 2.1, 2.2, 2.4, NFR 2.1, NFR 2.2_
+  - _Depends: 1_
+
+## Verify
+
+本 spec の実装後、watcher（stage-a-verify gate）が再実行すべき verify コマンドを以下の
+構造化ブロックで宣言する。
+
+<!-- stage-a-verify -->
+```sh
+go build ./... && go vet ./... && go test ./...
+```


### PR DESCRIPTION
## 概要

Issue #171（native auth endpoint に未認証 IP rate limit を適用する）の設計 PR です。`docs/specs/171-native-auth-ip-ratelimit/` に requirements.md（EARS）/ design.md / tasks.md を追加します。実装は本 PR マージ後に別 PR で行います。

## 設計の要点

- **既存パターンの完全再利用**: #38 導入済みの `unauthIPMW`（`IPRateLimiter`）を `POST /api/auth/token` / `POST /api/auth/refresh` / `POST /api/auth/revoke` の 3 ルートへ適用するのみ。変更は router.go の route 単位 `With` 追加（Logging の内側・MaxBodyBytes の外側）に閉じる
- **制限値は共用（分離しない）**: 既存インスタンスと `RATE_LIMIT_UNAUTH_IP`（既定 30 req/min/IP）をそのまま共用。正常トラフィック（token 交換 ≈ ログイン毎 / refresh ≈ 15 分毎 / revoke ≈ ログアウト毎）に十分な余裕があり、secret は 256bit 乱数で制限は多層防御 + 資源保護の位置づけのため、専用ノブ・第 2 インスタンスの新設は複雑化に見合わないと判断（design.md「制限値の設計判断」に比較表で記録）
- **revoke も対象に含める**: Issue 仮案は「Bearer 想定で対象外」でしたが、#168 で「未認証 + token 所持 = 権限」境界が確定し revoke は未認証グループに登録されるため、3 ルートすべてを保護対象としました（requirements.md Introduction / Open Questions に経緯を明記）
- **後方互換 / no-op**: 既存 /auth/google/* / /health の適用・閾値・429 応答形式（`writeRateLimitResponse`: Retry-After + 固定 JSON）は不変。`NativeAuthHandler` nil（署名鍵未設定）環境ではルート自体が未登録のため本変更は no-op
- **タスク分割**: 2 タスク（router 適用 + レート制限テスト → 縮退・後方互換 regression）

## 確認事項（レビュワー判断ポイント）

- **バケット共有の性質**: 同一 IP が native auth へ大量リクエストすると、その IP の /auth/google/* / /health も同じ IP バケットで 429 になります（逆も同様）。「同一攻撃元を全未認証入口で一括制限する」安全側の性質として許容する設計です（既存 3 ルート間で既に成立している挙動と同種。design.md「共用に伴う既知の性質」参照）
- **revoke の包含**: Issue 仮案からの変更点です。#168 の確定済み境界判断への追従として妥当かご確認ください
- **実装の前提**: 本 spec の実装は #166〜#168 の実装 PR マージ後に着手します（現時点で 3 ルートは未実装。design.md「前提」節）

## Mechanical Checks（design-review-gate）

- [x] Requirements traceability: 全 15 ID（1.1〜1.6 / 2.1〜2.4 / NFR 1.1〜3.1）が design.md で参照済み
- [x] File Structure Plan 具体化（プレースホルダなし）/ orphan component なし
- [x] Budget overflow check: 最上位タスク 2 件（≤10）
- [x] checkbox enforcement / verify block well-formed

## 関連

- Parent: #163
- Depends on: #166 #167 #168（いずれも設計 merge 済み・実装は別 PR）
- Related: #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)
