### PR TITLE
feat(#169): 既存 API に Bearer-or-Session 複合認証を追加する

### DIFF
--- a/docs/specs/169-bearer-or-session/impl-notes.md
+++ b/docs/specs/169-bearer-or-session/impl-notes.md
@@ -1,0 +1,150 @@
+# 実装ノート: Issue #169 Bearer-or-Session 複合認証
+
+## 実装サマリ
+
+Issue #169 の「既存認証必須 API への Bearer 認証の追加」を、design.md / tasks.md の指針に
+厳密に従って実装した。`Authorization: Bearer` を検出した要求は #166 の JWTIssuer と同一規約
+（同一署名鍵 / HS256 / claims）で access token を検証し、成立すれば既存 Cookie セッション
+認証と同一の user context を注入する。Bearer 不在の要求は既存 `SessionMiddleware` へ完全
+委譲する。
+
+設計の主要ポイントは原文どおり踏襲している:
+
+- **判定フロー 0〜3 をそのまま実装**: verifier nil なら `NewSessionMiddleware(sessionFinder)`
+  をそのまま返す縮退（Req 4.2 / 4.3。構成が導入前と文字どおり同一）/ Authorization 無し・
+  Bearer 以外の scheme は委譲（Req 3.1 / 3.2）/ Bearer 検出後は成功 or 401 の二択で Cookie へ
+  fallback しない（Req 1.4 / 2.4）
+- **JWTVerifier の検証規則**: `jwt.WithValidMethods(["HS256"])`（alg confusion 対策）/
+  `jwt.WithExpirationRequired` + leeway 0 / `token_use == "access"` 厳密一致 / `sub` 非空必須。
+  jti / kid は参照しない（失効リスト・複数鍵は Out of Scope）
+- **401 応答の同形性**: `http.Error(w, "unauthorized", http.StatusUnauthorized)` で既存
+  SessionMiddleware の未認証応答と status / body / Content-Type が完全一致（Req 2.6。
+  テストで両者の応答を直接比較）
+- **router は 1 行差し替え**: 認証必須グループの `NewSessionMiddleware(deps.SessionFinder)` を
+  `NewBearerOrSessionMiddleware(deps.JWTVerifier, deps.SessionFinder)` に差し替えのみ。
+  RateLimit / MaxBodyBytes / Logging の順序・位置・適用範囲は不変（NFR 2.1）
+- **既存 session.go は無変更・削除なし**。下流 handler も一切変更なし（既存
+  `ContextWithUserID` / `UserIDFromContext` を共用し context key の同一性を構造的に保証）
+- **wiring**: `cfg.NativeAuthJWTSecret != ""` 分岐内で `auth.NewJWTVerifier` を生成し
+  interface 型のローカル変数経由で注入（typed-nil を作らない）。未設定時の warn は
+  「Bearer auth も無効」を含む文言に更新（warn は 1 回のまま・起動成功）
+
+## タスクとコミット対応表
+
+| Task | 内容 | 実装コミット | 進捗 commit |
+|---|---|---|---|
+| 1 | auth: JWTVerifier を追加 | fbd21d7 `feat(auth)` | b4a6f74 `docs(tasks): mark 1` |
+| 2 | middleware: BearerOrSession 複合認証を追加 | 059af31 `feat(middleware)` | 67264f1 `docs(tasks): mark 2` |
+| 3 | router / app: 認証必須グループの差し替えと wiring | 43faf4e `feat(handler)` | 7b5bcfb `docs(tasks): mark 3` |
+| 4 | 統合確認: 発行 ↔ 検証の通しと既存回帰 | c51b84a `test(handler)` | b6b422d `docs(tasks): mark 4` |
+
+実装順序は tasks.md の番号順そのままで、`_Depends:_` の制約（2 → 1、3 → 2、4 → 3）は
+自然に満たされた。
+
+## 受入基準と担保テスト
+
+### Requirement 1: Bearer token による認証の成立
+
+| AC ID | 担保テスト |
+|---|---|
+| 1.1 (有効 Bearer を Cookie と同一のユーザー識別へ解決) | `middleware.TestBearerOrSession_ValidBearer_InjectsUserID` / `handler.TestNewRouter_BearerAuth_IssuerVerifierRoundTrip`（実物ペア通し） |
+| 1.2 (Cookie 認証時と同一の応答内容・形式) | `handler.TestNewRouter_BearerAuth_ReachesAPIWithoutCookie`（既存ルート・既存 handler を変更ゼロで透過動作）。下流は `UserIDFromContext` のみ参照 |
+| 1.3 (Cookie 併送を要求しない) | `middleware.TestBearerOrSession_ValidBearer_InjectsUserID`（Cookie 無し 200 / sessionFinder 0 回） |
+| 1.4 (両方提示時は token 側のユーザーで処理) | Bearer 検出後は Cookie 評価に到達しない実装構造 + `middleware.TestBearerOrSession_InvalidBearerWithValidCookie_Returns401`（検出後は成功 or 401 の二択の裏面検証） |
+
+### Requirement 2: 無効な Bearer token の拒否
+
+| AC ID | 担保テスト |
+|---|---|
+| 2.1 (署名検証不能を拒否) | `auth.TestVerifyAccessToken_WrongSecret` |
+| 2.2 (期限切れを拒否) | `auth.TestVerifyAccessToken_Expired`（超過 / 丁度の境界値）/ `handler.TestNewRouter_BearerAuth_ExpiredTokenWithValidCookie_Returns401` |
+| 2.3 (用途種別不一致を拒否) | `auth.TestVerifyAccessToken_TokenUseMismatch`（refresh / 欠落 / 空文字） |
+| 2.4 (無効 Bearer + 有効 Cookie で fallback しない) | `middleware.TestBearerOrSession_InvalidBearerWithValidCookie_Returns401`（sessionFinder 0 回）/ `handler.TestNewRouter_BearerAuth_ExpiredTokenWithValidCookie_Returns401` |
+| 2.5 (token 部空・形式不正を拒否) | `middleware.TestBearerOrSession_SchemeAndTokenEdgeCases`（`Bearer` 単独 / `Bearer ` 空白のみ）/ `auth.TestVerifyAccessToken_MalformedTokens`（非 JWT 文字列 / 空文字） |
+| 2.6 (未認証応答が既存と同一形式) | `middleware.TestBearerOrSession_401SameShapeAsSessionMiddleware`（status / body / Content-Type を SessionMiddleware の実応答と直接比較） |
+| 2.7 (拒否理由を区別できる情報を返さない) | 全拒否が同一の `http.Error` 固定応答（2.6 のテストで形状固定を担保）。理由は slog.Warn のみ |
+
+### Requirement 3: Bearer 不在時の委譲（既存挙動の維持）
+
+| AC ID | 担保テスト |
+|---|---|
+| 3.1 (Bearer 不在は Cookie 認証で処理) | `middleware.TestBearerOrSession_NoAuthorizationHeader_DelegatesToSession`（有効 Cookie 200 / verifier 0 回） |
+| 3.2 (Bearer 以外の方式は提示なし扱い) | `middleware.TestBearerOrSession_SchemeAndTokenEdgeCases`（Basic → 委譲） |
+| 3.3 (Cookie 有効時は導入前と同一応答) | 委譲先が既存 `NewSessionMiddleware` の戻り値そのもの + `handler.TestNewRouter_BearerAuth_NilVerifierKeepsLegacyBehavior`（Cookie 200） |
+| 3.4 (両方不在時は導入前と同一の未認証応答) | `middleware.TestBearerOrSession_NoAuthorizationHeader_DelegatesToSession`（Cookie 無し 401） |
+
+### Requirement 4: 検証の構成と安全な縮退
+
+| AC ID | 担保テスト |
+|---|---|
+| 4.1 (発行側と同一の鍵設定で受理) | `auth.TestVerifyAccessToken_IssuerVerifierRoundTrip`（同一 package の #166 JWTIssuer と固定 secret / 固定 now 共有）/ `handler.TestNewRouter_BearerAuth_IssuerVerifierRoundTrip`（router 通しの実物ペア） |
+| 4.2 (鍵未設定で Bearer 無効化・Cookie のみ提供) | `middleware.TestBearerOrSession_NilVerifier_FallsBackToSessionMiddleware` / `handler.TestNewRouter_BearerAuth_NilVerifierKeepsLegacyBehavior` |
+| 4.3 (鍵未設定時は token を評価しない) | `middleware.TestBearerOrSession_NilVerifier_FallsBackToSessionMiddleware`（不正 Bearer 付きでも Cookie で 200） |
+| 4.4 (鍵未設定でも起動成功) | `app.go` の分岐は verifier を生成しないだけで起動継続（#166 の既存分岐に同乗。既存 `config.TestLoad_NativeAuthJWT` が未設定起動を担保） |
+| 4.5 (固定鍵・固定時刻で決定論的検証) | `auth.newFixedVerifier`（非公開 now の注入。#166 issuer と同パターン）を全 unit test で使用 |
+
+### Non-Functional Requirements
+
+| NFR | 担保テスト・実装 |
+|---|---|
+| NFR 1.1 (token 値をログ・エラー応答に残さない) | `auth.TestVerifyAccessToken_ErrorDoesNotContainToken`。middleware の slog.Warn は error 文字列のみ。401 応答は固定文言 |
+| NFR 1.2 (セッション情報・外部照会なしで検証完結) | `JWTVerifier` は secret と now のみで検証（stateless）。Bearer パスで sessionFinder 0 回（`TestBearerOrSession_ValidBearer_InjectsUserID`） |
+| NFR 2.1 (既存 Cookie 認証の API 挙動を変更しない) | `session.go` 無変更・差し替え 1 箇所・middleware 順序不変。既存 Cookie 系テスト無変更 green（実 DB 接続のフルスイートで確認） |
+| NFR 2.2 (鍵未設定の既存デプロイで導入前と同一動作) | `handler.TestNewRouter_BearerAuth_NilVerifierKeepsLegacyBehavior`（nil 構成 = 従来構成） |
+| NFR 3.1 (全ケースを外部ネットワーク依存なしで検証) | auth 8 テスト / middleware 6 テスト / router 4 テストすべて in-process（DB / net 不要） |
+
+## 検証結果
+
+- `go build ./...`: 成功
+- `go vet ./...`: 警告なし
+- `go test ./...`: 全パッケージ pass
+- `TEST_DATABASE_URL` を設定した実 PostgreSQL 16 でも `go test -p 1 ./...` 全 pass（CI と同条件）
+- `gofmt -l <変更ファイル群>`: 出力なし
+
+## design からの逸脱
+
+無し。design.md の以下は **完全にそのまま** 実装した。
+
+- 判定フロー 0〜3（nil 縮退 / 委譲 / Bearer 二択）
+- 検証規則表（HS256 限定 / exp 必須 leeway 0 / token_use 厳密一致 / sub 非空 / jti・kid 不参照）
+- File Structure Plan の 6 ファイル（新規 2 + テスト 2 + 変更 2。新規 migration / 新規 config /
+  新規依存 / `.env.sample` 変更なし）
+- 401 応答の同形性（`http.Error` 固定）と `WWW-Authenticate` 不付与
+- Requirements Traceability / Testing Strategy の全項目
+
+## 実装上の判断
+
+### scheme / token 分離に `strings.Cut` を使用
+
+design.md は `strings.SplitN(v, " ", 2)` を例示しているが、等価でより読みやすい
+`strings.Cut(authz, " ")` を採用した（Go 1.18+ の標準 idiom。分離結果・挙動は同一で、
+scheme 比較は design どおり `strings.EqualFold`）。
+
+### 期限切れ token の組み立て（router 通しテスト）
+
+`auth.JWTIssuer` / `auth.JWTVerifier` の `now` は非公開 field のため handler パッケージから
+注入できない。router 通しの期限切れケースは同一 secret で exp が過去の JWT をテスト内で
+直接組み立てて検証した（検証側は実時刻で評価されるため決定論的に 401 になる）。
+
+## 追加した依存
+
+無し（`golang-jwt/jwt/v5` は #166 で追加済みの依存を共用。go.mod / go.sum 変更なし）。
+
+## 後続 Issue への引き継ぎ事項
+
+- **Issue #171 (IP レート制限)**: 本 spec の変更とは独立（認証必須グループの user 単位
+  RateLimit は従来位置のまま不変）。#171 は認証不要グループの native auth 3 ルートに
+  `unauthIPMW` を重ねる。
+- **Issue #172 (contract tests)**: Bearer 認証の契約（401 同形 / fallback なし / nil 縮退）は
+  本 spec の middleware / router テストでカバー済み。
+- **鍵ローテーション（将来 Issue）**: 検証は単一鍵 v1。JWT ヘッダ kid は発行側で出力済みの
+  ため、複数鍵受理は verifier 側の拡張のみで対応可能。
+
+## 確認事項（PR 本文転載用）
+
+- 設計矛盾は無し。
+- `strings.SplitN` の代わりに等価な `strings.Cut` を使用（上記「実装上の判断」参照）。
+- 未設定時の warn 文言を「POST /api/auth/token and Bearer auth are disabled」に更新
+  （design.md の指示どおり。warn 回数は 1 回のまま）。
+
+STATUS: complete

--- a/docs/specs/169-bearer-or-session/review-notes.md
+++ b/docs/specs/169-bearer-or-session/review-notes.md
@@ -1,0 +1,57 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-12T09:30:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-169-impl-bearer-or-session
+- HEAD commit: 7d5bb6a
+- Compared to: develop..HEAD
+
+## Verified Requirements
+
+- 1.1 — `internal/middleware/bearer_or_session.go` 判定フロー 3c で `VerifyAccessToken` 成功時に既存 `ContextWithUserID` で同一 context key へ userID 注入。`middleware.TestBearerOrSession_ValidBearer_InjectsUserID` / `handler.TestNewRouter_BearerAuth_IssuerVerifierRoundTrip` で担保
+- 1.2 — `internal/handler/router.go` の差し替えは認証 middleware 1 行のみ・下流ハンドラ無変更。`handler.TestNewRouter_BearerAuth_ReachesAPIWithoutCookie` で `/api/subscriptions` 到達確認
+- 1.3 — `bearer_or_session.go` の Bearer 成功パスは `sessionFinder` を呼ばない構造。`TestBearerOrSession_ValidBearer_InjectsUserID` で `finder.findCalls == 0` を assert
+- 1.4 — 判定フロー上 Bearer 検出後は成功 or 401 の二択（Cookie 評価へ降りない実装）。裏面検証は `TestBearerOrSession_InvalidBearerWithValidCookie_Returns401`（fallback しないことで「無効 Bearer なら Cookie 側ユーザーに解決しない」= 「有効 Bearer なら Bearer 側ユーザーで処理」の対偶）
+- 2.1 — `jwt_verifier.go` の `jwt.Parse` 署名検証失敗で error 返却。`auth.TestVerifyAccessToken_WrongSecret`
+- 2.2 — `jwt.WithExpirationRequired` + leeway 0。`auth.TestVerifyAccessToken_Expired`（exp 1 秒超過 / 丁度の境界）/ `handler.TestNewRouter_BearerAuth_ExpiredTokenWithValidCookie_Returns401`
+- 2.3 — `token_use == "access"` 厳密一致のみ受理。`auth.TestVerifyAccessToken_TokenUseMismatch`（refresh / 欠落 / 空文字の 3 ケース）
+- 2.4 — `bearer_or_session.go` 判定フロー 3b: 検証失敗時 `http.Error` 即応答。`TestBearerOrSession_InvalidBearerWithValidCookie_Returns401`（sessionFinder 0 回）/ `TestNewRouter_BearerAuth_ExpiredTokenWithValidCookie_Returns401`
+- 2.5 — 判定フロー 3a: token 部 trim 後空で 401。`TestBearerOrSession_SchemeAndTokenEdgeCases`（`Bearer` 単独 / `Bearer ` 空白のみ）/ `auth.TestVerifyAccessToken_MalformedTokens`（非 JWT 文字列 / 空文字）
+- 2.6 — `http.Error(w, "unauthorized", http.StatusUnauthorized)` で `session.go` の 3 箇所と同一文。`TestBearerOrSession_401SameShapeAsSessionMiddleware` で実応答（status / body / Content-Type）を直接比較
+- 2.7 — 全拒否パスが同一固定応答（Req 2.6 と同根拠）。理由は `slog.Warn` のみで応答に出さない
+- 3.1 — 判定フロー 1: Authorization 無しで `delegate.ServeHTTP`。`TestBearerOrSession_NoAuthorizationHeader_DelegatesToSession`（有効 Cookie 200 / verifier 0 回）
+- 3.2 — 判定フロー 2: `strings.EqualFold(scheme, "Bearer")` 偽で委譲。`TestBearerOrSession_SchemeAndTokenEdgeCases` Basic ケース
+- 3.3 — 委譲先は `NewSessionMiddleware(sessionFinder)` の戻り値そのもの。`TestNewRouter_BearerAuth_NilVerifierKeepsLegacyBehavior`（有効 Cookie 200）
+- 3.4 — 委譲先が既存 SessionMiddleware の戻り値そのもののため未認証応答が同一。`TestBearerOrSession_NoAuthorizationHeader_DelegatesToSession`（Cookie 無し 401）
+- 4.1 — `app.go` `cfg.NativeAuthJWTSecret != ""` 分岐内で `auth.NewJWTVerifier([]byte(cfg.NativeAuthJWTSecret))` を生成（issuer と同 env 値共用）。`auth.TestVerifyAccessToken_IssuerVerifierRoundTrip` / `handler.TestNewRouter_BearerAuth_IssuerVerifierRoundTrip`
+- 4.2 — `bearer_or_session.go` 判定フロー 0: `jwtVerifier == nil` で `NewSessionMiddleware(sessionFinder)` をそのまま返す。`TestBearerOrSession_NilVerifier_FallsBackToSessionMiddleware` / `TestNewRouter_BearerAuth_NilVerifierKeepsLegacyBehavior`
+- 4.3 — 判定フロー 0 では Authorization ヘッダを一切読まない（return された SessionMiddleware は Authorization を参照しない）。`TestBearerOrSession_NilVerifier_FallsBackToSessionMiddleware`「Bearer 付き + 有効 Cookie のとき Cookie で認証成立」サブテスト
+- 4.4 — `app.go` 未設定分岐は warn を出すのみで起動継続（verifier を生成しないだけ）。既存 `config.TestLoad_NativeAuthJWT` で未設定起動が担保される旨が impl-notes に明記
+- 4.5 — `JWTVerifier.now func() time.Time` 非公開 field + `newFixedVerifier` ヘルパー（同パッケージから注入）。全 verifier 単体テストで使用
+- NFR 1.1 — `jwt_verifier.go` の error 文字列は jwt ライブラリの error のみ（token 値を含まない）。`auth.TestVerifyAccessToken_ErrorDoesNotContainToken` で実検証。middleware 側 `slog.Warn` も `err.Error()` のみ渡す
+- NFR 1.2 — `JWTVerifier` は secret と now のみで検証（DB・外部呼び出しなし）。Bearer 成功パスで `sessionFinder` 0 回（`TestBearerOrSession_ValidBearer_InjectsUserID`）
+- NFR 2.1 — `session.go` 無変更（diff stat 確認）。差し替えは認証 middleware 1 箇所のみ・RateLimit / MaxBodyBytes / Logging の順序・位置・適用範囲は不変（router.go diff で確認）
+- NFR 2.2 — `deps.JWTVerifier` が nil なら `NewBearerOrSessionMiddleware` が SessionMiddleware を返すため構成が従来と文字どおり同一。`TestNewRouter_BearerAuth_NilVerifierKeepsLegacyBehavior`
+- NFR 3.1 — auth 8 テスト / middleware 6 テスト / router 4 テストすべて in-process（DB / 外部ネットワーク依存なし）。`go test ./internal/auth/ ./internal/middleware/ ./internal/handler/` で全 pass を確認
+
+## Findings
+
+なし（approve）。
+
+確認した観点:
+
+- **AC カバレッジ**: requirements.md の全 numeric ID（Req 1.1-1.4 / 2.1-2.7 / 3.1-3.4 / 4.1-4.5 / NFR 1.1-1.2 / 2.1-2.2 / 3.1）について実装または対応テストの紐付けを確認した（上記 Verified Requirements 参照）
+- **missing test**: 各 AC に対応するテストが新規追加されている（`internal/auth/jwt_verifier_test.go` 8 テスト、`internal/middleware/bearer_or_session_test.go` 6 テスト、`internal/handler/router_test.go` 4 ケース追加）。Req 2.6（401 同形）は実 `SessionMiddleware` の応答と直接比較する手堅い検証になっている
+- **boundary 逸脱**: design.md File Structure Plan のとおり `internal/auth/jwt_verifier.go(_test.go)` / `internal/middleware/bearer_or_session.go(_test.go)` の新規 4 ファイル + `internal/handler/router.go` / `internal/handler/router_test.go` / `internal/app/app.go` の変更 3 ファイル。`session.go` は無変更、新規 migration / config / 依存・`.env.sample` 変更なしを diff stat で確認
+- **CLAUDE.md テスト規約整合**: AAA 構造で書かれ、命名が `Test<対象>_<条件>_<期待結果>` 形式（Go の `t.Run` サブテストも含む）、table-driven の使用、stub と実物（issuer ↔ verifier 通し）の使い分けが規約に整合
+- **CLAUDE.md 禁止事項整合**: テストの assert 緩めは無し。`session.go` は無変更。secret はコミットされていない（テスト用固定値のみ）
+- **Feature Flag Protocol**: CLAUDE.md 採否 `opt-out` のため flag 観点の確認は適用外
+- **検証実行**: `go build ./...` 成功 / `go test ./internal/auth/ ./internal/middleware/ ./internal/handler/` 全 pass を実行確認
+
+## Summary
+
+design.md / tasks.md の指針どおりに 4 タスクが実装され、全 numeric ID（機能要件 19 件 + NFR 6 件）に紐づく実装またはテストが揃っている。境界逸脱なし、`session.go` 無変更、新規依存なし、401 同形性は実 SessionMiddleware との直接比較で担保。
+
+RESULT: approve

--- a/docs/specs/169-bearer-or-session/tasks.md
+++ b/docs/specs/169-bearer-or-session/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. auth: JWTVerifier を追加
+- [x] 1. auth: JWTVerifier を追加
   - `internal/auth/jwt_verifier.go` を新規作成: `NewJWTVerifier(secret []byte)` /
     `VerifyAccessToken(tokenString string) (string, error)`（design.md 検証規則表どおり:
     `jwt.WithValidMethods` で HS256 限定・`jwt.WithExpirationRequired` で exp 必須・

--- a/docs/specs/169-bearer-or-session/tasks.md
+++ b/docs/specs/169-bearer-or-session/tasks.md
@@ -25,7 +25,7 @@
   - _Requirements: 1.1, 1.3, 1.4, 2.4, 2.5, 2.6, 2.7, 3.1, 3.2, 4.2, 4.3, NFR 1.1_
   - _Depends: 1_
 
-- [ ] 3. router / app: 認証必須グループの差し替えと wiring
+- [x] 3. router / app: 認証必須グループの差し替えと wiring
   - `internal/handler/router.go`: `RouterDeps.JWTVerifier middleware.JWTVerifier`（任意・nil 可）を
     追加し、認証必須グループの `middleware.NewSessionMiddleware(deps.SessionFinder)` 行を
     `middleware.NewBearerOrSessionMiddleware(deps.JWTVerifier, deps.SessionFinder)` に 1 行

--- a/docs/specs/169-bearer-or-session/tasks.md
+++ b/docs/specs/169-bearer-or-session/tasks.md
@@ -11,7 +11,7 @@
     alg 偽装 / sub 空・不正文字列を table-driven で検証）
   - _Requirements: 2.1, 2.2, 2.3, 4.1, 4.5, NFR 1.2, NFR 3.1_
 
-- [ ] 2. middleware: BearerOrSession 複合認証を追加
+- [x] 2. middleware: BearerOrSession 複合認証を追加
   - `internal/middleware/bearer_or_session.go` を新規作成: `JWTVerifier` 最小 IF +
     `NewBearerOrSessionMiddleware(jwtVerifier, sessionFinder)`（design.md 判定フロー 0〜3:
     verifier nil なら `NewSessionMiddleware(sessionFinder)` をそのまま返す縮退 / Bearer scheme

--- a/docs/specs/169-bearer-or-session/tasks.md
+++ b/docs/specs/169-bearer-or-session/tasks.md
@@ -38,7 +38,7 @@
   - _Requirements: 1.2, 3.3, 3.4, 4.2, 4.4, NFR 2.1, NFR 2.2_
   - _Depends: 2_
 
-- [ ] 4. 統合確認: 発行 ↔ 検証の通しと既存回帰
+- [x] 4. 統合確認: 発行 ↔ 検証の通しと既存回帰
   - `internal/handler/router_test.go` に、#166 `auth.JWTIssuer` で発行した token を
     `auth.JWTVerifier` 注入済み `NewRouter` へ Bearer 提示し、Cookie 無しで既存 API ルートの
     認証が成立する通しケース（同一 secret・固定 now）を追加

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -210,20 +210,28 @@ func runServe(cfg *config.Config) error {
 		middleware.DefaultIPRateLimiterConfig(cfg.RateLimitUnauthIP),
 	)
 
-	// Native Auth トークン交換（Issue #166）: NATIVE_AUTH_JWT_SECRET が設定されているときのみ
-	// issuer / service / handler を組み立てて RouterDeps に注入する。未設定なら nil のまま、
-	// router 側で POST /api/auth/token は登録されず 404 になる（fail-closed / Req 3.2）。
-	// 起動時に運用者向け Warn を 1 回記録する（Req 3.3）。
+	// Native Auth トークン交換（Issue #166）と Bearer 認証の検証器（Issue #169）:
+	// NATIVE_AUTH_JWT_SECRET が設定されているときのみ issuer / service / handler /
+	// verifier を組み立てて RouterDeps に注入する。未設定なら nil のまま、router 側で
+	// POST /api/auth/token は登録されず 404（fail-closed / Req 3.2）、Bearer 認証は
+	// 無効化され認証必須 API は従来どおり Cookie セッション認証のみで動作する
+	// （#169 Req 4.2 / 4.4。起動は成功する）。起動時に運用者向け Warn を 1 回記録する。
+	//
+	// jwtVerifier は interface 型のため secret 設定時のみ非 nil の具象
+	// （*auth.JWTVerifier）を代入する（typed-nil を作らない）。
 	var nativeAuthHandler *handler.NativeAuthHandler
+	var jwtVerifier middleware.JWTVerifier
 	if cfg.NativeAuthJWTSecret != "" {
 		jwtIssuer := auth.NewJWTIssuer([]byte(cfg.NativeAuthJWTSecret), cfg.NativeAuthJWTKid)
 		nativeTokenService := auth.NewTokenService(authCodeRepo, refreshTokenRepo, jwtIssuer)
 		nativeAuthHandler = handler.NewNativeAuthHandler(nativeTokenService)
+		// 検証は発行と同一の env 値（署名鍵）を共用する（#169 Req 4.1）。
+		jwtVerifier = auth.NewJWTVerifier([]byte(cfg.NativeAuthJWTSecret))
 		slog.Info("native token exchange enabled",
 			slog.String("kid", cfg.NativeAuthJWTKid),
 		)
 	} else {
-		slog.Warn("NATIVE_AUTH_JWT_SECRET is not set; POST /api/auth/token is disabled")
+		slog.Warn("NATIVE_AUTH_JWT_SECRET is not set; POST /api/auth/token and Bearer auth are disabled")
 	}
 
 	deps := &handler.RouterDeps{
@@ -246,8 +254,9 @@ func runServe(cfg *config.Config) error {
 			SessionMaxAge: cfg.SessionMaxAge,
 		},
 
-		// Native Auth (Issue #166)
+		// Native Auth (Issue #166 / #169)
 		NativeAuthHandler: nativeAuthHandler,
+		JWTVerifier:       jwtVerifier,
 
 		FeedService:         feedService,
 		SubscriptionDeleter: subDeleterAdapter,

--- a/internal/auth/jwt_verifier.go
+++ b/internal/auth/jwt_verifier.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// JWTVerifier は JWTIssuer（#166）が発行した access token（HS256 JWT）を検証する
+// （Issue #169）。
+//
+// 検証は署名鍵と時刻のみで完結し、保存済みセッション情報・外部サービスへの照会を
+// 行わない（NFR 1.2: stateless 検証）。鍵 (secret) はコンストラクタで固定する。
+// テストでは内部 now func の上書きで時刻を決定論的に注入する（Req 4.5。JWTIssuer と
+// 同パターン）。本構造体は immutable であり、複数の goroutine から並行使用しても安全。
+type JWTVerifier struct {
+	secret []byte
+	now    func() time.Time
+}
+
+// NewJWTVerifier は secret を保持する JWTVerifier を生成する。
+//
+// secret は JWTIssuer と同一の env 値（NATIVE_AUTH_JWT_SECRET）から渡すこと（Req 4.1:
+// 発行側と同一の鍵設定で検証する）。
+func NewJWTVerifier(secret []byte) *JWTVerifier {
+	return &JWTVerifier{
+		secret: secret,
+		now:    time.Now,
+	}
+}
+
+// VerifyAccessToken は tokenString を検証し、成立時に userID（sub claim）を返す。
+//
+// 検証規則（design.md 検証規則表 / #166 発行規約との対応）:
+//   - alg: HS256 限定（jwt.WithValidMethods。none / RS256 等の alg 偽装を拒否 / Req 2.1）
+//   - 署名: secret による HMAC 署名検証（Req 2.1）
+//   - exp: 必須（jwt.WithExpirationRequired）かつ now 超過で拒否。leeway 0（Req 2.2）
+//   - token_use: "access" 厳密一致以外は拒否（refresh 等の流用防止 / Req 2.3）
+//   - sub: 非空必須。成功時の返り値 userID
+//   - iat: 存在時はライブラリ標準検証に委ねる（presence は要求しない）
+//   - jti / header kid: 参照しない（失効リスト・複数鍵受理は Out of Scope）
+//
+// 失敗理由は error に含まれるが、呼び出し側は理由を HTTP 応答に反映しないこと
+// （Req 2.7: 拒否理由を区別できる情報を返さない）。token 文字列自体も error に
+// 含まれない（NFR 1.1）。
+func (v *JWTVerifier) VerifyAccessToken(tokenString string) (string, error) {
+	token, err := jwt.Parse(
+		tokenString,
+		func(t *jwt.Token) (any, error) { return v.secret, nil },
+		jwt.WithValidMethods([]string{"HS256"}),
+		jwt.WithExpirationRequired(),
+		jwt.WithTimeFunc(func() time.Time { return v.now() }),
+	)
+	if err != nil {
+		// jwt ライブラリの error は token 値を含まない（NFR 1.1）。
+		return "", fmt.Errorf("access token validation failed: %w", err)
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", errors.New("access token validation failed: unexpected claims type")
+	}
+
+	// token_use == "access" の厳密一致（refresh token 等の認証流用を拒否 / Req 2.3）
+	if use, _ := claims["token_use"].(string); use != accessTokenUse {
+		return "", errors.New("access token validation failed: token_use is not access")
+	}
+
+	// sub 非空必須（ユーザー識別の正本 / Req 1.1 の userID 解決元）
+	sub, _ := claims["sub"].(string)
+	if sub == "" {
+		return "", errors.New("access token validation failed: sub is empty")
+	}
+
+	return sub, nil
+}

--- a/internal/auth/jwt_verifier_test.go
+++ b/internal/auth/jwt_verifier_test.go
@@ -1,0 +1,265 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// newFixedVerifier は now を固定時刻に差し替えた JWTVerifier を返すテストヘルパー。
+// package 内のため非公開 now を直接書き換えできる（Req 4.5: テストでは固定時刻注入。
+// jwt_issuer_test.go の newFixedIssuer と同パターン・同一 fixture を共有する）。
+func newFixedVerifier(t *testing.T, secret []byte, now time.Time) *JWTVerifier {
+	t.Helper()
+	verifier := NewJWTVerifier(secret)
+	verifier.now = func() time.Time { return now }
+	return verifier
+}
+
+// issueFixedToken は固定 secret / 固定 now の JWTIssuer（#166）で access token を発行する。
+// 発行 ↔ 検証の規約整合（Req 4.1）を実物ペアで検証するための共通 Arrange。
+func issueFixedToken(t *testing.T, userID string) string {
+	t.Helper()
+	issuer := newFixedIssuer(t, "v1")
+	tokenString, err := issuer.IssueAccessToken(userID)
+	if err != nil {
+		t.Fatalf("IssueAccessToken returned error: %v", err)
+	}
+	return tokenString
+}
+
+// signTokenWithClaims は任意 claims / 任意 method / 任意鍵で JWT を作るテストヘルパー。
+// 用途不一致・sub 欠落・alg 偽装など、正規 issuer では発行できない token を組み立てる。
+func signTokenWithClaims(t *testing.T, method jwt.SigningMethod, key any, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(method, claims)
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("SignedString returned error: %v", err)
+	}
+	return signed
+}
+
+// TestVerifyAccessToken_IssuerVerifierRoundTrip は #166 JWTIssuer と固定 secret /
+// 固定 now を共有して発行した token を VerifyAccessToken が受理し、userID（sub）を
+// 返すことを検証する（Testing Strategy 1 / Req 4.1: 発行 ↔ 検証の規約整合）。
+func TestVerifyAccessToken_IssuerVerifierRoundTrip(t *testing.T) {
+	// Arrange: 発行直後（exp 内）の時刻で検証する
+	const userID = "user-test-1"
+	tokenString := issueFixedToken(t, userID)
+	verifier := newFixedVerifier(t, fixedJWTSecret, fixedJWTIssuedAt.Add(1*time.Minute))
+
+	// Act
+	got, err := verifier.VerifyAccessToken(tokenString)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("VerifyAccessToken returned error: %v", err)
+	}
+	if got != userID {
+		t.Errorf("userID = %q, want %q (sub claim の解決 / Req 1.1)", got, userID)
+	}
+}
+
+// TestVerifyAccessToken_Expired は exp 超過の token を拒否することを検証する
+// （Testing Strategy 2 / Req 2.2。境界値: ちょうど exp 時刻も leeway 0 で拒否）。
+func TestVerifyAccessToken_Expired(t *testing.T) {
+	cases := []struct {
+		name string
+		now  time.Time
+	}{
+		{
+			name: "exp を 1 秒超過したとき拒否",
+			now:  fixedJWTIssuedAt.Add(AccessTokenTTL + 1*time.Second),
+		},
+		{
+			name: "exp 丁度のとき拒否（境界値: leeway 0）",
+			now:  fixedJWTIssuedAt.Add(AccessTokenTTL),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			tokenString := issueFixedToken(t, "user-test-1")
+			verifier := newFixedVerifier(t, fixedJWTSecret, tc.now)
+
+			// Act
+			got, err := verifier.VerifyAccessToken(tokenString)
+
+			// Assert
+			if err == nil {
+				t.Fatal("err = nil, want non-nil (期限切れは拒否 / Req 2.2)")
+			}
+			if got != "" {
+				t.Errorf("userID = %q, want empty", got)
+			}
+		})
+	}
+}
+
+// TestVerifyAccessToken_WrongSecret は異なる secret で署名された token を拒否することを
+// 検証する（Testing Strategy 3 / Req 2.1: 署名検証不能の拒否）。
+func TestVerifyAccessToken_WrongSecret(t *testing.T) {
+	// Arrange: 正規 issuer と異なる鍵で署名する
+	otherSecret := []byte("another-jwt-secret-32bytes-long-x")
+	issuer := NewJWTIssuer(otherSecret, "v1")
+	issuer.now = func() time.Time { return fixedJWTIssuedAt }
+	tokenString, err := issuer.IssueAccessToken("user-test-1")
+	if err != nil {
+		t.Fatalf("IssueAccessToken returned error: %v", err)
+	}
+	verifier := newFixedVerifier(t, fixedJWTSecret, fixedJWTIssuedAt.Add(1*time.Minute))
+
+	// Act
+	got, err := verifier.VerifyAccessToken(tokenString)
+
+	// Assert
+	if err == nil {
+		t.Fatal("err = nil, want non-nil (署名不正は拒否 / Req 2.1)")
+	}
+	if got != "" {
+		t.Errorf("userID = %q, want empty", got)
+	}
+}
+
+// TestVerifyAccessToken_TokenUseMismatch は token_use が "access" でない token を拒否する
+// ことを検証する（Testing Strategy 4 / Req 2.3: 用途種別の限定）。
+func TestVerifyAccessToken_TokenUseMismatch(t *testing.T) {
+	now := fixedJWTIssuedAt
+	baseClaims := func() jwt.MapClaims {
+		return jwt.MapClaims{
+			"sub": "user-test-1",
+			"iat": now.Unix(),
+			"exp": now.Add(AccessTokenTTL).Unix(),
+		}
+	}
+	cases := []struct {
+		name   string
+		mutate func(c jwt.MapClaims)
+	}{
+		{name: "token_use が refresh のとき拒否", mutate: func(c jwt.MapClaims) { c["token_use"] = "refresh" }},
+		{name: "token_use 欠落のとき拒否", mutate: func(c jwt.MapClaims) {}},
+		{name: "token_use が空文字のとき拒否", mutate: func(c jwt.MapClaims) { c["token_use"] = "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			claims := baseClaims()
+			tc.mutate(claims)
+			tokenString := signTokenWithClaims(t, jwt.SigningMethodHS256, fixedJWTSecret, claims)
+			verifier := newFixedVerifier(t, fixedJWTSecret, now.Add(1*time.Minute))
+
+			// Act
+			_, err := verifier.VerifyAccessToken(tokenString)
+
+			// Assert
+			if err == nil {
+				t.Fatal("err = nil, want non-nil (token_use 不一致は拒否 / Req 2.3)")
+			}
+		})
+	}
+}
+
+// TestVerifyAccessToken_AlgConfusion は HS256 以外のアルゴリズム（none）の token を
+// 拒否することを検証する（Testing Strategy 5 / alg 偽装拒否）。
+func TestVerifyAccessToken_AlgConfusion(t *testing.T) {
+	// Arrange: alg=none の unsigned token を組み立てる
+	now := fixedJWTIssuedAt
+	claims := jwt.MapClaims{
+		"sub":       "user-test-1",
+		"iat":       now.Unix(),
+		"exp":       now.Add(AccessTokenTTL).Unix(),
+		"token_use": accessTokenUse,
+	}
+	noneToken := signTokenWithClaims(t, jwt.SigningMethodNone, jwt.UnsafeAllowNoneSignatureType, claims)
+	verifier := newFixedVerifier(t, fixedJWTSecret, now.Add(1*time.Minute))
+
+	// Act
+	_, err := verifier.VerifyAccessToken(noneToken)
+
+	// Assert
+	if err == nil {
+		t.Fatal("err = nil, want non-nil (alg=none は WithValidMethods で拒否)")
+	}
+}
+
+// TestVerifyAccessToken_MalformedTokens は sub 空 / 欠落・exp 欠落・JWT 形式でない文字列・
+// 空文字列を拒否することを検証する（Testing Strategy 6 / Req 2.5 関連の形式不正系）。
+func TestVerifyAccessToken_MalformedTokens(t *testing.T) {
+	now := fixedJWTIssuedAt
+	withClaims := func(mutate func(c jwt.MapClaims)) string {
+		claims := jwt.MapClaims{
+			"sub":       "user-test-1",
+			"iat":       now.Unix(),
+			"exp":       now.Add(AccessTokenTTL).Unix(),
+			"token_use": accessTokenUse,
+		}
+		mutate(claims)
+		return signTokenWithClaims(t, jwt.SigningMethodHS256, fixedJWTSecret, claims)
+	}
+	cases := []struct {
+		name        string
+		tokenString string
+	}{
+		{name: "sub 空のとき拒否", tokenString: withClaims(func(c jwt.MapClaims) { c["sub"] = "" })},
+		{name: "sub 欠落のとき拒否", tokenString: withClaims(func(c jwt.MapClaims) { delete(c, "sub") })},
+		{name: "exp 欠落のとき拒否（WithExpirationRequired）", tokenString: withClaims(func(c jwt.MapClaims) { delete(c, "exp") })},
+		{name: "JWT 形式でない文字列のとき拒否", tokenString: "abc"},
+		{name: "空文字列のとき拒否", tokenString: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			verifier := newFixedVerifier(t, fixedJWTSecret, now.Add(1*time.Minute))
+
+			// Act
+			got, err := verifier.VerifyAccessToken(tc.tokenString)
+
+			// Assert
+			if err == nil {
+				t.Fatal("err = nil, want non-nil")
+			}
+			if got != "" {
+				t.Errorf("userID = %q, want empty", got)
+			}
+		})
+	}
+}
+
+// TestVerifyAccessToken_ErrorDoesNotContainToken はエラーメッセージに token 文字列が
+// 含まれないことを検証する（NFR 1.1: token 値をログ・エラーに残さない前提の担保）。
+func TestVerifyAccessToken_ErrorDoesNotContainToken(t *testing.T) {
+	// Arrange: 期限切れの正規 token（最も情報を持つ失敗ケース）
+	tokenString := issueFixedToken(t, "user-test-1")
+	verifier := newFixedVerifier(t, fixedJWTSecret, fixedJWTIssuedAt.Add(2*AccessTokenTTL))
+
+	// Act
+	_, err := verifier.VerifyAccessToken(tokenString)
+
+	// Assert
+	if err == nil {
+		t.Fatal("err = nil, want non-nil")
+	}
+	if strings.Contains(err.Error(), tokenString) {
+		t.Errorf("error message contains token string (NFR 1.1)")
+	}
+}
+
+// TestNewJWTVerifier_DefaultsNowToTimeNow は now がコンストラクタ既定で time.Now を
+// 指していること（テスト注入が無ければ実時刻ベースで検証される）を確認する。
+func TestNewJWTVerifier_DefaultsNowToTimeNow(t *testing.T) {
+	// Arrange
+	verifier := NewJWTVerifier(fixedJWTSecret)
+
+	// Act
+	before := time.Now()
+	got := verifier.now()
+	after := time.Now()
+
+	// Assert
+	if got.Before(before) || got.After(after) {
+		t.Errorf("verifier.now()=%v, want time within [%v, %v]", got, before, after)
+	}
+}

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -75,6 +75,12 @@ type RouterDeps struct {
 	// fail-closed パターン。/metrics と同じ後方互換指針）。
 	NativeAuthHandler *NativeAuthHandler
 
+	// JWTVerifier は Bearer access token の検証器（任意 / Issue #169）。
+	// nil の場合、認証必須グループは従来どおり Cookie セッション認証のみで動作する
+	// （NATIVE_AUTH_JWT_SECRET 未設定環境の後方互換。NewBearerOrSessionMiddleware が
+	// nil 縮退で既存 SessionMiddleware をそのまま返す）。
+	JWTVerifier middleware.JWTVerifier
+
 	// フィード
 	FeedService         FeedServiceInterface
 	SubscriptionDeleter SubscriptionDeleter
@@ -218,10 +224,15 @@ func NewRouter(deps *RouterDeps) http.Handler {
 	})
 
 	// --- 認証が必要なルート ---
-	// ミドルウェアスタック: Session → RateLimit(General) → Logging
-	// Logging を Session の後ろに置くことで user_id をログに含める。
+	// ミドルウェアスタック: BearerOrSession → RateLimit(General) → Logging
+	// Logging を認証 middleware の後ろに置くことで user_id をログに含める。
+	// BearerOrSession（Issue #169）は Authorization: Bearer があれば JWT 検証で認証し、
+	// 無ければ既存 SessionMiddleware に委譲する。deps.JWTVerifier が nil
+	// （NATIVE_AUTH_JWT_SECRET 未設定）の場合は SessionMiddleware そのものが返るため、
+	// 構成は本機能導入前と完全に同一（NFR 2.2）。RateLimit / MaxBodyBytes / Logging の
+	// 順序・位置・適用範囲は不変（NFR 2.1）。
 	r.Group(func(r chi.Router) {
-		r.Use(middleware.NewSessionMiddleware(deps.SessionFinder))
+		r.Use(middleware.NewBearerOrSessionMiddleware(deps.JWTVerifier, deps.SessionFinder))
 		r.Use(deps.RateLimiter.GeneralMiddleware())
 		// リクエストボディ上限を適用し、巨大ボディによるメモリ枯渇 DoS を防ぐ。
 		// 上限超過時は各ハンドラの json.Decode がエラーを返し 400 応答となる。

--- a/internal/handler/router_test.go
+++ b/internal/handler/router_test.go
@@ -409,3 +409,97 @@ func TestNewRouter_NativeAuthRevoke_NotRegisteredWhenHandlerNil(t *testing.T) {
 			w.Result().StatusCode, http.StatusNotFound)
 	}
 }
+
+// --- Bearer-or-Session 認証ルーティング（Issue #169 / design.md Testing Strategy router 1〜4） ---
+
+// newBearerAuthDeps は認証必須ルート（/api/subscriptions）への Bearer / Cookie 認証を
+// 検証するための最小 deps を返す。verifier / sessions を差し替えて各ケースを構成する。
+func newBearerAuthDeps(verifier middleware.JWTVerifier, sessions map[string]*model.Session) *RouterDeps {
+	deps := newMinimalDepsForNativeAuth(nil)
+	deps.JWTVerifier = verifier
+	deps.SessionFinder = &mockSessionFinderForRouter{sessions: sessions}
+	deps.SubscriptionService = &mockSubscriptionService{
+		listSubscriptionsFn: func(ctx context.Context, userID string) ([]subscriptionResponse, error) {
+			return []subscriptionResponse{}, nil
+		},
+	}
+	return deps
+}
+
+// stubRouterJWTVerifier は router テスト用の固定結果 JWTVerifier スタブ。
+type stubRouterJWTVerifier struct {
+	userID string
+	err    error
+}
+
+func (s *stubRouterJWTVerifier) VerifyAccessToken(tokenString string) (string, error) {
+	return s.userID, s.err
+}
+
+// TestNewRouter_BearerAuth_ReachesAPIWithoutCookie は JWTVerifier 注入時に Cookie 無し +
+// Bearer で既存の認証必須ルートに到達できることを検証する（Testing Strategy router 1 /
+// Req 1.1, 1.2: 下流ルートは変更ゼロで透過動作）。
+func TestNewRouter_BearerAuth_ReachesAPIWithoutCookie(t *testing.T) {
+	// Arrange
+	deps := newBearerAuthDeps(&stubRouterJWTVerifier{userID: "user-test-1"}, map[string]*model.Session{})
+	router := NewRouter(deps)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/subscriptions", nil)
+	req.Header.Set("Authorization", "Bearer stub-valid-token")
+	// Cookie 無し
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert: Bearer 認証で既存ルートに到達し 200
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d (Bearer で認証必須ルート到達 / Req 1.1)",
+			w.Result().StatusCode, http.StatusOK)
+	}
+}
+
+// TestNewRouter_BearerAuth_NilVerifierKeepsLegacyBehavior は JWTVerifier nil のとき
+// 従来構成（Cookie セッション認証のみ）と同一挙動になることを検証する
+// （Testing Strategy router 2 / Req 4.2 / NFR 2.2）。
+func TestNewRouter_BearerAuth_NilVerifierKeepsLegacyBehavior(t *testing.T) {
+	sessions := map[string]*model.Session{
+		"valid-session": {
+			ID:        "valid-session",
+			UserID:    "user-test-1",
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		},
+	}
+
+	t.Run("有効 Cookie のとき従来どおり 200", func(t *testing.T) {
+		// Arrange
+		router := NewRouter(newBearerAuthDeps(nil, sessions))
+		req := httptest.NewRequest(http.MethodGet, "/api/subscriptions", nil)
+		req.AddCookie(&http.Cookie{Name: "session_id", Value: "valid-session"})
+		w := httptest.NewRecorder()
+
+		// Act
+		router.ServeHTTP(w, req)
+
+		// Assert
+		if w.Result().StatusCode != http.StatusOK {
+			t.Errorf("status = %d, want %d (NFR 2.1: 既存 Cookie 認証は不変)", w.Result().StatusCode, http.StatusOK)
+		}
+	})
+
+	t.Run("Bearer 付き + Cookie 無しのとき従来どおり 401（token は評価されない）", func(t *testing.T) {
+		// Arrange
+		router := NewRouter(newBearerAuthDeps(nil, sessions))
+		req := httptest.NewRequest(http.MethodGet, "/api/subscriptions", nil)
+		req.Header.Set("Authorization", "Bearer anything")
+		w := httptest.NewRecorder()
+
+		// Act
+		router.ServeHTTP(w, req)
+
+		// Assert: 導入前と同一の未認証応答（Req 4.3）
+		if w.Result().StatusCode != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d (Req 4.2 / 4.3)", w.Result().StatusCode, http.StatusUnauthorized)
+		}
+	})
+}

--- a/internal/handler/router_test.go
+++ b/internal/handler/router_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
+
 	"github.com/hitoshi/feedman/internal/auth"
 	"github.com/hitoshi/feedman/internal/middleware"
 	"github.com/hitoshi/feedman/internal/model"
@@ -502,4 +504,75 @@ func TestNewRouter_BearerAuth_NilVerifierKeepsLegacyBehavior(t *testing.T) {
 			t.Errorf("status = %d, want %d (Req 4.2 / 4.3)", w.Result().StatusCode, http.StatusUnauthorized)
 		}
 	})
+}
+
+// TestNewRouter_BearerAuth_IssuerVerifierRoundTrip は #166 auth.JWTIssuer で発行した
+// 実物 token を auth.JWTVerifier 注入済み NewRouter へ Bearer 提示し、Cookie 無しで
+// 既存 API ルートの認証が成立することを検証する（Testing Strategy router 3 /
+// Req 1.1, 4.1: 同一 secret での発行 ↔ 検証の通し）。
+func TestNewRouter_BearerAuth_IssuerVerifierRoundTrip(t *testing.T) {
+	// Arrange: 発行と検証で同一 secret を共有する実物ペア
+	secret := []byte("router-roundtrip-secret-32bytes-x")
+	issuer := auth.NewJWTIssuer(secret, "v1")
+	tokenString, err := issuer.IssueAccessToken("user-roundtrip-1")
+	if err != nil {
+		t.Fatalf("IssueAccessToken returned error: %v", err)
+	}
+	deps := newBearerAuthDeps(auth.NewJWTVerifier(secret), map[string]*model.Session{})
+	router := NewRouter(deps)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/subscriptions", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenString)
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d (実物 issuer ↔ verifier の通し / Req 4.1)",
+			w.Result().StatusCode, http.StatusOK)
+	}
+}
+
+// TestNewRouter_BearerAuth_ExpiredTokenWithValidCookie_Returns401 は期限切れ token +
+// 有効 Cookie 併送で 401 になる（Cookie へ fallback しない）ことを router 通しで検証する
+// （Testing Strategy router 通し / Req 2.2, 2.4）。
+func TestNewRouter_BearerAuth_ExpiredTokenWithValidCookie_Returns401(t *testing.T) {
+	// Arrange: exp が過去の token を同一 secret で直接組み立てる
+	secret := []byte("router-roundtrip-secret-32bytes-x")
+	past := time.Now().Add(-1 * time.Hour)
+	expiredToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub":       "user-roundtrip-1",
+		"iat":       past.Add(-15 * time.Minute).Unix(),
+		"exp":       past.Unix(),
+		"token_use": "access",
+	})
+	tokenString, err := expiredToken.SignedString(secret)
+	if err != nil {
+		t.Fatalf("SignedString returned error: %v", err)
+	}
+
+	sessions := map[string]*model.Session{
+		"valid-session": {
+			ID:        "valid-session",
+			UserID:    "user-test-1",
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		},
+	}
+	router := NewRouter(newBearerAuthDeps(auth.NewJWTVerifier(secret), sessions))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/subscriptions", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenString)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "valid-session"})
+	w := httptest.NewRecorder()
+
+	// Act
+	router.ServeHTTP(w, req)
+
+	// Assert: 有効 Cookie が併送されていても fallback せず 401（Req 2.4）
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d (期限切れ Bearer は Cookie へ fallback しない / Req 2.2, 2.4)",
+			w.Result().StatusCode, http.StatusUnauthorized)
+	}
 }

--- a/internal/middleware/bearer_or_session.go
+++ b/internal/middleware/bearer_or_session.go
@@ -1,0 +1,83 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// JWTVerifier は BearerOrSession middleware が access token の検証に必要とする
+// 最小インターフェース（Issue #169）。auth.JWTVerifier が構造的に充足する
+// （SessionFinder と同じ interface segregation パターン）。
+type JWTVerifier interface {
+	// VerifyAccessToken は tokenString を検証し、成立時に userID を返す。
+	VerifyAccessToken(tokenString string) (string, error)
+}
+
+// NewBearerOrSessionMiddleware は Bearer 優先・Session 委譲の複合認証 middleware を返す
+// （Issue #169）。
+//
+// 判定フロー（design.md「判定フロー」参照）:
+//  0. jwtVerifier == nil（NATIVE_AUTH_JWT_SECRET 未設定）
+//     → NewSessionMiddleware(sessionFinder) をそのまま返す縮退（Req 4.2 / 4.3:
+//     全要求が従来どおり Cookie 評価。Authorization ヘッダは一切読まない）
+//  1. Authorization ヘッダ無し → 既存 SessionMiddleware に委譲（Req 3.1: 従来パス完全維持）
+//  2. ヘッダの scheme が Bearer 以外（Basic 等）→ 1 と同じく委譲（Req 3.2。
+//     従来も Authorization を無視していたため互換）
+//  3. scheme が Bearer（大文字小文字不区別 / RFC 9110 §11.1）:
+//     a. token 部（trim 後）が空 → 401（Req 2.5。委譲しない）
+//     b. VerifyAccessToken 失敗 → 401（Req 2.4: Cookie へ fallback しない）
+//     c. 成功 → ContextWithUserID で user context 注入 → next（Req 1.1 / 1.3:
+//     sessionFinder は呼ばない）
+//
+// 401 応答は既存 SessionMiddleware の未認証応答と同一形式
+// （http.Error(w, "unauthorized", http.StatusUnauthorized) / Req 2.6）であり、
+// 署名不正・期限切れ・用途不一致・形式不正の別を応答から区別できない（Req 2.7）。
+// 検証失敗は slog.Warn にエラー理由のみ記録し、token 文字列・claims 値は渡さない
+// （NFR 1.1）。
+func NewBearerOrSessionMiddleware(jwtVerifier JWTVerifier, sessionFinder SessionFinder) func(next http.Handler) http.Handler {
+	// 0. verifier 未設定環境では既存 SessionMiddleware をそのまま返す
+	//    （構成が本機能導入前と文字どおり同一になる fail-safe 縮退）。
+	if jwtVerifier == nil {
+		return NewSessionMiddleware(sessionFinder)
+	}
+
+	sessionMW := NewSessionMiddleware(sessionFinder)
+	return func(next http.Handler) http.Handler {
+		delegate := sessionMW(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// 1. Authorization ヘッダ無し → Cookie セッション認証へ委譲
+			authz := r.Header.Get("Authorization")
+			if authz == "" {
+				delegate.ServeHTTP(w, r)
+				return
+			}
+
+			// 2. scheme 分離。Bearer 以外（Basic 等）は従来どおり無視して委譲
+			scheme, token, _ := strings.Cut(authz, " ")
+			if !strings.EqualFold(scheme, "Bearer") {
+				delegate.ServeHTTP(w, r)
+				return
+			}
+
+			// 3a. Bearer scheme で token 部が空（"Bearer" 単独を含む）→ 401
+			token = strings.TrimSpace(token)
+			if token == "" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			// 3b. 検証失敗 → 401（有効な Cookie が併送されていても fallback しない）
+			userID, err := jwtVerifier.VerifyAccessToken(token)
+			if err != nil {
+				// token 文字列・claims 値はログに渡さない（NFR 1.1）。
+				slog.Warn("bearer token rejected", slog.String("error", err.Error()))
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			// 3c. 成功 → Cookie セッション認証と同一の context key に userID を注入
+			next.ServeHTTP(w, r.WithContext(ContextWithUserID(r.Context(), userID)))
+		})
+	}
+}

--- a/internal/middleware/bearer_or_session_test.go
+++ b/internal/middleware/bearer_or_session_test.go
@@ -1,0 +1,363 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/hitoshi/feedman/internal/model"
+)
+
+// --- モック定義（Issue #169） ---
+
+// stubJWTVerifier は JWTVerifier 最小 IF の record-and-return スタブ。
+type stubJWTVerifier struct {
+	verifyFn    func(tokenString string) (string, error)
+	verifyCalls int
+	lastToken   string
+}
+
+func (s *stubJWTVerifier) VerifyAccessToken(tokenString string) (string, error) {
+	s.verifyCalls++
+	s.lastToken = tokenString
+	if s.verifyFn != nil {
+		return s.verifyFn(tokenString)
+	}
+	return "", errors.New("not configured")
+}
+
+// countingSessionFinder は FindByID の呼び出し回数を記録する SessionFinder スタブ。
+// Bearer パスで sessionFinder が呼ばれないこと（Req 1.3 / 2.4）の検証に使う。
+type countingSessionFinder struct {
+	findByIDFn func(ctx context.Context, id string) (*model.Session, error)
+	findCalls  int
+}
+
+func (m *countingSessionFinder) FindByID(ctx context.Context, id string) (*model.Session, error) {
+	m.findCalls++
+	if m.findByIDFn != nil {
+		return m.findByIDFn(ctx, id)
+	}
+	return nil, nil
+}
+
+// validSessionFinder は固定の有効セッションを返す countingSessionFinder を生成する。
+func validSessionFinder(sessionID, userID string) *countingSessionFinder {
+	return &countingSessionFinder{
+		findByIDFn: func(ctx context.Context, id string) (*model.Session, error) {
+			if id == sessionID {
+				return &model.Session{
+					ID:        sessionID,
+					UserID:    userID,
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+				}, nil
+			}
+			return nil, nil
+		},
+	}
+}
+
+// captureHandler は下流到達時に UserIDFromContext の値を捕捉して 200 を返す handler を生成する。
+func captureHandler(t *testing.T, capturedUserID *string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID, err := UserIDFromContext(r.Context())
+		if err != nil {
+			t.Errorf("UserIDFromContext returned error: %v", err)
+		}
+		*capturedUserID = userID
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// --- テスト（design.md Testing Strategy middleware 1〜6） ---
+
+// TestBearerOrSession_ValidBearer_InjectsUserID は有効 Bearer で下流 handler が
+// UserIDFromContext で userID を取得でき、sessionFinder が呼ばれないことを検証する
+// （Testing Strategy 1 / Req 1.1, 1.3）。
+func TestBearerOrSession_ValidBearer_InjectsUserID(t *testing.T) {
+	// Arrange
+	verifier := &stubJWTVerifier{
+		verifyFn: func(tokenString string) (string, error) { return "user-bearer-1", nil },
+	}
+	finder := &countingSessionFinder{}
+	mw := NewBearerOrSessionMiddleware(verifier, finder)
+
+	var capturedUserID string
+	handler := mw(captureHandler(t, &capturedUserID))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d (Req 1.1)", w.Result().StatusCode, http.StatusOK)
+	}
+	if capturedUserID != "user-bearer-1" {
+		t.Errorf("userID = %q, want %q (Cookie セッションと同一の context 注入)", capturedUserID, "user-bearer-1")
+	}
+	if verifier.verifyCalls != 1 {
+		t.Errorf("VerifyAccessToken calls = %d, want 1", verifier.verifyCalls)
+	}
+	if verifier.lastToken != "valid-token" {
+		t.Errorf("verifier received token = %q, want %q", verifier.lastToken, "valid-token")
+	}
+	if finder.findCalls != 0 {
+		t.Errorf("sessionFinder calls = %d, want 0 (Bearer パスは session を参照しない / Req 1.3)", finder.findCalls)
+	}
+}
+
+// TestBearerOrSession_InvalidBearerWithValidCookie_Returns401 は無効 Bearer + 有効 Cookie
+// 併送で 401 を返し、Cookie へ fallback しない（sessionFinder 不呼び出し）ことを検証する
+// （Testing Strategy 2 / Req 2.4 / Req 1.4 の裏面）。
+func TestBearerOrSession_InvalidBearerWithValidCookie_Returns401(t *testing.T) {
+	// Arrange: verifier は常に失敗、Cookie は有効セッションを指す
+	verifier := &stubJWTVerifier{
+		verifyFn: func(tokenString string) (string, error) { return "", errors.New("token is expired") },
+	}
+	finder := validSessionFinder("valid-session-id", "user-cookie-1")
+	mw := NewBearerOrSessionMiddleware(verifier, finder)
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("downstream handler must not be reached")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set("Authorization", "Bearer expired-token")
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "valid-session-id"})
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d (無効 Bearer は Cookie へ fallback しない / Req 2.4)",
+			w.Result().StatusCode, http.StatusUnauthorized)
+	}
+	if finder.findCalls != 0 {
+		t.Errorf("sessionFinder calls = %d, want 0 (fallback 禁止 / Req 2.4)", finder.findCalls)
+	}
+}
+
+// TestBearerOrSession_401SameShapeAsSessionMiddleware は Bearer 拒否の 401 応答が
+// 既存 SessionMiddleware の未認証応答と同一（status / body / Content-Type）であることを
+// 検証する（Testing Strategy 3 / Req 2.6）。
+func TestBearerOrSession_401SameShapeAsSessionMiddleware(t *testing.T) {
+	// Arrange: 比較基準として既存 SessionMiddleware の未認証応答を取得する
+	sessionMW := NewSessionMiddleware(&countingSessionFinder{})
+	sessionHandler := sessionMW(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	baseReq := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	baseW := httptest.NewRecorder()
+	sessionHandler.ServeHTTP(baseW, baseReq)
+	baseResp := baseW.Result()
+	baseBody, _ := io.ReadAll(baseResp.Body)
+
+	// Bearer 拒否側の応答
+	verifier := &stubJWTVerifier{
+		verifyFn: func(tokenString string) (string, error) { return "", errors.New("signature is invalid") },
+	}
+	mw := NewBearerOrSessionMiddleware(verifier, &countingSessionFinder{})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set("Authorization", "Bearer bad-token")
+	w := httptest.NewRecorder()
+
+	// Act
+	handler.ServeHTTP(w, req)
+
+	// Assert: status / body / Content-Type が完全一致
+	resp := w.Result()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != baseResp.StatusCode {
+		t.Errorf("status = %d, want %d (SessionMiddleware と同形 / Req 2.6)", resp.StatusCode, baseResp.StatusCode)
+	}
+	if string(body) != string(baseBody) {
+		t.Errorf("body = %q, want %q (Req 2.6)", string(body), string(baseBody))
+	}
+	if got, want := resp.Header.Get("Content-Type"), baseResp.Header.Get("Content-Type"); got != want {
+		t.Errorf("Content-Type = %q, want %q (Req 2.6)", got, want)
+	}
+}
+
+// TestBearerOrSession_NoAuthorizationHeader_DelegatesToSession は Authorization 無しの
+// 要求が既存 SessionMiddleware に委譲されることを検証する（Testing Strategy 4 /
+// Req 3.1, 3.3, 3.4）。
+func TestBearerOrSession_NoAuthorizationHeader_DelegatesToSession(t *testing.T) {
+	t.Run("有効 Cookie のとき従来どおり 200", func(t *testing.T) {
+		// Arrange
+		verifier := &stubJWTVerifier{}
+		finder := validSessionFinder("valid-session-id", "user-cookie-1")
+		mw := NewBearerOrSessionMiddleware(verifier, finder)
+
+		var capturedUserID string
+		handler := mw(captureHandler(t, &capturedUserID))
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req.AddCookie(&http.Cookie{Name: "session_id", Value: "valid-session-id"})
+		w := httptest.NewRecorder()
+
+		// Act
+		handler.ServeHTTP(w, req)
+
+		// Assert
+		if w.Result().StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d (Req 3.1 / 3.3)", w.Result().StatusCode, http.StatusOK)
+		}
+		if capturedUserID != "user-cookie-1" {
+			t.Errorf("userID = %q, want %q", capturedUserID, "user-cookie-1")
+		}
+		if verifier.verifyCalls != 0 {
+			t.Errorf("VerifyAccessToken calls = %d, want 0 (Bearer 不在では検証しない)", verifier.verifyCalls)
+		}
+	})
+
+	t.Run("Cookie 無しのとき従来どおり 401", func(t *testing.T) {
+		// Arrange
+		mw := NewBearerOrSessionMiddleware(&stubJWTVerifier{}, &countingSessionFinder{})
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("downstream handler must not be reached")
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		w := httptest.NewRecorder()
+
+		// Act
+		handler.ServeHTTP(w, req)
+
+		// Assert
+		if w.Result().StatusCode != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d (Req 3.4)", w.Result().StatusCode, http.StatusUnauthorized)
+		}
+	})
+}
+
+// TestBearerOrSession_SchemeAndTokenEdgeCases は scheme / token 部の境界ケースを検証する
+// （Testing Strategy 5 / Req 2.5, 3.2 / 小文字 bearer の受理）。
+func TestBearerOrSession_SchemeAndTokenEdgeCases(t *testing.T) {
+	cases := []struct {
+		name          string
+		authorization string
+		wantStatus    int
+		wantDelegate  bool // true なら session 委譲（Cookie 無しのため 401 になる）
+		wantVerify    int  // VerifyAccessToken の期待呼び出し回数
+	}{
+		{
+			name:          "Basic scheme のとき session へ委譲（Req 3.2）",
+			authorization: "Basic dXNlcjpwYXNz",
+			wantStatus:    http.StatusUnauthorized, // Cookie 無しのため委譲先で 401
+			wantDelegate:  true,
+			wantVerify:    0,
+		},
+		{
+			name:          "Bearer 単独（token 部なし）のとき 401（Req 2.5）",
+			authorization: "Bearer",
+			wantStatus:    http.StatusUnauthorized,
+			wantDelegate:  false,
+			wantVerify:    0,
+		},
+		{
+			name:          "Bearer + 空白のみのとき 401（Req 2.5）",
+			authorization: "Bearer ",
+			wantStatus:    http.StatusUnauthorized,
+			wantDelegate:  false,
+			wantVerify:    0,
+		},
+		{
+			name:          "小文字 bearer のとき Bearer として受理（RFC 9110 §11.1）",
+			authorization: "bearer valid-token",
+			wantStatus:    http.StatusOK,
+			wantDelegate:  false,
+			wantVerify:    1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			verifier := &stubJWTVerifier{
+				verifyFn: func(tokenString string) (string, error) { return "user-bearer-1", nil },
+			}
+			finder := &countingSessionFinder{}
+			mw := NewBearerOrSessionMiddleware(verifier, finder)
+			handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+			req.Header.Set("Authorization", tc.authorization)
+			w := httptest.NewRecorder()
+
+			// Act
+			handler.ServeHTTP(w, req)
+
+			// Assert
+			if w.Result().StatusCode != tc.wantStatus {
+				t.Errorf("status = %d, want %d", w.Result().StatusCode, tc.wantStatus)
+			}
+			if verifier.verifyCalls != tc.wantVerify {
+				t.Errorf("VerifyAccessToken calls = %d, want %d", verifier.verifyCalls, tc.wantVerify)
+			}
+			if tc.wantDelegate && finder.findCalls != 0 {
+				// Cookie 無しの委譲は FindByID 到達前に 401 になるため 0 回で正しい。
+				// （委譲自体の検証は応答形状 = SessionMiddleware の 401 で担保）
+				t.Errorf("sessionFinder calls = %d, want 0 (Cookie 無しは FindByID 前に 401)", finder.findCalls)
+			}
+		})
+	}
+}
+
+// TestBearerOrSession_NilVerifier_FallsBackToSessionMiddleware は verifier nil のとき
+// Bearer 付き要求も Cookie で評価され、本機能導入前と同一挙動になることを検証する
+// （Testing Strategy 6 / Req 4.2, 4.3）。
+func TestBearerOrSession_NilVerifier_FallsBackToSessionMiddleware(t *testing.T) {
+	t.Run("Bearer 付き + 有効 Cookie のとき Cookie で認証成立（Bearer は評価されない）", func(t *testing.T) {
+		// Arrange: verifier nil。Bearer token は不正値だが評価されないため影響しない
+		finder := validSessionFinder("valid-session-id", "user-cookie-1")
+		mw := NewBearerOrSessionMiddleware(nil, finder)
+
+		var capturedUserID string
+		handler := mw(captureHandler(t, &capturedUserID))
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req.Header.Set("Authorization", "Bearer totally-invalid-token")
+		req.AddCookie(&http.Cookie{Name: "session_id", Value: "valid-session-id"})
+		w := httptest.NewRecorder()
+
+		// Act
+		handler.ServeHTTP(w, req)
+
+		// Assert: Cookie 認証で成立（Req 4.3: token を評価せず従来同一処理）
+		if w.Result().StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d (Req 4.2 / 4.3)", w.Result().StatusCode, http.StatusOK)
+		}
+		if capturedUserID != "user-cookie-1" {
+			t.Errorf("userID = %q, want %q (Cookie 由来)", capturedUserID, "user-cookie-1")
+		}
+		if finder.findCalls != 1 {
+			t.Errorf("sessionFinder calls = %d, want 1 (従来どおり Cookie 評価)", finder.findCalls)
+		}
+	})
+
+	t.Run("Bearer 付き + Cookie 無しのとき従来どおり 401", func(t *testing.T) {
+		// Arrange
+		mw := NewBearerOrSessionMiddleware(nil, &countingSessionFinder{})
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("downstream handler must not be reached")
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req.Header.Set("Authorization", "Bearer some-token")
+		w := httptest.NewRecorder()
+
+		// Act
+		handler.ServeHTTP(w, req)
+
+		// Assert
+		if w.Result().StatusCode != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d (導入前と同一の未認証応答)", w.Result().StatusCode, http.StatusUnauthorized)
+		}
+	})
+}


### PR DESCRIPTION
## 概要

Issue #169（umbrella #163 の子 Issue）の実装 PR です。設計 PR #195 でマージ済みの
`docs/specs/169-bearer-or-session/`（requirements.md / design.md / tasks.md）に厳密に従い、
既存の認証必須 API 群（`/api/*`）への Bearer 認証を追加しました。

Closes #169

## 変更内容

- `internal/auth/jwt_verifier.go`（新規）: `JWTVerifier`。#166 JWTIssuer と同一規約で検証（HS256 限定 / exp 必須・leeway 0 / `token_use=="access"` 厳密一致 / sub 非空。jti / kid 不参照）
- `internal/middleware/bearer_or_session.go`（新規）: `JWTVerifier` 最小 IF + `NewBearerOrSessionMiddleware`。verifier nil なら既存 `SessionMiddleware` をそのまま返す縮退。Bearer 検出後は成功 or 401 の二択（Cookie へ fallback しない）。**既存 session.go は無変更・削除なし**
- `internal/handler/router.go`: `RouterDeps.JWTVerifier`（任意）を追加し、認証必須グループの認証 middleware を 1 行差し替え（RateLimit / MaxBodyBytes / Logging の順序・位置は不変）
- `internal/app/app.go`: `NATIVE_AUTH_JWT_SECRET` 設定時のみ verifier を生成して注入。未設定時の warn 文言を Bearer 無効も含む内容に更新（warn 1 回のまま・起動成功）
- テスト: auth 8 / middleware 6 / router 4 ケース追加（401 同形性は実 SessionMiddleware の応答と直接比較 / 発行↔検証の実物ペア通し / 期限切れ + 有効 Cookie 併送で 401）

## 設計上のポイント

- 有効 Bearer は既存 `ContextWithUserID` で Cookie セッションと同一の context key に注入 → rate limit / logging / 全 handler が変更ゼロで透過動作（Req 1.2 / NFR 2.1）
- 無効 Bearer は有効 Cookie が併送されていても 401（黙示的 fallback の禁止 / Req 2.4）。401 応答は既存未認証応答と完全同形（Req 2.6 / 2.7）
- 署名鍵未設定環境では verifier 非生成 = Bearer 全無効で、構成が導入前と文字どおり同一（Req 4.2〜4.4 / NFR 2.2）

## Reviewer 判定

独立 context の Reviewer サブエージェントによるレビュー済み: **approve**
（`docs/specs/169-bearer-or-session/review-notes.md` 参照。AC 未カバー / missing test / boundary 逸脱のいずれも findings なし）

## 検証

- `go build ./...` / `go vet ./...` / `go test ./...` 全 green
- `TEST_DATABASE_URL` を設定した実 PostgreSQL 16 でも `go test -p 1 ./...` 全 pass（CI と同条件で事前確認）
- `gofmt -l`（変更ファイルのみ）差分なし
- 新規依存なし（`golang-jwt/jwt/v5` は #166 で追加済みを共用）

## 確認事項（レビュワー判断ポイント）

- design.md 例示の `strings.SplitN` の代わりに等価な `strings.Cut` を使用しています（挙動同一の Go 標準 idiom。scheme 比較は design どおり `strings.EqualFold`）
- router 通しの期限切れケースは、issuer / verifier の `now` が非公開で handler パッケージから注入できないため、同一 secret で exp が過去の JWT をテスト内で直接組み立てて検証しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)