### PR TITLE
feat(#167): POST /api/auth/refresh で refresh token をローテーションする

### DIFF
--- a/docs/specs/167-auth-refresh-rotation/impl-notes.md
+++ b/docs/specs/167-auth-refresh-rotation/impl-notes.md
@@ -1,0 +1,149 @@
+# 実装ノート: Issue #167 POST /api/auth/refresh（rotation 付き再発行）
+
+## 実装サマリ
+
+Issue #167 の `POST /api/auth/refresh` を、design.md / tasks.md の指針に厳密に従って実装した。
+有効な refresh token を rotation（旧 token の使用不可化 + 同一 family での新 token 発行）し、
+新しい access token（HS256 JWT / 15 分）と refresh token（256bit / hash 保存 / スライディング
+30 日）を #166 と同形の JSON で返すエンドポイントを、認証不要グループに追加した。
+
+設計の主要ポイントは原文どおり踏襲している:
+
+- 拒否は単一 sentinel `auth.ErrInvalidRefreshToken` に正規化し、handler は単一の
+  401 `INVALID_REFRESH_TOKEN` を返す（Req 2.6 の uniform 拒否 / SERVER.md §1.3）
+- rotation の正本ゲートは `MarkRotated` の atomic UPDATE（`WHERE rotated_at IS NULL`、
+  #164 設計）。事前の状態検証（RevokedAt / ExpiresAt / RotatedAt）は応答高速化のための
+  事前判定で、並行 rotation の高々 1 件成功は手順 3 が保証する（Req 3.1）
+- 新 token は同一 `FamilyID`・`ExpiresAt = now + RefreshTokenTTL`（30 日スライディング、
+  Req 1.3 / 1.4）。乱数生成・hash は #166 の `generateRefreshToken` / `HashNativeSecret` を共用
+- `NATIVE_AUTH_JWT_SECRET` 未設定環境では `NativeAuthHandler` が nil となり token / refresh
+  両ルートとも未登録（404 / fail-closed、NFR 2.2。#166 の縮退に同乗、追加の縮退制御なし）
+- 平文 refresh token は応答 JSON のみ。ログは hash 先頭 8 文字（NFR 1.2 / 1.3）
+
+## タスクとコミット対応表
+
+| Task | 内容 | 実装コミット | 進捗 commit |
+|---|---|---|---|
+| 1 | auth: TokenService.RotateRefreshToken を追加 | f67aeee `feat(auth)` | b8cd562 `docs(tasks): mark 1` |
+| 2 | handler: Refresh エンドポイントと router 登録 | 77d3342 `feat(handler)` | 9d5df17 `docs(tasks): mark 2` |
+| 3 | 統合テスト: token 交換 → refresh → 旧 token 拒否 | 4d908b2 `test(handler)` | 977af9e `docs(tasks): mark 3` |
+
+実装順序は tasks.md の番号順そのままで、`_Depends:_` の制約（task 2 → 1、task 3 → 2）は
+自然に満たされた。
+
+## 受入基準と担保テスト
+
+### Requirement 1: Rotation 付き再発行の成功パス
+
+| AC ID | 担保テスト |
+|---|---|
+| 1.1 (新 4 値 JSON 返却) | `handler.TestNativeAuthHandler_Refresh_Success` / `handler.TestIntegration_RefreshFlow_TokenExchangeRefreshSucceedsThenOldTokenRejected` |
+| 1.2 (旧 token rotation 確定・以後使用不可) | `auth.TestRotateRefreshToken_Success`（MarkRotated が旧 ID で呼ばれる）/ 統合テスト（旧 token 再 refresh → 401） |
+| 1.3 (hash 保存 / 同一 rotation family) | `auth.TestRotateRefreshToken_Success`（TokenHash = HashNativeSecret(新平文) / FamilyID・UserID 同一） |
+| 1.4 (スライディング 30 日) | `auth.TestRotateRefreshToken_Success`（ExpiresAt ≈ now + 30d） |
+| 1.5 (Cookie / Bearer なしで呼び出し可能) | `handler.TestNewRouter_NativeAuthRefresh_DoesNotRequireSession` |
+| 1.6 (token 交換と同一フィールド名) | `handler.TestNativeAuthHandler_Refresh_Success`（access_token / refresh_token / token_type / expires_in 検証） |
+
+### Requirement 2: 再発行の拒否パス
+
+| AC ID | 担保テスト |
+|---|---|
+| 2.1 (token 不明を拒否) | `auth.TestRotateRefreshToken_NotFound` / `handler.TestIntegration_RefreshFlow_UnknownRefreshTokenReturns401` |
+| 2.2 (期限切れを拒否) | `auth.TestRotateRefreshToken_Expired` |
+| 2.3 (失効済みを拒否) | `auth.TestRotateRefreshToken_Revoked` |
+| 2.4 (rotation 済みを拒否) | `auth.TestRotateRefreshToken_AlreadyRotated` / 統合テスト（旧 token 再 refresh → 401） |
+| 2.5 (不正 JSON / 必須欠落を拒否) | `handler.TestNativeAuthHandler_Refresh_InvalidJSON` / `_MissingField` |
+| 2.6 (拒否応答 uniform 化) | `handler.TestNativeAuthHandler_Refresh_InvalidRefreshToken`（sentinel と wrap の両方で同一 401 / 詳細反射なし）+ service 全拒否パスの sentinel 正規化検証 |
+| 2.7 (拒否時に新 token 永続化・状態変更なし) | `auth.TestRotateRefreshToken_NotFound` / `_Expired` / `_Revoked` / `_AlreadyRotated` / `_MarkRotatedRaceLoser`（いずれも CreateToken 0 回） |
+
+### Requirement 3: 並行 rotation の安全性
+
+| AC ID | 担保テスト |
+|---|---|
+| 3.1 (高々 1 件のみ成功) | `auth.TestRotateRefreshToken_MarkRotatedRaceLoser`（MarkRotated が ErrRefreshTokenAlreadyRotated を返す race 敗者 → ErrInvalidRefreshToken / CreateToken 0 回） |
+
+### Non-Functional Requirements
+
+| NFR | 担保テスト・実装 |
+|---|---|
+| NFR 1.1 (256bit エントロピー) | #166 の `generateRefreshToken`（crypto/rand 32 byte → base64url）を共用。`auth.TestRotateRefreshToken_Success` で TokenHash 長 64 文字を検証 |
+| NFR 1.2 (平文を永続化・ログに残さない) | `auth.TestRotateRefreshToken_Success`（保存 TokenHash != 平文）/ `_DoesNotLeakPlainSecretsInError`。slog は hash 先頭 8 文字のみ |
+| NFR 1.3 (エラー応答に入力値・内部詳細を反射しない) | `handler.TestNativeAuthHandler_Refresh_InternalError`（内部エラー文字列がメッセージに含まれない）/ `auth.TestRotateRefreshToken_DoesNotLeakPlainSecretsInError` |
+| NFR 2.1 (既存ルートの挙動不変) | 全既存テスト green（`go test ./...` 全パッケージ pass）。既存 `createIntegrationRouter` / 既存ルート登録は不変 |
+| NFR 2.2 (署名鍵未設定で refresh も非公開) | `handler.TestNewRouter_NativeAuthRefresh_NotRegisteredWhenHandlerNil`（404） |
+| NFR 3.1 (外部ネットワーク依存なし) | service 9 ケース / handler 6 ケース / router 3 ケース / 統合 2 ケースすべて mock 駆動で DB / net 不要 |
+
+## 検証結果
+
+- `go build ./...`: 成功
+- `go vet ./...`: 警告なし
+- `go test ./...`: 全パッケージ pass（2026-06-12 引き継ぎセッションで再確認済み）
+- `gofmt -l <変更ファイル群>`: 出力なし（フォーマット差分なし）
+
+DB 結合テスト（`internal/repository/*_db_test.go`）は `TEST_DATABASE_URL` 未設定時に skip
+する既存設計（CI では postgres サービス上で実行される）。本 spec は repository 層に変更を
+加えていない。
+
+## design からの逸脱
+
+無し。design.md の以下は **完全にそのまま** 実装した。
+
+- Rotation フロー手順 1〜7（JSON decode → FindByHash → 状態検証 → MarkRotated →
+  新 token 発行 → JWT 発行 → 応答）
+- Error Handling 表（400 INVALID_REQUEST / 401 INVALID_REFRESH_TOKEN / 500 INTERNAL_ERROR）
+- File Structure Plan に列挙された全ファイル（追加 / 変更ともに同一パス・同一責務。
+  新規ファイルなし・migration なし・wiring 変更なし）
+- `RefreshTokenStore` の `FindByHash` / `MarkRotated` 拡張（`repository.RefreshTokenRepository`
+  が引き続き構造的に充足することを既存の compile-time check で確認）
+- Testing Strategy 1〜10 の全ケース
+
+## 実装上の判断
+
+### `DisallowUnknownFields` の採用（#166 と同一判断）
+
+`Refresh` handler も #166 の `Token` handler と同じく `json.Decoder.DisallowUnknownFields()`
+で未知フィールドを拒否する。device_label 等の任意メタデータが Out of Scope（requirements.md）
+に明記されているため、フォーマット契約を厳密に保つ。`handler.TestNativeAuthHandler_Refresh_
+UnknownFieldRejected` で担保。エンドポイント間で JSON 受理規則が揃う。
+
+### FindByHash のインフラエラーは 401 に正規化しない
+
+`FindByHash` がインフラ起因のエラーを返した場合は `ErrInvalidRefreshToken` に正規化せず
+`%w` で wrap して 500 に振り分ける（token の有効性を判定できていないため、401 で「無効」と
+断定しない）。`auth.TestRotateRefreshToken_LookupErrorPropagates` で担保。design.md の
+Error Handling 表「上記以外 → 500」に従った分類。
+
+### 部分失敗（rotation 確定後の発行失敗）
+
+`MarkRotated` 成功後に新 token 生成・永続化・JWT 発行が失敗した場合、旧 token は消費済みの
+まま 500 を返す（クライアントは再ログイン）。requirements.md Open Questions の「安全側に
+倒して燃やす」方針どおり rollback は導入していない。`auth.TestRotateRefreshToken_
+CreateTokenFailure` で「ErrInvalidRefreshToken ではないこと」を担保。
+
+## 追加した依存
+
+無し（#166 までの依存で完結。go.mod / go.sum 変更なし）。
+
+## 後続 Issue への引き継ぎ事項
+
+- **Issue #168 (再利用検知 + revoke)**: 本 spec の拒否分岐のうち以下の 2 箇所が #168 で
+  「family 全体失効（RevokeFamily）+ 同一 401」へ昇格する拡張点（design.md Security
+  Considerations で局所化済み）:
+  1. `RotateRefreshToken` 手順 2 の `stored.RotatedAt != nil` 分岐（rotation 済み token の再利用検知）
+  2. 手順 3 の `ErrRefreshTokenAlreadyRotated` 分岐（並行 race 敗者 = 同時再利用）
+  また `RefreshTokenStore` IF は `FindByHash` / `MarkRotated` まで公開済み。#168 で
+  `RevokeFamily` の公開拡張が必要。
+- **Issue #169 (Bearer middleware)**: 本 spec で発行される access token の検証側。変更なし。
+- **Issue #171 (IP レート制限)**: `POST /api/auth/refresh` も `/api/auth/token` と同じく
+  IP 単位レート制限を経由しない。`router.go` の登録部位に `unauthIPMW` を重ねる追加変更が
+  想定される（router.go のコメントに #171 の領分である旨を明記済み）。
+
+## 確認事項（PR 本文転載用）
+
+- 設計矛盾は無し。
+- `Refresh` handler は #166 と同じく `DisallowUnknownFields` を採用（design.md /
+  requirements.md には明示されていない判断だが、#166 実装判断との整合を優先）。
+- `FindByHash` インフラエラーの 500 分類（401 に正規化しない）は design.md Error Handling
+  表の解釈として実装した判断。
+
+STATUS: complete

--- a/docs/specs/167-auth-refresh-rotation/review-notes.md
+++ b/docs/specs/167-auth-refresh-rotation/review-notes.md
@@ -1,0 +1,124 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-12T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: `claude/issue-167-impl-auth-refresh-rotation`
+- HEAD commit: `5ff825c417a30ec92eea48d3f6c3011af6c1fcb8`
+- Compared to: `merge-base(develop, HEAD)..HEAD`
+- 変更ファイル数: 9（spec 2 / 実装 2 / テスト 4 / router 1）
+- 変更行数: +1429 / -17
+
+### CLAUDE.md / Feature Flag Protocol 確認
+
+- `feedman/CLAUDE.md` の `## Feature Flag Protocol` の `**採否**: opt-out`。
+  opt-in 細目（旧パス削除 / `if (flag)` 分岐 / flag-off 不変 / 命名規約）は
+  **適用しない**。通常の 3 カテゴリ判定のみで評価した。
+
+## Verified Requirements
+
+### Requirement 1（rotation 付き再発行の成功パス）
+
+- **1.1** — `internal/handler/native_auth_handler.go:Refresh` が `tokenResponse`
+  で `access_token` / `refresh_token` / `token_type: "Bearer"` / `expires_in` (900) を
+  返却。`internal/handler/native_auth_handler_test.go:TestNativeAuthHandler_Refresh_Success`
+  および統合テスト `TestIntegration_RefreshFlow_TokenExchangeRefreshSucceedsThenOldTokenRejected`
+  で 4 フィールド検証。
+- **1.2** — `internal/auth/token_service.go:RotateRefreshToken` 手順 3 で
+  `MarkRotated(stored.ID, now)`。
+  `TestRotateRefreshToken_Success`（`lastMarkID == stored.ID`）/ 統合テスト（旧 token
+  再 refresh で 401）で担保。
+- **1.3** — 新 token の `FamilyID: stored.FamilyID` / `TokenHash: refreshHash`、
+  `CreateFamily` 未呼び出し。`TestRotateRefreshToken_Success` が同一 family / hash 一致 /
+  平文非保存を検証。
+- **1.4** — `ExpiresAt: now.Add(RefreshTokenTTL)`（30 日）。
+  `TestRotateRefreshToken_Success` が `wantExpiresAt == now+30d` で検証。
+- **1.5** — `internal/handler/router.go` で認証不要グループ（Session/Bearer middleware
+  非適用）に登録。`TestNewRouter_NativeAuthRefresh_DoesNotRequireSession` が
+  Cookie なしで 200 を確認。
+- **1.6** — `tokenResponse` 構造体を `Token` handler と共用。
+  `TestNativeAuthHandler_Refresh_Success` が snake_case 4 フィールドを検証。
+
+### Requirement 2（再発行の拒否パス）
+
+- **2.1** — `FindByHash` nil 戻り → `ErrInvalidRefreshToken`。
+  `TestRotateRefreshToken_NotFound` / 統合テスト
+  `TestIntegration_RefreshFlow_UnknownRefreshTokenReturns401` で担保。
+- **2.2** — `!stored.ExpiresAt.After(now)`（境界値 `==` も無効として扱う）。
+  `TestRotateRefreshToken_Expired` の 2 サブテスト（`<` と `==`）で検証。
+- **2.3** — `stored.RevokedAt != nil` → `ErrInvalidRefreshToken`。
+  `TestRotateRefreshToken_Revoked` で担保。
+- **2.4** — `stored.RotatedAt != nil` → `ErrInvalidRefreshToken`（事前判定 + atomic）。
+  `TestRotateRefreshToken_AlreadyRotated` および統合テストの 2 回目 refresh で担保。
+- **2.5** — `Refresh` handler で `json.Decoder` decode 失敗 / `req.RefreshToken == ""`
+  → 400 INVALID_REQUEST。`TestNativeAuthHandler_Refresh_InvalidJSON` /
+  `_MissingField`（空文字含む 2 ケース）で担保。
+- **2.6** — 全拒否を `auth.ErrInvalidRefreshToken` sentinel に正規化、handler は
+  `errors.Is` で 401 INVALID_REFRESH_TOKEN の固定 message を返却。
+  `TestNativeAuthHandler_Refresh_InvalidRefreshToken` が sentinel + `%w` wrap 両方で
+  同一応答を検証し、`message` に "expired" / "revoked" / "rotated" / "unknown" が
+  含まれないことを assert。
+- **2.7** — 全拒否ケースのテストで `createTokenCalls == 0` を検証。race 敗者
+  ケース（`_MarkRotatedRaceLoser`）でも新 token は永続化されない。
+
+### Requirement 3（並行 rotation の安全性）
+
+- **3.1** — `MarkRotated` の atomic UPDATE（`WHERE rotated_at IS NULL` / #164 設計）を
+  正本ゲートとして利用し、`ErrRefreshTokenAlreadyRotated` を `ErrInvalidRefreshToken` に
+  正規化。`TestRotateRefreshToken_MarkRotatedRaceLoser` が
+  `markRotatedCalls == 1` + `createTokenCalls == 0` で「race 敗者 = 高々 1 件のみ成功」を担保。
+
+### Non-Functional Requirements
+
+- **NFR 1.1** — `generateRefreshToken`（#166 既存、`crypto/rand` 32 byte = 256 bit）を
+  共用。`TestRotateRefreshToken_Success` が TokenHash 64 文字（SHA-256 hex）であることを
+  間接的に検証。
+- **NFR 1.2** — 永続化は `HashNativeSecret(plain)` のみ、平文はレスポンス JSON のみ。
+  ログは hash 先頭 8 文字（`slog.Info("refresh token rotation succeeded", ...,
+  slog.String("old_refresh_token_hash", tokenHash[:8]), ...)`）。
+  `TestRotateRefreshToken_Success`（`TokenHash != plain`）/
+  `_DoesNotLeakPlainSecretsInError` で担保。
+- **NFR 1.3** — エラー応答は固定 `APIError` メッセージで、内部エラー文字列を反射しない。
+  `TestNativeAuthHandler_Refresh_InternalError` が `"db connection refused"` が response
+  body に含まれないことを assert。
+- **NFR 2.1** — handler / service / router の追加のみ、既存ルートとロジック不変。
+  `go test ./internal/auth/... ./internal/handler/...` を実行し全パッケージ pass を
+  確認した（cached 含む）。
+- **NFR 2.2** — `router.go` の `if deps.NativeAuthHandler != nil` ガード内に
+  `POST /api/auth/refresh` を登録。`TestNewRouter_NativeAuthRefresh_NotRegisteredWhenHandlerNil`
+  が nil 時 404 を担保。
+- **NFR 3.1** — service / handler / router / 統合の全テストが mock 駆動で外部
+  ネットワーク・DB を必要としない（`testing` パッケージのみ）。
+
+### Boundary 確認
+
+design.md File Structure Plan で列挙された 6 ファイル
+（`internal/auth/token_service.go` / `_test.go`、`internal/handler/native_auth_handler.go` /
+`_test.go`、`internal/handler/router.go` / `_test.go`、`internal/handler/integration_test.go`）
++ spec 内 2 ファイル（`tasks.md` / `impl-notes.md`）のみが変更されており、
+File Structure Plan の境界に完全に合致する。
+
+- handler 層に SQL / 認可ロジックは含まれない（service 層に集約）。CLAUDE.md
+  「アーキテクチャと機能追加ガイド §1 レイヤリング」遵守。
+- repository 層は変更なし（#164 / #166 の既存 IF を構造的に拡張するのみ）。
+- `internal/repository/` / `internal/middleware/` / `internal/model/` /
+  `internal/security/` / migration 等への波及なし。
+- 既存ファイル `integration_test.go` への変更は #167 範囲（rotation 通し）に
+  限定されており、既存 `mockNativeTokenExchangeService` の `ExchangeAuthCode` 動作は
+  refresh token 平文の活性化を追加するのみで、token 交換側の AC（Issue #166）に
+  影響を与えない（既存テスト全 pass）。
+
+## Findings
+
+なし（approve）。
+
+## Summary
+
+Issue #167 の AC（Req 1.1〜1.6, 2.1〜2.7, 3.1, NFR 1.1〜1.3 / 2.1〜2.2 / 3.1）すべてに
+対応する実装と単体・統合テストが揃っており、design.md File Structure Plan の境界内に
+収まっている。`go test ./internal/auth/... ./internal/handler/...` も pass。CLAUDE.md
+「Feature Flag Protocol」は opt-out のため flag 細目は適用しない。3 カテゴリ
+（AC 未カバー / missing test / boundary 逸脱）いずれにも該当する findings なし。
+
+RESULT: approve

--- a/docs/specs/167-auth-refresh-rotation/tasks.md
+++ b/docs/specs/167-auth-refresh-rotation/tasks.md
@@ -13,7 +13,7 @@
     （既存 #166 ケースは変更しない。モックの interface 拡張追従は可）
   - _Requirements: 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 2.6, 2.7, 3.1, NFR 1.1, NFR 1.2, NFR 3.1_
 
-- [ ] 2. handler: Refresh エンドポイントと router 登録
+- [x] 2. handler: Refresh エンドポイントと router 登録
   - `internal/handler/native_auth_handler.go`: `TokenExchangeService` interface に
     `RotateRefreshToken` を追加し、`Refresh` handler を実装（200 / 400 INVALID_REQUEST /
     401 INVALID_REFRESH_TOKEN / 500 を `middleware.WriteErrorResponse` で応答。

--- a/docs/specs/167-auth-refresh-rotation/tasks.md
+++ b/docs/specs/167-auth-refresh-rotation/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. auth: TokenService.RotateRefreshToken を追加
+- [x] 1. auth: TokenService.RotateRefreshToken を追加
   - `internal/auth/token_service.go` に `ErrInvalidRefreshToken` sentinel を追加し、
     `RefreshTokenStore` interface を `FindByHash` / `MarkRotated` まで拡張
     （`repository.RefreshTokenRepository` が引き続き構造的に充足することを compile-time

--- a/docs/specs/167-auth-refresh-rotation/tasks.md
+++ b/docs/specs/167-auth-refresh-rotation/tasks.md
@@ -25,7 +25,7 @@
   - _Requirements: 1.1, 1.5, 1.6, 2.5, 2.6, NFR 1.3, NFR 2.1, NFR 2.2_
   - _Depends: 1_
 
-- [ ] 3. 統合テスト: token 交換 → refresh → 旧 token 拒否
+- [x] 3. 統合テスト: token 交換 → refresh → 旧 token 拒否
   - `internal/handler/integration_test.go` に「token 交換で pair 取得 → refresh 成功で
     新 pair 取得 → 旧 refresh token による再 refresh が 401」の通しケースを追加
     （issue AC「old token after rotation」に対応）

--- a/internal/auth/token_service.go
+++ b/internal/auth/token_service.go
@@ -22,6 +22,18 @@ import (
 // 添えてもよいが、その内部理由は **クライアントへ反射しないこと**（NFR 1.5）。
 var ErrInvalidGrant = errors.New("invalid grant")
 
+// ErrInvalidRefreshToken は refresh token の不明・期限切れ・失効済み・rotation 済みを
+// 区別せず表す sentinel error（Req 2.6: 拒否応答 uniform 化 / SERVER.md §1.3 の
+// 401 INVALID_REFRESH_TOKEN 契約）。
+//
+// handler 層は errors.Is(err, auth.ErrInvalidRefreshToken) で 401 INVALID_REFRESH_TOKEN
+// への振り分けを行う。本 sentinel をそのまま返さず %w で wrap して具体的な内部理由を
+// 添えてもよいが、その内部理由は **クライアントへ反射しないこと**（NFR 1.3）。
+//
+// token 交換側の ErrInvalidGrant（400 INVALID_GRANT）とは status code / error code が
+// 異なるため、混同しないこと。
+var ErrInvalidRefreshToken = errors.New("invalid refresh token")
+
 // RefreshTokenTTL は POST /api/auth/token で発行する refresh token の有効期間。
 // SERVER.md §1.4（30 日）に従う（Req 1.3 / design.md Data Models）。
 const RefreshTokenTTL = 30 * 24 * time.Hour
@@ -40,11 +52,22 @@ type AuthCodeConsumer interface {
 	MarkUsed(ctx context.Context, id string) error
 }
 
-// RefreshTokenStore は TokenService が refresh token の新規発行に必要とする最小 IF。
-// repository.RefreshTokenRepository が構造的に充足する。
+// RefreshTokenStore は TokenService が refresh token の新規発行 / rotation 操作に
+// 必要とする最小 IF。repository.RefreshTokenRepository が構造的に充足する
+// （interface segregation）。
+//
+// FindByHash / MarkRotated は Issue #167 の rotation で追加された。token 交換
+// （ExchangeAuthCode）では CreateFamily / CreateToken のみが使用され、refresh
+// （RotateRefreshToken）では FindByHash / MarkRotated / CreateToken が使用される。
 type RefreshTokenStore interface {
 	CreateFamily(ctx context.Context, family *model.RefreshTokenFamily) error
 	CreateToken(ctx context.Context, token *model.RefreshToken) error
+	// FindByHash は token_hash に一致する refresh_token を 1 件返す。
+	// 見つからない場合は (nil, nil) を返す。
+	FindByHash(ctx context.Context, tokenHash string) (*model.RefreshToken, error)
+	// MarkRotated は当該 ID の refresh_token の rotated_at を set する。
+	// 既に rotated_at が set 済みの場合は repository.ErrRefreshTokenAlreadyRotated を返す。
+	MarkRotated(ctx context.Context, id string, rotatedAt time.Time) error
 }
 
 // AccessTokenIssuer は TokenService が access token (JWT) の発行に必要とする最小 IF。
@@ -164,6 +187,101 @@ func (s *TokenService) ExchangeAuthCode(ctx context.Context, authCode, codeVerif
 		slog.String("user_id", stored.UserID),
 		slog.String("auth_code_hash", codeHash[:8]),
 		slog.String("refresh_token_hash", refreshHash[:8]),
+	)
+
+	return &TokenPair{
+		AccessToken:  accessToken,
+		RefreshToken: plainRefresh,
+		ExpiresIn:    int(AccessTokenTTL / time.Second),
+	}, nil
+}
+
+// RotateRefreshToken は refresh token の rotation 付き再発行を行う（Issue #167）。
+//
+// 手順（design.md「Rotation フロー（正常系）」参照）:
+//  1. HashNativeSecret(refreshToken) → RefreshTokenStore.FindByHash で検索
+//     - nil → ErrInvalidRefreshToken（Req 2.1）
+//  2. 状態検証（いずれかに該当なら ErrInvalidRefreshToken）
+//     - RevokedAt != nil（失効済み / Req 2.3）
+//     - ExpiresAt <= now（期限切れ / Req 2.2）
+//     - RotatedAt != nil（rotation 済み = 再利用 / Req 2.4）
+//  3. MarkRotated(id, now) で rotation 確定（Req 1.2）
+//     - ErrRefreshTokenAlreadyRotated → ErrInvalidRefreshToken（並行 race の敗者 / Req 3.1）
+//     ※ UPDATE ... WHERE rotated_at IS NULL の atomic 判定により高々 1 件のみ成功
+//  4. 新 refresh token（crypto/rand 32 byte）を同一 FamilyID で hash 保存
+//     ExpiresAt = now + RefreshTokenTTL（スライディング 30 日 / Req 1.3, 1.4）
+//  5. JWTIssuer.IssueAccessToken で新 access token を発行
+//
+// 拒否はすべて ErrInvalidRefreshToken に正規化される（Req 2.6: 拒否応答 uniform 化）。
+// 平文 refresh token は応答 JSON にのみ含まれ、ログ・エラーメッセージには残さない
+// （NFR 1.2 / 1.3）。
+func (s *TokenService) RotateRefreshToken(ctx context.Context, refreshToken string) (*TokenPair, error) {
+	// 1. token_hash で旧 token を検索
+	tokenHash := HashNativeSecret(refreshToken)
+	stored, err := s.refreshTokens.FindByHash(ctx, tokenHash)
+	if err != nil {
+		return nil, fmt.Errorf("refresh rotation: lookup refresh token: %w", err)
+	}
+	if stored == nil {
+		// token 不明（Req 2.1）
+		return nil, ErrInvalidRefreshToken
+	}
+
+	// 2. 状態検証（手順 3 の MarkRotated が atomic ゲートだが、応答高速化のため事前判定）
+	now := s.now()
+	if stored.RevokedAt != nil {
+		// 失効済み（family 単位 revoke でも token 行に set される / Req 2.3）
+		return nil, ErrInvalidRefreshToken
+	}
+	if !stored.ExpiresAt.After(now) {
+		// 期限切れ（Req 2.2）
+		return nil, ErrInvalidRefreshToken
+	}
+	if stored.RotatedAt != nil {
+		// 既に rotation 済み = 再利用（Req 2.4。#168 が family 失効へ昇格するまでは単純拒否）
+		return nil, ErrInvalidRefreshToken
+	}
+
+	// 3. rotation 確定（atomic UPDATE / Req 1.2 / 3.1）
+	// WHERE rotated_at IS NULL の判定により並行 rotation でも高々 1 件のみ成功する。
+	if err := s.refreshTokens.MarkRotated(ctx, stored.ID, now); err != nil {
+		if errors.Is(err, repository.ErrRefreshTokenAlreadyRotated) {
+			// race の敗者は ErrInvalidRefreshToken に正規化（Req 2.6 / 3.1）。
+			// Req 2.7: 新 token は永続化されない（手順 4 に進まない）。
+			return nil, ErrInvalidRefreshToken
+		}
+		return nil, fmt.Errorf("refresh rotation: mark rotated: %w", err)
+	}
+
+	// 4. 新 refresh token を発行（同一 FamilyID / スライディング 30 日 TTL / Req 1.3, 1.4）
+	plainRefresh, refreshHash, err := generateRefreshToken()
+	if err != nil {
+		// 旧 token は手順 3 で消費済み（Open Questions: 安全側に倒して燃やす）
+		return nil, fmt.Errorf("refresh rotation: generate refresh token: %w", err)
+	}
+	newToken := &model.RefreshToken{
+		ID:        uuid.New().String(),
+		FamilyID:  stored.FamilyID, // 同一 family（Req 1.3）
+		UserID:    stored.UserID,
+		TokenHash: refreshHash,
+		ExpiresAt: now.Add(RefreshTokenTTL), // スライディング 30 日（Req 1.4）
+	}
+	if err := s.refreshTokens.CreateToken(ctx, newToken); err != nil {
+		return nil, fmt.Errorf("refresh rotation: create new refresh token: %w", err)
+	}
+
+	// 5. 新 access token を発行（JWT / 15 分）
+	accessToken, err := s.issuer.IssueAccessToken(stored.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("refresh rotation: issue access token: %w", err)
+	}
+
+	// 機密値の追跡用に hash 先頭 8 文字のみログに残す（NFR 1.2）。
+	slog.Info("refresh token rotation succeeded",
+		slog.String("user_id", stored.UserID),
+		slog.String("family_id", stored.FamilyID),
+		slog.String("old_refresh_token_hash", tokenHash[:8]),
+		slog.String("new_refresh_token_hash", refreshHash[:8]),
 	)
 
 	return &TokenPair{

--- a/internal/auth/token_service_test.go
+++ b/internal/auth/token_service_test.go
@@ -45,15 +45,22 @@ func (m *mockAuthCodes) MarkUsed(ctx context.Context, id string) error {
 
 // mockRefreshTokens は RefreshTokenStore 最小 IF の record-and-return モック。
 // 永続化された family / token を捕捉して、テストで TokenHash / FamilyID / ExpiresAt
-// の整合を検証する。
+// の整合を検証する。FindByHash / MarkRotated は Issue #167 の rotation で追加された。
 type mockRefreshTokens struct {
 	createFamilyFn func(ctx context.Context, f *model.RefreshTokenFamily) error
 	createTokenFn  func(ctx context.Context, t *model.RefreshToken) error
+	findByHashFn   func(ctx context.Context, tokenHash string) (*model.RefreshToken, error)
+	markRotatedFn  func(ctx context.Context, id string, rotatedAt time.Time) error
 
 	createFamilyCalls int
 	createTokenCalls  int
+	findByHashCalls   int
+	markRotatedCalls  int
 	storedFamily      *model.RefreshTokenFamily
 	storedToken       *model.RefreshToken
+	lastFindHash      string
+	lastMarkID        string
+	lastMarkAt        time.Time
 }
 
 func (m *mockRefreshTokens) CreateFamily(ctx context.Context, f *model.RefreshTokenFamily) error {
@@ -70,6 +77,25 @@ func (m *mockRefreshTokens) CreateToken(ctx context.Context, t *model.RefreshTok
 	m.storedToken = t
 	if m.createTokenFn != nil {
 		return m.createTokenFn(ctx, t)
+	}
+	return nil
+}
+
+func (m *mockRefreshTokens) FindByHash(ctx context.Context, tokenHash string) (*model.RefreshToken, error) {
+	m.findByHashCalls++
+	m.lastFindHash = tokenHash
+	if m.findByHashFn != nil {
+		return m.findByHashFn(ctx, tokenHash)
+	}
+	return nil, nil
+}
+
+func (m *mockRefreshTokens) MarkRotated(ctx context.Context, id string, rotatedAt time.Time) error {
+	m.markRotatedCalls++
+	m.lastMarkID = id
+	m.lastMarkAt = rotatedAt
+	if m.markRotatedFn != nil {
+		return m.markRotatedFn(ctx, id, rotatedAt)
 	}
 	return nil
 }
@@ -464,6 +490,442 @@ func TestExchangeAuthCode_LookupErrorPropagates(t *testing.T) {
 		t.Errorf("pair = %+v, want nil", pair)
 	}
 	if authCodes.markUsedCalls != 0 || refreshTokens.createFamilyCalls != 0 || issuer.issueCalls != 0 {
+		t.Errorf("any downstream call must not occur on lookup error")
+	}
+}
+
+// --- RotateRefreshToken のテスト（Issue #167 / design.md Testing Strategy 1〜7） ---
+
+// newStoredRefreshToken は FindByHash の戻り値として使う有効な RefreshToken の fixture を返す。
+// ExpiresAt は fixedTokenServiceIssuedAt + 7 日（30 日 TTL の中盤）で「有効」を意味する。
+// RotatedAt / RevokedAt は nil。
+func newStoredRefreshToken(userID string) *model.RefreshToken {
+	return &model.RefreshToken{
+		ID:        "refresh-token-id-1",
+		FamilyID:  "family-id-1",
+		UserID:    userID,
+		TokenHash: HashNativeSecret("plain-refresh-token"),
+		ExpiresAt: fixedTokenServiceIssuedAt.Add(7 * 24 * time.Hour),
+	}
+}
+
+// TestRotateRefreshToken_Success は rotation 成功時に以下を検証する（Testing Strategy 1 /
+// Req 1.2, 1.3, 1.4）。
+//   - TokenPair の 3 値（AccessToken / RefreshToken / ExpiresIn=900）
+//   - FindByHash が plain refresh token の hash で 1 回呼ばれる
+//   - MarkRotated が旧 token の ID と now で 1 回呼ばれる
+//   - CreateToken の FamilyID / UserID が旧 token と同一
+//   - 新 token の ExpiresAt = now + 30d（スライディング延長）
+//   - 新 token の TokenHash が新平文の hash と一致する
+func TestRotateRefreshToken_Success(t *testing.T) {
+	// Arrange
+	const userID = "user-test-1"
+	svc, _, refreshTokens, issuer := newServiceWithMocks(t)
+	stored := newStoredRefreshToken(userID)
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return stored, nil
+	}
+
+	// Act
+	pair, err := svc.RotateRefreshToken(context.Background(), "plain-refresh-token")
+
+	// Assert: 成功で 3 値が揃う（Req 1.1 / 1.6 は handler 層のテストで担保）
+	if err != nil {
+		t.Fatalf("RotateRefreshToken returned error: %v", err)
+	}
+	if pair == nil {
+		t.Fatal("returned TokenPair is nil")
+	}
+	if pair.AccessToken == "" {
+		t.Error("AccessToken is empty")
+	}
+	if pair.RefreshToken == "" {
+		t.Error("RefreshToken is empty")
+	}
+	if pair.ExpiresIn != 900 {
+		t.Errorf("ExpiresIn = %d, want 900 (Req 1.4 / AccessTokenTTL=15min)", pair.ExpiresIn)
+	}
+
+	// Assert: FindByHash が plain の hash で 1 回呼ばれる
+	wantTokenHash := HashNativeSecret("plain-refresh-token")
+	if refreshTokens.findByHashCalls != 1 {
+		t.Errorf("FindByHash calls = %d, want 1", refreshTokens.findByHashCalls)
+	}
+	if refreshTokens.lastFindHash != wantTokenHash {
+		t.Errorf("FindByHash called with hash=%q, want %q (hash 一致照合)",
+			refreshTokens.lastFindHash, wantTokenHash)
+	}
+
+	// Assert: MarkRotated が旧 token の ID と固定 now で 1 回呼ばれる（Req 1.2）
+	if refreshTokens.markRotatedCalls != 1 {
+		t.Errorf("MarkRotated calls = %d, want 1", refreshTokens.markRotatedCalls)
+	}
+	if refreshTokens.lastMarkID != stored.ID {
+		t.Errorf("MarkRotated called with id=%q, want %q", refreshTokens.lastMarkID, stored.ID)
+	}
+	if !refreshTokens.lastMarkAt.Equal(fixedTokenServiceIssuedAt) {
+		t.Errorf("MarkRotated rotatedAt = %v, want %v", refreshTokens.lastMarkAt, fixedTokenServiceIssuedAt)
+	}
+
+	// Assert: CreateFamily は呼ばれない（同一 family に new token を発行する / Req 1.3）
+	if refreshTokens.createFamilyCalls != 0 {
+		t.Errorf("CreateFamily calls = %d, want 0 (rotation は同一 family / Req 1.3)",
+			refreshTokens.createFamilyCalls)
+	}
+
+	// Assert: CreateToken が 1 回呼ばれ、FamilyID / UserID が旧 token と同一（Req 1.3）
+	if refreshTokens.createTokenCalls != 1 {
+		t.Errorf("CreateToken calls = %d, want 1", refreshTokens.createTokenCalls)
+	}
+	if refreshTokens.storedToken.FamilyID != stored.FamilyID {
+		t.Errorf("new token.FamilyID = %q, want %q (= old token.FamilyID / Req 1.3)",
+			refreshTokens.storedToken.FamilyID, stored.FamilyID)
+	}
+	if refreshTokens.storedToken.UserID != userID {
+		t.Errorf("new token.UserID = %q, want %q", refreshTokens.storedToken.UserID, userID)
+	}
+
+	// Assert: 新 token の TokenHash が新平文の hash と一致する（NFR 1.2）
+	if got := HashNativeSecret(pair.RefreshToken); got != refreshTokens.storedToken.TokenHash {
+		t.Errorf("new token.TokenHash mismatch with HashNativeSecret(plain RefreshToken)")
+	}
+	// Assert: 平文がそのまま保存されていないこと（NFR 1.2）
+	if refreshTokens.storedToken.TokenHash == pair.RefreshToken {
+		t.Error("new token.TokenHash equals plain RefreshToken (must store only hash)")
+	}
+	// Assert: 旧 token とは異なる token が生成されている（rotation の本質）
+	if pair.RefreshToken == "plain-refresh-token" {
+		t.Error("new RefreshToken equals old plain (rotation must produce a new token)")
+	}
+	if refreshTokens.storedToken.TokenHash == stored.TokenHash {
+		t.Error("new token.TokenHash equals old token.TokenHash (rotation must change hash)")
+	}
+
+	// Assert: 新 token の ExpiresAt = now + 30d（スライディング延長 / Req 1.4）
+	wantExpiresAt := fixedTokenServiceIssuedAt.Add(RefreshTokenTTL)
+	if !refreshTokens.storedToken.ExpiresAt.Equal(wantExpiresAt) {
+		t.Errorf("new token.ExpiresAt = %v, want %v (= now + 30d / Req 1.4)",
+			refreshTokens.storedToken.ExpiresAt, wantExpiresAt)
+	}
+
+	// Assert: 新 token の RotatedAt / RevokedAt は nil（新世代として有効）
+	if refreshTokens.storedToken.RotatedAt != nil {
+		t.Errorf("new token.RotatedAt = %v, want nil (新世代は未 rotate)", refreshTokens.storedToken.RotatedAt)
+	}
+	if refreshTokens.storedToken.RevokedAt != nil {
+		t.Errorf("new token.RevokedAt = %v, want nil (新世代は未 revoke)", refreshTokens.storedToken.RevokedAt)
+	}
+
+	// Assert: issuer が当該 userID で呼ばれる
+	if issuer.issueCalls != 1 {
+		t.Errorf("IssueAccessToken calls = %d, want 1", issuer.issueCalls)
+	}
+	if issuer.lastUserID != userID {
+		t.Errorf("IssueAccessToken called with userID=%q, want %q", issuer.lastUserID, userID)
+	}
+}
+
+// TestRotateRefreshToken_NotFound は FindByHash が nil を返したとき
+// ErrInvalidRefreshToken を返し、MarkRotated / CreateToken に進まないことを検証する
+// （Testing Strategy 2 / Req 2.1, 2.6, 2.7）。
+func TestRotateRefreshToken_NotFound(t *testing.T) {
+	// Arrange
+	svc, _, refreshTokens, issuer := newServiceWithMocks(t)
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return nil, nil
+	}
+
+	// Act
+	pair, err := svc.RotateRefreshToken(context.Background(), "unknown-token")
+
+	// Assert
+	if !errors.Is(err, ErrInvalidRefreshToken) {
+		t.Errorf("err = %v, want ErrInvalidRefreshToken (Req 2.1 / 2.6)", err)
+	}
+	if pair != nil {
+		t.Errorf("pair = %+v, want nil", pair)
+	}
+	if refreshTokens.markRotatedCalls != 0 {
+		t.Errorf("MarkRotated calls = %d, want 0 (token 不明は MarkRotated 未到達)",
+			refreshTokens.markRotatedCalls)
+	}
+	// Req 2.7: 拒否時に新 token を永続化しない
+	if refreshTokens.createTokenCalls != 0 {
+		t.Errorf("CreateToken calls = %d, want 0 (Req 2.7)", refreshTokens.createTokenCalls)
+	}
+	if issuer.issueCalls != 0 {
+		t.Errorf("IssueAccessToken calls = %d, want 0", issuer.issueCalls)
+	}
+}
+
+// TestRotateRefreshToken_Expired は token の ExpiresAt が now 以下のとき
+// ErrInvalidRefreshToken を返し、MarkRotated に進まないことを検証する
+// （Testing Strategy 3 / Req 2.2, 2.6, 2.7）。
+func TestRotateRefreshToken_Expired(t *testing.T) {
+	cases := []struct {
+		name      string
+		expiresAt time.Time
+	}{
+		{
+			name:      "ExpiresAt < now のとき拒否",
+			expiresAt: fixedTokenServiceIssuedAt.Add(-1 * time.Hour),
+		},
+		{
+			name:      "ExpiresAt == now のとき拒否（境界値: After(now) でなければ無効）",
+			expiresAt: fixedTokenServiceIssuedAt,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			svc, _, refreshTokens, issuer := newServiceWithMocks(t)
+			stored := newStoredRefreshToken("user-test-1")
+			stored.ExpiresAt = tc.expiresAt
+			refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+				return stored, nil
+			}
+
+			// Act
+			pair, err := svc.RotateRefreshToken(context.Background(), "plain-refresh-token")
+
+			// Assert
+			if !errors.Is(err, ErrInvalidRefreshToken) {
+				t.Errorf("err = %v, want ErrInvalidRefreshToken (Req 2.2 / 2.6)", err)
+			}
+			if pair != nil {
+				t.Errorf("pair = %+v, want nil", pair)
+			}
+			if refreshTokens.markRotatedCalls != 0 {
+				t.Errorf("MarkRotated calls = %d, want 0 (期限切れは MarkRotated 未到達)",
+					refreshTokens.markRotatedCalls)
+			}
+			if refreshTokens.createTokenCalls != 0 {
+				t.Errorf("CreateToken calls = %d, want 0 (Req 2.7)", refreshTokens.createTokenCalls)
+			}
+			if issuer.issueCalls != 0 {
+				t.Errorf("IssueAccessToken calls = %d, want 0", issuer.issueCalls)
+			}
+		})
+	}
+}
+
+// TestRotateRefreshToken_Revoked は RevokedAt が set 済みの token に対して
+// ErrInvalidRefreshToken を返すことを検証する（Testing Strategy 4 / Req 2.3, 2.6, 2.7）。
+func TestRotateRefreshToken_Revoked(t *testing.T) {
+	// Arrange
+	svc, _, refreshTokens, issuer := newServiceWithMocks(t)
+	stored := newStoredRefreshToken("user-test-1")
+	revokedAt := fixedTokenServiceIssuedAt.Add(-30 * time.Minute)
+	stored.RevokedAt = &revokedAt
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return stored, nil
+	}
+
+	// Act
+	pair, err := svc.RotateRefreshToken(context.Background(), "plain-refresh-token")
+
+	// Assert
+	if !errors.Is(err, ErrInvalidRefreshToken) {
+		t.Errorf("err = %v, want ErrInvalidRefreshToken (Req 2.3 / 2.6)", err)
+	}
+	if pair != nil {
+		t.Errorf("pair = %+v, want nil", pair)
+	}
+	if refreshTokens.markRotatedCalls != 0 {
+		t.Errorf("MarkRotated calls = %d, want 0 (失効済みは MarkRotated 未到達)",
+			refreshTokens.markRotatedCalls)
+	}
+	if refreshTokens.createTokenCalls != 0 {
+		t.Errorf("CreateToken calls = %d, want 0 (Req 2.7)", refreshTokens.createTokenCalls)
+	}
+	if issuer.issueCalls != 0 {
+		t.Errorf("IssueAccessToken calls = %d, want 0", issuer.issueCalls)
+	}
+}
+
+// TestRotateRefreshToken_AlreadyRotated は RotatedAt が set 済みの token（再利用）に対して
+// ErrInvalidRefreshToken を返し、MarkRotated / CreateToken に進まないことを検証する
+// （Testing Strategy 5 / Req 2.4, 2.6, 2.7）。
+// #168 が family 失効へ昇格するまでは単純拒否のみ。
+func TestRotateRefreshToken_AlreadyRotated(t *testing.T) {
+	// Arrange
+	svc, _, refreshTokens, issuer := newServiceWithMocks(t)
+	stored := newStoredRefreshToken("user-test-1")
+	rotatedAt := fixedTokenServiceIssuedAt.Add(-1 * time.Hour)
+	stored.RotatedAt = &rotatedAt
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return stored, nil
+	}
+
+	// Act
+	pair, err := svc.RotateRefreshToken(context.Background(), "plain-refresh-token")
+
+	// Assert
+	if !errors.Is(err, ErrInvalidRefreshToken) {
+		t.Errorf("err = %v, want ErrInvalidRefreshToken (Req 2.4 / 2.6)", err)
+	}
+	if pair != nil {
+		t.Errorf("pair = %+v, want nil", pair)
+	}
+	// MarkRotated は呼ばれない（事前判定で拒否）
+	if refreshTokens.markRotatedCalls != 0 {
+		t.Errorf("MarkRotated calls = %d, want 0 (再利用は事前判定で拒否)",
+			refreshTokens.markRotatedCalls)
+	}
+	// Req 2.7: 新 token は永続化されない
+	if refreshTokens.createTokenCalls != 0 {
+		t.Errorf("CreateToken calls = %d, want 0 (再利用時は新 token 未作成 / Req 2.7)",
+			refreshTokens.createTokenCalls)
+	}
+	if issuer.issueCalls != 0 {
+		t.Errorf("IssueAccessToken calls = %d, want 0", issuer.issueCalls)
+	}
+}
+
+// TestRotateRefreshToken_MarkRotatedRaceLoser は並行 rotation race の敗者
+// （MarkRotated が ErrRefreshTokenAlreadyRotated を返す）に対して
+// ErrInvalidRefreshToken を返し、新 token を作成しないことを検証する
+// （Testing Strategy 6 / Req 3.1: 高々 1 件のみ成功）。
+//
+// 事前判定（RotatedAt nil）を通過した後で、atomic な MarkRotated が race の敗者を
+// 検出する正本ゲートの挙動を検証する。
+func TestRotateRefreshToken_MarkRotatedRaceLoser(t *testing.T) {
+	// Arrange
+	svc, _, refreshTokens, issuer := newServiceWithMocks(t)
+	stored := newStoredRefreshToken("user-test-1")
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return stored, nil
+	}
+	refreshTokens.markRotatedFn = func(ctx context.Context, id string, rotatedAt time.Time) error {
+		// 並行 rotation の敗者として ErrRefreshTokenAlreadyRotated を返す
+		return repository.ErrRefreshTokenAlreadyRotated
+	}
+
+	// Act
+	pair, err := svc.RotateRefreshToken(context.Background(), "plain-refresh-token")
+
+	// Assert
+	if !errors.Is(err, ErrInvalidRefreshToken) {
+		t.Errorf("err = %v, want ErrInvalidRefreshToken (Req 3.1 race 敗者 / Req 2.6)", err)
+	}
+	if pair != nil {
+		t.Errorf("pair = %+v, want nil", pair)
+	}
+	// MarkRotated は呼ばれる（race の敗者を検出する正本ゲート）
+	if refreshTokens.markRotatedCalls != 1 {
+		t.Errorf("MarkRotated calls = %d, want 1 (race ゲートに到達する)",
+			refreshTokens.markRotatedCalls)
+	}
+	// Req 3.1 + Req 2.7: 敗者は新 token を作成しない（= 高々 1 件のみ成功）
+	if refreshTokens.createTokenCalls != 0 {
+		t.Errorf("CreateToken calls = %d, want 0 (race 敗者は新 token 未作成 / Req 3.1)",
+			refreshTokens.createTokenCalls)
+	}
+	if issuer.issueCalls != 0 {
+		t.Errorf("IssueAccessToken calls = %d, want 0", issuer.issueCalls)
+	}
+}
+
+// TestRotateRefreshToken_CreateTokenFailure は新 token 永続化が失敗したとき、
+// ErrInvalidRefreshToken に正規化されず（インフラ起因の 500 として上層に渡す）に
+// 上層に伝播することを検証する（Testing Strategy 7）。
+// 旧 token は MarkRotated 済み（Open Questions: 安全側に倒して燃やす）。
+func TestRotateRefreshToken_CreateTokenFailure(t *testing.T) {
+	// Arrange
+	svc, _, refreshTokens, issuer := newServiceWithMocks(t)
+	stored := newStoredRefreshToken("user-test-1")
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return stored, nil
+	}
+	wantErr := errors.New("db unavailable")
+	refreshTokens.createTokenFn = func(ctx context.Context, t *model.RefreshToken) error {
+		return wantErr
+	}
+
+	// Act
+	pair, err := svc.RotateRefreshToken(context.Background(), "plain-refresh-token")
+
+	// Assert
+	if err == nil {
+		t.Fatal("err = nil, want non-nil")
+	}
+	if errors.Is(err, ErrInvalidRefreshToken) {
+		t.Errorf("err = %v, must not be ErrInvalidRefreshToken (インフラ起因の 500 として上層に渡す)", err)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want wrap of %v", err, wantErr)
+	}
+	if pair != nil {
+		t.Errorf("pair = %+v, want nil", pair)
+	}
+	// MarkRotated 済み（旧 token は消費済み / Open Questions）
+	if refreshTokens.markRotatedCalls != 1 {
+		t.Errorf("MarkRotated calls = %d, want 1 (旧 token は MarkRotated 済み)",
+			refreshTokens.markRotatedCalls)
+	}
+	// CreateToken は呼ばれたが失敗した
+	if refreshTokens.createTokenCalls != 1 {
+		t.Errorf("CreateToken calls = %d, want 1", refreshTokens.createTokenCalls)
+	}
+	// access token は発行されない（CreateToken 失敗で打ち切り）
+	if issuer.issueCalls != 0 {
+		t.Errorf("IssueAccessToken calls = %d, want 0 (CreateToken 失敗で打ち切り)",
+			issuer.issueCalls)
+	}
+}
+
+// TestRotateRefreshToken_DoesNotLeakPlainSecretsInError は ErrInvalidRefreshToken の
+// メッセージに平文 refresh token が含まれないことを保証する（NFR 1.2 / 1.3）。
+func TestRotateRefreshToken_DoesNotLeakPlainSecretsInError(t *testing.T) {
+	// Arrange
+	svc, _, refreshTokens, _ := newServiceWithMocks(t)
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return nil, nil
+	}
+
+	const secretToken = "very-secret-refresh-token-plain-value-12345"
+
+	// Act
+	_, err := svc.RotateRefreshToken(context.Background(), secretToken)
+
+	// Assert: ErrInvalidRefreshToken のメッセージに平文が含まれないこと
+	if !errors.Is(err, ErrInvalidRefreshToken) {
+		t.Fatalf("err = %v, want ErrInvalidRefreshToken", err)
+	}
+	msg := err.Error()
+	if strings.Contains(msg, secretToken) {
+		t.Errorf("error message %q contains plain refresh token (NFR 1.2 / 1.3)", msg)
+	}
+}
+
+// TestRotateRefreshToken_LookupErrorPropagates は FindByHash が DB エラーを返したとき、
+// ErrInvalidRefreshToken に正規化されず（インフラ起因として 500 に渡す）に上層に伝播する
+// ことを検証する。
+func TestRotateRefreshToken_LookupErrorPropagates(t *testing.T) {
+	// Arrange
+	svc, _, refreshTokens, issuer := newServiceWithMocks(t)
+	wantErr := fmt.Errorf("connection refused")
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return nil, wantErr
+	}
+
+	// Act
+	pair, err := svc.RotateRefreshToken(context.Background(), "plain-refresh-token")
+
+	// Assert
+	if err == nil {
+		t.Fatal("err = nil, want non-nil")
+	}
+	if errors.Is(err, ErrInvalidRefreshToken) {
+		t.Errorf("err = %v, must not be ErrInvalidRefreshToken (DB 障害は上層 500)", err)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want wrap of %v", err, wantErr)
+	}
+	if pair != nil {
+		t.Errorf("pair = %+v, want nil", pair)
+	}
+	if refreshTokens.markRotatedCalls != 0 || refreshTokens.createTokenCalls != 0 || issuer.issueCalls != 0 {
 		t.Errorf("any downstream call must not occur on lookup error")
 	}
 }

--- a/internal/handler/integration_test.go
+++ b/internal/handler/integration_test.go
@@ -1592,3 +1592,186 @@ func TestIntegration_NativeAuthFlow_UnknownAuthCodeReturns400(t *testing.T) {
 		t.Errorf("code = %v, want %q (Req 2.2 / 2.6)", resBody["code"], "INVALID_GRANT")
 	}
 }
+
+// --- Refresh ローテーションの通し統合テスト（Issue #167 / task 3） ---
+
+// runNativeLoginCallbackAndExchange は native login → callback → token 交換の通しを
+// 実行し、初回 refresh token 平文を返す。本ヘルパーは Refresh 通しテストで
+// 「正常な refresh token を払い出した状態」を作るために使う。
+func runNativeLoginCallbackAndExchange(t *testing.T, router http.Handler) (refreshToken string) {
+	t.Helper()
+
+	// 1. native login: state / challenge Cookie を取得
+	loginURL := "/auth/google/login?flow=native&code_challenge=" + nativeTestChallenge + "&code_challenge_method=S256"
+	req := httptest.NewRequest(http.MethodGet, loginURL, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	resp := w.Result()
+	if resp.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("login status = %d, want %d", resp.StatusCode, http.StatusTemporaryRedirect)
+	}
+	var oauthStateC, nativeChallengeC *http.Cookie
+	for _, c := range resp.Cookies() {
+		switch c.Name {
+		case "oauth_state":
+			oauthStateC = c
+		case "oauth_native_challenge":
+			nativeChallengeC = c
+		}
+	}
+	if oauthStateC == nil || nativeChallengeC == nil {
+		t.Fatal("login: expected both oauth_state and oauth_native_challenge cookies")
+	}
+
+	// 2. callback: アプリスキームへ auth_code が返る
+	callbackURL := "/auth/google/callback?code=test-auth-code&state=" + oauthStateC.Value
+	req = httptest.NewRequest(http.MethodGet, callbackURL, nil)
+	req.AddCookie(oauthStateC)
+	req.AddCookie(nativeChallengeC)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	resp = w.Result()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("callback status = %d, want %d", resp.StatusCode, http.StatusSeeOther)
+	}
+	const wantAuthCode = "integration-native-auth-code"
+	wantLocation := "feedman://auth/callback?auth_code=" + wantAuthCode
+	if location := resp.Header.Get("Location"); location != wantLocation {
+		t.Fatalf("callback Location = %q, want %q", location, wantLocation)
+	}
+
+	// 3. token 交換: 200 で 4 フィールドを取得
+	body := fmt.Sprintf(`{"auth_code":%q,"code_verifier":%q}`, wantAuthCode, "plain-verifier")
+	req = httptest.NewRequest(http.MethodPost, "/api/auth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("token exchange status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var tokenBody map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&tokenBody); err != nil {
+		t.Fatalf("token exchange decode body: %v", err)
+	}
+	rt, ok := tokenBody["refresh_token"].(string)
+	if !ok || rt == "" {
+		t.Fatalf("token exchange: refresh_token = %v, want non-empty string", tokenBody["refresh_token"])
+	}
+	return rt
+}
+
+// TestIntegration_RefreshFlow_TokenExchangeRefreshSucceedsThenOldTokenRejected は
+// 「token 交換で pair 取得 → 旧 refresh token で refresh 成功（新 pair 取得）→
+// 旧 refresh token で再 refresh が 401 INVALID_REFRESH_TOKEN」の通しケースを検証する。
+// Issue #167 の AC（Req 1.1, 1.2: 新 pair / 旧 token 拒否）に対応する。
+func TestIntegration_RefreshFlow_TokenExchangeRefreshSucceedsThenOldTokenRejected(t *testing.T) {
+	// Arrange: native login → callback → token 交換で初回 refresh token を取得
+	state := newIntegrationState()
+	tokenSvc := &mockNativeTokenExchangeService{}
+	router := createNativeAuthIntegrationRouter(state, tokenSvc)
+	oldRefreshToken := runNativeLoginCallbackAndExchange(t, router)
+
+	// Act 1: 旧 refresh token で refresh 成功（新 pair 取得 / Req 1.1）
+	body := fmt.Sprintf(`{"refresh_token":%q}`, oldRefreshToken)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("refresh 1st status = %d, want %d (Req 1.1)", resp.StatusCode, http.StatusOK)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("refresh 1st Content-Type = %q, want %q", ct, "application/json")
+	}
+	var newTokenBody map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&newTokenBody); err != nil {
+		t.Fatalf("refresh 1st decode body: %v", err)
+	}
+	// 4 フィールドが揃う（Req 1.1, 1.6: token 交換と同形）
+	newAccess, _ := newTokenBody["access_token"].(string)
+	newRefresh, _ := newTokenBody["refresh_token"].(string)
+	if newAccess == "" {
+		t.Error("refresh 1st: access_token is empty")
+	}
+	if newRefresh == "" {
+		t.Error("refresh 1st: refresh_token is empty")
+	}
+	if newTokenBody["token_type"] != "Bearer" {
+		t.Errorf("refresh 1st: token_type = %v, want %q", newTokenBody["token_type"], "Bearer")
+	}
+	if v, _ := newTokenBody["expires_in"].(float64); v != 900 {
+		t.Errorf("refresh 1st: expires_in = %v, want 900", v)
+	}
+	// 新 refresh token は旧と異なる（rotation の本質 / Req 1.2）
+	if newRefresh == oldRefreshToken {
+		t.Errorf("refresh 1st: new refresh_token equals old (rotation must produce different token)")
+	}
+
+	// Act 2: 同じ旧 refresh token で再 refresh → 401 INVALID_REFRESH_TOKEN（Req 1.2 / 2.4）
+	req = httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("refresh 2nd with old token status = %d, want %d (Req 1.2 / 2.4 / SERVER.md §1.3)",
+			resp.StatusCode, http.StatusUnauthorized)
+	}
+	var rejectBody map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&rejectBody)
+	if rejectBody["code"] != "INVALID_REFRESH_TOKEN" {
+		t.Errorf("refresh 2nd: code = %v, want %q (Req 2.6 uniform 拒否)",
+			rejectBody["code"], "INVALID_REFRESH_TOKEN")
+	}
+	if rejectBody["category"] != "auth" {
+		t.Errorf("refresh 2nd: category = %v, want %q", rejectBody["category"], "auth")
+	}
+	// 詳細な拒否理由を反射しない（Req 2.6 / NFR 1.3）
+	if msg, _ := rejectBody["message"].(string); strings.Contains(msg, "rotated") || strings.Contains(msg, "expired") || strings.Contains(msg, "revoked") {
+		t.Errorf("refresh 2nd: message %q must not differentiate rejection reasons", msg)
+	}
+
+	// 新 refresh token は依然有効（rotation 後に発行された世代）
+	body2 := fmt.Sprintf(`{"refresh_token":%q}`, newRefresh)
+	req = httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(body2))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("refresh with new token status = %d, want 200 (新 token は有効)",
+			w.Result().StatusCode)
+	}
+}
+
+// TestIntegration_RefreshFlow_UnknownRefreshTokenReturns401 は callback / token 交換を
+// 経由せず未知の refresh token を送ったとき 401 INVALID_REFRESH_TOKEN が返ることを
+// 検証する（Req 2.1, 2.6）。
+func TestIntegration_RefreshFlow_UnknownRefreshTokenReturns401(t *testing.T) {
+	// Arrange: 何も払い出していない状態で refresh だけ呼ぶ
+	state := newIntegrationState()
+	tokenSvc := &mockNativeTokenExchangeService{}
+	router := createNativeAuthIntegrationRouter(state, tokenSvc)
+
+	body := `{"refresh_token":"unknown-refresh-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	resp := w.Result()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d (Req 2.1)", resp.StatusCode, http.StatusUnauthorized)
+	}
+	var resBody map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&resBody)
+	if resBody["code"] != "INVALID_REFRESH_TOKEN" {
+		t.Errorf("code = %v, want %q (Req 2.6)", resBody["code"], "INVALID_REFRESH_TOKEN")
+	}
+}

--- a/internal/handler/integration_test.go
+++ b/internal/handler/integration_test.go
@@ -54,8 +54,10 @@ func newIntegrationState() *integrationState {
 // --- Native Auth 用 stateful mock service（Issue #166） ---
 
 // mockNativeTokenExchangeService は integration_test 内で auth_code → token 交換の
-// 単回利用と「同一 code の再交換 400」を検証するための簡易ステートフルモック。
-// 実際の repository/service 層を介さず、issuedCode との一致 + 単回フラグで判定する。
+// 単回利用と「同一 code の再交換 400」、および refresh token rotation の通しを
+// 検証するためのステートフルモック。実際の repository/service 層を介さず、
+// issuedCode との一致 + 単回フラグで判定し、refresh は払い出した平文と family ID を
+// 内部 map で追跡する（Issue #167）。
 type mockNativeTokenExchangeService struct {
 	mu           sync.Mutex
 	issuedCode   string
@@ -63,6 +65,15 @@ type mockNativeTokenExchangeService struct {
 	callCount    int
 	lastCode     string
 	lastVerifier string
+
+	// refresh tokens の rotation 用ステート（Issue #167）。
+	// activeRefresh[plain]=familyID で「現役の refresh token 平文 → family」を保持。
+	// rotation 成功で旧 plain を活性集合から外し（rotated 扱い）新 plain を追加する。
+	// 旧 plain は rotatedRefresh に move し、再提示時の「rotation 済み拒否」を判定する。
+	activeRefresh    map[string]string // plain → familyID
+	rotatedRefresh   map[string]struct{}
+	rotateCallCount  int
+	lastRefreshToken string
 }
 
 // IssueCode は事前に「払い出した auth_code 平文」を mock に登録する。
@@ -91,9 +102,62 @@ func (m *mockNativeTokenExchangeService) ExchangeAuthCode(ctx context.Context, a
 		return nil, auth.ErrInvalidGrant
 	}
 	m.used = true // 単回消費
+	// rotation 通しテスト用に、払い出した refresh token を family 付きで活性化する。
+	if m.activeRefresh == nil {
+		m.activeRefresh = make(map[string]string)
+	}
+	if m.rotatedRefresh == nil {
+		m.rotatedRefresh = make(map[string]struct{})
+	}
+	const plain = "integration-refresh-token"
+	const familyID = "family-integration"
+	m.activeRefresh[plain] = familyID
 	return &auth.TokenPair{
 		AccessToken:  "integration-access-token",
-		RefreshToken: "integration-refresh-token",
+		RefreshToken: plain,
+		ExpiresIn:    900,
+	}, nil
+}
+
+// RotateRefreshToken は Issue #167 の rotation を simulate する。
+//   - 活性集合に存在する plain → 旧 plain を rotated 集合へ move、新 plain を活性化して
+//     新 TokenPair を返す（同一 family に紐付け / Req 1.3, 1.4）
+//   - rotated 集合に存在する plain → ErrInvalidRefreshToken（Req 2.4: rotation 済み再利用）
+//   - 活性集合にも rotated 集合にも存在しない plain → ErrInvalidRefreshToken（Req 2.1: 不明）
+//
+// 連続 rotation の通しテストでは「N 回目の rotation で N 番目の plain が返る」決定論を
+// 担保するために、内部カウンタで新 plain を生成する。
+func (m *mockNativeTokenExchangeService) RotateRefreshToken(ctx context.Context, refreshToken string) (*auth.TokenPair, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rotateCallCount++
+	m.lastRefreshToken = refreshToken
+
+	if m.activeRefresh == nil {
+		return nil, auth.ErrInvalidRefreshToken
+	}
+	if _, isRotated := m.rotatedRefresh[refreshToken]; isRotated {
+		// rotation 済み再利用は単純拒否（#168 が family 失効へ昇格するまでは ErrInvalidRefreshToken）
+		return nil, auth.ErrInvalidRefreshToken
+	}
+	familyID, isActive := m.activeRefresh[refreshToken]
+	if !isActive {
+		// 不明
+		return nil, auth.ErrInvalidRefreshToken
+	}
+
+	// 旧 plain を rotated に move、新 plain を活性化（同一 family / Req 1.3）。
+	delete(m.activeRefresh, refreshToken)
+	if m.rotatedRefresh == nil {
+		m.rotatedRefresh = make(map[string]struct{})
+	}
+	m.rotatedRefresh[refreshToken] = struct{}{}
+	newPlain := fmt.Sprintf("integration-refresh-token-rot-%d", m.rotateCallCount)
+	m.activeRefresh[newPlain] = familyID
+
+	return &auth.TokenPair{
+		AccessToken:  fmt.Sprintf("integration-access-token-rot-%d", m.rotateCallCount),
+		RefreshToken: newPlain,
 		ExpiresIn:    900,
 	}, nil
 }

--- a/internal/handler/native_auth_handler.go
+++ b/internal/handler/native_auth_handler.go
@@ -14,8 +14,12 @@ import (
 
 // TokenExchangeService は NativeAuthHandler が必要とする最小サービス IF。
 // auth.TokenService が構造的に充足する（interface segregation）。
+//
+// RotateRefreshToken は Issue #167 で追加された。Token / Refresh handler のいずれも
+// auth.TokenService の各メソッドを呼ぶだけで、handler 層はビジネスロジックを持たない。
 type TokenExchangeService interface {
 	ExchangeAuthCode(ctx context.Context, authCode, codeVerifier string) (*auth.TokenPair, error)
+	RotateRefreshToken(ctx context.Context, refreshToken string) (*auth.TokenPair, error)
 }
 
 // NativeAuthHandler は POST /api/auth/token を処理する HTTP ハンドラ（Issue #166）。
@@ -111,6 +115,87 @@ func invalidGrantError() *model.APIError {
 	return &model.APIError{
 		Code:     "INVALID_GRANT",
 		Message:  "auth_code を交換できませんでした。",
+		Category: "auth",
+		Action:   "ログインからやり直してください。",
+	}
+}
+
+// refreshRequest は POST /api/auth/refresh のリクエストボディ（Issue #167）。
+// SERVER.md §1.3 の契約に従い、snake_case で受ける。
+type refreshRequest struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
+// Refresh は POST /api/auth/refresh を処理する（Issue #167）。
+//
+//   - 200: {access_token, refresh_token, token_type: "Bearer", expires_in: 900}（Req 1.1, 1.6）
+//     成功応答は Token と同一の tokenResponse 形式（Req 1.6: token 交換と同一フィールド）。
+//   - 400 INVALID_REQUEST:       JSON 不正・必須フィールド欠落（Req 2.5）
+//   - 401 INVALID_REFRESH_TOKEN: ErrInvalidRefreshToken に正規化された拒否（Req 2.6 / SERVER.md §1.3）
+//     token の存在有無 / 期限切れ / 失効済み / rotation 済みを区別しない（Req 2.6）。
+//   - 500 INTERNAL_ERROR:        上記以外（DB 障害・JWT 発行失敗など、NFR 1.3）
+//
+// 認証不要グループに登録されるため、セッション / Bearer なしで呼び出される（Req 1.5）。
+// token 交換の 400 INVALID_GRANT とは status code / error code が異なる点に注意。
+func (h *NativeAuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
+	// JSON 不正・必須フィールド欠落は 400 INVALID_REQUEST に合流する。
+	// ボディ上限超過（MaxBytesReader）も json.Decode のエラーとしてここで合流する。
+	var req refreshRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		// クライアント入力値・パーサ詳細はクライアントへ反射しない（NFR 1.3）。
+		slog.Info("refresh rejected: invalid request body")
+		middleware.WriteErrorResponse(w, http.StatusBadRequest, invalidRefreshRequestError())
+		return
+	}
+	if req.RefreshToken == "" {
+		slog.Info("refresh rejected: missing refresh_token")
+		middleware.WriteErrorResponse(w, http.StatusBadRequest, invalidRefreshRequestError())
+		return
+	}
+
+	pair, err := h.svc.RotateRefreshToken(r.Context(), req.RefreshToken)
+	if err != nil {
+		if errors.Is(err, auth.ErrInvalidRefreshToken) {
+			// token 不明 / 期限切れ / 失効済み / rotation 済みを区別しない（Req 2.6）。
+			slog.Info("refresh rejected: invalid refresh token")
+			middleware.WriteErrorResponse(w, http.StatusUnauthorized, invalidRefreshTokenError())
+			return
+		}
+		// インフラ起因（DB 障害 / JWT 発行失敗）。詳細は slog のみ、応答は固定メッセージ。
+		slog.Error("refresh failed", slog.String("error", err.Error()))
+		middleware.WriteInternalServerError(w)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(tokenResponse{
+		AccessToken:  pair.AccessToken,
+		RefreshToken: pair.RefreshToken,
+		TokenType:    "Bearer",
+		ExpiresIn:    pair.ExpiresIn,
+	})
+}
+
+// invalidRefreshRequestError は POST /api/auth/refresh の 400 INVALID_REQUEST 固定 APIError。
+// クライアント入力値・内部詳細を反射しないこと（NFR 1.3）。
+func invalidRefreshRequestError() *model.APIError {
+	return &model.APIError{
+		Code:     "INVALID_REQUEST",
+		Message:  "リクエストの形式が不正です。",
+		Category: "validation",
+		Action:   "refresh_token を正しい JSON 形式で送信してください。",
+	}
+}
+
+// invalidRefreshTokenError は POST /api/auth/refresh の 401 INVALID_REFRESH_TOKEN 固定 APIError。
+// refresh token の存在有無 / 期限切れ / 失効済み / rotation 済みを区別しない（Req 2.6）。
+// SERVER.md §1.3 の契約（401 INVALID_REFRESH_TOKEN）に対応する。
+func invalidRefreshTokenError() *model.APIError {
+	return &model.APIError{
+		Code:     "INVALID_REFRESH_TOKEN",
+		Message:  "refresh token が無効です。",
 		Category: "auth",
 		Action:   "ログインからやり直してください。",
 	}

--- a/internal/handler/native_auth_handler_test.go
+++ b/internal/handler/native_auth_handler_test.go
@@ -14,11 +14,15 @@ import (
 )
 
 // mockTokenExchangeService は TokenExchangeService 最小 IF の record-and-return モック。
+// rotateFn / lastRefreshToken / rotateCalls は Issue #167 で追加された。
 type mockTokenExchangeService struct {
-	exchangeFn   func(ctx context.Context, authCode, codeVerifier string) (*auth.TokenPair, error)
-	callCount    int
-	lastAuthCode string
-	lastVerifier string
+	exchangeFn       func(ctx context.Context, authCode, codeVerifier string) (*auth.TokenPair, error)
+	rotateFn         func(ctx context.Context, refreshToken string) (*auth.TokenPair, error)
+	callCount        int
+	rotateCalls      int
+	lastAuthCode     string
+	lastVerifier     string
+	lastRefreshToken string
 }
 
 func (m *mockTokenExchangeService) ExchangeAuthCode(ctx context.Context, authCode, codeVerifier string) (*auth.TokenPair, error) {
@@ -27,6 +31,15 @@ func (m *mockTokenExchangeService) ExchangeAuthCode(ctx context.Context, authCod
 	m.lastVerifier = codeVerifier
 	if m.exchangeFn != nil {
 		return m.exchangeFn(ctx, authCode, codeVerifier)
+	}
+	return nil, fmt.Errorf("not configured")
+}
+
+func (m *mockTokenExchangeService) RotateRefreshToken(ctx context.Context, refreshToken string) (*auth.TokenPair, error) {
+	m.rotateCalls++
+	m.lastRefreshToken = refreshToken
+	if m.rotateFn != nil {
+		return m.rotateFn(ctx, refreshToken)
 	}
 	return nil, fmt.Errorf("not configured")
 }
@@ -279,5 +292,250 @@ func TestNativeAuthHandler_Token_UnknownFieldRejected(t *testing.T) {
 	}
 	if svc.callCount != 0 {
 		t.Errorf("service called %d times, want 0 (未知フィールドは service 到達前に拒否)", svc.callCount)
+	}
+}
+
+// --- Refresh handler のテスト（Issue #167） ---
+
+// newRefreshRequest は handler 単体テスト用の JSON POST /api/auth/refresh リクエストを生成する。
+func newRefreshRequest(body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// TestNativeAuthHandler_Refresh_Success は service が成功した場合の応答契約を検証する
+// （Req 1.1, 1.6: JSON フィールド名 / token_type=Bearer / expires_in=900）。
+func TestNativeAuthHandler_Refresh_Success(t *testing.T) {
+	// Arrange
+	svc := &mockTokenExchangeService{
+		rotateFn: func(ctx context.Context, refreshToken string) (*auth.TokenPair, error) {
+			return &auth.TokenPair{
+				AccessToken:  "new-access-token",
+				RefreshToken: "new-refresh-token",
+				ExpiresIn:    900,
+			}, nil
+		},
+	}
+	h := NewNativeAuthHandler(svc)
+	req := newRefreshRequest(`{"refresh_token":"plain-refresh-token"}`)
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Refresh(w, req)
+
+	// Assert: 200 / Content-Type
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+	}
+
+	// Assert: ボディが snake_case の 4 フィールドを持つ（Req 1.6: token 交換と同形）
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["access_token"] != "new-access-token" {
+		t.Errorf("access_token = %v, want %q", body["access_token"], "new-access-token")
+	}
+	if body["refresh_token"] != "new-refresh-token" {
+		t.Errorf("refresh_token = %v, want %q", body["refresh_token"], "new-refresh-token")
+	}
+	if body["token_type"] != "Bearer" {
+		t.Errorf("token_type = %v, want %q (Req 1.1)", body["token_type"], "Bearer")
+	}
+	if v, _ := body["expires_in"].(float64); v != 900 {
+		t.Errorf("expires_in = %v, want 900 (Req 1.1)", v)
+	}
+
+	// Assert: service が plain な値で呼ばれた（hash 化は service 内部で行う）
+	if svc.rotateCalls != 1 {
+		t.Errorf("service.RotateRefreshToken called %d times, want 1", svc.rotateCalls)
+	}
+	if svc.lastRefreshToken != "plain-refresh-token" {
+		t.Errorf("service.lastRefreshToken = %q, want %q",
+			svc.lastRefreshToken, "plain-refresh-token")
+	}
+}
+
+// TestNativeAuthHandler_Refresh_InvalidRefreshToken は service が ErrInvalidRefreshToken を
+// 返したとき 401 INVALID_REFRESH_TOKEN 応答を返すことを検証する（Req 2.1, 2.2, 2.3, 2.4, 2.6 /
+// SERVER.md §1.3）。
+func TestNativeAuthHandler_Refresh_InvalidRefreshToken(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{name: "sentinel そのものを返したとき 401 INVALID_REFRESH_TOKEN", err: auth.ErrInvalidRefreshToken},
+		{
+			name: "ErrInvalidRefreshToken を wrap したエラーでも 401 INVALID_REFRESH_TOKEN",
+			err:  fmt.Errorf("token expired: %w", auth.ErrInvalidRefreshToken),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			svc := &mockTokenExchangeService{
+				rotateFn: func(ctx context.Context, refreshToken string) (*auth.TokenPair, error) {
+					return nil, tc.err
+				},
+			}
+			h := NewNativeAuthHandler(svc)
+			req := newRefreshRequest(`{"refresh_token":"plain-refresh-token"}`)
+			w := httptest.NewRecorder()
+
+			// Act
+			h.Refresh(w, req)
+
+			// Assert: 401 status code（SERVER.md §1.3。token 交換の 400 INVALID_GRANT とは異なる）
+			resp := w.Result()
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d (SERVER.md §1.3: 401 INVALID_REFRESH_TOKEN)",
+					resp.StatusCode, http.StatusUnauthorized)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body["code"] != "INVALID_REFRESH_TOKEN" {
+				t.Errorf("code = %v, want %q (Req 2.6)", body["code"], "INVALID_REFRESH_TOKEN")
+			}
+			if body["category"] != "auth" {
+				t.Errorf("category = %v, want %q", body["category"], "auth")
+			}
+			// 応答に詳細な拒否理由が反射されていない（Req 2.6 / NFR 1.3）
+			if msg, _ := body["message"].(string); strings.Contains(msg, "expired") || strings.Contains(msg, "revoked") || strings.Contains(msg, "rotated") || strings.Contains(msg, "unknown") {
+				t.Errorf("message %q must not differentiate rejection reasons (Req 2.6)", msg)
+			}
+		})
+	}
+}
+
+// TestNativeAuthHandler_Refresh_InvalidJSON は不正な JSON で 400 INVALID_REQUEST を
+// 返すことを検証する（Req 2.5）。
+func TestNativeAuthHandler_Refresh_InvalidJSON(t *testing.T) {
+	// Arrange
+	svc := &mockTokenExchangeService{}
+	h := NewNativeAuthHandler(svc)
+	req := newRefreshRequest(`{not valid json`)
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Refresh(w, req)
+
+	// Assert
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["code"] != "INVALID_REQUEST" {
+		t.Errorf("code = %v, want %q (Req 2.5)", body["code"], "INVALID_REQUEST")
+	}
+	if body["category"] != "validation" {
+		t.Errorf("category = %v, want %q", body["category"], "validation")
+	}
+	// service は呼ばれない
+	if svc.rotateCalls != 0 {
+		t.Errorf("service called %d times, want 0 (JSON 不正は service 到達前に拒否)", svc.rotateCalls)
+	}
+}
+
+// TestNativeAuthHandler_Refresh_MissingField は必須フィールド欠落で 400 INVALID_REQUEST を
+// 返すことを検証する（Req 2.5）。
+func TestNativeAuthHandler_Refresh_MissingField(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "refresh_token 欠落のとき 400 INVALID_REQUEST", body: `{}`},
+		{name: "refresh_token が空文字のとき 400 INVALID_REQUEST", body: `{"refresh_token":""}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			svc := &mockTokenExchangeService{}
+			h := NewNativeAuthHandler(svc)
+			req := newRefreshRequest(tc.body)
+			w := httptest.NewRecorder()
+
+			// Act
+			h.Refresh(w, req)
+
+			// Assert
+			resp := w.Result()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+			}
+			var body map[string]any
+			_ = json.NewDecoder(resp.Body).Decode(&body)
+			if body["code"] != "INVALID_REQUEST" {
+				t.Errorf("code = %v, want %q (Req 2.5)", body["code"], "INVALID_REQUEST")
+			}
+			if svc.rotateCalls != 0 {
+				t.Errorf("service called %d times, want 0", svc.rotateCalls)
+			}
+		})
+	}
+}
+
+// TestNativeAuthHandler_Refresh_InternalError は service が ErrInvalidRefreshToken 以外の
+// エラーを返したとき 500 INTERNAL_ERROR を返すことを検証する（NFR 1.3）。
+func TestNativeAuthHandler_Refresh_InternalError(t *testing.T) {
+	// Arrange
+	svc := &mockTokenExchangeService{
+		rotateFn: func(ctx context.Context, refreshToken string) (*auth.TokenPair, error) {
+			return nil, errors.New("db connection refused")
+		},
+	}
+	h := NewNativeAuthHandler(svc)
+	req := newRefreshRequest(`{"refresh_token":"x"}`)
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Refresh(w, req)
+
+	// Assert
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["code"] != "INTERNAL_ERROR" {
+		t.Errorf("code = %v, want %q", body["code"], "INTERNAL_ERROR")
+	}
+	// 内部詳細を反射しない（NFR 1.3）
+	if msg, _ := body["message"].(string); strings.Contains(msg, "db connection refused") {
+		t.Errorf("message %q leaks internal error detail (NFR 1.3)", msg)
+	}
+}
+
+// TestNativeAuthHandler_Refresh_UnknownFieldRejected は未知のフィールドを含む JSON で
+// 400 INVALID_REQUEST を返すことを検証する（DisallowUnknownFields による安全側挙動 /
+// design.md Out of Scope: device_label）。
+func TestNativeAuthHandler_Refresh_UnknownFieldRejected(t *testing.T) {
+	// Arrange
+	svc := &mockTokenExchangeService{}
+	h := NewNativeAuthHandler(svc)
+	req := newRefreshRequest(`{"refresh_token":"a","device_label":"iPhone"}`)
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Refresh(w, req)
+
+	// Assert
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (未知フィールドは厳密に拒否)", resp.StatusCode, http.StatusBadRequest)
+	}
+	if svc.rotateCalls != 0 {
+		t.Errorf("service called %d times, want 0 (未知フィールドは service 到達前に拒否)", svc.rotateCalls)
 	}
 }

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -200,14 +200,17 @@ func NewRouter(deps *RouterDeps) http.Handler {
 			}
 		}
 
-		// Native Auth トークン交換エンドポイント（Issue #166）。
-		// NATIVE_AUTH_JWT_SECRET 未設定のデプロイは NativeAuthHandler が nil となり、本ルートを
-		// 登録しない（404 / fail-closed）。Session / Bearer middleware は通らない（Req 1.5）。
+		// Native Auth トークン交換エンドポイント（Issue #166）と
+		// refresh ローテーションエンドポイント（Issue #167）。
+		// NATIVE_AUTH_JWT_SECRET 未設定のデプロイは NativeAuthHandler が nil となり、両ルートを
+		// 登録しない（404 / fail-closed / NFR 2.2）。Session / Bearer middleware は通らない（Req 1.5）。
 		// 巨大ボディ DoS 防止のためボディ上限ミドルウェア（DefaultMaxBodyBytes）を重ねる。
 		// IP レート制限（unauthIPMW）は Issue #171 の領分のため本 spec では適用しない。
 		if deps.NativeAuthHandler != nil {
 			r.With(middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
 				Post("/api/auth/token", deps.NativeAuthHandler.Token)
+			r.With(middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
+				Post("/api/auth/refresh", deps.NativeAuthHandler.Refresh)
 		}
 	})
 

--- a/internal/handler/router_test.go
+++ b/internal/handler/router_test.go
@@ -132,8 +132,10 @@ func TestSetupAuthRoutes_UnknownRoute_Returns404Or405(t *testing.T) {
 
 // alwaysSucceedExchangeService は service 層に到達したかを判定するための固定成功モック。
 // 200 応答が返れば handler に到達したことが確認できる。
+// RotateRefreshToken は Issue #167 で interface に追加されたため本モックでも実装する。
 type alwaysSucceedExchangeService struct {
-	callCount int
+	callCount   int
+	rotateCalls int
 }
 
 func (s *alwaysSucceedExchangeService) ExchangeAuthCode(ctx context.Context, authCode, codeVerifier string) (*auth.TokenPair, error) {
@@ -141,6 +143,15 @@ func (s *alwaysSucceedExchangeService) ExchangeAuthCode(ctx context.Context, aut
 	return &auth.TokenPair{
 		AccessToken:  "ok-access",
 		RefreshToken: "ok-refresh",
+		ExpiresIn:    900,
+	}, nil
+}
+
+func (s *alwaysSucceedExchangeService) RotateRefreshToken(ctx context.Context, refreshToken string) (*auth.TokenPair, error) {
+	s.rotateCalls++
+	return &auth.TokenPair{
+		AccessToken:  "ok-rotated-access",
+		RefreshToken: "ok-rotated-refresh",
 		ExpiresIn:    900,
 	}, nil
 }
@@ -257,5 +268,84 @@ func TestNewRouter_NativeAuthToken_WrongMethod_Returns405(t *testing.T) {
 	}
 	if svc.callCount != 0 {
 		t.Errorf("service called %d times, want 0 (GET は handler に到達しない)", svc.callCount)
+	}
+}
+
+// --- Refresh ルーティング（Issue #167 / Req 1.5, NFR 2.2） ---
+
+// TestNewRouter_NativeAuthRefresh_RegisteredWhenHandlerInjected は NativeAuthHandler を
+// 注入したとき POST /api/auth/refresh がセッション無しで到達し、200 が返ることを検証する
+// （Req 1.5: Cookie / Bearer なしで呼び出し可能）。
+func TestNewRouter_NativeAuthRefresh_RegisteredWhenHandlerInjected(t *testing.T) {
+	// Arrange
+	svc := &alwaysSucceedExchangeService{}
+	nh := NewNativeAuthHandler(svc)
+	router := NewRouter(newMinimalDepsForNativeAuth(nh))
+
+	body := `{"refresh_token":"plain-refresh-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d (handler 到達 / Req 1.5)", resp.StatusCode, http.StatusOK)
+	}
+	if svc.rotateCalls != 1 {
+		t.Errorf("service.RotateRefreshToken called %d times, want 1 (handler に到達していない可能性)",
+			svc.rotateCalls)
+	}
+}
+
+// TestNewRouter_NativeAuthRefresh_NotRegisteredWhenHandlerNil は NativeAuthHandler が
+// nil のとき POST /api/auth/refresh がルートとして登録されず 404 が返ることを検証する
+// （NFR 2.2: 署名鍵未設定環境の fail-closed）。
+func TestNewRouter_NativeAuthRefresh_NotRegisteredWhenHandlerNil(t *testing.T) {
+	// Arrange: NativeAuthHandler nil
+	router := NewRouter(newMinimalDepsForNativeAuth(nil))
+
+	body := `{"refresh_token":"x"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert: fail-closed として 404
+	if w.Result().StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (NativeAuthHandler nil で fail-closed / NFR 2.2)",
+			w.Result().StatusCode, http.StatusNotFound)
+	}
+}
+
+// TestNewRouter_NativeAuthRefresh_DoesNotRequireSession は注入時に Cookie 無しでも
+// 401 を返さず handler まで到達することを検証する（Req 1.5: Session middleware 通らない）。
+func TestNewRouter_NativeAuthRefresh_DoesNotRequireSession(t *testing.T) {
+	// Arrange
+	svc := &alwaysSucceedExchangeService{}
+	nh := NewNativeAuthHandler(svc)
+	router := NewRouter(newMinimalDepsForNativeAuth(nh))
+
+	body := `{"refresh_token":"x"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// セッション Cookie 無し
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert: 401 ではなく 200（Session middleware を経由していない）
+	resp := w.Result()
+	if resp.StatusCode == http.StatusUnauthorized {
+		t.Errorf("status = 401, want non-401 (Req 1.5: Cookie 無しで呼び出し可能)")
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 }


### PR DESCRIPTION
## 概要

Issue #167（umbrella #163 の子 Issue）の実装 PR です。設計 PR #191 でマージ済みの
`docs/specs/167-auth-refresh-rotation/`（requirements.md / design.md / tasks.md）に厳密に従い、
`POST /api/auth/refresh` の rotation 付き再発行を実装しました。

Closes #167

## 変更内容

- `internal/auth/token_service.go`: `ErrInvalidRefreshToken` sentinel 追加 / `RefreshTokenStore` IF を `FindByHash` / `MarkRotated` まで拡張 / `RotateRefreshToken` を design.md の rotation フロー手順どおり実装
- `internal/handler/native_auth_handler.go`: `Refresh` handler（200 / 400 INVALID_REQUEST / 401 INVALID_REFRESH_TOKEN / 500）。成功応答は #166 の `tokenResponse` を共用
- `internal/handler/router.go`: 認証不要グループの `NativeAuthHandler != nil` ガード内に `POST /api/auth/refresh` を登録（ボディ上限 middleware 付き / 署名鍵未設定環境では fail-closed 未登録）
- テスト: service 9 / handler 6 / router 3 / 統合 2 ケース追加（rotation 成功 / 全拒否パス / 並行 race 敗者 / 旧 token 再利用 401 の通しケース）
- `docs/specs/167-auth-refresh-rotation/`: tasks.md checkbox 更新（全 3 task 完了）/ impl-notes.md / review-notes.md

## 設計上のポイント

- 拒否は全て単一 sentinel `auth.ErrInvalidRefreshToken` に正規化し、token の存在有無・期限切れ・失効・rotation 済みを区別しない 401 を返す（Req 2.6）
- 並行 rotation の正本ゲートは `MarkRotated` の atomic UPDATE（`WHERE rotated_at IS NULL`、#164 設計）。race 敗者は新 token を永続化しない（Req 3.1 / 2.7）
- 新 token は同一 family・スライディング 30 日 TTL（Req 1.3 / 1.4）

## Reviewer 判定

独立 context の Reviewer サブエージェントによるレビュー済み: **approve**
（`docs/specs/167-auth-refresh-rotation/review-notes.md` 参照。AC 未カバー / missing test / boundary 逸脱のいずれも findings なし）

## 検証

- `go build ./...` / `go vet ./...` / `go test ./...` 全 green
- `gofmt -l`（変更ファイルのみ）差分なし
- DB 結合テストは CI の postgres サービス上で実行される

## 確認事項（レビュワー判断ポイント）

- `Refresh` handler は #166 の `Token` handler と同じく `DisallowUnknownFields` を採用しています（design.md / requirements.md には明示のない判断。#166 実装判断との整合を優先）
- `FindByHash` のインフラエラーは 401 に正規化せず 500 に分類しています（token の有効性を判定できていないため。design.md Error Handling 表「上記以外 → 500」の解釈）
- rotation 確定後の発行失敗は旧 token 消費済みのまま 500（requirements.md Open Questions の「安全側に倒して燃やす」方針どおり rollback なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)