### PR TITLE
feat(#168): refresh token 再利用検知で family を失効し POST /api/auth/revoke を追加する

### DIFF
--- a/docs/specs/168-reuse-detection-revoke/impl-notes.md
+++ b/docs/specs/168-reuse-detection-revoke/impl-notes.md
@@ -1,0 +1,144 @@
+# 実装ノート: Issue #168 再利用検知の family 失効と POST /api/auth/revoke
+
+## 実装サマリ
+
+Issue #168 の (1) rotation 済み refresh token 再利用検知時の **family 全体失効への昇格**と
+(2) **`POST /api/auth/revoke`** を、design.md / tasks.md の指針に厳密に従って実装した。
+
+設計の主要ポイントは原文どおり踏襲している:
+
+- `RotateRefreshToken` の拒否分岐 2 箇所（手順 2 の RotatedAt 検出 / 手順 3 の
+  `ErrRefreshTokenAlreadyRotated` 競合敗北）を `RevokeFamily` 実行 + `ErrInvalidRefreshToken`
+  に昇格（Req 1.1 / 1.2）。検知ログは `slog.Warn("refresh token reuse detected", family_id,
+  hash 先頭 8 文字)`
+- `RevokeFamily` 失敗時も拒否は維持（`slog.Error` で記録のみ、新 token は発行しない /
+  Req 1.5。内部エラーへ昇格させず安全側に倒す）
+- 昇格後も返すのは同一 sentinel `ErrInvalidRefreshToken` → handler は #167 と同じ
+  401 単一応答（Req 1.4: 再利用検知を区別できない）
+- RevokedAt 済み（失効済み）token の提示は再利用ではないため**昇格しない**単純拒否のまま
+  （#167 既存挙動の回帰維持）
+- `RevokeRefreshToken`: 不明 token は no-op nil（存在オラクルなし / Req 2.2）、既知 token は
+  状態（期限切れ・rotation 済み・失効済み）に関わらず family 失効（Req 2.1）、infra エラー
+  のみ error（500）
+- `Revoke` handler: 常に 204 ボディなし（成功 / 不明を区別しない）、400 INVALID_REQUEST /
+  500 INTERNAL_ERROR は #167 と同一ヘルパー共用
+- router: 認証不要グループの `NativeAuthHandler != nil` ガード内に `POST /api/auth/revoke`
+  を登録（ボディ上限 middleware 付き / fail-closed 同乗 / NFR 2.2）。既存 Web ログアウト
+  （`POST /auth/logout`）の経路は無変更（Req 2.6）
+
+## タスクとコミット対応表
+
+| Task | 内容 | 実装コミット | 進捗 commit |
+|---|---|---|---|
+| 1 | auth: 再利用検知の昇格と RevokeRefreshToken | 1f38351 `feat(auth)` | 2ddf9e5 `docs(tasks): mark 1` |
+| 2 | handler: Revoke エンドポイントと router 登録 | 14287ce `feat(handler)` | 734d9dd `docs(tasks): mark 2` |
+| 3 | 統合テスト: 再利用 family 全滅と revoke 後拒否 | eda6320 `test(handler)` | 76b289f `docs(tasks): mark 3` |
+
+実装順序は tasks.md の番号順そのままで、`_Depends:_` の制約（task 2 → 1、task 3 → 2）は
+自然に満たされた。
+
+## 受入基準と担保テスト
+
+### Requirement 1: Rotation 済み token 再利用の検知と family 失効
+
+| AC ID | 担保テスト |
+|---|---|
+| 1.1 (再利用提示で family 全体失効 + 拒否) | `auth.TestRotateRefreshToken_ReuseEscalatesToFamilyRevoke`（RevokeFamily が当該 FamilyID + now で 1 回 / 新 token 未作成）/ `handler.TestIntegration_ReuseDetection_FamilyRevoked` |
+| 1.2 (並行競合敗北でも同様に失効) | `auth.TestRotateRefreshToken_RaceLoserEscalatesToFamilyRevoke`（MarkRotated の ErrRefreshTokenAlreadyRotated 経由） |
+| 1.3 (失効 family の全 token を以後拒否) | `handler.TestIntegration_ReuseDetection_FamilyRevoked`（A 再提示後、現役だった B も 401）+ #167 既存の RevokedAt 検証分岐（`auth.TestRotateRefreshToken_Revoked`） |
+| 1.4 (通常拒否と区別できない同一応答) | `auth.TestRotateRefreshToken_ReuseEscalatesToFamilyRevoke`（同一 sentinel）/ 統合テスト（401 INVALID_REFRESH_TOKEN・message に reuse / revoked / family を含まない） |
+| 1.5 (失効永続化失敗でも新 token を発行しない) | `auth.TestRotateRefreshToken_ReuseRevokeFamilyFailureStillRejects`（RevokeFamily 失敗でも ErrInvalidRefreshToken / CreateToken 0 回） |
+
+### Requirement 2: Revoke エンドポイント
+
+| AC ID | 担保テスト |
+|---|---|
+| 2.1 (既知 token で family 失効 + 204) | `auth.TestRevokeRefreshToken_KnownToken`（4 状態の table-driven）/ `handler.TestNativeAuthHandler_Revoke_Success` / `handler.TestIntegration_RevokeFlow_RefreshRejectedAndIdempotent` |
+| 2.2 (不明・各状態でも同一の 204 / 冪等) | `auth.TestRevokeRefreshToken_UnknownTokenIsNoop` / `handler.TestNativeAuthHandler_Revoke_UnknownTokenAlso204` / 統合テスト（再 revoke 204 / 不明 token 204） |
+| 2.3 (revoke 後の refresh を拒否) | `handler.TestIntegration_RevokeFlow_RefreshRejectedAndIdempotent`（revoke → refresh 401） |
+| 2.4 (Cookie / Bearer なしで呼び出し可能) | `handler.TestNewRouter_NativeAuthRevoke_RegisteredWhenHandlerInjected`（Cookie 無しで 204） |
+| 2.5 (不正 JSON / 必須欠落を拒否) | `handler.TestNativeAuthHandler_Revoke_InvalidJSON`（4 サブケース）/ `_MissingField`（欠落 / 空文字） |
+| 2.6 (既存 Web ログアウトの挙動不変) | `POST /auth/logout` 経路への diff なし。既存 `TestSetupAuthRoutes_LogoutEndpoint` ほか全既存テスト無変更 green |
+
+### Non-Functional Requirements
+
+| NFR | 担保テスト・実装 |
+|---|---|
+| NFR 1.1 (平文を永続化・ログ・エラーに残さない) | `auth.TestRevokeRefreshToken_InfraErrorPropagates`（エラーメッセージに平文なし）。ログは hash 先頭 8 文字のみ |
+| NFR 1.2 (応答から存在有無・状態を推測不能) | `handler.TestNativeAuthHandler_Revoke_UnknownTokenAlso204`（同一 204 / ボディなし）/ 統合テスト Act 3〜4 |
+| NFR 1.3 (エラー応答に入力値・内部詳細を反射しない) | `handler.TestNativeAuthHandler_Revoke_InternalError`（内部エラー文字列が message に含まれない） |
+| NFR 2.1 (既存ルートの挙動不変) | 変更は RotateRefreshToken の拒否分岐内部 + 追加ルートのみ。`go test ./...` 全パッケージ pass（実 DB 接続でも確認、後述） |
+| NFR 2.2 (署名鍵未設定で revoke も非公開) | `handler.TestNewRouter_NativeAuthRevoke_NotRegisteredWhenHandlerNil`（404） |
+| NFR 3.1 (外部ネットワーク依存なし) | service 7 ケース / handler 5 ケース / router 2 ケース / 統合 2 ケースすべて mock 駆動 |
+
+## 検証結果
+
+- `go build ./...`: 成功
+- `go vet ./...`: 警告なし
+- `go test ./...`: 全パッケージ pass
+- `TEST_DATABASE_URL` を設定した実 PostgreSQL 16 でも `go test -p 1 ./...` 全 pass
+  （CI と同条件。#170 で顕在化した「ローカル skip / CI fail」の再発防止として実施）
+- `gofmt -l <変更ファイル群>`: 出力なし
+
+## design からの逸脱
+
+無し。design.md の以下は **完全にそのまま** 実装した。
+
+- 再利用検知の昇格フロー（手順 3 / 4 の拒否分岐拡張。RevokeFamily 失敗時の安全側処理を含む）
+- Revoke フロー手順 1〜4（decode → FindByHash → 不明なら no-op / 既知なら RevokeFamily → 204）
+- Error Handling 表（400 / 204 / 500 / 401 のマッピング）
+- File Structure Plan に列挙された 6 ファイル（新規ファイルなし・migration なし・wiring 変更なし）
+- `RefreshTokenStore` への `RevokeFamily` 追加（`repository.RefreshTokenRepository` が
+  引き続き構造的に充足。app.go の wiring が具象 repo を直接渡すため compile-time で検証される）
+- Testing Strategy 1〜10 の全ケース
+
+## 実装上の判断
+
+### 再利用昇格の共通ヘルパー `revokeFamilyOnReuse`
+
+昇格分岐は 2 箇所（RotatedAt 事前検出 / MarkRotated 競合敗北）で同一処理（slog.Warn →
+RevokeFamily → 失敗時 slog.Error）のため、private helper に切り出して重複を避けた
+（CLAUDE.md「コピペ重複を増やさない」）。
+
+### 統合テスト mock の family 失効追従と #167 通しテストの順序再構成
+
+`internal/handler/integration_test.go` の stateful mock（`mockNativeTokenExchangeService`）を
+family 失効の意味論に追従させた（rotated 集合が family を保持し、再利用検知で
+`revokedFamilies` へ昇格）。これに伴い #167 の通しテスト
+`TestIntegration_RefreshFlow_TokenExchangeRefreshSucceedsThenOldTokenRejected` は
+「新世代 token の有効性検証」を旧 token 再提示より**前**に行う順序へ再構成した。
+旧順序のままだと再利用検知後の family 全滅（本 spec の仕様）により新世代 token の 200 を
+検証できないため。検証観点自体（refresh 成功 / 新世代有効 / 旧 token 拒否 / uniform 401）は
+すべて維持しており、再利用検知後の family 全滅は新設の
+`TestIntegration_ReuseDetection_FamilyRevoked` が担う。
+
+### Revoke のリクエスト型・エラーヘルパー共用
+
+`Revoke` のリクエストボディは refresh と同一形式（`{"refresh_token"}`）のため
+`refreshRequest` / `invalidRefreshRequestError` を共用し、新型・新ヘルパーを増やしていない。
+`DisallowUnknownFields` も #166 / #167 と同一判断で適用（`handler.TestNativeAuthHandler_
+Revoke_InvalidJSON` の未知フィールドサブケースで担保）。
+
+## 追加した依存
+
+無し（go.mod / go.sum 変更なし）。
+
+## 後続 Issue への引き継ぎ事項
+
+- **Issue #169 (Bearer middleware)**: 本 spec の変更とは独立。`TokenExchangeService` IF は
+  Exchange / Rotate / Revoke の 3 メソッドに拡張済み。
+- **Issue #171 (IP レート制限)**: `POST /api/auth/revoke` も token / refresh と同じく
+  IP 単位レート制限を経由しない。router.go の登録部位 3 ルートすべてに `unauthIPMW` を
+  重ねる変更が想定される（コメント明記済み）。
+- **Issue #172 (contract tests)**: revoke の契約（204 / 400 / 500、冪等性）は本 spec の
+  handler / 統合テストでカバー済み。
+
+## 確認事項（PR 本文転載用）
+
+- 設計矛盾は無し。
+- #167 の通しテストの検証順序を再構成した（上記「実装上の判断」参照。検証観点は不変、
+  spec 主導の挙動変更への追従であり assert の弱体化ではない）。
+- `RevokeFamily` 失敗時に 500 ではなく 401 を返す（Req 1.5 / design.md の明示指示どおり。
+  通常の DB 障害（FindByHash 失敗等）は従来どおり 500）。
+
+STATUS: complete

--- a/docs/specs/168-reuse-detection-revoke/review-notes.md
+++ b/docs/specs/168-reuse-detection-revoke/review-notes.md
@@ -1,0 +1,114 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-12T08:55:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-168-impl-reuse-detection-revoke
+- HEAD commit: 4d01336
+- Compared to: develop..HEAD
+
+## Verified Requirements
+
+### Requirement 1: Rotation 済み token 再利用の検知と family 失効
+
+- **1.1** (再利用提示で family 全体失効 + 拒否) — `internal/auth/token_service.go` の
+  `RotateRefreshToken` 手順 2 で `stored.RotatedAt != nil` 分岐に `revokeFamilyOnReuse`
+  ヘルパーを差し込み、`RevokeFamily` 実行後に `ErrInvalidRefreshToken` を返す。
+  `auth.TestRotateRefreshToken_ReuseEscalatesToFamilyRevoke`（RevokeFamily が当該 FamilyID
+  + now で 1 回呼ばれ、新 token 未作成）と `handler.TestIntegration_ReuseDetection_FamilyRevoked`
+  Act 2（401 + 拒否応答が reuse/revoked/family を含まない）で担保。
+- **1.2** (並行 rotation 競合敗北でも同様に失効) — 手順 3 の `MarkRotated` race 分岐
+  （`ErrRefreshTokenAlreadyRotated`）でも同 helper を呼ぶ。
+  `auth.TestRotateRefreshToken_RaceLoserEscalatesToFamilyRevoke` で担保。
+- **1.3** (失効 family の全 token を以後拒否) — `RevokeFamily` 経由で family と配下 token の
+  `RevokedAt` が一括 set される（#164 既存実装に委譲）。
+  `handler.TestIntegration_ReuseDetection_FamilyRevoked` Act 3 で「A 再提示後、現役だった
+  B も 401」を確認。
+- **1.4** (通常拒否と区別できない同一応答) — 昇格時も返すのは同一 sentinel
+  `ErrInvalidRefreshToken`。`auth.TestRotateRefreshToken_ReuseEscalatesToFamilyRevoke` /
+  `handler.TestIntegration_ReuseDetection_FamilyRevoked`（message に reuse/revoked/family
+  を含まないことを検証）で担保。
+- **1.5** (失効永続化失敗でも新 token を発行しない) — `revokeFamilyOnReuse` 内で
+  `RevokeFamily` の error は `slog.Error` 記録のみで内部エラーへ昇格させず、呼び出し側の
+  `ErrInvalidRefreshToken` 拒否を維持する。`auth.TestRotateRefreshToken_ReuseRevokeFamilyFailureStillRejects`
+  で `CreateToken` 0 回 / `ErrInvalidRefreshToken` を検証。
+
+### Requirement 2: Revoke エンドポイント
+
+- **2.1** (既知 token で family 失効 + 204) — `TokenService.RevokeRefreshToken` が
+  `FindByHash` → `RevokeFamily` を実行し、`NativeAuthHandler.Revoke` が 204 を返す。
+  `auth.TestRevokeRefreshToken_KnownToken`（4 状態の table-driven）/
+  `handler.TestNativeAuthHandler_Revoke_Success` /
+  `handler.TestIntegration_RevokeFlow_RefreshRejectedAndIdempotent` Act 1 で担保。
+- **2.2** (不明・各状態でも同一の 204 / 冪等) — `FindByHash` nil で no-op nil（service）/
+  handler は同一 204 ボディなし。`auth.TestRevokeRefreshToken_UnknownTokenIsNoop` /
+  `handler.TestNativeAuthHandler_Revoke_UnknownTokenAlso204` / 統合 Act 3 (再 revoke) /
+  Act 4 (不明 token) で担保。
+- **2.3** (revoke 後の refresh 拒否) — `handler.TestIntegration_RevokeFlow_RefreshRejectedAndIdempotent`
+  Act 2 で revoke → 同 token refresh → 401 を確認。
+- **2.4** (Cookie / Bearer なしで呼び出し可能) — `router.go` の認証不要グループ
+  （Session middleware を経由しない）に `POST /api/auth/revoke` を登録。
+  `handler.TestNewRouter_NativeAuthRevoke_RegisteredWhenHandlerInjected` が Cookie 無しで
+  204 を確認。
+- **2.5** (不正 JSON / 必須欠落を拒否) — handler が `json.Decoder.DisallowUnknownFields` +
+  `req.RefreshToken == ""` で 400 INVALID_REQUEST を返す。
+  `handler.TestNativeAuthHandler_Revoke_InvalidJSON`（4 サブケース）/
+  `handler.TestNativeAuthHandler_Revoke_MissingField`（2 サブケース）で担保。
+- **2.6** (既存 Web ログアウトの挙動不変) — `internal/handler/router.go` diff は認証不要
+  グループ内の `POST /api/auth/revoke` 追加のみで、既存 `POST /auth/logout` 経路に変更なし。
+  既存テストが green のまま（NFR 2.1 と整合）。
+
+### Non-Functional Requirements
+
+- **NFR 1.1** (平文を永続化・ログ・エラーに残さない) — service は `HashNativeSecret` 後に
+  平文 token を破棄。slog は `hash[:8]` のみ。`auth.TestRevokeRefreshToken_InfraErrorPropagates`
+  でエラーメッセージに平文 token が含まれないことを検証。
+- **NFR 1.2** (応答から存在有無・状態を推測不能) — 不明 token も既知 token も同一の 204
+  ボディなし。`handler.TestNativeAuthHandler_Revoke_UnknownTokenAlso204` / 統合テスト Act 3〜4
+  で担保。
+- **NFR 1.3** (エラー応答に入力値・内部詳細を反射しない) — 400/500 ともに固定 APIError
+  メッセージ。`handler.TestNativeAuthHandler_Revoke_InternalError` が「db connection refused」
+  が message に含まれないことを検証。
+- **NFR 2.1** (既存ルートの挙動不変) — `RotateRefreshToken` の変更は拒否分岐内部のみ
+  （拒否応答 sentinel は変えていない）。`POST /auth/logout` / 既存 API 経路への diff なし。
+  `go test ./internal/auth/ ./internal/handler/` 全 pass で確認済み。
+- **NFR 2.2** (署名鍵未設定で revoke も非公開) — `NativeAuthHandler != nil` ガード内に
+  登録しているため nil 時は revoke も未登録。
+  `handler.TestNewRouter_NativeAuthRevoke_NotRegisteredWhenHandlerNil` で 404 を確認。
+- **NFR 3.1** (外部ネットワーク依存なし) — auth/handler とも service・store・issuer の
+  最小 mock 駆動。全テストが mock のみで構成され、外部ネットワーク・実 DB 接続なしで pass。
+
+## Findings
+
+なし（全 AC カバレッジ、対応テスト追加、boundary 準拠を確認）。
+
+### 補足: #167 既存統合テストの順序再構成に関する独立評価
+
+`TestIntegration_RefreshFlow_TokenExchangeRefreshSucceedsThenOldTokenRejected` は本実装で
+3 つの観点（rotation 成功 / 新世代 token B の有効性 / 旧 token A 再提示の 401 拒否）の
+**実行順序を再構成**している（B 有効性検証を A 再提示より前へ移動）。これを assertion の
+弱体化に当たるかどうか独立に検証した結果、**弱体化ではない**と判断する。理由:
+
+- 元の 3 観点はすべて維持されている（削除・置換なし。Act ラベルと assert メッセージが
+  更新されたのみ）
+- 順序入れ替えは #168 Req 1.3（再利用検知後の family 全滅）の必然的帰結。旧順序のままだと
+  A 再提示後に family が全滅し、新世代 B も拒否されてしまうため、`refresh with new token
+  status = 200` の assert が成立しなくなる
+- 「再利用検知後に新世代 token も拒否される」挙動は本 spec の新規 AC であり、独立した
+  新テスト `TestIntegration_ReuseDetection_FamilyRevoked` Act 3 で明示的に検証されている
+- impl-notes.md「実装上の判断」節でも spec 主導の挙動変更への追従である旨が明文化されている
+
+CLAUDE.md 禁止事項「テストを通すために実装ではなくテスト側を書き換えて弱めること」には
+該当しない（assert の削除・緩和ではなく、新 spec に整合させた配置変更）。
+
+## Summary
+
+Issue #168 の AC（Req 1.1〜1.5 / 2.1〜2.6 / NFR 1.1〜1.3 / 2.1〜2.2 / 3.1）すべてに対応する
+実装とテストが存在し、design.md の File Structure Plan で許可された 6 ファイル
+（+ impl-notes.md / tasks.md）に閉じている。boundary 逸脱なし。新規追加テストおよび既存
+テスト全パッケージ pass を確認した（`go test ./internal/auth/ ./internal/handler/`）。
+#167 既存統合テストの順序再構成は spec 主導の挙動変更への追従であり、assertion の弱体化に
+該当しない。
+
+RESULT: approve

--- a/docs/specs/168-reuse-detection-revoke/tasks.md
+++ b/docs/specs/168-reuse-detection-revoke/tasks.md
@@ -13,7 +13,7 @@
     （#167 既存ケースの検証内容は変えない。モックの interface 追従は可）
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, NFR 1.1, NFR 1.3, NFR 3.1_
 
-- [ ] 2. handler: Revoke エンドポイントと router 登録
+- [x] 2. handler: Revoke エンドポイントと router 登録
   - `internal/handler/native_auth_handler.go`: `TokenExchangeService` interface に
     `RevokeRefreshToken` を追加し、`Revoke` handler を実装（204 ボディなし /
     400 INVALID_REQUEST / 500 INTERNAL_ERROR）

--- a/docs/specs/168-reuse-detection-revoke/tasks.md
+++ b/docs/specs/168-reuse-detection-revoke/tasks.md
@@ -24,7 +24,7 @@
   - _Requirements: 2.1, 2.2, 2.4, 2.5, 2.6, NFR 1.2, NFR 2.1, NFR 2.2_
   - _Depends: 1_
 
-- [ ] 3. 統合テスト: 再利用 family 全滅と revoke 後拒否
+- [x] 3. 統合テスト: 再利用 family 全滅と revoke 後拒否
   - `internal/handler/integration_test.go` に design.md Testing Strategy 10 の 2 シナリオ
     （再利用 → family 全滅 / revoke 204 → refresh 401 → 再 revoke 204 の冪等）を追加
   - 既存の統合テスト・既存ルートが無変更で green であることを確認

--- a/docs/specs/168-reuse-detection-revoke/tasks.md
+++ b/docs/specs/168-reuse-detection-revoke/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. auth: 再利用検知の昇格と RevokeRefreshToken
+- [x] 1. auth: 再利用検知の昇格と RevokeRefreshToken
   - `internal/auth/token_service.go`: `RefreshTokenStore` interface に `RevokeFamily` を追加
     （compile-time check で `repository.RefreshTokenRepository` 充足を確認）
   - `RotateRefreshToken` の拒否分岐 2 箇所（手順 3 の RotatedAt 検出 / 手順 4 の

--- a/internal/auth/token_service.go
+++ b/internal/auth/token_service.go
@@ -52,13 +52,15 @@ type AuthCodeConsumer interface {
 	MarkUsed(ctx context.Context, id string) error
 }
 
-// RefreshTokenStore は TokenService が refresh token の新規発行 / rotation 操作に
-// 必要とする最小 IF。repository.RefreshTokenRepository が構造的に充足する
-// （interface segregation）。
+// RefreshTokenStore は TokenService が refresh token の新規発行 / rotation /
+// family 失効操作に必要とする最小 IF。repository.RefreshTokenRepository が構造的に
+// 充足する（interface segregation）。
 //
-// FindByHash / MarkRotated は Issue #167 の rotation で追加された。token 交換
-// （ExchangeAuthCode）では CreateFamily / CreateToken のみが使用され、refresh
-// （RotateRefreshToken）では FindByHash / MarkRotated / CreateToken が使用される。
+// FindByHash / MarkRotated は Issue #167 の rotation で、RevokeFamily は Issue #168 の
+// 再利用検知昇格 / revoke で追加された。token 交換（ExchangeAuthCode）では
+// CreateFamily / CreateToken のみが使用され、refresh（RotateRefreshToken）では
+// FindByHash / MarkRotated / CreateToken / RevokeFamily が、revoke
+// （RevokeRefreshToken）では FindByHash / RevokeFamily が使用される。
 type RefreshTokenStore interface {
 	CreateFamily(ctx context.Context, family *model.RefreshTokenFamily) error
 	CreateToken(ctx context.Context, token *model.RefreshToken) error
@@ -68,6 +70,9 @@ type RefreshTokenStore interface {
 	// MarkRotated は当該 ID の refresh_token の rotated_at を set する。
 	// 既に rotated_at が set 済みの場合は repository.ErrRefreshTokenAlreadyRotated を返す。
 	MarkRotated(ctx context.Context, id string, rotatedAt time.Time) error
+	// RevokeFamily は当該 family と配下の全 token の revoked_at を一括 set する。
+	// 既に revoked の family に対しては冪等に成功する（#164 の二重 revoke 安全設計）。
+	RevokeFamily(ctx context.Context, familyID string, revokedAt time.Time) error
 }
 
 // AccessTokenIssuer は TokenService が access token (JWT) の発行に必要とする最小 IF。
@@ -204,9 +209,11 @@ func (s *TokenService) ExchangeAuthCode(ctx context.Context, authCode, codeVerif
 //  2. 状態検証（いずれかに該当なら ErrInvalidRefreshToken）
 //     - RevokedAt != nil（失効済み / Req 2.3）
 //     - ExpiresAt <= now（期限切れ / Req 2.2）
-//     - RotatedAt != nil（rotation 済み = 再利用 / Req 2.4）
+//     - RotatedAt != nil（rotation 済み = 再利用検知。Issue #168 Req 1.1: family 全体を
+//     失効させてから拒否する）
 //  3. MarkRotated(id, now) で rotation 確定（Req 1.2）
-//     - ErrRefreshTokenAlreadyRotated → ErrInvalidRefreshToken（並行 race の敗者 / Req 3.1）
+//     - ErrRefreshTokenAlreadyRotated → 並行 race の敗者 = 同時再利用検知（Req 3.1 /
+//     Issue #168 Req 1.2: family 全体を失効させてから拒否する）
 //     ※ UPDATE ... WHERE rotated_at IS NULL の atomic 判定により高々 1 件のみ成功
 //  4. 新 refresh token（crypto/rand 32 byte）を同一 FamilyID で hash 保存
 //     ExpiresAt = now + RefreshTokenTTL（スライディング 30 日 / Req 1.3, 1.4）
@@ -238,7 +245,9 @@ func (s *TokenService) RotateRefreshToken(ctx context.Context, refreshToken stri
 		return nil, ErrInvalidRefreshToken
 	}
 	if stored.RotatedAt != nil {
-		// 既に rotation 済み = 再利用（Req 2.4。#168 が family 失効へ昇格するまでは単純拒否）
+		// 既に rotation 済み = 再利用検知（#167 Req 2.4 / #168 Req 1.1）。
+		// 漏えいの兆候として family 全体を失効させてから同一の拒否を返す（strict 方針）。
+		s.revokeFamilyOnReuse(ctx, stored.FamilyID, tokenHash, now)
 		return nil, ErrInvalidRefreshToken
 	}
 
@@ -246,8 +255,11 @@ func (s *TokenService) RotateRefreshToken(ctx context.Context, refreshToken stri
 	// WHERE rotated_at IS NULL の判定により並行 rotation でも高々 1 件のみ成功する。
 	if err := s.refreshTokens.MarkRotated(ctx, stored.ID, now); err != nil {
 		if errors.Is(err, repository.ErrRefreshTokenAlreadyRotated) {
-			// race の敗者は ErrInvalidRefreshToken に正規化（Req 2.6 / 3.1）。
+			// race の敗者 = atomic な rotation 確定で先行された提示（#167 Req 3.1 /
+			// #168 Req 1.2）。手順 2 の事前判定をすり抜けた同時再利用なので、
+			// 同様に family 全体を失効させてから拒否する（検知漏れ防止）。
 			// Req 2.7: 新 token は永続化されない（手順 4 に進まない）。
+			s.revokeFamilyOnReuse(ctx, stored.FamilyID, tokenHash, now)
 			return nil, ErrInvalidRefreshToken
 		}
 		return nil, fmt.Errorf("refresh rotation: mark rotated: %w", err)
@@ -289,6 +301,66 @@ func (s *TokenService) RotateRefreshToken(ctx context.Context, refreshToken stri
 		RefreshToken: plainRefresh,
 		ExpiresIn:    int(AccessTokenTTL / time.Second),
 	}, nil
+}
+
+// revokeFamilyOnReuse は rotation 済み refresh token の再利用検知時に family 全体を
+// 失効させる（Issue #168 Req 1.1 / 1.2 / 1.3）。
+//
+// RevokeFamily の失敗時も呼び出し側の拒否（ErrInvalidRefreshToken）は維持される
+// （Req 1.5: 失効の永続化が失敗しても新 token は発行しない。エラーは slog.Error で
+// 記録するのみで、内部詳細をクライアントへ反射しない）。
+// 検知イベントは slog.Warn で記録する（hash は先頭 8 文字のみ / NFR 1.1）。
+func (s *TokenService) revokeFamilyOnReuse(ctx context.Context, familyID, tokenHash string, now time.Time) {
+	slog.Warn("refresh token reuse detected",
+		slog.String("family_id", familyID),
+		slog.String("refresh_token_hash", tokenHash[:8]),
+	)
+	if err := s.refreshTokens.RevokeFamily(ctx, familyID, now); err != nil {
+		// 安全側: 失効に失敗しても拒否は維持される（呼び出し側が
+		// ErrInvalidRefreshToken を返す）。ここでは記録のみ行う。
+		slog.Error("failed to revoke refresh token family on reuse detection",
+			slog.String("family_id", familyID),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// RevokeRefreshToken は提示された refresh token の family 全体を失効する
+// （Issue #168 Req 2.1 / design.md「Revoke フロー」参照）。
+//
+// 手順:
+//  1. HashNativeSecret(refreshToken) → FindByHash
+//     - nil → 何もせず nil を返す（存在オラクルを作らない / Req 2.2）
+//  2. RevokeFamily(token.FamilyID, now)（#164 設計により二重 revoke 冪等）
+//
+// token の状態（期限切れ・rotation 済み・失効済み）に関わらず family を失効する
+// （クライアントが古い世代の token しか保持していなくてもログアウトを成立させる）。
+// infra エラー（FindByHash / RevokeFamily の失敗）のみ error を返す（handler は 500）。
+// 平文 refresh token はログ・エラーメッセージに残さない（NFR 1.1）。
+func (s *TokenService) RevokeRefreshToken(ctx context.Context, refreshToken string) error {
+	// 1. token_hash で対象 token を検索
+	tokenHash := HashNativeSecret(refreshToken)
+	stored, err := s.refreshTokens.FindByHash(ctx, tokenHash)
+	if err != nil {
+		return fmt.Errorf("refresh revoke: lookup refresh token: %w", err)
+	}
+	if stored == nil {
+		// 不明 token は何もせず成功扱い（冪等・存在オラクルなし / Req 2.2 / NFR 1.2）
+		return nil
+	}
+
+	// 2. family 全体を失効（二重 revoke は #164 設計により冪等 / Req 2.1）
+	if err := s.refreshTokens.RevokeFamily(ctx, stored.FamilyID, s.now()); err != nil {
+		return fmt.Errorf("refresh revoke: revoke family: %w", err)
+	}
+
+	// 機密値の追跡用に hash 先頭 8 文字のみログに残す（NFR 1.1）。
+	slog.Info("refresh token family revoked",
+		slog.String("user_id", stored.UserID),
+		slog.String("family_id", stored.FamilyID),
+		slog.String("refresh_token_hash", tokenHash[:8]),
+	)
+	return nil
 }
 
 // generateRefreshToken は crypto/rand から 256bit を取り出し、base64url（no-pad）

--- a/internal/auth/token_service_test.go
+++ b/internal/auth/token_service_test.go
@@ -45,22 +45,27 @@ func (m *mockAuthCodes) MarkUsed(ctx context.Context, id string) error {
 
 // mockRefreshTokens は RefreshTokenStore 最小 IF の record-and-return モック。
 // 永続化された family / token を捕捉して、テストで TokenHash / FamilyID / ExpiresAt
-// の整合を検証する。FindByHash / MarkRotated は Issue #167 の rotation で追加された。
+// の整合を検証する。FindByHash / MarkRotated は Issue #167 の rotation で、
+// RevokeFamily は Issue #168 の再利用検知昇格 / revoke で追加された。
 type mockRefreshTokens struct {
 	createFamilyFn func(ctx context.Context, f *model.RefreshTokenFamily) error
 	createTokenFn  func(ctx context.Context, t *model.RefreshToken) error
 	findByHashFn   func(ctx context.Context, tokenHash string) (*model.RefreshToken, error)
 	markRotatedFn  func(ctx context.Context, id string, rotatedAt time.Time) error
+	revokeFamilyFn func(ctx context.Context, familyID string, revokedAt time.Time) error
 
-	createFamilyCalls int
-	createTokenCalls  int
-	findByHashCalls   int
-	markRotatedCalls  int
-	storedFamily      *model.RefreshTokenFamily
-	storedToken       *model.RefreshToken
-	lastFindHash      string
-	lastMarkID        string
-	lastMarkAt        time.Time
+	createFamilyCalls  int
+	createTokenCalls   int
+	findByHashCalls    int
+	markRotatedCalls   int
+	revokeFamilyCalls  int
+	storedFamily       *model.RefreshTokenFamily
+	storedToken        *model.RefreshToken
+	lastFindHash       string
+	lastMarkID         string
+	lastMarkAt         time.Time
+	lastRevokeFamilyID string
+	lastRevokeAt       time.Time
 }
 
 func (m *mockRefreshTokens) CreateFamily(ctx context.Context, f *model.RefreshTokenFamily) error {
@@ -96,6 +101,16 @@ func (m *mockRefreshTokens) MarkRotated(ctx context.Context, id string, rotatedA
 	m.lastMarkAt = rotatedAt
 	if m.markRotatedFn != nil {
 		return m.markRotatedFn(ctx, id, rotatedAt)
+	}
+	return nil
+}
+
+func (m *mockRefreshTokens) RevokeFamily(ctx context.Context, familyID string, revokedAt time.Time) error {
+	m.revokeFamilyCalls++
+	m.lastRevokeFamilyID = familyID
+	m.lastRevokeAt = revokedAt
+	if m.revokeFamilyFn != nil {
+		return m.revokeFamilyFn(ctx, familyID, revokedAt)
 	}
 	return nil
 }
@@ -746,7 +761,9 @@ func TestRotateRefreshToken_Revoked(t *testing.T) {
 // TestRotateRefreshToken_AlreadyRotated は RotatedAt が set 済みの token（再利用）に対して
 // ErrInvalidRefreshToken を返し、MarkRotated / CreateToken に進まないことを検証する
 // （Testing Strategy 5 / Req 2.4, 2.6, 2.7）。
-// #168 が family 失効へ昇格するまでは単純拒否のみ。
+// #168 で family 失効への昇格が追加された（昇格時の RevokeFamily 呼び出しは
+// TestRotateRefreshToken_ReuseEscalatesToFamilyRevoke が検証する。本テストの
+// 検証内容＝拒否応答と新 token 未作成は #167 から不変）。
 func TestRotateRefreshToken_AlreadyRotated(t *testing.T) {
 	// Arrange
 	svc, _, refreshTokens, issuer := newServiceWithMocks(t)
@@ -895,6 +912,300 @@ func TestRotateRefreshToken_DoesNotLeakPlainSecretsInError(t *testing.T) {
 	msg := err.Error()
 	if strings.Contains(msg, secretToken) {
 		t.Errorf("error message %q contains plain refresh token (NFR 1.2 / 1.3)", msg)
+	}
+}
+
+// --- 再利用検知の family 失効昇格と RevokeRefreshToken のテスト
+// （Issue #168 / design.md Testing Strategy 1〜7） ---
+
+// TestRotateRefreshToken_ReuseEscalatesToFamilyRevoke は RotatedAt 済み token の提示
+// （再利用検知）で RevokeFamily が当該 FamilyID と now で呼ばれ、ErrInvalidRefreshToken
+// が返り、新 token が作成されないことを検証する（Testing Strategy 1 / Req 1.1, 1.4）。
+func TestRotateRefreshToken_ReuseEscalatesToFamilyRevoke(t *testing.T) {
+	// Arrange
+	svc, _, refreshTokens, issuer := newServiceWithMocks(t)
+	stored := newStoredRefreshToken("user-test-1")
+	rotatedAt := fixedTokenServiceIssuedAt.Add(-1 * time.Hour)
+	stored.RotatedAt = &rotatedAt
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return stored, nil
+	}
+
+	// Act
+	pair, err := svc.RotateRefreshToken(context.Background(), "plain-refresh-token")
+
+	// Assert: 拒否応答は通常の無効 token と同一 sentinel（Req 1.4）
+	if !errors.Is(err, ErrInvalidRefreshToken) {
+		t.Errorf("err = %v, want ErrInvalidRefreshToken (Req 1.4: 通常拒否と区別しない)", err)
+	}
+	if pair != nil {
+		t.Errorf("pair = %+v, want nil", pair)
+	}
+	// Assert: RevokeFamily が当該 FamilyID と now で 1 回呼ばれる（Req 1.1）
+	if refreshTokens.revokeFamilyCalls != 1 {
+		t.Errorf("RevokeFamily calls = %d, want 1 (再利用検知で family 失効昇格 / Req 1.1)",
+			refreshTokens.revokeFamilyCalls)
+	}
+	if refreshTokens.lastRevokeFamilyID != stored.FamilyID {
+		t.Errorf("RevokeFamily called with familyID=%q, want %q",
+			refreshTokens.lastRevokeFamilyID, stored.FamilyID)
+	}
+	if !refreshTokens.lastRevokeAt.Equal(fixedTokenServiceIssuedAt) {
+		t.Errorf("RevokeFamily revokedAt = %v, want %v",
+			refreshTokens.lastRevokeAt, fixedTokenServiceIssuedAt)
+	}
+	// Assert: 新 token は作成されない
+	if refreshTokens.createTokenCalls != 0 {
+		t.Errorf("CreateToken calls = %d, want 0 (再利用検知時は新 token 未作成)",
+			refreshTokens.createTokenCalls)
+	}
+	if issuer.issueCalls != 0 {
+		t.Errorf("IssueAccessToken calls = %d, want 0", issuer.issueCalls)
+	}
+}
+
+// TestRotateRefreshToken_RaceLoserEscalatesToFamilyRevoke は並行 rotation race の敗者
+// （MarkRotated が ErrRefreshTokenAlreadyRotated を返す = atomic な rotation 確定で
+// 先行された提示）でも同様に RevokeFamily へ昇格することを検証する
+// （Testing Strategy 2 / Req 1.2, 1.4）。
+func TestRotateRefreshToken_RaceLoserEscalatesToFamilyRevoke(t *testing.T) {
+	// Arrange
+	svc, _, refreshTokens, issuer := newServiceWithMocks(t)
+	stored := newStoredRefreshToken("user-test-1")
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return stored, nil
+	}
+	refreshTokens.markRotatedFn = func(ctx context.Context, id string, rotatedAt time.Time) error {
+		return repository.ErrRefreshTokenAlreadyRotated
+	}
+
+	// Act
+	pair, err := svc.RotateRefreshToken(context.Background(), "plain-refresh-token")
+
+	// Assert
+	if !errors.Is(err, ErrInvalidRefreshToken) {
+		t.Errorf("err = %v, want ErrInvalidRefreshToken (Req 1.4)", err)
+	}
+	if pair != nil {
+		t.Errorf("pair = %+v, want nil", pair)
+	}
+	// Assert: race 敗者も family 失効に昇格する（Req 1.2: 検知漏れ防止）
+	if refreshTokens.revokeFamilyCalls != 1 {
+		t.Errorf("RevokeFamily calls = %d, want 1 (race 敗者も昇格 / Req 1.2)",
+			refreshTokens.revokeFamilyCalls)
+	}
+	if refreshTokens.lastRevokeFamilyID != stored.FamilyID {
+		t.Errorf("RevokeFamily called with familyID=%q, want %q",
+			refreshTokens.lastRevokeFamilyID, stored.FamilyID)
+	}
+	if refreshTokens.createTokenCalls != 0 {
+		t.Errorf("CreateToken calls = %d, want 0", refreshTokens.createTokenCalls)
+	}
+	if issuer.issueCalls != 0 {
+		t.Errorf("IssueAccessToken calls = %d, want 0", issuer.issueCalls)
+	}
+}
+
+// TestRotateRefreshToken_ReuseRevokeFamilyFailureStillRejects は昇格時の RevokeFamily が
+// 失敗しても、拒否（ErrInvalidRefreshToken）が維持され新 token が発行されないことを
+// 検証する（Testing Strategy 3 / Req 1.5: 安全側に倒す）。
+func TestRotateRefreshToken_ReuseRevokeFamilyFailureStillRejects(t *testing.T) {
+	// Arrange
+	svc, _, refreshTokens, issuer := newServiceWithMocks(t)
+	stored := newStoredRefreshToken("user-test-1")
+	rotatedAt := fixedTokenServiceIssuedAt.Add(-1 * time.Hour)
+	stored.RotatedAt = &rotatedAt
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return stored, nil
+	}
+	refreshTokens.revokeFamilyFn = func(ctx context.Context, familyID string, revokedAt time.Time) error {
+		return errors.New("db unavailable")
+	}
+
+	// Act
+	pair, err := svc.RotateRefreshToken(context.Background(), "plain-refresh-token")
+
+	// Assert: RevokeFamily 失敗でも拒否は維持（内部エラーへ昇格させない / Req 1.5）
+	if !errors.Is(err, ErrInvalidRefreshToken) {
+		t.Errorf("err = %v, want ErrInvalidRefreshToken (RevokeFamily 失敗でも拒否を維持 / Req 1.5)", err)
+	}
+	if pair != nil {
+		t.Errorf("pair = %+v, want nil", pair)
+	}
+	if refreshTokens.revokeFamilyCalls != 1 {
+		t.Errorf("RevokeFamily calls = %d, want 1", refreshTokens.revokeFamilyCalls)
+	}
+	// Req 1.5: 新 token は発行されない
+	if refreshTokens.createTokenCalls != 0 {
+		t.Errorf("CreateToken calls = %d, want 0 (Req 1.5)", refreshTokens.createTokenCalls)
+	}
+	if issuer.issueCalls != 0 {
+		t.Errorf("IssueAccessToken calls = %d, want 0", issuer.issueCalls)
+	}
+}
+
+// TestRotateRefreshToken_RevokedIsNotEscalated は RevokedAt set 済み（失効済み）token の
+// refresh が引き続き昇格なしの単純拒否であることを検証する（Testing Strategy 7 /
+// #167 既存挙動の回帰。失効済み提示は再利用検知ではない）。
+func TestRotateRefreshToken_RevokedIsNotEscalated(t *testing.T) {
+	// Arrange
+	svc, _, refreshTokens, _ := newServiceWithMocks(t)
+	stored := newStoredRefreshToken("user-test-1")
+	revokedAt := fixedTokenServiceIssuedAt.Add(-30 * time.Minute)
+	stored.RevokedAt = &revokedAt
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return stored, nil
+	}
+
+	// Act
+	_, err := svc.RotateRefreshToken(context.Background(), "plain-refresh-token")
+
+	// Assert
+	if !errors.Is(err, ErrInvalidRefreshToken) {
+		t.Errorf("err = %v, want ErrInvalidRefreshToken", err)
+	}
+	// 失効済みは再利用ではないため RevokeFamily は呼ばれない（昇格なし）
+	if refreshTokens.revokeFamilyCalls != 0 {
+		t.Errorf("RevokeFamily calls = %d, want 0 (失効済みは昇格対象外)",
+			refreshTokens.revokeFamilyCalls)
+	}
+}
+
+// TestRevokeRefreshToken_KnownToken は既知 token の提示で RevokeFamily が当該 FamilyID と
+// now で呼ばれ、nil が返ることを検証する（Testing Strategy 4 / Req 2.1）。
+// token の状態（有効・期限切れ・rotation 済み・失効済み）に関わらず family を失効する
+// （design.md「Revoke フロー」: 古い世代の token しか持たないクライアントのログアウトも
+// 成立させる）。
+func TestRevokeRefreshToken_KnownToken(t *testing.T) {
+	pastTime := fixedTokenServiceIssuedAt.Add(-1 * time.Hour)
+	cases := []struct {
+		name   string
+		mutate func(tok *model.RefreshToken)
+	}{
+		{name: "有効な token のとき family を失効する", mutate: func(tok *model.RefreshToken) {}},
+		{name: "期限切れ token でも family を失効する", mutate: func(tok *model.RefreshToken) {
+			tok.ExpiresAt = pastTime
+		}},
+		{name: "rotation 済み token でも family を失効する", mutate: func(tok *model.RefreshToken) {
+			tok.RotatedAt = &pastTime
+		}},
+		{name: "失効済み token でも冪等に成功する", mutate: func(tok *model.RefreshToken) {
+			tok.RevokedAt = &pastTime
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			svc, _, refreshTokens, _ := newServiceWithMocks(t)
+			stored := newStoredRefreshToken("user-test-1")
+			tc.mutate(stored)
+			refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+				return stored, nil
+			}
+
+			// Act
+			err := svc.RevokeRefreshToken(context.Background(), "plain-refresh-token")
+
+			// Assert
+			if err != nil {
+				t.Fatalf("RevokeRefreshToken returned error: %v", err)
+			}
+			if refreshTokens.findByHashCalls != 1 {
+				t.Errorf("FindByHash calls = %d, want 1", refreshTokens.findByHashCalls)
+			}
+			if refreshTokens.lastFindHash != HashNativeSecret("plain-refresh-token") {
+				t.Errorf("FindByHash called with hash=%q, want hash of plain token",
+					refreshTokens.lastFindHash)
+			}
+			if refreshTokens.revokeFamilyCalls != 1 {
+				t.Errorf("RevokeFamily calls = %d, want 1 (Req 2.1)", refreshTokens.revokeFamilyCalls)
+			}
+			if refreshTokens.lastRevokeFamilyID != stored.FamilyID {
+				t.Errorf("RevokeFamily called with familyID=%q, want %q",
+					refreshTokens.lastRevokeFamilyID, stored.FamilyID)
+			}
+			if !refreshTokens.lastRevokeAt.Equal(fixedTokenServiceIssuedAt) {
+				t.Errorf("RevokeFamily revokedAt = %v, want %v",
+					refreshTokens.lastRevokeAt, fixedTokenServiceIssuedAt)
+			}
+		})
+	}
+}
+
+// TestRevokeRefreshToken_UnknownTokenIsNoop は不明 token の提示で RevokeFamily を
+// 呼ばずに nil を返すことを検証する（Testing Strategy 5 / Req 2.2: 冪等・存在オラクル
+// なし）。
+func TestRevokeRefreshToken_UnknownTokenIsNoop(t *testing.T) {
+	// Arrange
+	svc, _, refreshTokens, _ := newServiceWithMocks(t)
+	refreshTokens.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+		return nil, nil
+	}
+
+	// Act
+	err := svc.RevokeRefreshToken(context.Background(), "unknown-token")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("RevokeRefreshToken returned error: %v (不明 token は成功扱い / Req 2.2)", err)
+	}
+	if refreshTokens.revokeFamilyCalls != 0 {
+		t.Errorf("RevokeFamily calls = %d, want 0 (不明 token は no-op / Req 2.2)",
+			refreshTokens.revokeFamilyCalls)
+	}
+}
+
+// TestRevokeRefreshToken_InfraErrorPropagates は FindByHash / RevokeFamily の DB 障害が
+// error として上層に伝播する（500 系）こと、およびエラーメッセージに平文 token が
+// 含まれないことを検証する（Testing Strategy 6 / NFR 1.1, 1.3）。
+func TestRevokeRefreshToken_InfraErrorPropagates(t *testing.T) {
+	const secretToken = "very-secret-refresh-token-plain-value-67890"
+	wantErr := errors.New("db unavailable")
+
+	cases := []struct {
+		name  string
+		setup func(m *mockRefreshTokens)
+	}{
+		{
+			name: "FindByHash の DB 障害が伝播する",
+			setup: func(m *mockRefreshTokens) {
+				m.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+					return nil, wantErr
+				}
+			},
+		},
+		{
+			name: "RevokeFamily の DB 障害が伝播する",
+			setup: func(m *mockRefreshTokens) {
+				m.findByHashFn = func(ctx context.Context, hash string) (*model.RefreshToken, error) {
+					return newStoredRefreshToken("user-test-1"), nil
+				}
+				m.revokeFamilyFn = func(ctx context.Context, familyID string, revokedAt time.Time) error {
+					return wantErr
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			svc, _, refreshTokens, _ := newServiceWithMocks(t)
+			tc.setup(refreshTokens)
+
+			// Act
+			err := svc.RevokeRefreshToken(context.Background(), secretToken)
+
+			// Assert
+			if err == nil {
+				t.Fatal("err = nil, want non-nil (DB 障害は 500 系へ)")
+			}
+			if !errors.Is(err, wantErr) {
+				t.Errorf("err = %v, want wrap of %v", err, wantErr)
+			}
+			if strings.Contains(err.Error(), secretToken) {
+				t.Errorf("error message %q contains plain refresh token (NFR 1.1 / 1.3)", err.Error())
+			}
+		})
 	}
 }
 

--- a/internal/handler/integration_test.go
+++ b/internal/handler/integration_test.go
@@ -66,14 +66,19 @@ type mockNativeTokenExchangeService struct {
 	lastCode     string
 	lastVerifier string
 
-	// refresh tokens の rotation 用ステート（Issue #167）。
+	// refresh tokens の rotation 用ステート（Issue #167 / #168）。
 	// activeRefresh[plain]=familyID で「現役の refresh token 平文 → family」を保持。
 	// rotation 成功で旧 plain を活性集合から外し（rotated 扱い）新 plain を追加する。
-	// 旧 plain は rotatedRefresh に move し、再提示時の「rotation 済み拒否」を判定する。
+	// 旧 plain は rotatedRefresh に move し（family を保持）、再提示時の再利用検知 →
+	// family 失効昇格（#168 Req 1.1）を simulate する。revokedFamilies は失効済み
+	// family の集合で、配下 token の refresh 拒否（#168 Req 1.3 / 2.3）を判定する。
 	activeRefresh    map[string]string // plain → familyID
-	rotatedRefresh   map[string]struct{}
+	rotatedRefresh   map[string]string // plain → familyID（rotation 済み）
+	revokedFamilies  map[string]struct{}
 	rotateCallCount  int
+	revokeCallCount  int
 	lastRefreshToken string
+	lastRevokeToken  string
 }
 
 // IssueCode は事前に「払い出した auth_code 平文」を mock に登録する。
@@ -107,7 +112,7 @@ func (m *mockNativeTokenExchangeService) ExchangeAuthCode(ctx context.Context, a
 		m.activeRefresh = make(map[string]string)
 	}
 	if m.rotatedRefresh == nil {
-		m.rotatedRefresh = make(map[string]struct{})
+		m.rotatedRefresh = make(map[string]string)
 	}
 	const plain = "integration-refresh-token"
 	const familyID = "family-integration"
@@ -119,11 +124,15 @@ func (m *mockNativeTokenExchangeService) ExchangeAuthCode(ctx context.Context, a
 	}, nil
 }
 
-// RotateRefreshToken は Issue #167 の rotation を simulate する。
+// RotateRefreshToken は Issue #167 の rotation と Issue #168 の再利用検知昇格を
+// simulate する。
+//   - rotated 集合に存在する plain → 再利用検知。当該 family を失効してから
+//     ErrInvalidRefreshToken（#168 Req 1.1, 1.4）
+//   - 活性集合に存在するが family 失効済みの plain → ErrInvalidRefreshToken
+//     （#168 Req 1.3 / 2.3: family 全滅後は全 token 拒否）
 //   - 活性集合に存在する plain → 旧 plain を rotated 集合へ move、新 plain を活性化して
-//     新 TokenPair を返す（同一 family に紐付け / Req 1.3, 1.4）
-//   - rotated 集合に存在する plain → ErrInvalidRefreshToken（Req 2.4: rotation 済み再利用）
-//   - 活性集合にも rotated 集合にも存在しない plain → ErrInvalidRefreshToken（Req 2.1: 不明）
+//     新 TokenPair を返す（同一 family に紐付け / #167 Req 1.3, 1.4）
+//   - 活性集合にも rotated 集合にも存在しない plain → ErrInvalidRefreshToken（#167 Req 2.1: 不明）
 //
 // 連続 rotation の通しテストでは「N 回目の rotation で N 番目の plain が返る」決定論を
 // 担保するために、内部カウンタで新 plain を生成する。
@@ -136,8 +145,9 @@ func (m *mockNativeTokenExchangeService) RotateRefreshToken(ctx context.Context,
 	if m.activeRefresh == nil {
 		return nil, auth.ErrInvalidRefreshToken
 	}
-	if _, isRotated := m.rotatedRefresh[refreshToken]; isRotated {
-		// rotation 済み再利用は単純拒否（#168 が family 失効へ昇格するまでは ErrInvalidRefreshToken）
+	if familyID, isRotated := m.rotatedRefresh[refreshToken]; isRotated {
+		// rotation 済み再利用 = 再利用検知。family 全体を失効してから拒否（#168 Req 1.1）。
+		m.revokeFamilyLocked(familyID)
 		return nil, auth.ErrInvalidRefreshToken
 	}
 	familyID, isActive := m.activeRefresh[refreshToken]
@@ -145,13 +155,17 @@ func (m *mockNativeTokenExchangeService) RotateRefreshToken(ctx context.Context,
 		// 不明
 		return nil, auth.ErrInvalidRefreshToken
 	}
+	if _, revoked := m.revokedFamilies[familyID]; revoked {
+		// family 失効済み（revoke 経由 / 再利用検知経由を問わず拒否 / #168 Req 1.3, 2.3）
+		return nil, auth.ErrInvalidRefreshToken
+	}
 
 	// 旧 plain を rotated に move、新 plain を活性化（同一 family / Req 1.3）。
 	delete(m.activeRefresh, refreshToken)
 	if m.rotatedRefresh == nil {
-		m.rotatedRefresh = make(map[string]struct{})
+		m.rotatedRefresh = make(map[string]string)
 	}
-	m.rotatedRefresh[refreshToken] = struct{}{}
+	m.rotatedRefresh[refreshToken] = familyID
 	newPlain := fmt.Sprintf("integration-refresh-token-rot-%d", m.rotateCallCount)
 	m.activeRefresh[newPlain] = familyID
 
@@ -162,10 +176,34 @@ func (m *mockNativeTokenExchangeService) RotateRefreshToken(ctx context.Context,
 	}, nil
 }
 
-// RevokeRefreshToken は TokenExchangeService の interface 追従（Issue #168 task 2）。
-// revoke の意味論（family 失効）の simulate と通しシナリオは task 3 で実装する。
+// RevokeRefreshToken は Issue #168 の revoke を simulate する。
+//   - 活性 / rotated いずれかの集合に存在する plain → 当該 family を失効して nil
+//     （token の状態に関わらず失効 / Req 2.1）
+//   - 不明な plain → 何もせず nil（冪等・存在オラクルなし / Req 2.2）
 func (m *mockNativeTokenExchangeService) RevokeRefreshToken(ctx context.Context, refreshToken string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.revokeCallCount++
+	m.lastRevokeToken = refreshToken
+
+	familyID, ok := m.activeRefresh[refreshToken]
+	if !ok {
+		familyID, ok = m.rotatedRefresh[refreshToken]
+	}
+	if !ok {
+		// 不明 token は no-op（Req 2.2）
+		return nil
+	}
+	m.revokeFamilyLocked(familyID)
 	return nil
+}
+
+// revokeFamilyLocked は family を失効済み集合へ加える。呼び出し側で mu を保持していること。
+func (m *mockNativeTokenExchangeService) revokeFamilyLocked(familyID string) {
+	if m.revokedFamilies == nil {
+		m.revokedFamilies = make(map[string]struct{})
+	}
+	m.revokedFamilies[familyID] = struct{}{}
 }
 
 // createNativeAuthIntegrationRouter は native auth 系統（login / callback / token 交換）の
@@ -1716,32 +1754,10 @@ func TestIntegration_RefreshFlow_TokenExchangeRefreshSucceedsThenOldTokenRejecte
 		t.Errorf("refresh 1st: new refresh_token equals old (rotation must produce different token)")
 	}
 
-	// Act 2: 同じ旧 refresh token で再 refresh → 401 INVALID_REFRESH_TOKEN（Req 1.2 / 2.4）
-	req = httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w = httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	resp = w.Result()
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("refresh 2nd with old token status = %d, want %d (Req 1.2 / 2.4 / SERVER.md §1.3)",
-			resp.StatusCode, http.StatusUnauthorized)
-	}
-	var rejectBody map[string]any
-	_ = json.NewDecoder(resp.Body).Decode(&rejectBody)
-	if rejectBody["code"] != "INVALID_REFRESH_TOKEN" {
-		t.Errorf("refresh 2nd: code = %v, want %q (Req 2.6 uniform 拒否)",
-			rejectBody["code"], "INVALID_REFRESH_TOKEN")
-	}
-	if rejectBody["category"] != "auth" {
-		t.Errorf("refresh 2nd: category = %v, want %q", rejectBody["category"], "auth")
-	}
-	// 詳細な拒否理由を反射しない（Req 2.6 / NFR 1.3）
-	if msg, _ := rejectBody["message"].(string); strings.Contains(msg, "rotated") || strings.Contains(msg, "expired") || strings.Contains(msg, "revoked") {
-		t.Errorf("refresh 2nd: message %q must not differentiate rejection reasons", msg)
-	}
-
-	// 新 refresh token は依然有効（rotation 後に発行された世代）
+	// Act 2: 新 refresh token は有効（rotation 後に発行された世代で再 refresh 成功）
+	// ※ #168 で旧 token 再利用が family 失効へ昇格したため、新世代の有効性検証は
+	//   旧 token 再提示（Act 3）より前に行う（再利用検知後は family 全滅で B も拒否される。
+	//   その挙動自体は TestIntegration_ReuseDetection_FamilyRevoked が検証する）。
 	body2 := fmt.Sprintf(`{"refresh_token":%q}`, newRefresh)
 	req = httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(body2))
 	req.Header.Set("Content-Type", "application/json")
@@ -1750,6 +1766,31 @@ func TestIntegration_RefreshFlow_TokenExchangeRefreshSucceedsThenOldTokenRejecte
 	if w.Result().StatusCode != http.StatusOK {
 		t.Errorf("refresh with new token status = %d, want 200 (新 token は有効)",
 			w.Result().StatusCode)
+	}
+
+	// Act 3: 最初の旧 refresh token で再 refresh → 401 INVALID_REFRESH_TOKEN（Req 1.2 / 2.4）
+	req = httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("refresh with old token status = %d, want %d (Req 1.2 / 2.4 / SERVER.md §1.3)",
+			resp.StatusCode, http.StatusUnauthorized)
+	}
+	var rejectBody map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&rejectBody)
+	if rejectBody["code"] != "INVALID_REFRESH_TOKEN" {
+		t.Errorf("refresh with old token: code = %v, want %q (Req 2.6 uniform 拒否)",
+			rejectBody["code"], "INVALID_REFRESH_TOKEN")
+	}
+	if rejectBody["category"] != "auth" {
+		t.Errorf("refresh with old token: category = %v, want %q", rejectBody["category"], "auth")
+	}
+	// 詳細な拒否理由を反射しない（Req 2.6 / NFR 1.3）
+	if msg, _ := rejectBody["message"].(string); strings.Contains(msg, "rotated") || strings.Contains(msg, "expired") || strings.Contains(msg, "revoked") {
+		t.Errorf("refresh with old token: message %q must not differentiate rejection reasons", msg)
 	}
 }
 
@@ -1779,5 +1820,135 @@ func TestIntegration_RefreshFlow_UnknownRefreshTokenReturns401(t *testing.T) {
 	_ = json.NewDecoder(resp.Body).Decode(&resBody)
 	if resBody["code"] != "INVALID_REFRESH_TOKEN" {
 		t.Errorf("code = %v, want %q (Req 2.6)", resBody["code"], "INVALID_REFRESH_TOKEN")
+	}
+}
+
+// --- 再利用検知 family 全滅 / revoke の通しテスト（Issue #168 / design.md Testing Strategy 10） ---
+
+// TestIntegration_ReuseDetection_FamilyRevoked は「token 交換 → refresh（旧 A → 新 B）→
+// A を再提示 → 401 → 以後 B でも 401」の family 全滅シナリオを検証する（Req 1.1, 1.3, 1.4）。
+func TestIntegration_ReuseDetection_FamilyRevoked(t *testing.T) {
+	// Arrange: native login → callback → token 交換で初回 refresh token A を取得
+	state := newIntegrationState()
+	tokenSvc := &mockNativeTokenExchangeService{}
+	router := createNativeAuthIntegrationRouter(state, tokenSvc)
+	tokenA := runNativeLoginCallbackAndExchange(t, router)
+
+	// Act 1: A で refresh 成功 → 新 token B を取得
+	bodyA := fmt.Sprintf(`{"refresh_token":%q}`, tokenA)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(bodyA))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("refresh A status = %d, want 200", w.Result().StatusCode)
+	}
+	var pairBody map[string]any
+	if err := json.NewDecoder(w.Result().Body).Decode(&pairBody); err != nil {
+		t.Fatalf("decode refresh A body: %v", err)
+	}
+	tokenB, _ := pairBody["refresh_token"].(string)
+	if tokenB == "" || tokenB == tokenA {
+		t.Fatalf("refresh A must return new token B (got %q)", tokenB)
+	}
+
+	// Act 2: rotation 済みの A を再提示 → 再利用検知で 401（Req 1.1）
+	req = httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(bodyA))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("replay A status = %d, want %d (Req 1.1: 再利用検知で拒否)",
+			resp.StatusCode, http.StatusUnauthorized)
+	}
+	// 拒否応答は通常の無効 token と区別できない同一応答（Req 1.4）
+	var replayBody map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&replayBody)
+	if replayBody["code"] != "INVALID_REFRESH_TOKEN" {
+		t.Errorf("replay A: code = %v, want %q (Req 1.4)", replayBody["code"], "INVALID_REFRESH_TOKEN")
+	}
+	if msg, _ := replayBody["message"].(string); strings.Contains(msg, "reuse") || strings.Contains(msg, "revoked") || strings.Contains(msg, "family") {
+		t.Errorf("replay A: message %q must not reveal reuse detection (Req 1.4)", msg)
+	}
+
+	// Act 3: family 全滅により、現役だったはずの B でも以後 401（Req 1.3）
+	bodyB := fmt.Sprintf(`{"refresh_token":%q}`, tokenB)
+	req = httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(bodyB))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Errorf("refresh B after family revoke status = %d, want %d (Req 1.3: family 全滅)",
+			w.Result().StatusCode, http.StatusUnauthorized)
+	}
+}
+
+// TestIntegration_RevokeFlow_RefreshRejectedAndIdempotent は「token 交換 → revoke 204 →
+// 同 token で refresh → 401 → 再 revoke → 204」の revoke 後拒否と冪等性を検証する
+// （Req 2.1, 2.2, 2.3）。
+func TestIntegration_RevokeFlow_RefreshRejectedAndIdempotent(t *testing.T) {
+	// Arrange: native login → callback → token 交換で refresh token を取得
+	state := newIntegrationState()
+	tokenSvc := &mockNativeTokenExchangeService{}
+	router := createNativeAuthIntegrationRouter(state, tokenSvc)
+	refreshToken := runNativeLoginCallbackAndExchange(t, router)
+	body := fmt.Sprintf(`{"refresh_token":%q}`, refreshToken)
+
+	// Act 1: revoke → 204 ボディなし（Req 2.1）
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/revoke", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusNoContent {
+		t.Fatalf("revoke 1st status = %d, want %d (Req 2.1)", w.Result().StatusCode, http.StatusNoContent)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("revoke 1st body = %q, want empty (204 はボディなし)", w.Body.String())
+	}
+
+	// Act 2: revoke 済み token で refresh → 401（Req 2.3: family の全 token を拒否）
+	req = httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("refresh after revoke status = %d, want %d (Req 2.3)",
+			resp.StatusCode, http.StatusUnauthorized)
+	}
+	var rejectBody map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&rejectBody)
+	if rejectBody["code"] != "INVALID_REFRESH_TOKEN" {
+		t.Errorf("refresh after revoke: code = %v, want %q", rejectBody["code"], "INVALID_REFRESH_TOKEN")
+	}
+
+	// Act 3: 同じ token で再 revoke → 204（Req 2.2: 冪等・失効済みでも同一応答）
+	req = httptest.NewRequest(http.MethodPost, "/api/auth/revoke", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusNoContent {
+		t.Errorf("revoke 2nd status = %d, want %d (Req 2.2: 冪等)", w.Result().StatusCode, http.StatusNoContent)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("revoke 2nd body = %q, want empty", w.Body.String())
+	}
+
+	// Act 4: 不明 token の revoke も同一の 204（Req 2.2 / NFR 1.2: 存在オラクルなし）
+	unknownBody := `{"refresh_token":"never-issued-token"}`
+	req = httptest.NewRequest(http.MethodPost, "/api/auth/revoke", strings.NewReader(unknownBody))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusNoContent {
+		t.Errorf("revoke unknown status = %d, want %d (Req 2.2: 不明 token でも区別しない)",
+			w.Result().StatusCode, http.StatusNoContent)
 	}
 }

--- a/internal/handler/integration_test.go
+++ b/internal/handler/integration_test.go
@@ -162,6 +162,12 @@ func (m *mockNativeTokenExchangeService) RotateRefreshToken(ctx context.Context,
 	}, nil
 }
 
+// RevokeRefreshToken は TokenExchangeService の interface 追従（Issue #168 task 2）。
+// revoke の意味論（family 失効）の simulate と通しシナリオは task 3 で実装する。
+func (m *mockNativeTokenExchangeService) RevokeRefreshToken(ctx context.Context, refreshToken string) error {
+	return nil
+}
+
 // createNativeAuthIntegrationRouter は native auth 系統（login / callback / token 交換）の
 // 通し検証用に、token 交換 service を stateful mock として注入した router を返す。
 // 既存 createIntegrationRouter は固定 mock の listItems などに依存しているため、ここでは

--- a/internal/handler/native_auth_handler.go
+++ b/internal/handler/native_auth_handler.go
@@ -15,11 +15,13 @@ import (
 // TokenExchangeService は NativeAuthHandler が必要とする最小サービス IF。
 // auth.TokenService が構造的に充足する（interface segregation）。
 //
-// RotateRefreshToken は Issue #167 で追加された。Token / Refresh handler のいずれも
-// auth.TokenService の各メソッドを呼ぶだけで、handler 層はビジネスロジックを持たない。
+// RotateRefreshToken は Issue #167 で、RevokeRefreshToken は Issue #168 で追加された。
+// Token / Refresh / Revoke handler のいずれも auth.TokenService の各メソッドを呼ぶだけで、
+// handler 層はビジネスロジックを持たない。
 type TokenExchangeService interface {
 	ExchangeAuthCode(ctx context.Context, authCode, codeVerifier string) (*auth.TokenPair, error)
 	RotateRefreshToken(ctx context.Context, refreshToken string) (*auth.TokenPair, error)
+	RevokeRefreshToken(ctx context.Context, refreshToken string) error
 }
 
 // NativeAuthHandler は POST /api/auth/token を処理する HTTP ハンドラ（Issue #166）。
@@ -199,4 +201,45 @@ func invalidRefreshTokenError() *model.APIError {
 		Category: "auth",
 		Action:   "ログインからやり直してください。",
 	}
+}
+
+// Revoke は POST /api/auth/revoke を処理する（Issue #168）。
+//
+//   - 204: 失効成功または対象不明（ボディなし）。token の存在有無・状態を区別しない
+//     （Req 2.1, 2.2 / NFR 1.2: 冪等・列挙オラクルなし）。
+//   - 400 INVALID_REQUEST: JSON 不正・必須フィールド欠落（Req 2.5）
+//   - 500 INTERNAL_ERROR:  infra エラー（DB 障害など、NFR 1.3）
+//
+// 認証不要グループに登録されるため、セッション / Bearer なしで呼び出される
+// （Req 2.4: refresh token の所持自体を失効権限とみなす。requirements.md Open
+// Questions / RFC 7009 §2.1 の public client 慣行）。
+// リクエストボディは refresh と同一形式（refreshRequest を共用）。
+func (h *NativeAuthHandler) Revoke(w http.ResponseWriter, r *http.Request) {
+	// JSON 不正・必須フィールド欠落は 400 INVALID_REQUEST に合流する。
+	// ボディ上限超過（MaxBytesReader）も json.Decode のエラーとしてここで合流する。
+	var req refreshRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		// クライアント入力値・パーサ詳細はクライアントへ反射しない（NFR 1.3）。
+		slog.Info("revoke rejected: invalid request body")
+		middleware.WriteErrorResponse(w, http.StatusBadRequest, invalidRefreshRequestError())
+		return
+	}
+	if req.RefreshToken == "" {
+		slog.Info("revoke rejected: missing refresh_token")
+		middleware.WriteErrorResponse(w, http.StatusBadRequest, invalidRefreshRequestError())
+		return
+	}
+
+	if err := h.svc.RevokeRefreshToken(r.Context(), req.RefreshToken); err != nil {
+		// infra 起因（DB 障害）のみここに到達する（不明 token は service が nil を返す）。
+		// 詳細は slog のみ、応答は固定メッセージ（NFR 1.3）。
+		slog.Error("revoke failed", slog.String("error", err.Error()))
+		middleware.WriteInternalServerError(w)
+		return
+	}
+
+	// 失効成功・対象不明のいずれも同一の 204（ボディなし / Req 2.2 / NFR 1.2）。
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/handler/native_auth_handler_test.go
+++ b/internal/handler/native_auth_handler_test.go
@@ -14,15 +14,19 @@ import (
 )
 
 // mockTokenExchangeService は TokenExchangeService 最小 IF の record-and-return モック。
-// rotateFn / lastRefreshToken / rotateCalls は Issue #167 で追加された。
+// rotateFn / lastRefreshToken / rotateCalls は Issue #167 で、revokeFn / revokeCalls /
+// lastRevokeToken は Issue #168 で追加された。
 type mockTokenExchangeService struct {
 	exchangeFn       func(ctx context.Context, authCode, codeVerifier string) (*auth.TokenPair, error)
 	rotateFn         func(ctx context.Context, refreshToken string) (*auth.TokenPair, error)
+	revokeFn         func(ctx context.Context, refreshToken string) error
 	callCount        int
 	rotateCalls      int
+	revokeCalls      int
 	lastAuthCode     string
 	lastVerifier     string
 	lastRefreshToken string
+	lastRevokeToken  string
 }
 
 func (m *mockTokenExchangeService) ExchangeAuthCode(ctx context.Context, authCode, codeVerifier string) (*auth.TokenPair, error) {
@@ -42,6 +46,15 @@ func (m *mockTokenExchangeService) RotateRefreshToken(ctx context.Context, refre
 		return m.rotateFn(ctx, refreshToken)
 	}
 	return nil, fmt.Errorf("not configured")
+}
+
+func (m *mockTokenExchangeService) RevokeRefreshToken(ctx context.Context, refreshToken string) error {
+	m.revokeCalls++
+	m.lastRevokeToken = refreshToken
+	if m.revokeFn != nil {
+		return m.revokeFn(ctx, refreshToken)
+	}
+	return nil
 }
 
 // newRequest は handler 単体テスト用の JSON POST リクエストを生成する。
@@ -537,5 +550,179 @@ func TestNativeAuthHandler_Refresh_UnknownFieldRejected(t *testing.T) {
 	}
 	if svc.rotateCalls != 0 {
 		t.Errorf("service called %d times, want 0 (未知フィールドは service 到達前に拒否)", svc.rotateCalls)
+	}
+}
+
+// --- Revoke のテスト（Issue #168 / design.md Testing Strategy 8） ---
+
+// newRevokeRequest は Revoke handler 単体テスト用の JSON POST リクエストを生成する。
+func newRevokeRequest(body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/revoke", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// TestNativeAuthHandler_Revoke_Success は service が成功した場合に 204 + ボディなしを
+// 返すことを検証する（Req 2.1）。
+func TestNativeAuthHandler_Revoke_Success(t *testing.T) {
+	// Arrange
+	svc := &mockTokenExchangeService{}
+	h := NewNativeAuthHandler(svc)
+	req := newRevokeRequest(`{"refresh_token":"plain-refresh-token"}`)
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Revoke(w, req)
+
+	// Assert: 204 / ボディなし
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d (Req 2.1)", resp.StatusCode, http.StatusNoContent)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty (204 はボディなし)", w.Body.String())
+	}
+
+	// Assert: service が plain な値で呼ばれた（hash 化は service 内部で行う）
+	if svc.revokeCalls != 1 {
+		t.Errorf("service.RevokeRefreshToken called %d times, want 1", svc.revokeCalls)
+	}
+	if svc.lastRevokeToken != "plain-refresh-token" {
+		t.Errorf("service.lastRevokeToken = %q, want %q",
+			svc.lastRevokeToken, "plain-refresh-token")
+	}
+}
+
+// TestNativeAuthHandler_Revoke_UnknownTokenAlso204 は不明 token（service が no-op nil を
+// 返す）でも既知 token と区別できない同一の 204 を返すことを検証する
+// （Req 2.2 / NFR 1.2: 冪等・列挙オラクルなし）。
+func TestNativeAuthHandler_Revoke_UnknownTokenAlso204(t *testing.T) {
+	// Arrange: service は不明 token に対して nil（no-op 成功）を返す
+	svc := &mockTokenExchangeService{
+		revokeFn: func(ctx context.Context, refreshToken string) error {
+			return nil
+		},
+	}
+	h := NewNativeAuthHandler(svc)
+	req := newRevokeRequest(`{"refresh_token":"unknown-token"}`)
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Revoke(w, req)
+
+	// Assert: 既知 token の場合と同一の 204 + ボディなし（区別できない）
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d (Req 2.2: 不明 token でも同一応答)", resp.StatusCode, http.StatusNoContent)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("body = %q, want empty (NFR 1.2: 存在有無を推測させない)", w.Body.String())
+	}
+}
+
+// TestNativeAuthHandler_Revoke_InvalidJSON は不正 JSON ボディに対して
+// 400 INVALID_REQUEST を返し、service に到達しないことを検証する（Req 2.5）。
+func TestNativeAuthHandler_Revoke_InvalidJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "壊れた JSON", body: `{"refresh_token":`},
+		{name: "JSON ではない文字列", body: `not-json`},
+		{name: "空ボディ", body: ``},
+		{name: "未知フィールド", body: `{"refresh_token":"x","extra":"y"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			svc := &mockTokenExchangeService{}
+			h := NewNativeAuthHandler(svc)
+			req := newRevokeRequest(tc.body)
+			w := httptest.NewRecorder()
+
+			// Act
+			h.Revoke(w, req)
+
+			// Assert
+			resp := w.Result()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d (Req 2.5)", resp.StatusCode, http.StatusBadRequest)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body["code"] != "INVALID_REQUEST" {
+				t.Errorf("code = %v, want %q", body["code"], "INVALID_REQUEST")
+			}
+			if svc.revokeCalls != 0 {
+				t.Errorf("service called %d times, want 0 (入力不正は service 到達前に拒否)", svc.revokeCalls)
+			}
+		})
+	}
+}
+
+// TestNativeAuthHandler_Revoke_MissingField は refresh_token 欠落（または空文字）に対して
+// 400 INVALID_REQUEST を返すことを検証する（Req 2.5 / 境界値: 空入力）。
+func TestNativeAuthHandler_Revoke_MissingField(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "refresh_token フィールドなし", body: `{}`},
+		{name: "refresh_token が空文字", body: `{"refresh_token":""}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			svc := &mockTokenExchangeService{}
+			h := NewNativeAuthHandler(svc)
+			req := newRevokeRequest(tc.body)
+			w := httptest.NewRecorder()
+
+			// Act
+			h.Revoke(w, req)
+
+			// Assert
+			resp := w.Result()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d (Req 2.5)", resp.StatusCode, http.StatusBadRequest)
+			}
+			if svc.revokeCalls != 0 {
+				t.Errorf("service called %d times, want 0", svc.revokeCalls)
+			}
+		})
+	}
+}
+
+// TestNativeAuthHandler_Revoke_InternalError は service が infra エラーを返した場合に
+// 500 INTERNAL_ERROR を返し、内部詳細を反射しないことを検証する（NFR 1.3）。
+func TestNativeAuthHandler_Revoke_InternalError(t *testing.T) {
+	// Arrange
+	svc := &mockTokenExchangeService{
+		revokeFn: func(ctx context.Context, refreshToken string) error {
+			return errors.New("db connection refused")
+		},
+	}
+	h := NewNativeAuthHandler(svc)
+	req := newRevokeRequest(`{"refresh_token":"x"}`)
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Revoke(w, req)
+
+	// Assert
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if body["code"] != "INTERNAL_ERROR" {
+		t.Errorf("code = %v, want %q", body["code"], "INTERNAL_ERROR")
+	}
+	// 内部詳細を反射しない（NFR 1.3）
+	if msg, _ := body["message"].(string); strings.Contains(msg, "db connection refused") {
+		t.Errorf("message %q leaks internal error detail (NFR 1.3)", msg)
 	}
 }

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -200,10 +200,11 @@ func NewRouter(deps *RouterDeps) http.Handler {
 			}
 		}
 
-		// Native Auth トークン交換エンドポイント（Issue #166）と
-		// refresh ローテーションエンドポイント（Issue #167）。
-		// NATIVE_AUTH_JWT_SECRET 未設定のデプロイは NativeAuthHandler が nil となり、両ルートを
-		// 登録しない（404 / fail-closed / NFR 2.2）。Session / Bearer middleware は通らない（Req 1.5）。
+		// Native Auth トークン交換エンドポイント（Issue #166）・refresh ローテーション
+		// エンドポイント（Issue #167）・revoke エンドポイント（Issue #168）。
+		// NATIVE_AUTH_JWT_SECRET 未設定のデプロイは NativeAuthHandler が nil となり、全ルートを
+		// 登録しない（404 / fail-closed / NFR 2.2）。Session / Bearer middleware は通らない
+		// （Req 1.5 / #168 Req 2.4: revoke は token 所持自体を失効権限とみなす）。
 		// 巨大ボディ DoS 防止のためボディ上限ミドルウェア（DefaultMaxBodyBytes）を重ねる。
 		// IP レート制限（unauthIPMW）は Issue #171 の領分のため本 spec では適用しない。
 		if deps.NativeAuthHandler != nil {
@@ -211,6 +212,8 @@ func NewRouter(deps *RouterDeps) http.Handler {
 				Post("/api/auth/token", deps.NativeAuthHandler.Token)
 			r.With(middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
 				Post("/api/auth/refresh", deps.NativeAuthHandler.Refresh)
+			r.With(middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
+				Post("/api/auth/revoke", deps.NativeAuthHandler.Revoke)
 		}
 	})
 

--- a/internal/handler/router_test.go
+++ b/internal/handler/router_test.go
@@ -132,10 +132,12 @@ func TestSetupAuthRoutes_UnknownRoute_Returns404Or405(t *testing.T) {
 
 // alwaysSucceedExchangeService は service 層に到達したかを判定するための固定成功モック。
 // 200 応答が返れば handler に到達したことが確認できる。
-// RotateRefreshToken は Issue #167 で interface に追加されたため本モックでも実装する。
+// RotateRefreshToken は Issue #167 で、RevokeRefreshToken は Issue #168 で interface に
+// 追加されたため本モックでも実装する。
 type alwaysSucceedExchangeService struct {
 	callCount   int
 	rotateCalls int
+	revokeCalls int
 }
 
 func (s *alwaysSucceedExchangeService) ExchangeAuthCode(ctx context.Context, authCode, codeVerifier string) (*auth.TokenPair, error) {
@@ -154,6 +156,11 @@ func (s *alwaysSucceedExchangeService) RotateRefreshToken(ctx context.Context, r
 		RefreshToken: "ok-rotated-refresh",
 		ExpiresIn:    900,
 	}, nil
+}
+
+func (s *alwaysSucceedExchangeService) RevokeRefreshToken(ctx context.Context, refreshToken string) error {
+	s.revokeCalls++
+	return nil
 }
 
 // newMinimalDepsForNativeAuth は Native Auth 関連ルートのみを検証するための最小 deps を返す。
@@ -347,5 +354,58 @@ func TestNewRouter_NativeAuthRefresh_DoesNotRequireSession(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+// --- Revoke ルーティング（Issue #168 / Req 2.4, NFR 2.2 / design.md Testing Strategy 9） ---
+
+// TestNewRouter_NativeAuthRevoke_RegisteredWhenHandlerInjected は NativeAuthHandler を
+// 注入したとき POST /api/auth/revoke がセッション無しで到達し、204 が返ることを検証する
+// （Req 2.4: Cookie / Bearer なしで呼び出し可能 = token 所持自体が失効権限）。
+func TestNewRouter_NativeAuthRevoke_RegisteredWhenHandlerInjected(t *testing.T) {
+	// Arrange
+	svc := &alwaysSucceedExchangeService{}
+	nh := NewNativeAuthHandler(svc)
+	router := NewRouter(newMinimalDepsForNativeAuth(nh))
+
+	body := `{"refresh_token":"plain-refresh-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/revoke", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// セッション Cookie 無し
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert: Cookie 無しで 204（Session middleware を経由していない）
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("status = %d, want %d (handler 到達 / Req 2.4)", resp.StatusCode, http.StatusNoContent)
+	}
+	if svc.revokeCalls != 1 {
+		t.Errorf("service.RevokeRefreshToken called %d times, want 1 (handler に到達していない可能性)",
+			svc.revokeCalls)
+	}
+}
+
+// TestNewRouter_NativeAuthRevoke_NotRegisteredWhenHandlerNil は NativeAuthHandler が
+// nil のとき POST /api/auth/revoke がルートとして登録されず 404 が返ることを検証する
+// （NFR 2.2: 署名鍵未設定環境の fail-closed）。
+func TestNewRouter_NativeAuthRevoke_NotRegisteredWhenHandlerNil(t *testing.T) {
+	// Arrange: NativeAuthHandler nil
+	router := NewRouter(newMinimalDepsForNativeAuth(nil))
+
+	body := `{"refresh_token":"x"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/revoke", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert: fail-closed として 404
+	if w.Result().StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want %d (NativeAuthHandler nil で fail-closed / NFR 2.2)",
+			w.Result().StatusCode, http.StatusNotFound)
 	}
 }


### PR DESCRIPTION
## 概要

Issue #168（umbrella #163 の子 Issue）の実装 PR です。設計 PR #192 でマージ済みの
`docs/specs/168-reuse-detection-revoke/`（requirements.md / design.md / tasks.md）に厳密に従い、
(1) rotation 済み refresh token 再利用検知時の family 全体失効への昇格、(2) `POST /api/auth/revoke` を実装しました。

Closes #168

## 変更内容

- `internal/auth/token_service.go`: `RefreshTokenStore` IF に `RevokeFamily` を追加 / `RotateRefreshToken` の拒否分岐 2 箇所（RotatedAt 検出・MarkRotated 競合敗北）を `RevokeFamily` + 同一 401 へ昇格（`revokeFamilyOnReuse` ヘルパー）/ `RevokeRefreshToken` を追加
- `internal/handler/native_auth_handler.go`: `Revoke` handler（204 ボディなし / 400 / 500）。リクエスト型・エラーヘルパーは #167 と共用
- `internal/handler/router.go`: 認証不要グループに `POST /api/auth/revoke` を登録（ボディ上限 middleware 付き / 署名鍵未設定時は fail-closed 未登録）
- テスト: service 7 / handler 5 / router 2 / 統合 2 ケース追加（再利用→family 全滅 / revoke→refresh 拒否→再 revoke 冪等の通しケース含む）
- `docs/specs/168-reuse-detection-revoke/`: tasks.md checkbox 更新（全 3 task 完了）/ impl-notes.md / review-notes.md

## 設計上のポイント

- 再利用検知は strict 方針（正規クライアントの再送も失効対象。SERVER.md §1.4 準拠、再ログインで回復可能）
- 昇格後も応答は通常拒否と同一の 401 INVALID_REFRESH_TOKEN（Req 1.4: 検知を区別させない）。`RevokeFamily` 失敗時も拒否を維持し新 token を発行しない（Req 1.5）
- revoke は未認証 + token 所持 = 権限（RFC 7009 §2.1 の public client 慣行）。常に 204 で冪等・列挙オラクルなし

## Reviewer 判定

独立 context の Reviewer サブエージェントによるレビュー済み: **approve**
（`docs/specs/168-reuse-detection-revoke/review-notes.md` 参照。#167 既存統合テストの順序再構成が assert 弱体化に当たらないことも独立評価済み）

## 検証

- `go build ./...` / `go vet ./...` / `go test ./...` 全 green
- `TEST_DATABASE_URL` を設定した実 PostgreSQL 16 でも `go test -p 1 ./...` 全 pass（CI と同条件で事前確認）
- `gofmt -l`（変更ファイルのみ）差分なし

## 確認事項（レビュワー判断ポイント）

- **#167 既存統合テストの順序再構成**: `TestIntegration_RefreshFlow_TokenExchangeRefreshSucceedsThenOldTokenRejected` の「新世代 token 有効性」検証を旧 token 再提示より前に移動しています。再利用検知後は family 全滅（本 spec Req 1.3）により新世代も拒否されるためで、検証観点（refresh 成功 / 新世代有効 / 旧 token 拒否 / uniform 401）はすべて維持しています。family 全滅の挙動自体は新設の `TestIntegration_ReuseDetection_FamilyRevoked` が検証します
- `RevokeFamily` 失敗時は 500 ではなく 401 を返します（design.md の明示指示。Req 1.5 の安全側設計。FindByHash 等の通常の DB 障害は従来どおり 500）
- 失効済み（RevokedAt set）token の提示は再利用検知ではないため family 失効に昇格しません（#167 既存挙動を維持。`TestRotateRefreshToken_RevokedIsNotEscalated` で回帰担保）

🤖 Generated with [Claude Code](https://claude.com/claude-code)