### PR TITLE
feat(#171): native auth エンドポイントに IP 単位レート制限を適用する

### DIFF
--- a/docs/specs/171-native-auth-ip-ratelimit/impl-notes.md
+++ b/docs/specs/171-native-auth-ip-ratelimit/impl-notes.md
@@ -1,0 +1,106 @@
+# 実装ノート: Issue #171 native auth エンドポイントの IP rate limit
+
+## 実装サマリ
+
+Issue #171 の「native auth 3 エンドポイント（`POST /api/auth/token` / `POST /api/auth/refresh` /
+`POST /api/auth/revoke`）への未認証 IP 単位レート制限の適用」を、design.md / tasks.md の
+指針に厳密に従って実装した。
+
+変更は `router.go` の native auth ルート登録 3 行に既存 `unauthIPMW` を重ねるのみ:
+
+- `unauthIPMW` は route 単位チェーンの最外（MaxBodyBytes より外側 / Logging の内側）に配置。
+  閾値超過時はボディ上限 wrap・JSON decode・永続化層参照のいずれにも到達せずに既存共通の
+  429（Retry-After 付き）で遮断される（Req 1.1〜1.3 の「処理を試行せずに」/ NFR 2.2 の
+  既存順序規約と一致）
+- **制限値・インスタンスは既存と共用**（design.md「制限値の設計判断」どおり）:
+  env `RATE_LIMIT_UNAUTH_IP`（既定 30 req/min/IP）の単一 `IPRateLimiter` を共用し、
+  native auth 専用の制限値・設定ノブ・インスタンスは新設しない
+- `IPRateLimiter` 本体・config・app.go の wiring・既存ルート・`RouterDeps` はすべて不変
+- `NativeAuthHandler` nil（署名鍵未設定）環境では 3 ルート自体が未登録のため本変更は no-op
+  （Req 2.4）。`UnauthIPRateLimiter` nil なら素通し（既存未認証ルートと同一の縮退規約）
+
+## タスクとコミット対応表
+
+| Task | 内容 | 実装コミット | 進捗 commit |
+|---|---|---|---|
+| 1 | router: 3 ルートへ unauthIPMW 適用 + レート制限テスト | c74b0a2 `feat(handler)` | 57b791a `docs(tasks): mark 1` |
+| 2 | 縮退・後方互換の regression テスト | 84810cc `test(handler)` | 3bb1b43 `docs(tasks): mark 2` |
+
+実装順序は tasks.md の番号順そのままで、`_Depends:_` の制約（task 2 → 1）は自然に満たされた。
+
+## 受入基準と担保テスト
+
+### Requirement 1: native auth エンドポイントへの IP 単位レート制限
+
+| AC ID | 担保テスト |
+|---|---|
+| 1.1 (token 超過で 429 / 処理未試行) | `handler.TestNewRouter_NativeAuthIPRateLimit_429OnExcess`（token サブケース: 429 + service 未呼び出し） |
+| 1.2 (refresh 超過で 429 / 処理未試行) | 同上（refresh サブケース） |
+| 1.3 (revoke 超過で 429 / 処理未試行) | 同上（revoke サブケース） |
+| 1.4 (閾値以内は通常どおり通過) | 同上（各サブケースの 1 回目が 200 / 204 で service 到達）/ `_Degradations`（limiter nil の 5 連続通過） |
+| 1.5 (Retry-After ヘッダーで待機時間通知) | `_429OnExcess`（Retry-After 非空検証）/ `_SameShapeAsExistingRoutes` |
+| 1.6 (IP ごとの独立カウント) | `handler.TestNewRouter_NativeAuthIPRateLimit_IndependentPerIP`（IP A 枯渇後も IP B は通過） |
+
+### Requirement 2: 既存挙動の後方互換
+
+| AC ID | 担保テスト |
+|---|---|
+| 2.1 (既存未認証 3 ルートの適用範囲・閾値不変) | 既存 `router_unauth_ratelimit_test.go` が無変更で green（実装も既存 3 ルートの登録・単一インスタンス構成を変更していない） |
+| 2.2 (認証済み userID 単位制限の不変) | 認証必須グループに diff なし。既存テスト無変更 green |
+| 2.3 (429 応答が既存と同一形式) | `handler.TestNewRouter_NativeAuthIPRateLimit_SameShapeAsExistingRoutes`（/health の 429 と status / Content-Type / Retry-After / JSON ボディを直接比較） |
+| 2.4 (native auth 無効環境で導入前と同一挙動) | `handler.TestNewRouter_NativeAuthIPRateLimit_Degradations`（NativeAuthHandler nil + limiter ありで 3 ルート 404 のまま） |
+
+### Non-Functional Requirements
+
+| NFR | 担保テスト・実装 |
+|---|---|
+| NFR 1.1 (拒否事象の運用ログ) | 既存 `IPRateLimiter` の拒否ログ（`slog.Warn("rate limit exceeded", limit_type=unauth_ip)`）を変更なしで共用 |
+| NFR 1.2 (拒否ログに token・PII を含めない) | 同上（#38 設計のまま。ログは limit 種別 + IP のみ） |
+| NFR 2.1 (設定未指定でも既定値で有効化) | config / wiring 不変のため、既定 30 req/min/IP がそのまま native auth ルートにも効く |
+| NFR 2.2 (既存ルートの middleware 種類・順序不変) | 既存ルートへの diff ゼロ（native auth ルートへの route 単位 `With` 追加のみ）。既存テスト無変更 green |
+| NFR 3.1 (within/over を外部依存なしで検証可能) | 追加テスト 4 本すべて httptest + モック service + 小 burst の `IPRateLimiter` 注入で in-process 完結 |
+
+## 検証結果
+
+- `go build ./...`: 成功
+- `go vet ./...`: 警告なし
+- `go test ./...`: 全パッケージ pass
+- `TEST_DATABASE_URL` を設定した実 PostgreSQL 16 でも `go test -p 1 ./...` 全 pass（CI と同条件）
+- `gofmt -l <変更ファイル群>`: 出力なし
+
+## design からの逸脱
+
+無し。design.md の以下は **完全にそのまま** 実装した。
+
+- Components and Interfaces の router 変更（3 行への `unauthIPMW` 追加。
+  `r.With(unauthIPMW, middleware.NewMaxBodyBytesMiddleware(...))` の形）
+- 制限値の共用判断（新 env / 新インスタンス / config 変更なし）
+- File Structure Plan（変更は router.go / router_test.go の 2 ファイルのみ）
+- Testing Strategy 1〜6 の全ケース（7〜8 は既存テストの無変更 green 確認で充足）
+
+## 実装上の判断
+
+無し（設計が 1 行 × 3 の機械的適用として確定しており、判断余地のある箇所はなかった）。
+テストは既存 `router_unauth_ratelimit_test.go` の `doRouterReq` / burst=1 注入パターンを
+踏襲し、3 ルートの table-driven 化と /health 429 との直接比較で形式同一性を担保した。
+
+## 追加した依存
+
+無し（go.mod / go.sum 変更なし。テストの `golang.org/x/time/rate` import は既存依存）。
+
+## 後続 Issue への引き継ぎ事項
+
+- **Issue #172 (contract tests)**: native auth 3 ルートの 429 契約（Retry-After + 共通 JSON）は
+  本 spec のテストでカバー済み。
+- **将来の閾値分離**: native auth に独立した閾値が必要になった場合は、config に値を追加して
+  別 `IPRateLimiter` インスタンスを配線するだけで本設計を変えずに分離できる
+  （design.md「制限値の設計判断」の拡張点記録どおり。本 spec では実装していない）。
+
+## 確認事項（PR 本文転載用）
+
+- 設計矛盾は無し。
+- 同一 IP が native auth へ大量リクエストすると、同じバケットを共有する `/auth/google/*`・
+  `/health` も 429 になる（逆も同様）。これは design.md「共用に伴う既知の性質」として
+  設計段階で確定済みの安全側挙動（既存 3 ルート間で既に成立している挙動と同種）。
+
+STATUS: complete

--- a/docs/specs/171-native-auth-ip-ratelimit/review-notes.md
+++ b/docs/specs/171-native-auth-ip-ratelimit/review-notes.md
@@ -1,0 +1,62 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-12T09:20:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-171-impl-native-auth-ip-ratelimit
+- HEAD commit: 38b03e47712b9e633dbbd638acf1b1741a7b08a2
+- Compared to: develop..HEAD
+- 変更ファイル（実装範囲）: `internal/handler/router.go` / `internal/handler/router_test.go`
+  （design.md File Structure Plan と完全一致）
+- 変更ファイル（spec / 進捗）: `docs/specs/171-native-auth-ip-ratelimit/impl-notes.md` /
+  `docs/specs/171-native-auth-ip-ratelimit/tasks.md`（task 1, 2 の `- [x]` 進捗 mark）
+
+## Verified Requirements
+
+- 1.1 — `TestNewRouter_NativeAuthIPRateLimit_429OnExcess` の `token` サブケース。
+  burst=1 注入で 1 回目 200 → 2 回目 429、`callCount` が 1 のままで service 到達なしを確認
+  （router.go で `r.With(unauthIPMW, MaxBodyBytes).Post("/api/auth/token", ...)` の最外側 unauthIPMW 適用）
+- 1.2 — 同テストの `refresh` サブケース。`rotateCalls` が 1 のままで 2 回目 429
+- 1.3 — 同テストの `revoke` サブケース。`revokeCalls` が 1 のままで 2 回目 429
+- 1.4 — 同テスト各サブケースの 1 回目応答（200/204 + service 到達 1 回）+
+  `_Degradations` の "UnauthIPRateLimiter nil で 5 連続通過" サブケース
+- 1.5 — `_429OnExcess` で `Retry-After` ヘッダー非空を検証 + `_SameShapeAsExistingRoutes` で
+  /health 429 の Retry-After と同形式を確認
+- 1.6 — `TestNewRouter_NativeAuthIPRateLimit_IndependentPerIP`。IP A 枯渇後に
+  IP B(`198.51.100.20`) からの要求が 200 で通過し、`callCount == 2`（IP 別バケット）
+- 2.1 — 既存未認証 3 ルート（`/health` / `/auth/google/login` / `/auth/google/callback`）の
+  ルート登録に diff ゼロ、既存 `router_unauth_ratelimit_test.go` 系も無変更 green
+  （`go test ./internal/handler/ ./internal/middleware/` 全 pass）
+- 2.2 — 認証必須グループ（Session → RateLimit(General) → Logging）に diff ゼロ。
+  middleware 種類・順序は無変更
+- 2.3 — `TestNewRouter_NativeAuthIPRateLimit_SameShapeAsExistingRoutes`。
+  /health 429 と /api/auth/token 429 を status / Content-Type / body / Retry-After で
+  直接比較し同一形式を確認
+- 2.4 — `_Degradations` の "NativeAuthHandler nil のとき 3 ルートは 404 のまま"
+  サブケース（limiter ありでも 3 ルートとも 404 = 本変更が no-op）
+- NFR 1.1 — 既存 `IPRateLimiter` の `slog.Warn("rate limit exceeded", limit_type=unauth_ip)`
+  をそのまま共用。テスト実行ログにも `WARN rate limit exceeded limit_type=unauth_ip` が
+  3 ルートで出力されることを確認
+- NFR 1.2 — 同上（#38 設計のまま、limit 種別のみで PII なし）
+- NFR 2.1 — config / app.go / `RouterDeps` に diff なし。env 未指定で既定 30 req/min/IP が
+  そのまま native auth 3 ルートにも適用される（既存 wiring に同乗）
+- NFR 2.2 — 既存ルートのチェーンに変更なし、native auth ルートへの route 単位 `With` 追加のみ
+  （design.md の文言と一致）
+- NFR 3.1 — 追加テスト 4 本すべて httptest + モック service（`alwaysSucceedExchangeService`）+
+  小 burst の `IPRateLimiter` 注入で in-process 完結（外部ネットワーク・DB 依存なし）
+
+## Findings
+
+なし（approve のため Findings は記載なし。確認した観点は「Verified Requirements」を参照）。
+
+## Summary
+
+design.md の Components and Interfaces（router 3 ルートへの `unauthIPMW` 追加）と File
+Structure Plan（router.go + router_test.go のみ変更）に厳密に従った最小実装。
+requirements.md の全 numeric ID（Req 1.1〜1.6, 2.1〜2.4, NFR 1.1, 1.2, 2.1, 2.2, 3.1）が
+追加テスト 4 本（`_429OnExcess` table-driven / `_IndependentPerIP` /
+`_SameShapeAsExistingRoutes` / `_Degradations`）と既存テスト無変更 green で担保されている。
+boundary 逸脱なし、`go test ./internal/handler/ ./internal/middleware/` 全 pass。
+
+RESULT: approve

--- a/docs/specs/171-native-auth-ip-ratelimit/tasks.md
+++ b/docs/specs/171-native-auth-ip-ratelimit/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. router: native auth 3 ルートへ unauthIPMW を適用しレート制限テストを追加
+- [x] 1. router: native auth 3 ルートへ unauthIPMW を適用しレート制限テストを追加
   - `internal/handler/router.go`: `NativeAuthHandler != nil` ガード内の
     `POST /api/auth/token` / `POST /api/auth/refresh` / `POST /api/auth/revoke` の
     route 単位チェーン最外（MaxBodyBytes より外側）に既存 `unauthIPMW` を追加する

--- a/docs/specs/171-native-auth-ip-ratelimit/tasks.md
+++ b/docs/specs/171-native-auth-ip-ratelimit/tasks.md
@@ -12,7 +12,7 @@
   - 拒否ログ（NFR 1.1, 1.2）は既存 `IPRateLimiter` の共用で充足（実装変更なし）
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 2.3, NFR 1.1, NFR 1.2, NFR 3.1_
 
-- [ ] 2. 縮退・後方互換の regression テスト
+- [x] 2. 縮退・後方互換の regression テスト
   - `internal/handler/router_test.go` に design.md Testing Strategy 6 を追加
     （`NativeAuthHandler` nil で 3 ルートが 404 のまま = 本変更 no-op /
     `UnauthIPRateLimiter` nil で 3 ルートが制限なしで到達する縮退規約）

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -212,13 +212,15 @@ func NewRouter(deps *RouterDeps) http.Handler {
 		// 登録しない（404 / fail-closed / NFR 2.2）。Session / Bearer middleware は通らない
 		// （Req 1.5 / #168 Req 2.4: revoke は token 所持自体を失効権限とみなす）。
 		// 巨大ボディ DoS 防止のためボディ上限ミドルウェア（DefaultMaxBodyBytes）を重ねる。
-		// IP レート制限（unauthIPMW）は Issue #171 の領分のため本 spec では適用しない。
+		// 未認証で公開される token 系入口のため、既存未認証 3 ルートと同じ IP 単位
+		// レート制限（unauthIPMW）を route チェーン最外に重ねる（Issue #171 / SERVER.md §1.7。
+		// 閾値超過時はボディ上限 wrap・JSON decode・永続化層参照に到達せず 429 で遮断）。
 		if deps.NativeAuthHandler != nil {
-			r.With(middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
+			r.With(unauthIPMW, middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
 				Post("/api/auth/token", deps.NativeAuthHandler.Token)
-			r.With(middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
+			r.With(unauthIPMW, middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
 				Post("/api/auth/refresh", deps.NativeAuthHandler.Refresh)
-			r.With(middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
+			r.With(unauthIPMW, middleware.NewMaxBodyBytesMiddleware(middleware.DefaultMaxBodyBytes)).
 				Post("/api/auth/revoke", deps.NativeAuthHandler.Revoke)
 		}
 	})

--- a/internal/handler/router_test.go
+++ b/internal/handler/router_test.go
@@ -739,3 +739,46 @@ func TestNewRouter_NativeAuthIPRateLimit_SameShapeAsExistingRoutes(t *testing.T)
 		t.Errorf("429 body = %q, want %q (既存未認証ルートと同一形式 / Req 2.3)", got, want)
 	}
 }
+
+// TestNewRouter_NativeAuthIPRateLimit_Degradations は縮退構成での後方互換を検証する
+// （Testing Strategy 6 / Req 2.4）。
+func TestNewRouter_NativeAuthIPRateLimit_Degradations(t *testing.T) {
+	t.Run("NativeAuthHandler nilのとき3ルートは404のまま（本変更はno-op）", func(t *testing.T) {
+		// Arrange: handler なし + limiter あり
+		deps := newMinimalDepsForNativeAuth(nil)
+		ipRL := middleware.NewIPRateLimiter(middleware.IPRateLimiterConfig{
+			Rate: rate.Limit(1), Burst: 1, CleanupInterval: 1 * time.Minute,
+		})
+		defer ipRL.Stop()
+		deps.UnauthIPRateLimiter = ipRL
+		router := NewRouter(deps)
+
+		// Act & Assert: 3 ルートとも 404（fail-closed のまま / Req 2.4）
+		for _, path := range []string{"/api/auth/token", "/api/auth/refresh", "/api/auth/revoke"} {
+			w := doNativeAuthPost(router, path, `{}`, "203.0.113.50:50000")
+			if w.Result().StatusCode != http.StatusNotFound {
+				t.Errorf("%s status = %d, want 404 (NativeAuthHandler nil / Req 2.4)", path, w.Result().StatusCode)
+			}
+		}
+	})
+
+	t.Run("UnauthIPRateLimiter nilのとき3ルートは制限なしで到達する", func(t *testing.T) {
+		// Arrange: handler あり + limiter なし（既存縮退規約: 素通し no-op）
+		svc := &alwaysSucceedExchangeService{}
+		deps := newMinimalDepsForNativeAuth(NewNativeAuthHandler(svc))
+		router := NewRouter(deps)
+		body := `{"auth_code":"a","code_verifier":"v"}`
+
+		// Act: 同一 IP から連続リクエスト
+		for i := 0; i < 5; i++ {
+			w := doNativeAuthPost(router, "/api/auth/token", body, "203.0.113.60:50000")
+			// Assert: すべて通過（制限なし）
+			if w.Result().StatusCode != http.StatusOK {
+				t.Fatalf("request %d status = %d, want 200 (limiter nil は素通し)", i+1, w.Result().StatusCode)
+			}
+		}
+		if svc.callCount != 5 {
+			t.Errorf("service calls = %d, want 5", svc.callCount)
+		}
+	})
+}

--- a/internal/handler/router_test.go
+++ b/internal/handler/router_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/time/rate"
 
 	"github.com/hitoshi/feedman/internal/auth"
 	"github.com/hitoshi/feedman/internal/middleware"
@@ -574,5 +575,167 @@ func TestNewRouter_BearerAuth_ExpiredTokenWithValidCookie_Returns401(t *testing.
 	if w.Result().StatusCode != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d (期限切れ Bearer は Cookie へ fallback しない / Req 2.2, 2.4)",
 			w.Result().StatusCode, http.StatusUnauthorized)
+	}
+}
+
+// --- native auth 3 ルートの IP 単位レート制限（Issue #171 / design.md Testing Strategy） ---
+
+// newNativeAuthRateLimitRouter は NativeAuthHandler + UnauthIPRateLimiter（指定 burst）を
+// 注入した router を構築する。burst=1 なら同一 IP の 2 回目で必ず 429 になる。
+func newNativeAuthRateLimitRouter(burst int) (http.Handler, *alwaysSucceedExchangeService, *middleware.IPRateLimiter) {
+	svc := &alwaysSucceedExchangeService{}
+	nh := NewNativeAuthHandler(svc)
+	deps := newMinimalDepsForNativeAuth(nh)
+	deps.UnauthIPRateLimiter = middleware.NewIPRateLimiter(middleware.IPRateLimiterConfig{
+		Rate:            rate.Limit(1),
+		Burst:           burst,
+		CleanupInterval: 1 * time.Minute,
+	})
+	return NewRouter(deps), svc, deps.UnauthIPRateLimiter
+}
+
+// nativeAuthRouteCases は 3 ルートの path / リクエストボディ / 通過時 status / service
+// 呼び出し回数の参照を共通化する table。
+type nativeAuthRouteCase struct {
+	name       string
+	path       string
+	body       string
+	wantStatus int
+	calls      func(svc *alwaysSucceedExchangeService) int
+}
+
+func nativeAuthRouteCases() []nativeAuthRouteCase {
+	return []nativeAuthRouteCase{
+		{
+			name:       "token",
+			path:       "/api/auth/token",
+			body:       `{"auth_code":"a","code_verifier":"v"}`,
+			wantStatus: http.StatusOK,
+			calls:      func(svc *alwaysSucceedExchangeService) int { return svc.callCount },
+		},
+		{
+			name:       "refresh",
+			path:       "/api/auth/refresh",
+			body:       `{"refresh_token":"x"}`,
+			wantStatus: http.StatusOK,
+			calls:      func(svc *alwaysSucceedExchangeService) int { return svc.rotateCalls },
+		},
+		{
+			name:       "revoke",
+			path:       "/api/auth/revoke",
+			body:       `{"refresh_token":"x"}`,
+			wantStatus: http.StatusNoContent,
+			calls:      func(svc *alwaysSucceedExchangeService) int { return svc.revokeCalls },
+		},
+	}
+}
+
+// doNativeAuthPost は指定 path へ JSON POST を送る（RemoteAddr 指定付き）。
+func doNativeAuthPost(router http.Handler, path, body, remoteAddr string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = remoteAddr
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// TestNewRouter_NativeAuthIPRateLimit_429OnExcess は同一 IP の閾値超過時に 3 ルートが
+// 429 + Retry-After で応答し、service（handler 以降）に到達しないことを検証する
+// （Testing Strategy 1〜3 / Req 1.1, 1.2, 1.3, 1.4, 1.5）。
+func TestNewRouter_NativeAuthIPRateLimit_429OnExcess(t *testing.T) {
+	for _, tc := range nativeAuthRouteCases() {
+		t.Run(tc.name+"で同一IP超過のとき429を返しserviceに到達しない", func(t *testing.T) {
+			// Arrange: burst=1（1 回目で枯渇）
+			router, svc, ipRL := newNativeAuthRateLimitRouter(1)
+			defer ipRL.Stop()
+
+			// Act 1: 1 回目は閾値以内なので通常応答（Req 1.4）
+			w1 := doNativeAuthPost(router, tc.path, tc.body, "203.0.113.10:50000")
+			if w1.Result().StatusCode != tc.wantStatus {
+				t.Fatalf("1st status = %d, want %d (閾値以内は通過 / Req 1.4)",
+					w1.Result().StatusCode, tc.wantStatus)
+			}
+			if got := tc.calls(svc); got != 1 {
+				t.Fatalf("1st service calls = %d, want 1", got)
+			}
+
+			// Act 2: 2 回目は超過 → 429
+			w2 := doNativeAuthPost(router, tc.path, tc.body, "203.0.113.10:50001")
+
+			// Assert: 429 + Retry-After、service 未到達（Req 1.1〜1.3, 1.5）
+			resp := w2.Result()
+			if resp.StatusCode != http.StatusTooManyRequests {
+				t.Fatalf("2nd status = %d, want %d (Req 1.1-1.3)", resp.StatusCode, http.StatusTooManyRequests)
+			}
+			if resp.Header.Get("Retry-After") == "" {
+				t.Error("Retry-After header is empty (Req 1.5)")
+			}
+			if got := tc.calls(svc); got != 1 {
+				t.Errorf("service calls after 429 = %d, want 1 (429 は handler 到達前に遮断)", got)
+			}
+		})
+	}
+}
+
+// TestNewRouter_NativeAuthIPRateLimit_IndependentPerIP は別 IP からの要求が超過 IP の
+// 影響を受けないことを検証する（Testing Strategy 4 / Req 1.6）。
+func TestNewRouter_NativeAuthIPRateLimit_IndependentPerIP(t *testing.T) {
+	// Arrange: burst=1 で IP A を枯渇させる
+	router, svc, ipRL := newNativeAuthRateLimitRouter(1)
+	defer ipRL.Stop()
+	body := `{"auth_code":"a","code_verifier":"v"}`
+
+	if w := doNativeAuthPost(router, "/api/auth/token", body, "203.0.113.10:50000"); w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("IP A 1st status = %d, want 200", w.Result().StatusCode)
+	}
+	if w := doNativeAuthPost(router, "/api/auth/token", body, "203.0.113.10:50001"); w.Result().StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("IP A 2nd status = %d, want 429", w.Result().StatusCode)
+	}
+
+	// Act: 別 IP B からの要求
+	w := doNativeAuthPost(router, "/api/auth/token", body, "198.51.100.20:50000")
+
+	// Assert: IP B は独立カウントのため通過する（Req 1.6）
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("IP B status = %d, want 200 (IP ごとに独立カウント / Req 1.6)", w.Result().StatusCode)
+	}
+	if svc.callCount != 2 {
+		t.Errorf("service calls = %d, want 2 (IP A 1回 + IP B 1回)", svc.callCount)
+	}
+}
+
+// TestNewRouter_NativeAuthIPRateLimit_SameShapeAsExistingRoutes は native auth ルートの
+// 429 応答（status / Retry-After / Content-Type / JSON ボディ）が既存未認証ルート
+// （/health）の 429 と同一形式であることを検証する（Testing Strategy 5 / Req 2.3）。
+func TestNewRouter_NativeAuthIPRateLimit_SameShapeAsExistingRoutes(t *testing.T) {
+	// Arrange: 基準となる /health の 429 応答を取得する
+	router, _, ipRL := newNativeAuthRateLimitRouter(1)
+	defer ipRL.Stop()
+	doRouterReq(router, http.MethodGet, "/health", "203.0.113.30:50000") // burst 消費
+	baseW := doRouterReq(router, http.MethodGet, "/health", "203.0.113.30:50001")
+	baseResp := baseW.Result()
+	if baseResp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("health 2nd status = %d, want 429", baseResp.StatusCode)
+	}
+
+	// Act: native auth ルートの 429 応答（別 IP で burst 消費 → 超過）
+	body := `{"auth_code":"a","code_verifier":"v"}`
+	doNativeAuthPost(router, "/api/auth/token", body, "203.0.113.40:50000")
+	w := doNativeAuthPost(router, "/api/auth/token", body, "203.0.113.40:50001")
+	resp := w.Result()
+
+	// Assert: status / Content-Type / ボディが /health の 429 と一致（Req 2.3）
+	if resp.StatusCode != baseResp.StatusCode {
+		t.Errorf("status = %d, want %d", resp.StatusCode, baseResp.StatusCode)
+	}
+	if got, want := resp.Header.Get("Content-Type"), baseResp.Header.Get("Content-Type"); got != want {
+		t.Errorf("Content-Type = %q, want %q", got, want)
+	}
+	if resp.Header.Get("Retry-After") == "" {
+		t.Error("Retry-After header is empty")
+	}
+	if got, want := w.Body.String(), baseW.Body.String(); got != want {
+		t.Errorf("429 body = %q, want %q (既存未認証ルートと同一形式 / Req 2.3)", got, want)
 	}
 }


### PR DESCRIPTION
## 概要

Issue #171（umbrella #163 の子 Issue）の実装 PR です。設計 PR #193 でマージ済みの
`docs/specs/171-native-auth-ip-ratelimit/`（requirements.md / design.md / tasks.md）に厳密に従い、
native auth 3 エンドポイント（`POST /api/auth/token` / `refresh` / `revoke`）へ #38 導入済みの
未認証 IP 単位レート制限を適用しました（SERVER.md §1.7）。

Closes #171

## 変更内容

- `internal/handler/router.go`: `NativeAuthHandler != nil` ガード内の 3 ルート登録に既存 `unauthIPMW` を追加（route チェーン最外 / MaxBodyBytes より外側）。**変更はこの 3 行のみ**
- `internal/handler/router_test.go`: テスト 4 本追加（超過 429 + Retry-After + service 未到達 × 3 ルート / IP 独立カウント / /health の 429 との形式同一性の直接比較 / 縮退 2 系統）
- `IPRateLimiter` 本体・config・app.go・`RouterDeps`・既存ルートはすべて不変

## 設計上のポイント

- 制限値は既存の env `RATE_LIMIT_UNAUTH_IP`（既定 30 req/min/IP）・単一インスタンスを共用（design.md「制限値の設計判断」どおり。新設定ノブなし / NFR 2.1）
- 閾値超過時はボディ上限 wrap・JSON decode・永続化層参照に到達せず、既存共通の 429（Retry-After + 固定 JSON）で遮断（Req 1.1〜1.3 / 2.3）
- 署名鍵未設定環境では 3 ルート未登録のため本変更は no-op（Req 2.4 / fail-closed 同乗）

## Reviewer 判定

独立 context の Reviewer サブエージェントによるレビュー済み: **approve**
（`docs/specs/171-native-auth-ip-ratelimit/review-notes.md` 参照。AC 未カバー / missing test / boundary 逸脱のいずれも findings なし）

## 検証

- `go build ./...` / `go vet ./...` / `go test ./...` 全 green
- `TEST_DATABASE_URL` を設定した実 PostgreSQL 16 でも `go test -p 1 ./...` 全 pass（CI と同条件で事前確認）
- `gofmt -l`（変更ファイルのみ）差分なし / 新規依存なし

## 確認事項（レビュワー判断ポイント）

- 同一 IP が native auth エンドポイントへ大量リクエストすると、同じバケットを共有する `/auth/google/*`・`/health` も 429 になります（逆も同様）。これは design.md「共用に伴う既知の性質」として設計段階で確定済みの安全側挙動です（既存 3 ルート間で既に成立している挙動と同種）

🤖 Generated with [Claude Code](https://claude.com/claude-code)