### PR TITLE
feat(#170): 退会時に native auth state を cleanup する

### DIFF
--- a/docs/specs/170-withdraw-native-auth-cleanup/impl-notes.md
+++ b/docs/specs/170-withdraw-native-auth-cleanup/impl-notes.md
@@ -1,0 +1,125 @@
+# 実装ノート: Issue #170 退会時の native auth state cleanup
+
+## 実装サマリ
+
+Issue #170 の「退会フローにおける native auth 認証状態の cleanup」を、design.md / tasks.md の
+指針に厳密に従って実装した。退会トランザクション（`user.Service.withdrawTx`）の sessions 削除
+直後・users 削除前に、当該ユーザーの auth_codes / refresh_token_families の明示削除 2 段を
+挿入し、既存退会フローと同一の原子性境界（単一 tx / 全成功時のみ Commit）で実行する。
+
+設計の主要ポイントは原文どおり踏襲している:
+
+- 削除順序: item_states → subscriptions → sessions → **auth_codes →
+  refresh_token_families** → users（新 2 段は sessions 直後・users 前に挿入。
+  既存手順の順序・エラー処理・ログは不変）
+- refresh_tokens は `refresh_token_families` の DELETE に伴い FK ON DELETE CASCADE で
+  連動削除される（family 単位の DELETE 1 文。#164 の保存構造をそのまま利用）
+- repository は `PostgresSessionRepo` と同じ **2 段パターン**（`DeleteByUserID` が
+  `DeleteByUserIDExec(ctx, q DBTX, userID)` へ委譲）で DBTX 対応。エラー message に
+  user_id の値を含めない
+- service 層の deleter は **nil ガード付き**（nil なら当該段スキップ。既存 deleter 群と
+  同一方針。本番 wiring では常に非 nil を注入）
+- レガシー（非 tx）パスには明示削除を追加せず、users 削除時の FK CASCADE による DB 防衛線で
+  行残存を防ぐ（design.md どおり。SERVER.md §1.5 の「自動削除でも担保されるが明示推奨」の
+  明示側は tx パスで実装）
+
+## タスクとコミット対応表
+
+| Task | 内容 | 実装コミット | 進捗 commit |
+|---|---|---|---|
+| 1 | repository: ユーザー単位削除の追加（AuthCodeRepository 拡張 + DBTX 対応） | a0b2678 `feat(repository)` | 7c95ed8 `docs(tasks): mark 1` |
+| 2 | user: 退会トランザクションへの native auth 削除統合 | 73740ac `feat(user)` | f5f9c95 `docs(tasks): mark 2` |
+| 3 | app wiring と統合検証 | 13d2020 `feat(app)` | 2f094e4 `docs(tasks): mark 3` |
+
+実装順序は tasks.md の番号順そのままで、`_Depends:_` の制約（task 2 → 1、task 3 → 2）は
+自然に満たされた。
+
+## 受入基準と担保テスト
+
+### Requirement 1: 退会時の native auth 認証状態の削除
+
+| AC ID | 担保テスト |
+|---|---|
+| 1.1 (認可コードをすべて削除) | `user.TestService_Withdraw_Tx_CommitsOnSuccess`（auth_codes 段の呼び出し順検証）/ `repository.TestWithdrawIntegration_NativeAuthCleanup`（DB 結合: Commit 後 auth_codes 0 件）/ `repository` の `DeleteByUserID_当該userのみ削除し他userに影響しない` |
+| 1.2 (refresh token と rotation family をすべて削除) | 同上（refresh_token_families 段）+ `DeleteByUserIDExec_共有txでCommitすると当該userのfamily+tokensが消えて他userは残る`（FK CASCADE で tokens 連動削除を検証） |
+
+### Requirement 2: 退会フローへの統合と原子性
+
+| AC ID | 担保テスト |
+|---|---|
+| 2.1 (同一の原子性境界内で実行) | `user.TestService_Withdraw_Tx_CommitsOnSuccess`（単一 tx 上で 6 段が順に実行・Commit 1 回）/ `repository.TestWithdrawIntegration_NativeAuthCleanup`（共有 tx で sessions → auth_codes → families → users を削除して Commit） |
+| 2.2 (native auth 削除失敗で全体失敗・確定しない) | `user.TestService_Withdraw_Tx_RollsBackOnAuthCodeDeleteError` / `_RollsBackOnRefreshTokenDeleteError`（Rollback 実行・Commit 未到達・後段未呼び出しの fail-fast 検証） |
+| 2.3 (後段失敗時に native auth 削除を確定しない) | `repository.TestWithdrawIntegration_NativeAuthRollback`（共有 tx で native auth 削除後に Rollback → 全行残存を検証）/ `user.TestService_Withdraw_Tx_RollsBackOnRefreshTokenDeleteError`（中間失敗で先行削除も未確定） |
+
+### Requirement 3: 他ユーザーへの非影響
+
+| AC ID | 担保テスト |
+|---|---|
+| 3.1 (他ユーザーの認証状態を削除も失効もしない) | `repository` DB 結合テストの他ユーザー残存検証（auth_codes / families+tokens の双方）+ `TestWithdrawIntegration_NativeAuthCleanup` の他ユーザー行残存検証 |
+
+### Non-Functional Requirements
+
+| NFR | 担保テスト・実装 |
+|---|---|
+| NFR 1.1 (退会 API の応答形式不変) | `Withdraw` のシグネチャ・エラー wrap 形式は不変（追加 2 段も既存と同じ `fmt.Errorf("...: %w")`）。既存 handler テストが無変更で green / `user.TestService_Withdraw_Tx_NilNativeAuthDeletersSkip`（nil 注入でも従来どおり成功） |
+| NFR 1.2 (退会以外の native auth 操作を変更しない) | `AuthCodeRepository` への追加は `DeleteByUserID` のみ。既存メソッド・既存 `DeleteByUserID`（refresh 側）は委譲化のみで SQL・エラー message 不変。既存テスト無変更 green |
+| NFR 1.3 (データ移行・保存構造の変更なし) | migration 追加なし（FK CASCADE は #164 で定義済みの保存構造を利用） |
+| NFR 2.1 (残存しないことを明示的に検証) | `repository.TestWithdrawIntegration_NativeAuthCleanup`（退会フロー相当の削除を Commit 後、native auth 3 テーブルが 0 件であることを直接 COUNT 検証） |
+
+## 検証結果
+
+- `go build ./...`: 成功
+- `go vet ./...`: 警告なし
+- `go test ./...`: 全パッケージ pass（2026-06-12 引き継ぎセッションで再確認済み）
+- `gofmt -l <変更ファイル群>`: 出力なし（フォーマット差分なし）
+
+DB 結合テスト（`postgres_auth_code_repo_db_test.go` / `postgres_refresh_token_repo_db_test.go` /
+`postgres_withdraw_integration_db_test.go` の追加分）は `TEST_DATABASE_URL` 未設定時に skip
+する既存設計で、CI では postgres サービス上で実行される。
+
+## design からの逸脱
+
+無し。design.md の以下は **完全にそのまま** 実装した。
+
+- File Structure Plan に列挙された全ファイル（変更 7 ファイル。これに加え task 3 指定の
+  退会フロー統合 DB テストを `internal/repository/postgres_withdraw_integration_db_test.go`
+  として新設、compile-time interface checks の拡張で `withdraw_wiring_test.go` を更新）
+- `TxAuthCodeDeleter` / `TxRefreshTokenDeleter` の最小 IF（`DeleteByUserIDTx` 1 メソッド）と
+  adapter 同型パターン（`querierFromTx` → `DeleteByUserIDExec`）
+- Requirements Traceability の手順 4〜5 挿入位置（sessions 直後・users 前）
+- 新規 migration なし・レガシーパス無変更・`NewService`（非 tx コンストラクタ）無変更
+
+## 実装上の判断
+
+### 既存テストへの nil 注入
+
+`NewServiceWithTx` の引数拡張に伴い、既存の tx パステスト 5 件には native auth deleter を
+`nil` で注入した（各テストの検証対象が native auth 段と無関係なため。コメントで理由を明記）。
+nil ガード経路自体は専用の `TestService_Withdraw_Tx_NilNativeAuthDeletersSkip` が検証する。
+
+### 削除順序: auth_codes → refresh_token_families
+
+design.md の手順番号どおり認可コード → refresh token の順とした。両テーブル間に FK は無く
+順序の機能的制約は無いが、トレーサビリティのため design の記述順を維持した。
+
+## 追加した依存
+
+無し（go.mod / go.sum 変更なし）。
+
+## 引き継ぎメモ
+
+- task 3（app wiring / 13d2020）は前任セッションが developer エージェント停止後に
+  build / vet / test green を確認してコミットしたもの。本引き継ぎセッションで全 diff を
+  再検証し、Reviewer も通常どおり全 diff をレビューしている。
+- **Issue #168 (revoke)**: `POST /api/auth/revoke` は本 spec と独立（退会は物理削除、revoke
+  は failure 失効）。本 spec の `DeleteByUserIDExec` 2 段パターンは #168 では使用しない。
+
+## 確認事項（PR 本文転載用）
+
+- 設計矛盾は無し。
+- レガシー（非 tx）パスは design.md どおり明示削除を追加していない（本番 wiring は常に
+  tx パス。レガシーパスは FK CASCADE が防衛線）。
+- 退会フロー統合 DB テストは service 層を経由せず repository レイヤの共有 tx 操作で
+  退会相当の削除列を再現している（tasks.md task 3 の指定どおり）。
+
+STATUS: complete

--- a/docs/specs/170-withdraw-native-auth-cleanup/review-notes.md
+++ b/docs/specs/170-withdraw-native-auth-cleanup/review-notes.md
@@ -1,0 +1,129 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-11T23:32:28Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-170-impl-withdraw-native-auth-cleanup
+- HEAD commit: 92220b8
+- Compared to: $(git merge-base develop HEAD)..HEAD（merge-base: 9edfce4）
+- 対象 commit 群: a0b2678 / 7c95ed8 / 73740ac / f5f9c95 / 13d2020 / 2f094e4 / 92220b8
+- 検証実行: `go build ./...` / `go vet ./...` / `go test ./internal/user/ ./internal/repository/ ./internal/app/` すべて pass
+- Feature Flag Protocol: `opt-out`（細目チェックは適用外）
+
+## Verified Requirements
+
+- **1.1**（退会時に当該ユーザーの一時認可コードをすべて削除）
+  - 実装: `internal/user/service.go` の `withdrawTx` 手順 4（sessions 直後）に
+    `s.txAuthCodeDeleter.DeleteByUserIDTx(ctx, tx, userID)` を挿入。
+    `PostgresAuthCodeRepo.DeleteByUserID` / `DeleteByUserIDExec` が
+    `DELETE FROM auth_codes WHERE user_id = $1` を実行
+  - テスト: `TestService_Withdraw_Tx_CommitsOnSuccess`（順序検証で `auth_codes` を含む）/
+    `TestPostgresAuthCodeRepo_DB/DeleteByUserID_当該userのみ削除し他userに影響しない` /
+    `TestWithdrawIntegration_NativeAuthCleanup`（Commit 後 auth_codes=0 件を COUNT で検証）
+
+- **1.2**（退会時に refresh token と rotation family をすべて削除）
+  - 実装: `withdrawTx` 手順 5 に `s.txRefreshTokenDeleter.DeleteByUserIDTx` を挿入。
+    `PostgresRefreshTokenRepo.DeleteByUserIDExec` が
+    `DELETE FROM refresh_token_families WHERE user_id = $1` を発行し、配下 refresh_tokens は
+    FK ON DELETE CASCADE で連動削除
+  - テスト: `TestService_Withdraw_Tx_CommitsOnSuccess`（順序検証で `refresh_token_families` を含む）/
+    `TestPostgresRefreshTokenRepo_DB/DeleteByUserIDExec_共有txでCommitすると当該userのfamily+tokensが消えて他userは残る` /
+    `TestWithdrawIntegration_NativeAuthCleanup`（refresh_token_families と refresh_tokens の双方が 0 件を COUNT で検証）
+
+- **2.1**（既存退会フローと同一の原子性境界内で実行）
+  - 実装: 新規 2 段は既存と同じ `tx` を引き回して呼び出される。新規 tx 開始なし。
+    `withdraw_wiring.go` の 2 アダプタは `querierFromTx(tx)` 経由で repository の Exec 変種を呼ぶ
+  - テスト: `TestService_Withdraw_Tx_CommitsOnSuccess`（単一 tx 上で 6 段 → Commit 1 回）/
+    `TestWithdrawIntegration_NativeAuthCleanup`（共有 tx で sessions → auth_codes →
+    refresh_token_families → users の順に削除して Commit）
+
+- **2.2**（途中失敗で退会全体を失敗させ、それまでの削除を確定しない）
+  - 実装: 既存と同じ `%w` wrap + 即 return → `defer Rollback` が全戻し
+  - テスト: `TestService_Withdraw_Tx_RollsBackOnAuthCodeDeleteError`（auth_codes 失敗時に
+    Commit 未到達 + refresh_token_families / user 未呼び出しを検証）/
+    `TestService_Withdraw_Tx_RollsBackOnRefreshTokenDeleteError`（refresh_token 失敗時に
+    user 削除未到達 + Rollback を検証）
+
+- **2.3**（native auth 削除より後の段階で失敗時に native auth 削除を確定しない）
+  - 実装: defer Rollback により users 削除 / Commit 失敗時も新規 2 段が未確定に戻る
+  - テスト: `TestWithdrawIntegration_NativeAuthRollback`（共有 tx で 3 段削除後に
+    Rollback → 3 テーブルすべて残存を COUNT で検証）/
+    `TestService_Withdraw_Tx_RollsBackOnRefreshTokenDeleteError`（中間失敗で先行削除も未確定）
+
+- **3.1**（他ユーザーの認証状態を削除も失効もしない）
+  - 実装: 削除 SQL の `WHERE user_id = $1` スコープ
+  - テスト: `TestPostgresAuthCodeRepo_DB/DeleteByUserID_当該userのみ削除し他userに影響しない` /
+    `TestPostgresRefreshTokenRepo_DB/DeleteByUserIDExec_共有txでCommitすると当該userのfamily+tokensが消えて他userは残る` /
+    `TestWithdrawIntegration_NativeAuthCleanup`（bystander user の 3 テーブル + sessions が
+    残存することを検証）
+
+- **NFR 1.1**（退会 API の応答形式不変）
+  - 実装: handler / adapter / `Withdraw` の signature・戻り値型は不変。エラー wrap も既存と
+    同形式（`fmt.Errorf("...: %w", err)`）
+  - テスト: 既存 handler テストが無変更で green。
+    `TestService_Withdraw_Tx_NilNativeAuthDeletersSkip`（nil 注入時の従来動作維持）
+
+- **NFR 1.2**（退会以外の native auth 操作の挙動を変更しない）
+  - 実装: `AuthCodeRepository` interface に `DeleteByUserID` を追加（Create / FindByHash /
+    MarkUsed は不変）。`RefreshTokenRepository` interface は不変。
+    `PostgresRefreshTokenRepo.DeleteByUserID` は `DeleteByUserIDExec(ctx, r.db, userID)` への
+    委譲化のみ（SQL・エラー message 不変の挙動等価 refactor）
+  - 既存 repository テスト・user テストの未変更箇所が green
+
+- **NFR 1.3**（データ移行・保存構造の変更なしに導入）
+  - 実装: migration 追加なし（File Structure Plan に migration ファイルが含まれない）。
+    FK ON DELETE CASCADE は #164 で導入済みの保存構造を温存
+
+- **NFR 2.1**（退会完了後に当該ユーザーの認可コード・refresh token・rotation family が
+  残存しないことを明示的に検証）
+  - テスト: `TestWithdrawIntegration_NativeAuthCleanup` が Commit 後に
+    `SELECT COUNT(*) FROM auth_codes / refresh_token_families / refresh_tokens WHERE user_id = $1`
+    の 3 件すべてを 0 で assert（refresh_tokens は family CASCADE 経路の期待挙動を明文化）
+
+## Findings
+
+なし。確認した観点は以下のとおり。
+
+### 確認した観点
+
+1. **削除順序の規約遵守**: design.md「削除順序の決定」と service.go の挿入位置が完全一致
+   （手順 4: auth_codes / 手順 5: refresh_token_families / 手順 6: users）。
+   `TestService_Withdraw_Tx_CommitsOnSuccess` の `want` 配列が 6 段を順に検証している
+2. **トランザクション境界**: `withdrawTx` 内で `s.txBeginner.BeginTx` の戻り値 `tx` を 4〜5 段に
+   そのまま渡しており、新規 tx 開始や別 tx 利用は無い。`withdraw_wiring.go` のアダプタも
+   `querierFromTx(tx)` 経由で同一 `*sql.Tx` を再利用
+3. **nil ガード方針**: 既存 `txStateDeleter` 等と同型の `if s.txAuthCodeDeleter != nil` /
+   `if s.txRefreshTokenDeleter != nil` のガードで段スキップ。本番 wiring（`app.go`）では
+   `&txAuthCodeDeleterAdapter{repo: authCodeRepo}` / `&txRefreshTokenDeleterAdapter{repo: refreshTokenRepo}`
+   を常に注入するため、本番では skip されない
+4. **boundary 逸脱**: design.md File Structure Plan に列挙されたファイル
+   （`internal/repository/interfaces.go` / `postgres_auth_code_repo.go` /
+   `postgres_refresh_token_repo.go` / `postgres_auth_code_repo_db_test.go` /
+   `postgres_refresh_token_repo_db_test.go` / `internal/user/service.go` /
+   `internal/user/service_test.go` / `internal/app/withdraw_wiring.go` / `internal/app/app.go`）
+   と diff 内変更ファイル群が一致。task 3 の追加分として明示された
+   `internal/repository/postgres_withdraw_integration_db_test.go` の新設・
+   `internal/app/withdraw_wiring_test.go` の compile-time interface check 拡張も
+   impl-notes.md「design からの逸脱」節で事前に開示済みで、tasks.md task 3 の
+   `_Boundary:_` 内（repository / app）に閉じている
+5. **handler / adapter 変更なし**: `internal/handler/` 配下に diff は無く、退会 API の
+   応答形式は不変（NFR 1.1）
+6. **既存メソッドの挙動等価性**: `PostgresRefreshTokenRepo.DeleteByUserID` は SQL 文・
+   エラー message を保ったまま `DeleteByUserIDExec` に委譲化されており、既存 DB 結合テスト
+   （`DeleteByUserID_...` サブテスト群）が無変更で green
+7. **インターフェース分離の維持**: `AuthCodeRepository` interface に `DeleteByUserID` を
+   追加したのみで、`auth.AuthCodeCreator`（#165）/ `auth.AuthCodeConsumer`（#166 設計）の
+   狭い IF を持つ既存利用側は影響を受けない
+8. **テスト規約**: Arrange / Act / Assert の 3 パート分離、`<対象>: <条件>のとき<期待結果>`
+   形式の命名、table-driven ではなく `t.Run` サブテストでの 1 テスト = 1 検証対象、
+   いずれも CLAUDE.md の Go テスト規約に従っている
+
+## Summary
+
+design.md / tasks.md の指針に厳密に従い、退会 tx に native auth 削除 2 段を sessions 直後・
+users 前に挿入する実装が完了している。全 numeric ID（Req 1.1〜1.2 / 2.1〜2.3 / 3.1 /
+NFR 1.1〜1.3 / NFR 2.1）に対し、対応する実装と単体テスト・DB 結合テストが確認できた。
+boundary 逸脱なし、`go build` / `go vet` / `go test ./internal/{user,repository,app}/` すべて pass。
+
+RESULT: approve

--- a/docs/specs/170-withdraw-native-auth-cleanup/tasks.md
+++ b/docs/specs/170-withdraw-native-auth-cleanup/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. repository: ユーザー単位削除の追加（AuthCodeRepository 拡張 + DBTX 対応）
+- [x] 1. repository: ユーザー単位削除の追加（AuthCodeRepository 拡張 + DBTX 対応）
   - `internal/repository/interfaces.go`: `AuthCodeRepository` に
     `DeleteByUserID(ctx context.Context, userID string) error` を追加（doc comment は
     `RefreshTokenRepository.DeleteByUserID` と対になる文面。冪等・CASCADE 併存の旨を明記）

--- a/docs/specs/170-withdraw-native-auth-cleanup/tasks.md
+++ b/docs/specs/170-withdraw-native-auth-cleanup/tasks.md
@@ -16,7 +16,7 @@
     サブテストが無変更で green であることを確認
   - _Requirements: 1.1, 1.2, 3.1, NFR 1.2, NFR 1.3_
 
-- [ ] 2. user: 退会トランザクションへの native auth 削除統合
+- [x] 2. user: 退会トランザクションへの native auth 削除統合
   - `internal/user/service.go`: `TxAuthCodeDeleter` / `TxRefreshTokenDeleter` を追加し、
     `NewServiceWithTx` の引数を 2 つ拡張。`withdrawTx` の sessions 削除直後（users 削除前）に
     nil ガード付きの削除 2 段（認可コード → refresh token）を挿入する。既存手順

--- a/docs/specs/170-withdraw-native-auth-cleanup/tasks.md
+++ b/docs/specs/170-withdraw-native-auth-cleanup/tasks.md
@@ -28,7 +28,7 @@
   - _Requirements: 1.1, 1.2, 2.1, 2.2, 2.3_
   - _Depends: 1_
 
-- [ ] 3. app wiring と統合検証
+- [x] 3. app wiring と統合検証
   - `internal/app/withdraw_wiring.go`: `txAuthCodeDeleterAdapter` /
     `txRefreshTokenDeleterAdapter` を追加（`querierFromTx` → `DeleteByUserIDExec` の既存
     アダプタ同型）し、`newTxUserService` の引数と compile-time interface checks を拡張

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -176,7 +176,11 @@ func runServe(cfg *config.Config) error {
 		subRepo, itemStateRepo, feedRepo,
 		fetcher, manualFetchTxBeginner, serveCollector,
 	)
-	userService := newTxUserService(txBeginner, userRepo, sessionRepo, subRepo, itemStateRepo)
+	// Issue #170: 退会トランザクションへ native auth 認証状態（auth_codes /
+	// refresh_token_families）の明示削除を統合するため、authCodeRepo /
+	// refreshTokenRepo を newTxUserService に渡す。これらの repo は #165 / #166 で
+	// 上記の native auth 配線にも共用される。
+	userService := newTxUserService(txBeginner, userRepo, sessionRepo, subRepo, itemStateRepo, authCodeRepo, refreshTokenRepo)
 
 	// 5. ハンドラーアダプタの構築
 	subServiceAdapter := handler.NewSubscriptionServiceAdapter(subService)

--- a/internal/app/withdraw_wiring.go
+++ b/internal/app/withdraw_wiring.go
@@ -77,6 +77,35 @@ func (a *txSessionDeleterAdapter) DeleteByUserIDTx(ctx context.Context, tx user.
 	return a.repo.DeleteByUserIDExec(ctx, q, userID)
 }
 
+// txAuthCodeDeleterAdapter は認可コードリポジトリを user.TxAuthCodeDeleter に
+// 適合させる（Issue #170 Req 1.1, 2.1）。
+type txAuthCodeDeleterAdapter struct {
+	repo *repository.PostgresAuthCodeRepo
+}
+
+func (a *txAuthCodeDeleterAdapter) DeleteByUserIDTx(ctx context.Context, tx user.Tx, userID string) error {
+	q, err := querierFromTx(tx)
+	if err != nil {
+		return err
+	}
+	return a.repo.DeleteByUserIDExec(ctx, q, userID)
+}
+
+// txRefreshTokenDeleterAdapter は refresh token リポジトリを
+// user.TxRefreshTokenDeleter に適合させる（Issue #170 Req 1.2, 2.1）。
+// family の DELETE 1 文で配下 tokens は FK CASCADE により連動削除される。
+type txRefreshTokenDeleterAdapter struct {
+	repo *repository.PostgresRefreshTokenRepo
+}
+
+func (a *txRefreshTokenDeleterAdapter) DeleteByUserIDTx(ctx context.Context, tx user.Tx, userID string) error {
+	q, err := querierFromTx(tx)
+	if err != nil {
+		return err
+	}
+	return a.repo.DeleteByUserIDExec(ctx, q, userID)
+}
+
 // txUserDeleterAdapter はユーザーリポジトリを user.TxUserDeleter に適合させる。
 type txUserDeleterAdapter struct {
 	repo *repository.PostgresUserRepo
@@ -96,15 +125,17 @@ func (a *txUserDeleterAdapter) DeleteByIDTx(ctx context.Context, tx user.Tx, id 
 
 // newTxUserService はトランザクション対応の退会サービスを組み立てる。
 //
-// Issue #170: native auth deleter (auth_code / refresh_token) は Task 3 で
-// 正式なアダプタを注入するため、本 commit 時点では nil を渡してビルド整合のみ
-// 維持する（withdraw 時の native auth 明示削除は Task 3 完了後に有効化される）。
+// Issue #170: native auth deleter（auth_code / refresh_token）を末尾に追加し、
+// 退会トランザクションへ auth_codes / refresh_token_families の明示削除を
+// 統合する。
 func newTxUserService(
 	beginner *repository.SQLTxBeginner,
 	userRepo *repository.PostgresUserRepo,
 	sessionRepo *repository.PostgresSessionRepo,
 	subRepo *repository.PostgresSubscriptionRepo,
 	itemStateRepo *repository.PostgresItemStateRepo,
+	authCodeRepo *repository.PostgresAuthCodeRepo,
+	refreshTokenRepo *repository.PostgresRefreshTokenRepo,
 ) *user.Service {
 	return user.NewServiceWithTx(
 		&txBeginnerAdapter{beginner: beginner},
@@ -112,8 +143,8 @@ func newTxUserService(
 		&txSessionDeleterAdapter{repo: sessionRepo},
 		&txSubscriptionDeleterAdapter{repo: subRepo},
 		&txItemStateDeleterAdapter{repo: itemStateRepo},
-		nil, // TODO(Issue #170 Task 3): txAuthCodeDeleterAdapter を注入
-		nil, // TODO(Issue #170 Task 3): txRefreshTokenDeleterAdapter を注入
+		&txAuthCodeDeleterAdapter{repo: authCodeRepo},
+		&txRefreshTokenDeleterAdapter{repo: refreshTokenRepo},
 	)
 }
 
@@ -124,4 +155,6 @@ var (
 	_ user.TxSubscriptionDeleter = (*txSubscriptionDeleterAdapter)(nil)
 	_ user.TxSessionDeleter      = (*txSessionDeleterAdapter)(nil)
 	_ user.TxUserDeleter         = (*txUserDeleterAdapter)(nil)
+	_ user.TxAuthCodeDeleter     = (*txAuthCodeDeleterAdapter)(nil)
+	_ user.TxRefreshTokenDeleter = (*txRefreshTokenDeleterAdapter)(nil)
 )

--- a/internal/app/withdraw_wiring.go
+++ b/internal/app/withdraw_wiring.go
@@ -95,6 +95,10 @@ func (a *txUserDeleterAdapter) DeleteByIDTx(ctx context.Context, tx user.Tx, id 
 }
 
 // newTxUserService はトランザクション対応の退会サービスを組み立てる。
+//
+// Issue #170: native auth deleter (auth_code / refresh_token) は Task 3 で
+// 正式なアダプタを注入するため、本 commit 時点では nil を渡してビルド整合のみ
+// 維持する（withdraw 時の native auth 明示削除は Task 3 完了後に有効化される）。
 func newTxUserService(
 	beginner *repository.SQLTxBeginner,
 	userRepo *repository.PostgresUserRepo,
@@ -108,6 +112,8 @@ func newTxUserService(
 		&txSessionDeleterAdapter{repo: sessionRepo},
 		&txSubscriptionDeleterAdapter{repo: subRepo},
 		&txItemStateDeleterAdapter{repo: itemStateRepo},
+		nil, // TODO(Issue #170 Task 3): txAuthCodeDeleterAdapter を注入
+		nil, // TODO(Issue #170 Task 3): txRefreshTokenDeleterAdapter を注入
 	)
 }
 

--- a/internal/app/withdraw_wiring_test.go
+++ b/internal/app/withdraw_wiring_test.go
@@ -31,6 +31,8 @@ func TestQuerierFromTx_RejectsUnexpectedType(t *testing.T) {
 
 // TestNewTxUserService_Constructs はトランザクション対応の退会サービスが
 // 配線できることを検証する（nil リポジトリでも構築自体は成功する）。
+// Issue #170: native auth deleter（auth_code / refresh_token）の repository を
+// 末尾に追加した呼び出し signature を検証する。
 func TestNewTxUserService_Constructs(t *testing.T) {
 	beginner := repository.NewSQLTxBeginner(nil)
 	svc := newTxUserService(
@@ -39,6 +41,8 @@ func TestNewTxUserService_Constructs(t *testing.T) {
 		repository.NewPostgresSessionRepo(nil),
 		repository.NewPostgresSubscriptionRepo(nil),
 		repository.NewPostgresItemStateRepo(nil),
+		repository.NewPostgresAuthCodeRepo(nil),
+		repository.NewPostgresRefreshTokenRepo(nil),
 	)
 	if svc == nil {
 		t.Fatal("expected non-nil user.Service")
@@ -47,10 +51,13 @@ func TestNewTxUserService_Constructs(t *testing.T) {
 
 // TestWithdrawWiringAdapters_SatisfyInterfaces は各アダプタが
 // user パッケージのトランザクション対応インターフェースを満たすことを検証する。
+// Issue #170: txAuthCodeDeleterAdapter / txRefreshTokenDeleterAdapter も対象。
 func TestWithdrawWiringAdapters_SatisfyInterfaces(t *testing.T) {
 	var _ user.TxBeginner = (*txBeginnerAdapter)(nil)
 	var _ user.TxItemStateDeleter = (*txItemStateDeleterAdapter)(nil)
 	var _ user.TxSubscriptionDeleter = (*txSubscriptionDeleterAdapter)(nil)
 	var _ user.TxSessionDeleter = (*txSessionDeleterAdapter)(nil)
 	var _ user.TxUserDeleter = (*txUserDeleterAdapter)(nil)
+	var _ user.TxAuthCodeDeleter = (*txAuthCodeDeleterAdapter)(nil)
+	var _ user.TxRefreshTokenDeleter = (*txRefreshTokenDeleterAdapter)(nil)
 }

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -73,6 +73,11 @@ type AuthCodeRepository interface {
 	// 当該レコードが 1) 既に used = true, 2) expires_at <= now(), 3) 存在しない の
 	// いずれかの場合は ErrAuthCodeNotUsable を返し、永続化状態は変更しない（Req 2.6）。
 	MarkUsed(ctx context.Context, id string) error
+
+	// DeleteByUserID は当該ユーザーに属する全ての auth_code を削除する（Issue #170 Req 1.1）。
+	// 対象 0 件でも成功する（冪等）。FK ON DELETE CASCADE で users 削除時にも到達するが、
+	// 退会フローからの明示的削除経路として提供する（RefreshTokenRepository.DeleteByUserID と対）。
+	DeleteByUserID(ctx context.Context, userID string) error
 }
 
 // RefreshTokenRepository は native auth の refresh token / family 永続化操作を公開する。

--- a/internal/repository/postgres_auth_code_repo.go
+++ b/internal/repository/postgres_auth_code_repo.go
@@ -123,5 +123,31 @@ func (r *PostgresAuthCodeRepo) MarkUsed(ctx context.Context, id string) error {
 	return nil
 }
 
+// DeleteByUserID は当該ユーザーに属する全ての auth_code を削除する（Issue #170 Req 1.1）。
+//
+// 対象 0 件でも成功する（冪等）。退会フロー（user.Service.withdrawTx）からの
+// 明示的削除経路として提供する。FK ON DELETE CASCADE による防衛線も維持される
+// （RefreshTokenRepository.DeleteByUserID と対）。
+func (r *PostgresAuthCodeRepo) DeleteByUserID(ctx context.Context, userID string) error {
+	return r.DeleteByUserIDExec(ctx, r.db, userID)
+}
+
+// DeleteByUserIDExec は指定の DBTX（*sql.DB または共有トランザクション）上で
+// 当該ユーザーに属する全ての auth_code を削除する（Issue #170 Req 1.1, 2.1）。
+//
+// SQL: DELETE FROM auth_codes WHERE user_id = $1
+// PostgresSessionRepo の 2 段パターン（DeleteByUserID + DeleteByUserIDExec）と同型。
+func (r *PostgresAuthCodeRepo) DeleteByUserIDExec(ctx context.Context, q DBTX, userID string) error {
+	_, err := q.ExecContext(ctx,
+		`DELETE FROM auth_codes WHERE user_id = $1`,
+		userID,
+	)
+	if err != nil {
+		// NFR 1.2: user_id の値はメッセージに含めない。
+		return fmt.Errorf("failed to delete auth_codes by user: %w", err)
+	}
+	return nil
+}
+
 // compile-time interface check
 var _ AuthCodeRepository = (*PostgresAuthCodeRepo)(nil)

--- a/internal/repository/postgres_auth_code_repo_db_test.go
+++ b/internal/repository/postgres_auth_code_repo_db_test.go
@@ -278,6 +278,120 @@ func TestPostgresAuthCodeRepo_DB(t *testing.T) {
 		}
 	})
 
+	// Case 7 (Issue #170 Req 1.1, 3.1): DeleteByUserID は当該 user のみ削除し、他 user に影響しない
+	t.Run("DeleteByUserID_当該userのみ削除し他userに影響しない", func(t *testing.T) {
+		userA := insertTestUserForAuthCode(t, db, "issue170-delete-target@test.com")
+		userB := insertTestUserForAuthCode(t, db, "issue170-delete-bystander@test.com")
+
+		// user A に 2 件、user B に 1 件の auth_code を作成
+		codeA1 := newTestAuthCode(userA, "hash-issue170-a-1-0123456789abcd00", time.Now().Add(60*time.Second).UTC())
+		codeA2 := newTestAuthCode(userA, "hash-issue170-a-2-0123456789abcd00", time.Now().Add(60*time.Second).UTC())
+		codeB := newTestAuthCode(userB, "hash-issue170-b-0123456789abcd0000", time.Now().Add(60*time.Second).UTC())
+		for _, c := range []*model.AuthCode{codeA1, codeA2, codeB} {
+			if err := repo.Create(ctx, c); err != nil {
+				t.Fatalf("Create に失敗: %v", err)
+			}
+		}
+
+		// Act: user A の auth_code を一括削除
+		if err := repo.DeleteByUserID(ctx, userA); err != nil {
+			t.Fatalf("DeleteByUserID に失敗: %v", err)
+		}
+
+		// Assert: user A の auth_codes は 0 件
+		var countA int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM auth_codes WHERE user_id = $1`, userA).Scan(&countA); err != nil {
+			t.Fatalf("user A COUNT 取得に失敗: %v", err)
+		}
+		if countA != 0 {
+			t.Errorf("user A の auth_codes が残存している: got %d, want 0", countA)
+		}
+
+		// user B の auth_codes は 1 件残っている
+		var countB int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM auth_codes WHERE user_id = $1`, userB).Scan(&countB); err != nil {
+			t.Fatalf("user B COUNT 取得に失敗: %v", err)
+		}
+		if countB != 1 {
+			t.Errorf("user B の auth_codes が DeleteByUserID(A) で削除された: got %d, want 1", countB)
+		}
+	})
+
+	// Case 8 (Issue #170 Req 1.1 冪等): 対象 0 件でも DeleteByUserID は成功する
+	t.Run("DeleteByUserID_対象0件でも成功する", func(t *testing.T) {
+		userID := insertTestUserForAuthCode(t, db, "issue170-empty@test.com")
+		// auth_code を一切作成しない状態で DeleteByUserID
+		if err := repo.DeleteByUserID(ctx, userID); err != nil {
+			t.Errorf("0 件削除でエラーを返した（冪等性違反）: %v", err)
+		}
+	})
+
+	// Case 9 (Issue #170 Req 2.1): DeleteByUserIDExec が共有 tx に参加し、Rollback で取り消される
+	t.Run("DeleteByUserIDExec_共有txに参加しRollbackで取り消される", func(t *testing.T) {
+		userID := insertTestUserForAuthCode(t, db, "issue170-tx-rollback@test.com")
+		code := newTestAuthCode(userID, "hash-issue170-tx-rollback-01234567", time.Now().Add(60*time.Second).UTC())
+		if err := repo.Create(ctx, code); err != nil {
+			t.Fatalf("Create に失敗: %v", err)
+		}
+
+		// Act: 共有 tx を開いて DeleteByUserIDExec を呼び、Rollback する
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("BeginTx に失敗: %v", err)
+		}
+		if err := repo.DeleteByUserIDExec(ctx, tx, userID); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("DeleteByUserIDExec に失敗: %v", err)
+		}
+		if err := tx.Rollback(); err != nil {
+			t.Fatalf("Rollback に失敗: %v", err)
+		}
+
+		// Assert: Rollback により削除が取り消され、auth_code は依然存在する
+		var count int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM auth_codes WHERE user_id = $1`, userID,
+		).Scan(&count); err != nil {
+			t.Fatalf("COUNT 取得に失敗: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("Rollback 後の auth_codes が残存していない: got %d, want 1", count)
+		}
+	})
+
+	// Case 10 (Issue #170 Req 2.1): DeleteByUserIDExec を共有 tx 上で Commit すると削除が確定する
+	t.Run("DeleteByUserIDExec_共有txでCommitすると削除が確定する", func(t *testing.T) {
+		userID := insertTestUserForAuthCode(t, db, "issue170-tx-commit@test.com")
+		code := newTestAuthCode(userID, "hash-issue170-tx-commit-0123456789", time.Now().Add(60*time.Second).UTC())
+		if err := repo.Create(ctx, code); err != nil {
+			t.Fatalf("Create に失敗: %v", err)
+		}
+
+		// Act: 共有 tx を開いて DeleteByUserIDExec を呼び、Commit する
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("BeginTx に失敗: %v", err)
+		}
+		if err := repo.DeleteByUserIDExec(ctx, tx, userID); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("DeleteByUserIDExec に失敗: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("Commit に失敗: %v", err)
+		}
+
+		// Assert: Commit により削除が確定し、auth_code は 0 件
+		var count int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM auth_codes WHERE user_id = $1`, userID,
+		).Scan(&count); err != nil {
+			t.Fatalf("COUNT 取得に失敗: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("Commit 後の auth_codes が削除されていない: got %d, want 0", count)
+		}
+	})
+
 	// Case 5 (Req 1.5 / 3.6 同系統 cascade): users 削除時に auth_codes が cascade 削除される
 	t.Run("users削除時にauth_codesがCASCADE削除される", func(t *testing.T) {
 		userID := insertTestUserForAuthCode(t, db, "cascade@test.com")

--- a/internal/repository/postgres_refresh_token_repo.go
+++ b/internal/repository/postgres_refresh_token_repo.go
@@ -199,8 +199,22 @@ func (r *PostgresRefreshTokenRepo) RevokeFamily(ctx context.Context, familyID st
 // refresh_token_families を DELETE すると、refresh_tokens.family_id への FK
 // ON DELETE CASCADE により配下の token も自動削除される。本実装は family の DELETE
 // 1 文だけを発行する（refresh_tokens は明示 DELETE しない）。
+//
+// Issue #170: 共有トランザクション上で実行する場合は DeleteByUserIDExec を直接呼ぶ。
+// 本メソッドは r.db を渡して同 Exec 変種に委譲する（SQL・エラーメッセージは挙動等価）。
 func (r *PostgresRefreshTokenRepo) DeleteByUserID(ctx context.Context, userID string) error {
-	if _, err := r.db.ExecContext(ctx,
+	return r.DeleteByUserIDExec(ctx, r.db, userID)
+}
+
+// DeleteByUserIDExec は指定の DBTX（*sql.DB または共有トランザクション）上で
+// 当該ユーザーに属する全ての refresh_token と family を削除する（Issue #170 Req 1.2, 2.1）。
+//
+// refresh_token_families を DELETE すると、refresh_tokens.family_id への FK
+// ON DELETE CASCADE により配下の token も自動削除される（本メソッドは family の
+// DELETE 1 文だけを発行する）。退会トランザクション（user.Service.withdrawTx）への
+// 統合経路として提供する（PostgresSessionRepo / PostgresAuthCodeRepo と同型）。
+func (r *PostgresRefreshTokenRepo) DeleteByUserIDExec(ctx context.Context, q DBTX, userID string) error {
+	if _, err := q.ExecContext(ctx,
 		`DELETE FROM refresh_token_families WHERE user_id = $1`,
 		userID,
 	); err != nil {

--- a/internal/repository/postgres_refresh_token_repo_db_test.go
+++ b/internal/repository/postgres_refresh_token_repo_db_test.go
@@ -397,6 +397,144 @@ func TestPostgresRefreshTokenRepo_DB(t *testing.T) {
 		}
 	})
 
+	// Case 8 (Issue #170 Req 1.2, 2.1): DeleteByUserIDExec が共有 tx に参加し、
+	// 配下 tokens も FK CASCADE で削除される。他 user は影響を受けない
+	t.Run("DeleteByUserIDExec_共有txでCommitすると当該userのfamily+tokensが消えて他userは残る", func(t *testing.T) {
+		userA := insertTestUserForRefreshToken(t, db, "issue170-exec-target@test.com")
+		userB := insertTestUserForRefreshToken(t, db, "issue170-exec-bystander@test.com")
+
+		// user A: family + token を 1 件
+		familyA := newTestRefreshTokenFamily(userA)
+		if err := repo.CreateFamily(ctx, familyA); err != nil {
+			t.Fatalf("CreateFamily A に失敗: %v", err)
+		}
+		tokenA := newTestRefreshToken(familyA.ID, userA, "hash-issue170-exec-a-0123456789abcd", time.Now().Add(24*time.Hour).UTC())
+		if err := repo.CreateToken(ctx, tokenA); err != nil {
+			t.Fatalf("CreateToken A に失敗: %v", err)
+		}
+
+		// user B: family + token を 1 件（削除対象外）
+		familyB := newTestRefreshTokenFamily(userB)
+		if err := repo.CreateFamily(ctx, familyB); err != nil {
+			t.Fatalf("CreateFamily B に失敗: %v", err)
+		}
+		tokenB := newTestRefreshToken(familyB.ID, userB, "hash-issue170-exec-b-0123456789abcd", time.Now().Add(24*time.Hour).UTC())
+		if err := repo.CreateToken(ctx, tokenB); err != nil {
+			t.Fatalf("CreateToken B に失敗: %v", err)
+		}
+
+		// Act: 共有 tx を開いて user A の DeleteByUserIDExec を呼び、Commit する
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("BeginTx に失敗: %v", err)
+		}
+		if err := repo.DeleteByUserIDExec(ctx, tx, userA); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("DeleteByUserIDExec に失敗: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("Commit に失敗: %v", err)
+		}
+
+		// Assert: user A の family / token は 0 件
+		var familyCountA, tokenCountA int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM refresh_token_families WHERE user_id = $1`, userA,
+		).Scan(&familyCountA); err != nil {
+			t.Fatalf("user A family COUNT に失敗: %v", err)
+		}
+		if familyCountA != 0 {
+			t.Errorf("user A の family が削除されていない: got %d, want 0", familyCountA)
+		}
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM refresh_tokens WHERE user_id = $1`, userA,
+		).Scan(&tokenCountA); err != nil {
+			t.Fatalf("user A token COUNT に失敗: %v", err)
+		}
+		if tokenCountA != 0 {
+			t.Errorf("user A の token が FK CASCADE で削除されていない: got %d, want 0", tokenCountA)
+		}
+
+		// Assert: user B の family / token は影響を受けず残っている
+		var familyCountB, tokenCountB int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM refresh_token_families WHERE user_id = $1`, userB,
+		).Scan(&familyCountB); err != nil {
+			t.Fatalf("user B family COUNT に失敗: %v", err)
+		}
+		if familyCountB != 1 {
+			t.Errorf("user B の family が DeleteByUserIDExec(A) で削除された: got %d, want 1", familyCountB)
+		}
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM refresh_tokens WHERE user_id = $1`, userB,
+		).Scan(&tokenCountB); err != nil {
+			t.Fatalf("user B token COUNT に失敗: %v", err)
+		}
+		if tokenCountB != 1 {
+			t.Errorf("user B の token が DeleteByUserIDExec(A) で削除された: got %d, want 1", tokenCountB)
+		}
+	})
+
+	// Case 9 (Issue #170 Req 2.2): DeleteByUserIDExec を共有 tx 上で Rollback すると削除が取り消される
+	t.Run("DeleteByUserIDExec_Rollbackすると削除が取り消される", func(t *testing.T) {
+		userID := insertTestUserForRefreshToken(t, db, "issue170-exec-rollback@test.com")
+		family := newTestRefreshTokenFamily(userID)
+		if err := repo.CreateFamily(ctx, family); err != nil {
+			t.Fatalf("CreateFamily に失敗: %v", err)
+		}
+		token := newTestRefreshToken(family.ID, userID, "hash-issue170-exec-rollback-01234", time.Now().Add(24*time.Hour).UTC())
+		if err := repo.CreateToken(ctx, token); err != nil {
+			t.Fatalf("CreateToken に失敗: %v", err)
+		}
+
+		// Act: 共有 tx 上で DeleteByUserIDExec を呼び Rollback する
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("BeginTx に失敗: %v", err)
+		}
+		if err := repo.DeleteByUserIDExec(ctx, tx, userID); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("DeleteByUserIDExec に失敗: %v", err)
+		}
+		if err := tx.Rollback(); err != nil {
+			t.Fatalf("Rollback に失敗: %v", err)
+		}
+
+		// Assert: Rollback により削除が取り消され、family / token は残っている
+		var familyCount, tokenCount int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM refresh_token_families WHERE user_id = $1`, userID,
+		).Scan(&familyCount); err != nil {
+			t.Fatalf("family COUNT に失敗: %v", err)
+		}
+		if familyCount != 1 {
+			t.Errorf("Rollback 後の family が残存していない: got %d, want 1", familyCount)
+		}
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM refresh_tokens WHERE user_id = $1`, userID,
+		).Scan(&tokenCount); err != nil {
+			t.Fatalf("token COUNT に失敗: %v", err)
+		}
+		if tokenCount != 1 {
+			t.Errorf("Rollback 後の token が残存していない: got %d, want 1", tokenCount)
+		}
+	})
+
+	// Case 10 (Issue #170 Req 1.2 冪等): DeleteByUserIDExec は対象 0 件でも成功する
+	t.Run("DeleteByUserIDExec_対象0件でも成功する", func(t *testing.T) {
+		userID := insertTestUserForRefreshToken(t, db, "issue170-exec-empty@test.com")
+		// family / token を一切作成しない状態
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("BeginTx に失敗: %v", err)
+		}
+		if err := repo.DeleteByUserIDExec(ctx, tx, userID); err != nil {
+			_ = tx.Rollback()
+			t.Errorf("0 件削除でエラーを返した（冪等性違反）: %v", err)
+		}
+		_ = tx.Commit()
+	})
+
 	// Case 7 (NFR 1.1 セキュリティ回帰): 平文 token 文字列で逆引き SELECT しても 0 件
 	// 永続化領域に「平文 token を書いていない」ことを自動検出するための回帰テスト。
 	// Create は token_hash を保存するため、平文の "plain-token-xxx" 文字列を直接

--- a/internal/repository/postgres_withdraw_integration_db_test.go
+++ b/internal/repository/postgres_withdraw_integration_db_test.go
@@ -1,0 +1,291 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"github.com/hitoshi/feedman/internal/database"
+	"github.com/hitoshi/feedman/internal/model"
+)
+
+// 本ファイルは Issue #170 の design.md §Testing Strategy ケース 6（退会フロー相当の
+// 統合検証）を実装する。
+//
+// 共有トランザクション上で sessions → auth_codes → refresh_token_families → users
+// を削除して Commit した後、当該ユーザーの native auth 3 テーブル（auth_codes /
+// refresh_token_families / refresh_tokens）が 0 件・他ユーザーの行が残存することを
+// 検証する。
+//
+// 環境変数 TEST_DATABASE_URL が設定されていればそれを使用し、未設定の場合は
+// docker-compose 上の PostgreSQL を想定したデフォルト値を使う。DB へ接続できない
+// 環境では t.Skip でスキップされ、CI（DB を起動しない）では実行されない。
+
+// withdrawTestDatabaseURL はテスト用のデータベース URL を返す。
+func withdrawTestDatabaseURL() string {
+	if url := os.Getenv("TEST_DATABASE_URL"); url != "" {
+		return url
+	}
+	return "postgres://feedman:feedman@localhost:5432/feedman_test?sslmode=disable"
+}
+
+// setupWithdrawTestDB はテスト用 DB を準備しマイグレーション適用済みの *sql.DB を返す。
+// DB に接続できない場合は t.Skip でテストをスキップする（NFR 3.1）。
+func setupWithdrawTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dbURL := withdrawTestDatabaseURL()
+
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		t.Fatalf("データベースへの接続に失敗: %v", err)
+	}
+
+	if err := db.Ping(); err != nil {
+		db.Close()
+		t.Skipf("テスト用データベースに接続できません（スキップ）: %v", err)
+	}
+
+	cleanupSQL := `
+		DROP TABLE IF EXISTS refresh_tokens CASCADE;
+		DROP TABLE IF EXISTS refresh_token_families CASCADE;
+		DROP TABLE IF EXISTS auth_codes CASCADE;
+		DROP TABLE IF EXISTS user_cross_feed_views CASCADE;
+		DROP TABLE IF EXISTS sessions CASCADE;
+		DROP TABLE IF EXISTS user_settings CASCADE;
+		DROP TABLE IF EXISTS item_states CASCADE;
+		DROP TABLE IF EXISTS subscriptions CASCADE;
+		DROP TABLE IF EXISTS items CASCADE;
+		DROP TABLE IF EXISTS feeds CASCADE;
+		DROP TABLE IF EXISTS identities CASCADE;
+		DROP TABLE IF EXISTS users CASCADE;
+		DROP TABLE IF EXISTS schema_migrations CASCADE;
+	`
+	if _, err := db.Exec(cleanupSQL); err != nil {
+		db.Close()
+		t.Fatalf("クリーンアップに失敗: %v", err)
+	}
+
+	if err := database.RunMigrations(dbURL); err != nil {
+		db.Close()
+		t.Fatalf("マイグレーション実行に失敗: %v", err)
+	}
+
+	return db
+}
+
+// insertTestUserForWithdraw はテスト用ユーザーを作成し、その ID を返す。
+func insertTestUserForWithdraw(t *testing.T, db *sql.DB, email string) string {
+	t.Helper()
+	var userID string
+	err := db.QueryRow(
+		`INSERT INTO users (email, name) VALUES ($1, $2) RETURNING id`,
+		email, "Withdraw Integration Test User",
+	).Scan(&userID)
+	if err != nil {
+		t.Fatalf("ユーザー挿入に失敗: %v", err)
+	}
+	return userID
+}
+
+// seedNativeAuthDataForWithdraw は当該ユーザーの auth_codes / refresh_token_families
+// / refresh_tokens にそれぞれテスト用レコードを 1 件ずつ作成する。戻り値は
+// (familyID, tokenHash) で、検証側で件数確認に使う。
+func seedNativeAuthDataForWithdraw(t *testing.T, db *sql.DB, userID, suffix string) {
+	t.Helper()
+	ctx := context.Background()
+	authCodeRepo := NewPostgresAuthCodeRepo(db)
+	refreshTokenRepo := NewPostgresRefreshTokenRepo(db)
+
+	// auth_code
+	authCode := &model.AuthCode{
+		CodeHash:      "hash-withdraw-integration-code-" + suffix,
+		UserID:        userID,
+		PKCEChallenge: "test-pkce-challenge-withdraw-int",
+		ExpiresAt:     time.Now().Add(60 * time.Second).UTC(),
+		Used:          false,
+	}
+	if err := authCodeRepo.Create(ctx, authCode); err != nil {
+		t.Fatalf("auth_code Create に失敗 (%s): %v", suffix, err)
+	}
+
+	// refresh_token_family + refresh_token
+	family := &model.RefreshTokenFamily{UserID: userID}
+	if err := refreshTokenRepo.CreateFamily(ctx, family); err != nil {
+		t.Fatalf("CreateFamily に失敗 (%s): %v", suffix, err)
+	}
+	token := &model.RefreshToken{
+		FamilyID:  family.ID,
+		UserID:    userID,
+		TokenHash: "hash-withdraw-integration-token-" + suffix,
+		ExpiresAt: time.Now().Add(24 * time.Hour).UTC(),
+	}
+	if err := refreshTokenRepo.CreateToken(ctx, token); err != nil {
+		t.Fatalf("CreateToken に失敗 (%s): %v", suffix, err)
+	}
+}
+
+// countByUserID は指定テーブルで当該 user_id の行数を返す（検証ヘルパ）。
+func countByUserID(t *testing.T, db *sql.DB, table, userID string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM `+table+` WHERE user_id = $1`, userID,
+	).Scan(&count); err != nil {
+		t.Fatalf("%s COUNT 取得に失敗: %v", table, err)
+	}
+	return count
+}
+
+// TestWithdrawIntegration_NativeAuthCleanup は退会フロー相当の統合検証として、
+// 共有トランザクション上で sessions → auth_codes → refresh_token_families →
+// users を削除して Commit した後、当該ユーザーの native auth 3 テーブルが 0 件・
+// 他ユーザーの行が残存することを検証する（Issue #170 design.md §Testing Strategy
+// ケース 6 / Req 1.1, 1.2, 2.1, 3.1 / NFR 2.1）。
+//
+// 本テストは PostgresAuthCodeRepo / PostgresRefreshTokenRepo / PostgresSessionRepo /
+// PostgresUserRepo の Exec 変種が共有トランザクション上で協調動作することを
+// 検証する（user.Service.withdrawTx と同じ削除順序を repository レイヤから直接
+// 再現するため、handler / service 層には依存しない）。
+func TestWithdrawIntegration_NativeAuthCleanup(t *testing.T) {
+	db := setupWithdrawTestDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	// Arrange: target user と bystander user に native auth + session を seed する
+	targetUserID := insertTestUserForWithdraw(t, db, "withdraw-target@test.com")
+	bystanderUserID := insertTestUserForWithdraw(t, db, "withdraw-bystander@test.com")
+
+	seedNativeAuthDataForWithdraw(t, db, targetUserID, "target")
+	seedNativeAuthDataForWithdraw(t, db, bystanderUserID, "bystander")
+
+	// 各 user に session を 1 件追加（sessions の削除も確認するため）
+	for _, uid := range []string{targetUserID, bystanderUserID} {
+		if _, err := db.Exec(
+			`INSERT INTO sessions (id, user_id, data, expires_at, created_at)
+			 VALUES (gen_random_uuid(), $1, '{}'::jsonb, now() + interval '1 hour', now())`,
+			uid,
+		); err != nil {
+			t.Fatalf("session 挿入に失敗 (%s): %v", uid, err)
+		}
+	}
+
+	// Sanity check: 削除前は両 user に 3 テーブル + sessions が 1 件ずつ存在する
+	for _, table := range []string{"auth_codes", "refresh_token_families", "refresh_tokens", "sessions"} {
+		if c := countByUserID(t, db, table, targetUserID); c != 1 {
+			t.Fatalf("seed sanity: target %s = %d, want 1", table, c)
+		}
+		if c := countByUserID(t, db, table, bystanderUserID); c != 1 {
+			t.Fatalf("seed sanity: bystander %s = %d, want 1", table, c)
+		}
+	}
+
+	// Act: 共有 tx 上で sessions → auth_codes → refresh_token_families → users を
+	// 削除して Commit する（user.Service.withdrawTx と同じ順序）。
+	authCodeRepo := NewPostgresAuthCodeRepo(db)
+	refreshTokenRepo := NewPostgresRefreshTokenRepo(db)
+	sessionRepo := NewPostgresSessionRepo(db)
+	userRepo := NewPostgresUserRepo(db)
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx に失敗: %v", err)
+	}
+	defer func() {
+		// 失敗時の保険。成功経路では Commit 済みなので no-op。
+		_ = tx.Rollback()
+	}()
+
+	if err := sessionRepo.DeleteByUserIDExec(ctx, tx, targetUserID); err != nil {
+		t.Fatalf("sessions 削除に失敗: %v", err)
+	}
+	if err := authCodeRepo.DeleteByUserIDExec(ctx, tx, targetUserID); err != nil {
+		t.Fatalf("auth_codes 削除に失敗: %v", err)
+	}
+	if err := refreshTokenRepo.DeleteByUserIDExec(ctx, tx, targetUserID); err != nil {
+		t.Fatalf("refresh_token_families 削除に失敗: %v", err)
+	}
+	if err := userRepo.DeleteByIDExec(ctx, tx, targetUserID); err != nil {
+		t.Fatalf("users 削除に失敗: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit に失敗: %v", err)
+	}
+
+	// Assert 1: target user の native auth 3 テーブルが 0 件
+	for _, table := range []string{"auth_codes", "refresh_token_families", "refresh_tokens"} {
+		if c := countByUserID(t, db, table, targetUserID); c != 0 {
+			t.Errorf("退会後の target %s が残存している: got %d, want 0", table, c)
+		}
+	}
+	// sessions も削除されている
+	if c := countByUserID(t, db, "sessions", targetUserID); c != 0 {
+		t.Errorf("退会後の target sessions が残存している: got %d, want 0", c)
+	}
+	// users 自体も削除されている
+	var userExists int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM users WHERE id = $1`, targetUserID).Scan(&userExists); err != nil {
+		t.Fatalf("users COUNT 取得に失敗: %v", err)
+	}
+	if userExists != 0 {
+		t.Errorf("退会後の target users が残存している: got %d, want 0", userExists)
+	}
+
+	// Assert 2: bystander user の native auth 3 テーブル + sessions は影響を受けず残存
+	for _, table := range []string{"auth_codes", "refresh_token_families", "refresh_tokens", "sessions"} {
+		if c := countByUserID(t, db, table, bystanderUserID); c != 1 {
+			t.Errorf("bystander %s が target 退会で削除された: got %d, want 1 (他ユーザー非影響)", table, c)
+		}
+	}
+}
+
+// TestWithdrawIntegration_NativeAuthRollback は退会フロー相当のトランザクション内
+// 削除を Rollback した場合、target user の 3 テーブルすべてが残存することを検証する
+// （Issue #170 Req 2.2 / 2.3 の「途中失敗時に部分的な削除状態を確定しない」を
+// repository レイヤ単体で再現する統合テスト）。
+func TestWithdrawIntegration_NativeAuthRollback(t *testing.T) {
+	db := setupWithdrawTestDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	targetUserID := insertTestUserForWithdraw(t, db, "withdraw-rollback-target@test.com")
+	seedNativeAuthDataForWithdraw(t, db, targetUserID, "rollback")
+
+	authCodeRepo := NewPostgresAuthCodeRepo(db)
+	refreshTokenRepo := NewPostgresRefreshTokenRepo(db)
+	sessionRepo := NewPostgresSessionRepo(db)
+
+	// Act: 共有 tx で sessions → auth_codes → refresh_token_families を削除し Rollback する
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx に失敗: %v", err)
+	}
+	if err := sessionRepo.DeleteByUserIDExec(ctx, tx, targetUserID); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("sessions 削除に失敗: %v", err)
+	}
+	if err := authCodeRepo.DeleteByUserIDExec(ctx, tx, targetUserID); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("auth_codes 削除に失敗: %v", err)
+	}
+	if err := refreshTokenRepo.DeleteByUserIDExec(ctx, tx, targetUserID); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("refresh_token_families 削除に失敗: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback に失敗: %v", err)
+	}
+
+	// Assert: Rollback により target user の native auth 3 テーブルすべてが残存する
+	for _, table := range []string{"auth_codes", "refresh_token_families", "refresh_tokens"} {
+		if c := countByUserID(t, db, table, targetUserID); c != 1 {
+			t.Errorf("Rollback 後の target %s が残存していない: got %d, want 1 (部分削除確定の禁止)", table, c)
+		}
+	}
+}

--- a/internal/repository/postgres_withdraw_integration_db_test.go
+++ b/internal/repository/postgres_withdraw_integration_db_test.go
@@ -166,9 +166,11 @@ func TestWithdrawIntegration_NativeAuthCleanup(t *testing.T) {
 
 	// 各 user に session を 1 件追加（sessions の削除も確認するため）
 	for _, uid := range []string{targetUserID, bystanderUserID} {
+		// sessions.id は VARCHAR(255)、data は BYTEA（initial_schema.up.sql）。
+		// PostgresSessionRepo.Create と同じく data には []byte("{}") 相当を入れる。
 		if _, err := db.Exec(
 			`INSERT INTO sessions (id, user_id, data, expires_at, created_at)
-			 VALUES (gen_random_uuid(), $1, '{}'::jsonb, now() + interval '1 hour', now())`,
+			 VALUES (gen_random_uuid()::text, $1, '{}'::bytea, now() + interval '1 hour', now())`,
 			uid,
 		); err != nil {
 			t.Fatalf("session 挿入に失敗 (%s): %v", uid, err)

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -60,6 +60,18 @@ type TxItemStateDeleter interface {
 	DeleteByUserIDTx(ctx context.Context, tx Tx, userID string) error
 }
 
+// TxAuthCodeDeleter は共有トランザクション上で native auth 一時認可コードを
+// 一括削除するインターフェース（Issue #170 Req 1.1, 2.1）。
+type TxAuthCodeDeleter interface {
+	DeleteByUserIDTx(ctx context.Context, tx Tx, userID string) error
+}
+
+// TxRefreshTokenDeleter は共有トランザクション上で refresh token（family ごと）を
+// 一括削除するインターフェース（Issue #170 Req 1.2, 2.1）。
+type TxRefreshTokenDeleter interface {
+	DeleteByUserIDTx(ctx context.Context, tx Tx, userID string) error
+}
+
 // Service はユーザー管理のサービス層。
 // 退会処理のビジネスロジックを提供する。
 //
@@ -74,11 +86,13 @@ type Service struct {
 	stateDeleter ItemStateDeleter
 
 	// トランザクションパス用のフィールド（txBeginner != nil のとき使用）。
-	txBeginner       TxBeginner
-	txUserDeleter    TxUserDeleter
-	txSessionDeleter TxSessionDeleter
-	txSubDeleter     TxSubscriptionDeleter
-	txStateDeleter   TxItemStateDeleter
+	txBeginner            TxBeginner
+	txUserDeleter         TxUserDeleter
+	txSessionDeleter      TxSessionDeleter
+	txSubDeleter          TxSubscriptionDeleter
+	txStateDeleter        TxItemStateDeleter
+	txAuthCodeDeleter     TxAuthCodeDeleter     // Issue #170: native auth 認可コード削除
+	txRefreshTokenDeleter TxRefreshTokenDeleter // Issue #170: native auth refresh token 削除
 }
 
 // NewService は Service の新しいインスタンスを生成する（レガシー・非トランザクションパス）。
@@ -102,30 +116,48 @@ func NewService(
 // NewServiceWithTx はトランザクション対応の Service を生成する。
 //
 // 退会処理は txBeginner が開始する単一トランザクション上で
-// item_states → subscriptions → sessions → user の順に削除し、
-// 全成功時のみコミット、途中失敗時は全ロールバックする。
+// item_states → subscriptions → sessions → auth_codes → refresh_token_families →
+// user の順に削除し、全成功時のみコミット、途中失敗時は全ロールバックする
+// （Issue #170 で auth_codes / refresh_token_families の削除 2 段を sessions の
+// 直後・user の前に挿入）。
+//
+// authCodeDeleter / refreshTokenDeleter は nil でも構築でき、その場合は当該段は
+// スキップされる（既存 deleter 群と同じ nil ガード方針。本番 wiring では常に非 nil
+// を注入する）。
 func NewServiceWithTx(
 	txBeginner TxBeginner,
 	userDeleter TxUserDeleter,
 	sessionDeleter TxSessionDeleter,
 	subDeleter TxSubscriptionDeleter,
 	stateDeleter TxItemStateDeleter,
+	authCodeDeleter TxAuthCodeDeleter,
+	refreshTokenDeleter TxRefreshTokenDeleter,
 ) *Service {
 	return &Service{
-		txBeginner:       txBeginner,
-		txUserDeleter:    userDeleter,
-		txSessionDeleter: sessionDeleter,
-		txSubDeleter:     subDeleter,
-		txStateDeleter:   stateDeleter,
+		txBeginner:            txBeginner,
+		txUserDeleter:         userDeleter,
+		txSessionDeleter:      sessionDeleter,
+		txSubDeleter:          subDeleter,
+		txStateDeleter:        stateDeleter,
+		txAuthCodeDeleter:     authCodeDeleter,
+		txRefreshTokenDeleter: refreshTokenDeleter,
 	}
 }
 
 // Withdraw はユーザーの退会処理を実行する。
-// 削除順序: item_states → subscriptions → sessions → user（+ CASCADE: identities, user_settings）
+// 削除順序（トランザクションパス）: item_states → subscriptions → sessions →
+// auth_codes → refresh_token_families → user
+// （+ CASCADE: identities, user_settings, refresh_tokens）
 // feeds と items は共有キャッシュとして残す。
 //
+// Issue #170: native auth の認証状態（auth_codes / refresh_token_families）を
+// sessions の直後・user の前に挿入する。refresh_tokens は
+// refresh_token_families の DELETE に伴い FK ON DELETE CASCADE で削除される。
+//
 // txBeginner が設定されている場合は単一トランザクションで原子的に削除し、
-// 途中失敗時は全ロールバックする。設定されていない場合はレガシーの逐次削除を行う。
+// 途中失敗時は全ロールバックする。設定されていない場合はレガシーの逐次削除を行う
+// （レガシーパスでは native auth の明示削除を行わず、user 削除時の FK CASCADE
+// による DB 防衛線で 3 テーブルの行残存を防ぐ）。
 func (s *Service) Withdraw(ctx context.Context, userID string) error {
 	if s.txBeginner != nil {
 		return s.withdrawTx(ctx, userID)
@@ -181,7 +213,22 @@ func (s *Service) withdrawTx(ctx context.Context, userID string) error {
 		}
 	}
 
-	// 4. ユーザーを削除（identities, user_settings は CASCADE 削除）
+	// 4. native auth 認可コードを削除（Issue #170 Req 1.1, 2.1）
+	if s.txAuthCodeDeleter != nil {
+		if err := s.txAuthCodeDeleter.DeleteByUserIDTx(ctx, tx, userID); err != nil {
+			return fmt.Errorf("認可コードの削除に失敗しました: %w", err)
+		}
+	}
+
+	// 5. native auth refresh token（family ごと、配下 tokens は FK CASCADE）を削除
+	//    （Issue #170 Req 1.2, 2.1）
+	if s.txRefreshTokenDeleter != nil {
+		if err := s.txRefreshTokenDeleter.DeleteByUserIDTx(ctx, tx, userID); err != nil {
+			return fmt.Errorf("refresh token の削除に失敗しました: %w", err)
+		}
+	}
+
+	// 6. ユーザーを削除（identities, user_settings は CASCADE 削除）
 	if err := s.txUserDeleter.DeleteByIDTx(ctx, tx, userID); err != nil {
 		return fmt.Errorf("ユーザーの削除に失敗しました: %w", err)
 	}

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -161,15 +161,50 @@ func (d *txUserDeleter) DeleteByIDTx(ctx context.Context, tx Tx, id string) erro
 	return d.deleteErr
 }
 
+// txAuthCodeDeleter は TxAuthCodeDeleter を満たす fake（Issue #170）。
+type txAuthCodeDeleter struct {
+	rec *txRecorder
+	err error
+}
+
+func (d *txAuthCodeDeleter) DeleteByUserIDTx(ctx context.Context, tx Tx, userID string) error {
+	d.rec.order = append(d.rec.order, "auth_codes")
+	return d.err
+}
+
+// txRefreshTokenDeleter は TxRefreshTokenDeleter を満たす fake（Issue #170）。
+type txRefreshTokenDeleter struct {
+	rec *txRecorder
+	err error
+}
+
+func (d *txRefreshTokenDeleter) DeleteByUserIDTx(ctx context.Context, tx Tx, userID string) error {
+	d.rec.order = append(d.rec.order, "refresh_token_families")
+	return d.err
+}
+
 // newTxService はトランザクション対応の Service を組み立てるテストヘルパ。
+// Issue #170: native auth deleter（auth code / refresh token）を末尾に追加。
+// nil を渡すと当該段はスキップされる（既存テストとの後方互換）。
 func newTxService(
 	beginner *fakeTxBeginner,
 	user *txUserDeleter,
 	session *txSessionDeleter,
 	sub *txSubDeleter,
 	state *txItemStateDeleter,
+	authCode *txAuthCodeDeleter,
+	refreshToken *txRefreshTokenDeleter,
 ) *Service {
-	return NewServiceWithTx(beginner, user, session, sub, state)
+	// nil 互換のため、対応するフィールドが nil なら interface も nil を渡す。
+	var authCodeDeleter TxAuthCodeDeleter
+	if authCode != nil {
+		authCodeDeleter = authCode
+	}
+	var refreshTokenDeleter TxRefreshTokenDeleter
+	if refreshToken != nil {
+		refreshTokenDeleter = refreshToken
+	}
+	return NewServiceWithTx(beginner, user, session, sub, state, authCodeDeleter, refreshTokenDeleter)
 }
 
 // --- レガシー（非トランザクション）パスのテスト ---
@@ -248,7 +283,10 @@ func TestService_Withdraw_UserNotFound(t *testing.T) {
 // --- トランザクション対応パスのテスト ---
 
 // TestService_Withdraw_Tx_CommitsOnSuccess は全削除成功時にコミットされ、
-// 子→親の順序で削除されることを検証する（AC 1.1 / 1.4 / NFR 2.1）。
+// item_states → subscriptions → sessions → auth_codes → refresh_token_families →
+// user の順で削除されることを検証する（AC 1.1 / 1.4 / Issue #170 Req 1.1, 1.2, 2.1
+// / NFR 2.1）。Issue #170 で sessions の直後・user の前に native auth 2 段
+// （auth_codes / refresh_token_families）が挿入された。
 func TestService_Withdraw_Tx_CommitsOnSuccess(t *testing.T) {
 	// Arrange
 	rec := &txRecorder{}
@@ -264,6 +302,8 @@ func TestService_Withdraw_Tx_CommitsOnSuccess(t *testing.T) {
 		&txSessionDeleter{rec: rec},
 		&txSubDeleter{rec: rec},
 		&txItemStateDeleter{rec: rec},
+		&txAuthCodeDeleter{rec: rec},
+		&txRefreshTokenDeleter{rec: rec},
 	)
 
 	// Act
@@ -279,7 +319,7 @@ func TestService_Withdraw_Tx_CommitsOnSuccess(t *testing.T) {
 	if beginner.rolledBack {
 		t.Error("expected no rollback on success")
 	}
-	want := []string{"item_states", "subscriptions", "sessions", "user"}
+	want := []string{"item_states", "subscriptions", "sessions", "auth_codes", "refresh_token_families", "user"}
 	if len(rec.order) != len(want) {
 		t.Fatalf("delete order = %v, want %v", rec.order, want)
 	}
@@ -308,6 +348,8 @@ func TestService_Withdraw_Tx_RollsBackOnDeleteError(t *testing.T) {
 		&txSessionDeleter{rec: rec},
 		&txSubDeleter{rec: rec, err: deleteErr},
 		&txItemStateDeleter{rec: rec},
+		nil, // Issue #170: 本テストは subscriptions 失敗のみを検証するため auth/refresh は注入しない
+		nil,
 	)
 
 	// Act
@@ -349,6 +391,8 @@ func TestService_Withdraw_Tx_UserNotFound(t *testing.T) {
 		&txSessionDeleter{rec: rec},
 		&txSubDeleter{rec: rec},
 		&txItemStateDeleter{rec: rec},
+		nil, // Issue #170: 存在しないユーザーは tx 開始すらしないため deleter は不要
+		nil,
 	)
 
 	// Act
@@ -387,6 +431,8 @@ func TestService_Withdraw_Tx_NoRelatedData(t *testing.T) {
 		&txSessionDeleter{rec: rec},
 		&txSubDeleter{rec: rec},
 		&txItemStateDeleter{rec: rec},
+		nil, // Issue #170: nil ガード経路の検証は別テスト (TestService_Withdraw_Tx_NilNativeAuthDeletersSkip) が担う
+		nil,
 	)
 
 	// Act
@@ -422,6 +468,8 @@ func TestService_Withdraw_Tx_CommitError(t *testing.T) {
 		&txSessionDeleter{rec: rec},
 		&txSubDeleter{rec: rec},
 		&txItemStateDeleter{rec: rec},
+		nil, // Issue #170: コミットエラーの検証なので native auth deleter は不要
+		nil,
 	)
 
 	// Act
@@ -457,6 +505,8 @@ func TestService_Withdraw_Tx_BeginError(t *testing.T) {
 		&txSessionDeleter{rec: rec},
 		&txSubDeleter{rec: rec},
 		&txItemStateDeleter{rec: rec},
+		nil, // Issue #170: tx 開始失敗のため deleter は呼ばれない
+		nil,
 	)
 
 	// Act
@@ -471,5 +521,150 @@ func TestService_Withdraw_Tx_BeginError(t *testing.T) {
 	}
 	if len(rec.order) != 0 {
 		t.Errorf("expected no deletes when begin fails, got %v", rec.order)
+	}
+}
+
+// --- Issue #170: 退会時の native auth 認証状態削除のテスト ---
+
+// TestService_Withdraw_Tx_RollsBackOnAuthCodeDeleteError は auth_codes 削除が
+// 失敗したとき、退会全体が Rollback され user / refresh_token_families 削除に
+// 到達しないことを検証する（Issue #170 Req 2.2）。
+func TestService_Withdraw_Tx_RollsBackOnAuthCodeDeleteError(t *testing.T) {
+	// Arrange
+	rec := &txRecorder{}
+	beginner := &fakeTxBeginner{}
+	deleteErr := errors.New("auth_code delete failed")
+	user := &txUserDeleter{
+		rec: rec,
+		findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+			return &model.User{ID: id}, nil
+		},
+	}
+	refreshTokenDel := &txRefreshTokenDeleter{rec: rec}
+	svc := newTxService(beginner,
+		user,
+		&txSessionDeleter{rec: rec},
+		&txSubDeleter{rec: rec},
+		&txItemStateDeleter{rec: rec},
+		&txAuthCodeDeleter{rec: rec, err: deleteErr},
+		refreshTokenDel,
+	)
+
+	// Act
+	err := svc.Withdraw(context.Background(), "user-1")
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error from failing auth_code delete, got nil")
+	}
+	if !errors.Is(err, deleteErr) {
+		t.Errorf("expected error to wrap %v, got %v", deleteErr, err)
+	}
+	if beginner.committed {
+		t.Error("expected no commit when auth_code delete fails")
+	}
+	if !beginner.rolledBack {
+		t.Error("expected rollback when auth_code delete fails")
+	}
+	// auth_codes 失敗後の refresh_token_families / user は呼ばれない（fail-fast）
+	for _, step := range rec.order {
+		if step == "refresh_token_families" {
+			t.Error("expected refresh_token_families delete NOT to be called after auth_codes failure")
+		}
+		if step == "user" {
+			t.Error("expected user delete NOT to be called after auth_codes failure")
+		}
+	}
+	if user.deleteCalled {
+		t.Error("expected user delete NOT to be called after auth_codes failure")
+	}
+}
+
+// TestService_Withdraw_Tx_RollsBackOnRefreshTokenDeleteError は
+// refresh_token_families 削除が失敗したとき、退会全体が Rollback され user 削除に
+// 到達しないことを検証する（Issue #170 Req 2.2 / 2.3）。
+func TestService_Withdraw_Tx_RollsBackOnRefreshTokenDeleteError(t *testing.T) {
+	// Arrange
+	rec := &txRecorder{}
+	beginner := &fakeTxBeginner{}
+	deleteErr := errors.New("refresh_token delete failed")
+	user := &txUserDeleter{
+		rec: rec,
+		findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+			return &model.User{ID: id}, nil
+		},
+	}
+	svc := newTxService(beginner,
+		user,
+		&txSessionDeleter{rec: rec},
+		&txSubDeleter{rec: rec},
+		&txItemStateDeleter{rec: rec},
+		&txAuthCodeDeleter{rec: rec},
+		&txRefreshTokenDeleter{rec: rec, err: deleteErr},
+	)
+
+	// Act
+	err := svc.Withdraw(context.Background(), "user-1")
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected error from failing refresh_token delete, got nil")
+	}
+	if !errors.Is(err, deleteErr) {
+		t.Errorf("expected error to wrap %v, got %v", deleteErr, err)
+	}
+	if beginner.committed {
+		t.Error("expected no commit when refresh_token delete fails")
+	}
+	if !beginner.rolledBack {
+		t.Error("expected rollback when refresh_token delete fails")
+	}
+	if user.deleteCalled {
+		t.Error("expected user delete NOT to be called after refresh_token failure")
+	}
+}
+
+// TestService_Withdraw_Tx_NilNativeAuthDeletersSkip は native auth deleter が
+// 両方 nil のとき、退会が従来どおり成功し（NFR 1.1 後方互換）、
+// auth_codes / refresh_token_families の段がスキップされることを検証する
+// （Issue #170 nil ガード）。
+func TestService_Withdraw_Tx_NilNativeAuthDeletersSkip(t *testing.T) {
+	// Arrange: native auth deleter を nil で構築
+	rec := &txRecorder{}
+	beginner := &fakeTxBeginner{}
+	user := &txUserDeleter{
+		rec: rec,
+		findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+			return &model.User{ID: id}, nil
+		},
+	}
+	svc := newTxService(beginner,
+		user,
+		&txSessionDeleter{rec: rec},
+		&txSubDeleter{rec: rec},
+		&txItemStateDeleter{rec: rec},
+		nil, // authCode deleter を注入しない（nil ガード経路を踏む）
+		nil, // refreshToken deleter を注入しない
+	)
+
+	// Act
+	err := svc.Withdraw(context.Background(), "user-1")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("Withdraw returned error: %v", err)
+	}
+	if !beginner.committed {
+		t.Error("expected commit when native auth deleters are nil")
+	}
+	// nil ガードにより auth_codes / refresh_token_families は order に現れない
+	want := []string{"item_states", "subscriptions", "sessions", "user"}
+	if len(rec.order) != len(want) {
+		t.Fatalf("delete order = %v, want %v (native auth steps skipped)", rec.order, want)
+	}
+	for i := range want {
+		if rec.order[i] != want[i] {
+			t.Errorf("delete order[%d] = %q, want %q", i, rec.order[i], want[i])
+		}
 	}
 }


### PR DESCRIPTION
## 概要

Issue #170（umbrella #163 の子 Issue）の実装 PR です。設計 PR #194 でマージ済みの
`docs/specs/170-withdraw-native-auth-cleanup/`（requirements.md / design.md / tasks.md）に
厳密に従い、退会フローへの native auth 認証状態（auth_codes / refresh_token_families）の
明示削除を統合しました。

Closes #170

## 変更内容

- `internal/repository/`: `AuthCodeRepository` に `DeleteByUserID` を追加。`PostgresAuthCodeRepo` / `PostgresRefreshTokenRepo` に `DeleteByUserIDExec`（DBTX 対応の 2 段パターン、`PostgresSessionRepo` と同型）を追加
- `internal/user/service.go`: `TxAuthCodeDeleter` / `TxRefreshTokenDeleter` を追加し、退会トランザクションの sessions 削除直後・users 削除前に nil ガード付きの削除 2 段を挿入（既存手順の順序・エラー処理・ログは不変）
- `internal/app/`: adapter 2 種追加と `newTxUserService` の wiring 拡張
- テスト: service 単体（順序 / Rollback / nil スキップ）+ repository DB 結合（他ユーザー非影響 / 0 件冪等 / 共有 tx 参加）+ 退会フロー統合 DB テスト（Commit 後 3 テーブル 0 件 / Rollback で全行残存）
- `docs/specs/170-withdraw-native-auth-cleanup/`: tasks.md checkbox 更新（全 3 task 完了）/ impl-notes.md / review-notes.md

## 設計上のポイント

- 削除順序: item_states → subscriptions → sessions → **auth_codes → refresh_token_families** → users。同一の原子性境界（単一 tx）で実行し、途中失敗は全 Rollback（Req 2.1〜2.3）
- refresh_tokens は family の DELETE に伴い FK ON DELETE CASCADE で連動削除（#164 の保存構造を利用、migration 追加なし / NFR 1.3）
- レガシー（非 tx）パスは design.md どおり明示削除を追加せず、FK CASCADE が防衛線（本番 wiring は常に tx パス）

## Reviewer 判定

独立 context の Reviewer サブエージェントによるレビュー済み: **approve**
（`docs/specs/170-withdraw-native-auth-cleanup/review-notes.md` 参照。AC 未カバー / missing test / boundary 逸脱のいずれも findings なし）

## 検証

- `go build ./...` / `go vet ./...` / `go test ./...` 全 green
- `gofmt -l`（変更ファイルのみ）差分なし
- DB 結合テスト追加分は CI の postgres サービス上で実行される

## 確認事項（レビュワー判断ポイント）

- レガシー（非 tx）パスには明示削除を追加していません（design.md の判断どおり。FK CASCADE による DB 防衛線で行残存を防止）
- 退会フロー統合 DB テストは service 層を経由せず repository レイヤの共有 tx 操作で退会相当の削除列を再現しています（tasks.md task 3 の指定どおり）
- task 3（app wiring）のコミットは前任セッションが developer エージェント停止後に検証してコミットしたものです。本セッションで全 diff を再検証し、Reviewer も全 diff を対象にレビューしています

🤖 Generated with [Claude Code](https://claude.com/claude-code)