### PR TITLE
spec(#172): native auth API の contract / integration tests の要件定義・設計・タスク分割

### DIFF
--- a/docs/specs/172-native-auth-contract-tests/design.md
+++ b/docs/specs/172-native-auth-contract-tests/design.md
@@ -1,0 +1,517 @@
+# Design Document
+
+## Overview
+
+**Purpose**: 本機能は native token 認証（親 Issue #163 / サブ Issue #164〜#171）の
+**end-to-end な契約整合**を機械的に保証するための **横断契約 / 統合テストレイヤー**と、
+iOS 仕様 `feedman-ios/design/SERVER.md` §1 との同期確認文書を整備する。これにより、
+複数 Issue にまたがる挙動・JSON 形状・エラー契約・SERVER.md §1 との差分が、後続変更で
+気付かないうちに iOS クライアント仕様からずれる事故を防ぐ。
+
+**Users**: Feedman 運用者・サーバー開発者・iOS 実装者。`go test ./...`（CI ジョブ
+`backend` 一式）に新規テストが組み込まれ、PR ごとに自動で実行される。SERVER.md §1 と
+実装のずれは review 時に `contract-notes.md` を参照することで一目で確認できる。
+
+**Impact**: 既存実装（#164〜#171）の動作は変更しない（テスト追加のみ）。既存テスト
+（`internal/handler/integration_test.go` の handler 統合群、`internal/handler/router_test.go`
+の Bearer / IP rate limit 群、`internal/auth/*_test.go` の unit 群、`internal/repository/*_db_test.go`
+の DB 結合群）の挙動も変えない。新規テスト群は CI の `backend` ジョブで起動された
+PostgreSQL 16 service container（既存 `TEST_DATABASE_URL`）に相乗りし、追加インフラを
+要求しない。
+
+### Goals
+
+- ネイティブ OAuth callback → `auth_code` 発行 → `POST /api/auth/token` 交換 →
+  `POST /api/auth/refresh` rotation → `POST /api/auth/revoke` → Bearer 付き既存 API への
+  到達、の **end-to-end 動線**を 1 つの実物経路（real `auth.TokenService` + real `JWTIssuer` +
+  real `JWTVerifier` + real `PostgresAuthCodeRepo` + real `PostgresRefreshTokenRepo`）で通す
+  契約テストを 1 件追加する（Req 1.1〜1.6 を 1 経路で同時カバー）
+- token 系 JSON 応答契約（フィールド名・型・status・revoke の 204 / ボディなし・native
+  callback の Location URL）を **未知フィールド混入なし**まで固定する契約テストを追加する
+  （Req 2.1〜2.6）
+- 拒否パス契約（auth_code・refresh token・Bearer token の 4 区分すべての拒否理由を
+  応答から区別できない uniform 拒否）を契約テストとして固定する（Req 3.1〜3.6）
+- 既存 web Cookie セッション認証フローへの後方互換（NFR 2.1 / 2.2）を契約テストとして
+  明示する（既存テストで担保されている部分は重複追加しない）
+- SERVER.md §1（§1.3 / §1.4 / §1.5 / §1.8）と実装 #164〜#171 の対照表を
+  `contract-notes.md` として記録し、承認済み逸脱（revoke 未認証化 / DB スキーマ差分）を
+  明文化する（Req 4.1〜4.5）
+
+### Non-Goals
+
+- 新規エンドポイントの追加実装 / 既存実装の挙動変更（テスト・文書のみ）
+- 実 Google OAuth プロバイダー / 実 FCM への接続を伴う E2E テスト（NFR 1.1）
+- 各 spec（#165〜#171）固有の unit / 内部実装詳細の再検証（NFR 3.1）
+- 鍵ローテーション（複数 kid 並行受理）の契約検証（要件 Out of Scope に従う）
+- 既存 web Cookie セッション認証フローの新規契約検証（後方互換維持の確認のみ / 要件
+  Out of Scope に従う）
+- 既存 `integration_test.go` の通しテスト群（callback→exchange / rotation / family revoke /
+  revoke 冪等）の置き換え。既存テストは「stateful mock を service 層に注入した handler
+  通し」として保持し、本 spec は **stateful mock 経路で漏れている契約観点**（JSON 厳密
+  shape / Bearer→API 到達 / Bearer 拒否 4 区分）を追加するか、**実物 service 経路**で 1
+  経路通す形で補完する
+
+## Architecture
+
+### Existing Architecture Analysis
+
+本 spec が動作する範囲は既存 architecture の **延長線上**であり、新たなアーキテクチャ
+パターンを導入しない。尊重すべき既存境界:
+
+- **handler 層**（`internal/handler/`）: HTTP I/O + chi router 構成。既存 test pattern は
+  `httptest.NewRecorder()` + `RouterDeps` 経由の `NewRouter` 起動。`integration_test.go` は
+  `createIntegrationRouter` / `createNativeAuthIntegrationRouter` 2 種のヘルパーで「stateful
+  mock を service 層に注入した router」を組み立てる。本 spec の handler/integration 層追加
+  テストはこの pattern に従う
+- **service 層**（`internal/auth/`）: `auth.TokenService` / `auth.Service` / `auth.JWTIssuer`
+  / `auth.JWTVerifier` がドメインロジック。最小 IF（`AuthCodeConsumer` / `RefreshTokenStore`
+  / `AccessTokenIssuer`）を経由した interface segregation 設計のため、real service 経路で
+  unit 純粋ロジックを再検証する必要はない（unit は既存 `*_test.go` で完結）
+- **repository 層**（`internal/repository/`）: `PostgresAuthCodeRepo` / `PostgresRefreshTokenRepo`
+  が DB 結合テスト（`*_db_test.go`）で個別に検証済み。`TEST_DATABASE_URL` env で接続先を
+  切替可能。未到達時 `t.Skipf` で silent skip する慣行
+- **middleware 層**（`internal/middleware/`）: `BearerOrSessionMiddleware` が Bearer 認証を
+  実装。Bearer → context user ID 注入 → 既存 API hander 透過動作の round-trip は
+  `router_test.go` の `TestNewRouter_BearerAuth_IssuerVerifierRoundTrip` で確認済み
+
+維持すべき統合点:
+
+- `RouterDeps.NativeAuthHandler == nil` 縮退（fail-closed 404）と `JWTVerifier == nil`
+  縮退（Cookie-only fallback）は既存テストで担保済み。本 spec で重複追加しない
+- 既存 IP rate limit / max body bytes / CORS / security headers の各 middleware 構成は
+  本 spec の追加テストでは触らない（NFR 2.1 / 2.2）
+
+解消・回避する technical debt: なし（テスト追加のみ）。
+
+### Architecture Pattern & Boundary Map
+
+**Architecture Integration**:
+- 採用パターン: 既存の **Hexagonal/clean architecture**（handler→service→repo）をそのまま
+  踏襲。新規 layer は追加しない
+- ドメイン／機能境界: 既存通り。本 spec が触る境界は (a) `handler` パッケージのテスト
+  ファイル、(b) `internal/handler/contract` 等のサブパッケージは作らず `internal/handler` に
+  追加（既存テスト helper を再利用するため）、(c) `docs/specs/172-...` に notes 文書
+- 既存パターンの維持: stateful mock 経路（`createNativeAuthIntegrationRouter` /
+  `mockNativeTokenExchangeService`）はそのまま使用し、契約観点の追加を「同 router の
+  別 test case」として実装する。実物 service 経路の DB-backed test は
+  **新規ファイル**（`internal/handler/native_auth_e2e_db_test.go`）に分離し、DB 不在時の
+  `t.Skipf` パターンを repository 層と同型で実装する
+- 新規コンポーネントの根拠: なし（test 追加のみ）。新規 production code は導入しない
+
+```mermaid
+flowchart TB
+    subgraph "test layer"
+      A[Contract Tests<br/>integration_test.go 追加分]
+      B[E2E DB-backed Test<br/>native_auth_e2e_db_test.go 新規]
+      C[SERVER.md ↔ 実装<br/>contract-notes.md 新規]
+    end
+
+    subgraph "production code（変更なし）"
+      D[handler / router.go]
+      E[auth.TokenService<br/>JWTIssuer / JWTVerifier]
+      F[repository / Postgres*Repo]
+      G[middleware / BearerOrSession]
+    end
+
+    A -->|stateful mock 経路| D
+    A -->|real Issuer + Verifier| G
+    B -->|real service 経路<br/>DB 接続可能時のみ| D
+    B --> E
+    B --> F
+    B --> G
+    C -.参照.-> E
+    C -.参照.-> F
+```
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Test runtime | Go 1.25 標準 `testing` パッケージ | 全契約テスト実行 | CI: `go test -p 1 ./...`（既存設定） |
+| HTTP test | `net/http/httptest` | `NewRecorder` / `NewRequest` で router を駆動 | 外部ネットワーク不要 / NFR 1.1 |
+| JSON 比較 | 標準 `encoding/json` + map 比較 | 厳密フィールド集合の検証 | `json.Decoder.DisallowUnknownFields()` も併用可 |
+| JWT 直接組立 | `github.com/golang-jwt/jwt/v5` | 拒否用 token（expired / wrong token_use / wrong signature）の生成 | 既存 `router_test.go` の expired token 生成と同手法 |
+| DB | PostgreSQL 16（CI service container） | E2E DB-backed test 用 | `TEST_DATABASE_URL`、`t.Skipf` で未到達時 skip |
+| マイグレーション | `internal/database.RunMigrations` | DB 初期化（既存 helper を再利用） | repo DB test と同型のセットアップ |
+| SERVER.md 参照 | `/home/hitoshi/github/feedman-ios/design/SERVER.md` | 契約同期確認 | 本 repo 外の文書。同期は contract-notes.md で実施 |
+
+## File Structure Plan
+
+### Directory Structure
+
+```
+docs/specs/172-native-auth-contract-tests/
+├── requirements.md           # 既存（PM 確定済み）
+├── design.md                 # 本ファイル
+├── tasks.md                  # 後述
+└── contract-notes.md         # 新規: SERVER.md §1 ↔ 実装の対照表 + 承認済み逸脱
+
+internal/handler/
+├── integration_test.go       # 既存 — 末尾に契約観点テストを追加（後述）
+├── native_auth_e2e_db_test.go  # 新規: real service + real repo + real JWT round-trip
+└── router_test.go            # 既存 — 触らない（Bearer / IP rate limit は既存テストで担保）
+```
+
+### Modified Files
+
+- `internal/handler/integration_test.go` — **末尾に追加**:
+  - `TestContract_TokenResponse_ExactJSONShape`（Req 2.1, 2.3, 2.4 / NFR 1.3）
+  - `TestContract_RefreshResponse_ExactJSONShape`（Req 2.2, 2.3, 2.4）
+  - `TestContract_RevokeResponse_204AndEmptyBody`（Req 2.5）
+  - `TestContract_NativeCallbackLocation_AppSchemeAndAuthCode`（Req 2.6）
+  - `TestContract_BearerAccessToken_ReachesProtectedAPI_SameUserAsCookie`（Req 1.5 / NFR 2.1）
+  - `TestContract_BearerToken_RejectionUniformity_AllRejectionShapes`（Req 3.5, 3.6 /
+    署名不正・期限切れ・token_use 不一致・形式不正 を table-driven で uniform 検証）
+  - 既存の `createNativeAuthIntegrationRouter` / `runNativeLoginCallbackAndExchange` を
+    そのまま再利用し、新規ヘルパーは原則作らない（追加するのは Bearer round-trip 用の
+    最小 wiring helper だけ）
+- `internal/handler/native_auth_e2e_db_test.go` — **新規ファイル**:
+  - `TestE2E_NativeAuthFullFlow_DBBacked`（Req 1.1〜1.6 を 1 経路で同時カバー）
+    - `t.Skipf` パターンで DB 未到達時に skip
+    - real `auth.TokenService`（real `PostgresAuthCodeRepo` + real `PostgresRefreshTokenRepo`
+      + real `JWTIssuer`）と real `JWTVerifier` を wire し、`createNativeAuthIntegrationRouter`
+      では到達できない「token 交換が real DB に永続化される」「real refresh token rotation
+      が real DB 上で起こる」「real JWT が real verifier で受理される」までを 1 通し検証
+    - 固定鍵（`[]byte("e2e-contract-test-secret-32bytes!")`）と固定 `now` 注入で決定論を
+      確保（NFR 1.2 / 1.3）
+- `docs/specs/172-native-auth-contract-tests/contract-notes.md` — **新規ファイル**:
+  - SERVER.md §1.3（`POST /api/auth/token` / `/refresh` / `/revoke` の req/res JSON 契約）↔
+    実装の対照表
+  - SERVER.md §1.4（token 寿命・形式）↔ 実装の対照表
+  - SERVER.md §1.5（DB スキーマ）↔ 実装スキーマの対照表
+  - SERVER.md §1.8（受け入れ基準）↔ 検証テスト ID の対照表
+  - 承認済み逸脱: §1.3 `revoke` を「Bearer 認証下」と記述 vs 実装 #168 で「未認証 +
+    token 所持 = 権限」を採用（Req 4.3）
+  - 承認済み逸脱: §1.5 `auth_codes` の単一テーブル例 vs 実装 #164 で
+    `refresh_token_families` / `refresh_tokens` 2 テーブル分離（Req 4.4）
+  - 未承認差分発見時のエスカレーション方針: Issue コメントで人間判断を仰ぐ（Req 4.5）
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Test Cases |
+|-------------|---------|------------|------------|------------|
+| 1.1 | callback で `auth_code` 発行 + アプリスキーム redirect | NativeAuthCallback / NativeAuthHandler / TokenService | `GET /auth/google/callback?...&flow=native` | `TestE2E_NativeAuthFullFlow_DBBacked` step1〜2 |
+| 1.2 | `POST /api/auth/token` で PKCE 検証 + 本トークン交換 | NativeAuthHandler.Token / auth.TokenService.ExchangeAuthCode | `POST /api/auth/token` | `TestE2E_NativeAuthFullFlow_DBBacked` step3 / 既存 `TestIntegration_NativeAuthFlow_CallbackThenExchangeSucceeds` |
+| 1.3 | `POST /api/auth/refresh` rotation 付き再発行 | NativeAuthHandler.Refresh / auth.TokenService.RotateRefreshToken | `POST /api/auth/refresh` | `TestE2E_NativeAuthFullFlow_DBBacked` step4 / 既存 `TestIntegration_RefreshFlow_*` |
+| 1.4 | `POST /api/auth/revoke` で refresh token 失効 | NativeAuthHandler.Revoke / auth.TokenService.RevokeRefreshToken | `POST /api/auth/revoke` | `TestE2E_NativeAuthFullFlow_DBBacked` step5 / 既存 `TestIntegration_RevokeFlow_*` |
+| 1.5 | Bearer 提示で既存 API が Cookie と同一ユーザーで応答 | BearerOrSessionMiddleware / JWTVerifier | `Authorization: Bearer <jwt>` → `/api/subscriptions` 等 | `TestContract_BearerAccessToken_ReachesProtectedAPI_SameUserAsCookie` / `TestE2E_NativeAuthFullFlow_DBBacked` step6 |
+| 1.6 | 全動線が外部ネットワーク・実 Google OAuth・実 FCM 不要 | — | — | 全テストが `httptest` のみ。DB は `TEST_DATABASE_URL` のみ |
+| 2.1 | `POST /api/auth/token` 成功応答が 4 フィールド | NativeAuthHandler.Token / tokenResponse | response body | `TestContract_TokenResponse_ExactJSONShape` |
+| 2.2 | `POST /api/auth/refresh` 成功応答が 4 フィールド | NativeAuthHandler.Refresh / tokenResponse | response body | `TestContract_RefreshResponse_ExactJSONShape` |
+| 2.3 | `token_type` フィールド値が `Bearer` | NativeAuthHandler / tokenResponse | response body | 上 2 件で同時アサート |
+| 2.4 | `expires_in` フィールド値が 900 | NativeAuthHandler / tokenResponse | response body | 上 2 件で同時アサート |
+| 2.5 | `POST /api/auth/revoke` 成功応答が 204 + ボディなし | NativeAuthHandler.Revoke | response status / body length | `TestContract_RevokeResponse_204AndEmptyBody` |
+| 2.6 | callback の Location が `feedman://auth/callback?auth_code=<...>` | AuthHandler.handleNativeCallback | `Location` ヘッダ | `TestContract_NativeCallbackLocation_AppSchemeAndAuthCode` |
+| 3.1 | 不正 / 期限切れ / 使用済み `auth_code` を拒否 | NativeAuthHandler.Token / TokenService | response status / code | `TestE2E_NativeAuthFullFlow_DBBacked` (unknown / consumed / expired サブケース) |
+| 3.2 | PKCE verifier 不一致を拒否 | NativeAuthHandler.Token / TokenService | response status / code | `TestE2E_NativeAuthFullFlow_DBBacked` (wrong verifier サブケース) |
+| 3.3 | 不明 / 期限切れ / 失効 / rotation 済み refresh token を拒否 | NativeAuthHandler.Refresh / TokenService | response status / code | `TestE2E_NativeAuthFullFlow_DBBacked` (unknown / rotated サブケース) |
+| 3.4 | rotation 済み refresh token 再提示で family 全滅 | TokenService.RotateRefreshToken | response status / code | 既存 `TestIntegration_ReuseDetection_FamilyRevoked` + `TestE2E_NativeAuthFullFlow_DBBacked` (rotated → family-wide reject) |
+| 3.5 | Bearer の署名不正 / 期限切れ / 用途不一致 / 形式不正を拒否 | BearerOrSessionMiddleware / JWTVerifier | `/api/subscriptions` 401 | `TestContract_BearerToken_RejectionUniformity_AllRejectionShapes` |
+| 3.6 | 拒否応答が原因の別を区別できない | NativeAuthHandler / BearerOrSessionMiddleware | response body | 上記 3.1〜3.5 各テストで同時アサート |
+| 4.1 | SERVER.md §1 と実装の整合を記録 | `contract-notes.md` | — | `contract-notes.md` 内容のレビューで確認 |
+| 4.2 | 差分を「承認済み逸脱」として明示 | `contract-notes.md` | — | 同上 |
+| 4.3 | revoke 未認証化を承認済み逸脱として明文化 | `contract-notes.md` | — | 同上 |
+| 4.4 | DB スキーマ差分（テーブル分離）を承認済み逸脱として明文化 | `contract-notes.md` | — | 同上 |
+| 4.5 | 未承認差分発見時のエスカレーション方針記録 | `contract-notes.md` | — | 同上 |
+| NFR 1.1 | 外部依存なしで完了 | 全テスト | — | `httptest` + 内蔵 `TEST_DATABASE_URL` PostgreSQL のみ |
+| NFR 1.2 | 時刻依存を固定時刻注入で決定論的に再現 | JWTIssuer / JWTVerifier / TokenService の `now` field | — | E2E DB test で `time.Time` 固定値を注入 |
+| NFR 1.3 | 署名鍵を固定値として注入 | JWTIssuer / JWTVerifier の secret | — | E2E DB test で固定 `[]byte` を注入 |
+| NFR 2.1 | 既存 web Cookie セッション動線が変化しない | — | — | 既存 `TestIntegration_AuthFlow_LoginCallbackMeLogout` 等が引き続き green であることで担保 |
+| NFR 2.2 | 既存テスト結果が同一に保たれる | — | — | 本 spec は既存テストを変更しない（追加のみ） |
+| NFR 3.1 | 各 spec 固有の内部詳細を再検証しない | — | — | 本 design.md で「unit 範囲は既存 `*_test.go` に委譲」を明示 |
+
+## Components and Interfaces
+
+### Test Layer
+
+#### Contract Test Suite (`internal/handler/integration_test.go` 追加分)
+
+| Field | Detail |
+|-------|--------|
+| Intent | stateful mock 経路で漏れている契約観点（JSON 厳密 shape / Bearer→API 到達 / Bearer 拒否 4 区分 / native callback Location）を追加する |
+| Requirements | 1.5, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 3.5, 3.6, NFR 2.1 |
+
+**Responsibilities & Constraints**
+- 既存 `createNativeAuthIntegrationRouter` / `createIntegrationRouter` / `runNativeLoginCallbackAndExchange`
+  ヘルパーを再利用し、独自 router を新規構築しない
+- JSON 応答の **厳密フィールド集合**（追加・欠落なし）を `map[string]any` で検証する
+  （余剰キーが入っていないことも検証する。`len(body) == 4` 等の総数アサートを併用）
+- Bearer round-trip では既存 `router_test.go` の `TestNewRouter_BearerAuth_IssuerVerifierRoundTrip`
+  と同様に real `auth.JWTIssuer` + real `auth.JWTVerifier` を組み合わせる
+- 拒否 token の生成は既存 `TestNewRouter_BearerAuth_ExpiredTokenWithValidCookie_Returns401`
+  と同手法（`jwt.NewWithClaims` + 直接 sign）で行う
+- 全テストは外部ネットワーク不要 / DB 不要（NFR 1.1）
+
+**Dependencies**
+- Inbound: `go test ./internal/handler` （Critical）
+- Outbound: 既存 `createNativeAuthIntegrationRouter` / `RouterDeps` / `auth.JWTIssuer` /
+  `auth.JWTVerifier` / `middleware.JWTVerifier` interface（All Critical）
+- External: なし
+
+**Contracts**: API [x] / Service [ ] / Event [ ] / Batch [ ] / State [ ]
+
+##### API Contracts under test
+
+| Test | Method | Endpoint | Assertion |
+|------|--------|----------|-----------|
+| TokenResponse JSON shape | POST | /api/auth/token | 200 / body = {access_token, refresh_token, token_type:"Bearer", expires_in:900} + 余剰キー無 |
+| RefreshResponse JSON shape | POST | /api/auth/refresh | 200 / body = {access_token, refresh_token, token_type:"Bearer", expires_in:900} + 余剰キー無 |
+| RevokeResponse | POST | /api/auth/revoke | 204 / body 長 0 |
+| Native Callback Location | GET | /auth/google/callback?flow=native | 303 / Location = `feedman://auth/callback?auth_code=<one-time-code>` |
+| Bearer→Protected API | GET | /api/subscriptions | 200 / userID が JWT sub と一致 |
+| Bearer 拒否 uniform | GET | /api/subscriptions | 401 / body 形式・status が 4 区分すべて同一 |
+
+#### E2E DB-backed Test (`internal/handler/native_auth_e2e_db_test.go` 新規)
+
+| Field | Detail |
+|-------|--------|
+| Intent | callback→exchange→refresh→revoke→Bearer-API の動線を **実物 service + 実物 repository + 実物 JWT** で 1 経路通すゴールデンパス |
+| Requirements | 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 3.1, 3.2, 3.3, 3.4, NFR 1.1, NFR 1.2, NFR 1.3 |
+
+**Responsibilities & Constraints**
+- `TEST_DATABASE_URL` で接続可能な PostgreSQL に接続し、未到達時は `t.Skipf` で silent skip
+  （`internal/repository/postgres_refresh_token_repo_db_test.go` と同手法）
+- `internal/database.RunMigrations` で schema を up し、`auth_codes` / `refresh_token_families`
+  / `refresh_tokens` / `users` テーブルを初期化
+- real `PostgresAuthCodeRepo` + real `PostgresRefreshTokenRepo` + real `auth.JWTIssuer`
+  + real `auth.JWTVerifier` を組み合わせて `auth.TokenService` を構築
+- `auth.Service` も real で組み立てるが、`OAuthProvider` だけは外部ネットワークを避けるため
+  **fake provider**（`ExchangeCode` が固定 `OAuthUserInfo` を返す軽量実装）を注入する
+  （内部に既に test 用 fake 雛形が存在しないため、本ファイル内で 30 行未満の最小実装を置く）
+- `auth.JWTIssuer` / `auth.JWTVerifier` / `auth.TokenService` の `now` field を **package-private
+  override**（既存 unit test と同じ仕組み）で固定 `time.Time` に差し替え、refresh の expires_at
+  境界と access token の exp 境界を決定論で検証する（NFR 1.2）
+- 署名鍵を固定 `[]byte("e2e-contract-test-secret-32bytes!")` で注入（NFR 1.3）
+- DB テスト並列化は避ける（既存 CI `-p 1` と同じ前提で動く）
+- 拒否サブケースは同テスト内で逐次実行する（unknown auth_code / consumed auth_code /
+  wrong verifier / unknown refresh token / replay rotated refresh token → family 全滅）
+
+**Dependencies**
+- Inbound: `go test ./internal/handler` （DB 到達時のみ）
+- Outbound: `auth.TokenService` / `auth.Service` / `JWTIssuer` / `JWTVerifier` /
+  `PostgresAuthCodeRepo` / `PostgresRefreshTokenRepo` / `database.RunMigrations`
+  / `BearerOrSessionMiddleware` （All Critical）
+- External: PostgreSQL（DB 到達時のみ。未到達時 skip）
+
+**Contracts**: API [x] / Service [x] / State [x]
+
+##### Test fixture wiring
+
+```text
+db := setupNativeAuthE2EDB(t)           // 既存 setupRefreshTokenTestDB と同型
+authCodeRepo := repository.NewPostgresAuthCodeRepo(db)
+refreshTokenRepo := repository.NewPostgresRefreshTokenRepo(db)
+secret := []byte("e2e-contract-test-secret-32bytes!")
+issuer := auth.NewJWTIssuer(secret, "v1-e2e")
+verifier := auth.NewJWTVerifier(secret)
+tokenService := auth.NewTokenService(authCodeRepo, refreshTokenRepo, issuer)
+
+oauthFake := &fakeOAuthProviderForE2E{ /* 固定 userInfo を返す */ }
+authService := auth.NewService(oauthFake, userRepo, identityRepo, sessionRepo, authCodeRepo,
+    auth.ServiceConfig{SessionMaxAge: 86400})
+
+deps := &handler.RouterDeps{
+    AuthService:       authService,
+    AuthConfig:        handler.AuthHandlerConfig{BaseURL: "http://localhost:3000"},
+    NativeAuthHandler: handler.NewNativeAuthHandler(tokenService),
+    JWTVerifier:       verifier,
+    SessionFinder:     &mockSessionFinderForRouter{ ... },
+    SubscriptionService: /* 既存 mock を最小 wiring */,
+    ...
+}
+router := handler.NewRouter(deps)
+```
+
+##### State transitions checked
+
+| Step | State change | Assertion |
+|------|--------------|-----------|
+| 1. native login | oauth_state / oauth_native_challenge cookies issued | 307 redirect + 2 Set-Cookie |
+| 2. callback | auth_codes row inserted; no session_id cookie | 303 redirect to `feedman://auth/callback?auth_code=...` |
+| 3. token exchange | auth_codes.used = true; refresh_token_families / refresh_tokens rows created | 200 / 4 JSON fields / DB row counts |
+| 4. refresh | new refresh_tokens row in same family; old token marked rotated | 200 / new pair distinct from old / family_id 同一 |
+| 5. revoke | family revoked_at set; subsequent refresh denied | 204 + 401 on retry |
+| 6. Bearer → /api/subscriptions | JWTVerifier accepts token; context user_id matches sub | 200 / response derived from sub user |
+
+#### Contract Notes Document (`docs/specs/172-native-auth-contract-tests/contract-notes.md` 新規)
+
+| Field | Detail |
+|-------|--------|
+| Intent | SERVER.md §1 と実装 #164〜#171 の整合を人間 reviewer が一目で確認できる形で固定する |
+| Requirements | 4.1, 4.2, 4.3, 4.4, 4.5 |
+
+**Responsibilities & Constraints**
+- 既存実装と SERVER.md §1.3 / §1.4 / §1.5 / §1.8 を section ごとに対照表化する
+- 「承認済み逸脱」として最低 2 件（revoke 未認証化 / DB スキーマ差分）を明文化する
+- 整合確認の過程で未承認差分を見つけた場合は **本 spec で確定させず**、Issue コメントで
+  人間判断を仰ぐ旨を末尾に記録する（Req 4.5）
+- 日本語ベース（CLAUDE.md 言語方針）
+
+**Dependencies**
+- Inbound: review process（人間 reviewer / Architect / Developer 全員）
+- Outbound: SERVER.md §1（feedman-ios リポジトリ） / 実装ファイル（`internal/handler/native_auth_handler.go`
+  / `internal/auth/token_service.go` / migrations）
+
+**Contracts**: 文書のみ。コードからの import なし
+
+##### Structure
+
+```markdown
+# Contract Notes: native auth API ↔ SERVER.md §1
+
+## §1.3 Endpoint contracts
+
+### POST /api/auth/token
+| 項目 | SERVER.md §1.3 | 実装 | 整合 |
+| Request | {auth_code, code_verifier} | tokenRequest (snake_case) | ✓ |
+| Response | {access_token, refresh_token, token_type:"Bearer", expires_in:900} | tokenResponse | ✓ |
+| Error | 400 INVALID_GRANT | invalidGrantError() | ✓ |
+
+### POST /api/auth/refresh
+（同型の対照表）
+
+### POST /api/auth/revoke
+（同型の対照表 + 承認済み逸脱 4.3）
+
+## §1.4 Token design
+（access JWT 15 分 / refresh opaque 30 日 / 承認済み逸脱なし）
+
+## §1.5 DB schema
+（テーブル分離の承認済み逸脱 4.4）
+
+## §1.8 受け入れ基準 ↔ テスト ID
+| 受け入れ基準 | 対応テスト |
+| 既存 Web (Cookie) 変更なし | TestIntegration_AuthFlow_LoginCallbackMeLogout 等 |
+| flow=native が auth_code を返す | TestContract_NativeCallbackLocation_... + TestE2E_... |
+| POST /api/auth/token が PKCE 検証 | TestE2E_NativeAuthFullFlow_DBBacked step3 |
+| POST /api/auth/refresh rotation + family 失効 | 既存 TestIntegration_ReuseDetection_FamilyRevoked + TestE2E_... |
+| Bearer 付き既存 API が Cookie と同結果 | TestContract_BearerAccessToken_ReachesProtectedAPI_... + TestE2E_... step6 |
+| 退会で refresh_tokens / auth_codes 削除 | 既存 TestPostgresWithdrawIntegration_DB (#170) |
+
+## 承認済み逸脱
+- 4.3 revoke 未認証化（#168 で採用 / RFC 7009 §2.1 public client 慣行）
+- 4.4 DB スキーマ分離（#164 で `refresh_token_families` 追加）
+
+## 未承認差分エスカレーション方針
+（Req 4.5）
+```
+
+## Data Models
+
+本 spec はテスト追加のみで、ドメインモデルや DB スキーマには一切変更を加えない。
+SERVER.md §1 と実装 #164〜#171 の **対照**のみを `contract-notes.md` で固定する。
+
+参照する既存モデル:
+- `model.AuthCode` / `model.RefreshTokenFamily` / `model.RefreshToken`（#164 で導入）
+- `model.User` / `model.Session`（既存）
+
+E2E DB-backed test 中の **fixture seed**:
+- `users` 1 行（fake OAuth provider が返す sub と紐付ける）
+- 他の `feeds` / `subscriptions` 等は最小限（Bearer→`/api/subscriptions` 通り抜けの確認に
+  必要な範囲のみ。fake `SubscriptionService` を注入する方法も検討するが、real wiring を
+  選択する場合は `users` 1 行に紐づく empty subscription 一覧で十分）
+
+## Error Handling
+
+### Error Strategy
+
+本 spec のテストは production code のエラー戦略を検証する側であり、独自のエラーハンドリングを
+持たない。検証対象のエラー応答は既存実装の固定 APIError（`invalidRequestError` /
+`invalidGrantError` / `invalidRefreshTokenError`）と既存 BearerOrSessionMiddleware の
+plain text 401 で、それぞれの応答 shape が **uniform**（拒否理由を区別できない）ことを
+契約として固定する。
+
+### Error Categories and Responses
+
+| 拒否カテゴリ | 期待される応答 | 検証テスト |
+|---|---|---|
+| auth_code 不明 / 期限切れ / 使用済み / verifier 不一致 | 400 / `code:INVALID_GRANT` / category:auth / message が原因を区別しない | `TestE2E_NativeAuthFullFlow_DBBacked` 拒否サブケース |
+| refresh token 不明 / 期限切れ / 失効 / rotation 済み | 401 / `code:INVALID_REFRESH_TOKEN` / 同上 | `TestE2E_NativeAuthFullFlow_DBBacked` 拒否サブケース + 既存 `TestIntegration_RefreshFlow_*` |
+| Bearer 署名不正 / 期限切れ / token_use 不一致 / 形式不正 | 401 / plain text `unauthorized` / body 完全同一 | `TestContract_BearerToken_RejectionUniformity_AllRejectionShapes`（4 サブケースを table-driven） |
+| revoke 不明 token | 204 / body なし（成功と同一） | `TestE2E_NativeAuthFullFlow_DBBacked` revoke unknown サブケース + 既存 `TestIntegration_RevokeFlow_*` |
+
+各拒否テストでは応答 body の `message` フィールドに **原因区別語**（"used" / "expired" /
+"rotated" / "revoked" / "signature" 等）が含まれていないことを `strings.Contains` 否定で
+アサートする（Req 3.6 / 既存テストと同方針）。
+
+## Testing Strategy
+
+### Unit Tests
+
+本 spec は unit テストを追加しない。各 spec（#165〜#171）の unit 範囲は対応する
+`*_test.go` で完結している（NFR 3.1）。
+
+### Integration / Contract Tests（`internal/handler/integration_test.go` 追加分）
+
+外部ネットワーク・DB 不要。`go test ./internal/handler` で実行される。
+
+1. `TestContract_TokenResponse_ExactJSONShape` — `POST /api/auth/token` 200 応答の
+   フィールド集合 {access_token, refresh_token, token_type:"Bearer", expires_in:900} を
+   厳密に固定（余剰キー混入を `len(body) == 4` で除去）（Req 2.1, 2.3, 2.4）
+2. `TestContract_RefreshResponse_ExactJSONShape` — `POST /api/auth/refresh` 200 応答の
+   同フィールド集合を厳密に固定（Req 2.2, 2.3, 2.4）
+3. `TestContract_RevokeResponse_204AndEmptyBody` — `POST /api/auth/revoke` 成功時の
+   204 + body 長 0 を契約として固定（Req 2.5）
+4. `TestContract_NativeCallbackLocation_AppSchemeAndAuthCode` — callback の Location が
+   `feedman://auth/callback?auth_code=<one-time-code>` 形式であることを正規表現または
+   prefix 一致 + クエリ抽出で固定（Req 2.6）
+5. `TestContract_BearerAccessToken_ReachesProtectedAPI_SameUserAsCookie` — 同一 userID で
+   発行した JWT を Bearer として `/api/subscriptions` に提示し、Cookie 経由（同 userID）
+   と同一の応答（userID コンテキストが同じ）を得ることを契約として固定（Req 1.5 /
+   NFR 2.1）
+6. `TestContract_BearerToken_RejectionUniformity_AllRejectionShapes` — 4 拒否区分（署名
+   不正 / 期限切れ / token_use 不一致 / 形式不正）を table-driven で発生させ、すべて 401 +
+   完全同一の応答 body を返すことを契約として固定（Req 3.5, 3.6）
+
+### E2E Tests（`internal/handler/native_auth_e2e_db_test.go` 新規 / DB 必須）
+
+`TEST_DATABASE_URL` 到達時のみ実行（未到達時 `t.Skipf`）。
+
+7. `TestE2E_NativeAuthFullFlow_DBBacked` — 1 つのテスト関数内で以下 step を逐次実行
+   （Req 1.1〜1.6, 3.1〜3.4, NFR 1.1〜1.3）:
+   - step1: native login で 2 Cookie 取得
+   - step2: callback → 303 + Location（real `PostgresAuthCodeRepo.Create` 経由）
+   - step3: token 交換 → 200 + DB の auth_codes.used=true / refresh_tokens 1 行
+   - step3-reject: unknown auth_code / consumed auth_code / wrong verifier を順次拒否
+   - step4: refresh → 200 + 新 token pair / 旧 token は MarkRotated 済み
+   - step4-reject: rotated 済み旧 token 再提示 → 401 + family revoked / 新世代 token も 401
+   - step5: 新 family を再構築（revoke 用に再 callback → exchange）→ revoke 204 → 同 token
+     で refresh → 401 / 同 token で revoke 再実行 → 204（冪等）
+   - step6: ステップ 3 で発行された JWT を Bearer として `/api/subscriptions` に提示
+     → 200（real `JWTVerifier` 経路）
+
+### Performance / Load
+
+対象外（本 spec の検証範囲は契約整合のみ）。
+
+## Optional Sections
+
+### Security Considerations
+
+本 spec はテスト追加のみで production code を変更しないため、追加のセキュリティ影響を
+持たない。固定鍵 `[]byte("e2e-contract-test-secret-32bytes!")` はテストコード内に直接
+記述するが、これは production secret ではなく、リポジトリの既存テストパターン
+（`router_test.go` の `[]byte("router-roundtrip-secret-32bytes-x")` と同型）に準拠する。
+
+`contract-notes.md` には平文 token / 認証情報 / OAuth client secret は一切含めない。
+
+### Supporting References
+
+- 要件: `docs/specs/172-native-auth-contract-tests/requirements.md`
+- iOS 仕様正本: `/home/hitoshi/github/feedman-ios/design/SERVER.md` §1
+- 既存実装（変更しない）:
+  - #165 native callback: `internal/auth/native.go` / `internal/handler/auth_handler.go`
+  - #166 token exchange: `internal/auth/token_service.go` / `internal/handler/native_auth_handler.go`
+  - #167 refresh rotation: 同上
+  - #168 revoke + family revoke on reuse: 同上
+  - #169 BearerOrSessionMiddleware + JWTVerifier: `internal/middleware/bearer_or_session.go`
+    / `internal/auth/jwt_verifier.go`
+  - #170 withdraw cleanup: `internal/repository/postgres_withdraw_integration_db_test.go`
+  - #171 unauthIPMW: `internal/handler/router.go`
+- 既存テスト資産（重複させない）:
+  - `internal/handler/integration_test.go`（stateful mock 経路の通し）
+  - `internal/handler/router_test.go`（Bearer round-trip / IP rate limit）
+  - `internal/repository/postgres_refresh_token_repo_db_test.go` /
+    `internal/repository/postgres_auth_code_repo_db_test.go` /
+    `internal/repository/postgres_withdraw_integration_db_test.go`（DB 結合）
+- CI: `.github/workflows/ci.yml`（`TEST_DATABASE_URL` + `go test -p 1 ./...`）

--- a/docs/specs/172-native-auth-contract-tests/requirements.md
+++ b/docs/specs/172-native-auth-contract-tests/requirements.md
@@ -1,0 +1,114 @@
+# Requirements Document
+
+## Introduction
+
+Feedman の native token 認証（親 Issue #163）は iOS v1 が依存するサーバー契約であり、
+Issue #164〜#171 にまたがって実装された。各 spec は単体で要件カバレッジを満たしているが、
+複数 Issue にまたがる主要な動線 —— ネイティブ OAuth → `auth_code` 発行 → token 交換 →
+refresh rotation → revoke → Bearer 認証付き既存 API 呼び出し —— の **end-to-end な契約整合**
+は、横断的な検証手段を持たない限り iOS 側仕様（feedman-ios `design/SERVER.md` §1）からの
+ずれを検出できない。
+
+本 spec は **native auth API の contract / integration テスト整備、および iOS 仕様
+（SERVER.md §1）との同期確認**のみを対象とする。新規エンドポイントの追加実装、iOS
+クライアント実装、v1 スコープ外機能（push 通知・OPML 等）は扱わない。実装済み spec
+（#165〜#171）が定めた挙動・JSON 形状・エラー契約を「契約として何が検証されるべきか」の
+観点で要件化し、検証手段（テストファイル配置・関数名・helper 構成）の選定は design の
+領分とする。
+
+## Requirements
+
+### Requirement 1: Native OAuth フロー全体の契約検証
+
+**Objective:** As a Feedman iOS / サーバー運用者, I want native OAuth フロー全体の主要動線が
+契約として検証されてほしい, so that 複数 Issue にまたがる実装の整合が iOS 仕様からずれた
+ことを早期に検出できる
+
+#### Acceptance Criteria
+
+1. The Native Auth Contract Test Suite shall ネイティブ OAuth callback での一時 `auth_code` 発行とアプリスキームへのリダイレクトを契約として検証する
+2. The Native Auth Contract Test Suite shall `POST /api/auth/token` による `auth_code` と PKCE verifier の本トークン交換を契約として検証する
+3. The Native Auth Contract Test Suite shall `POST /api/auth/refresh` による rotation 付き再発行を契約として検証する
+4. The Native Auth Contract Test Suite shall `POST /api/auth/revoke` による refresh token 失効を契約として検証する
+5. The Native Auth Contract Test Suite shall 発行済み access token を `Authorization: Bearer` として認証必須既存 API に提示した際に、Cookie セッション認証時と同一のユーザー識別で応答されることを契約として検証する
+6. The Native Auth Contract Test Suite shall 上記 5 つの動線を、外部ネットワーク・実 Google OAuth・実 FCM への接続なしで実行可能とする
+
+### Requirement 2: JSON 応答契約（フィールド名・型・status）の検証
+
+**Objective:** As a Feedman iOS 実装者, I want token 系応答の JSON 形状が iOS 仕様と一致して
+ほしい, so that クライアント側の decoder が壊れない
+
+#### Acceptance Criteria
+
+1. The Native Auth Contract Test Suite shall `POST /api/auth/token` の成功応答が JSON フィールド `access_token` / `refresh_token` / `token_type` / `expires_in` を含むことを検証する
+2. The Native Auth Contract Test Suite shall `POST /api/auth/refresh` の成功応答が JSON フィールド `access_token` / `refresh_token` / `token_type` / `expires_in` を含むことを検証する
+3. The Native Auth Contract Test Suite shall token 系成功応答の `token_type` フィールド値が `Bearer` であることを検証する
+4. The Native Auth Contract Test Suite shall token 系成功応答の `expires_in` フィールド値が 900（秒）であることを検証する
+5. The Native Auth Contract Test Suite shall `POST /api/auth/revoke` の成功応答が HTTP 204 No Content かつボディなしであることを検証する
+6. The Native Auth Contract Test Suite shall native callback 成功時のリダイレクト先 URL が `feedman://auth/callback?auth_code=<one-time-code>` の形式であることを検証する
+
+### Requirement 3: エラー契約（拒否パス）の検証
+
+**Objective:** As a Feedman 運用者, I want 不正・期限切れ・再利用などの拒否パスが契約として
+検証されてほしい, so that 攻撃面の縮退・列挙オラクル防止が後続変更でも維持される
+
+#### Acceptance Criteria
+
+1. The Native Auth Contract Test Suite shall 不正・期限切れ・使用済みの `auth_code` を提示した `POST /api/auth/token` 要求が token を発行せず拒否されることを検証する
+2. The Native Auth Contract Test Suite shall 保存済み challenge と一致しない PKCE verifier を提示した `POST /api/auth/token` 要求が token を発行せず拒否されることを検証する
+3. The Native Auth Contract Test Suite shall 不明・期限切れ・失効済み・rotation 済みの refresh token を提示した `POST /api/auth/refresh` 要求が新 token を発行せず拒否されることを検証する
+4. The Native Auth Contract Test Suite shall rotation 済みの refresh token を `POST /api/auth/refresh` に再提示した際に、当該 family に属する以後の refresh 要求も拒否されることを検証する
+5. The Native Auth Contract Test Suite shall 署名不正・期限切れ・用途種別不一致・形式不正の Bearer token を認証必須 API に提示した要求が、Cookie セッションへの fallback なしで未認証として拒否されることを検証する
+6. The Native Auth Contract Test Suite shall 上記の拒否応答が、原因の別（auth_code の存在有無 / 期限切れ / 使用済み / verifier 不一致、refresh token の存在有無 / 期限切れ / 失効済み / rotation 済み、Bearer の署名不正 / 期限切れ / 用途不一致 / 形式不正）を区別できる情報を含まないことを検証する
+
+### Requirement 4: iOS 仕様（SERVER.md §1）との同期確認
+
+**Objective:** As a Feedman / iOS 双方の開発者, I want サーバー実装と iOS 仕様の差分が
+明示されてほしい, so that 暗黙の差分により iOS 実装が想定外の挙動に遭遇しない
+
+#### Acceptance Criteria
+
+1. The Implementation Notes shall サーバー実装（#164〜#171）と feedman-ios `design/SERVER.md` §1（エンドポイント契約・トークン設計・受け入れ基準）の整合を確認した結果を記録する
+2. Where 実装が SERVER.md §1 の記述と異なるとき, the Implementation Notes shall 当該差分を「承認済み逸脱」として明示し、根拠となる Issue / spec を参照する
+3. The Implementation Notes shall SERVER.md §1.3 が `POST /api/auth/revoke` を「Bearer 認証下」と記述するのに対し、実装が #168 で「未認証 + token 所持 = 権限」を採用済みであることを承認済み逸脱として明文化する
+4. The Implementation Notes shall SERVER.md §1.5 の DB スキーマ例と、#164 で確定した実装スキーマとの差分（テーブル分離等）を承認済み逸脱として明文化する
+5. If 整合確認の過程で SERVER.md §1 と実装の間に承認されていない差分を発見したとき, the Implementation Notes shall 当該差分を本 spec で確定させず、Issue コメントによる人間判断を仰ぐ旨を記録する
+
+## Non-Functional Requirements
+
+### NFR 1: テスト容易性・決定性
+
+1. The Native Auth Contract Test Suite shall 実 Google OAuth プロバイダー・実 FCM・実外部ネットワークへの接続なしで全契約検証を完了する
+2. The Native Auth Contract Test Suite shall 時刻依存（access token の 900 秒有効期限・refresh token の 30 日有効期限・`auth_code` の 60 秒有効期限）の検証において、固定時刻の注入により決定論的に再現可能とする
+3. The Native Auth Contract Test Suite shall 署名鍵を固定値として注入し、token 発行・検証の決定論的な再現を可能とする
+
+### NFR 2: 後方互換性
+
+1. The Native Auth Contract Test Suite shall 既存 Web Cookie セッション認証の動線（ログイン・ログアウト・認証必須 API への Cookie 提示）が本 spec 導入により挙動変更されないことを検証する
+2. The Native Auth Contract Test Suite shall 既存テストスイートの実行結果を本 spec 導入前と同一に保つ
+
+### NFR 3: 既存 spec との非重複
+
+1. The Native Auth Contract Test Suite shall 各 spec（#165〜#171）固有の内部詳細を再検証せず、複数 spec を跨ぐ契約整合（end-to-end な動線・JSON 形状・横断的なエラー契約・iOS 仕様同期）のみを対象とする
+
+## Out of Scope
+
+- 新規エンドポイントの追加実装（既存実装の挙動を契約として固定するのみ）
+- iOS クライアント実装（クライアント側の利用検証は feedman-ios 側で行う）
+- push 通知 / OPML 等の v1 スコープ外機能（SERVER.md §2 以降）
+- 各 spec（#165〜#171）固有の単体レベル要件の再要件化（各 spec の requirements.md が
+  正本）
+- 実 Google OAuth プロバイダーへの接続を伴う E2E テスト
+- 鍵ローテーション（複数 kid 並行受理）の契約検証 — 単一鍵での発行・検証までを対象
+- 既存 Web Cookie セッション認証フローの新規契約検証（後方互換維持の確認のみ行う）
+
+## Open Questions
+
+- なし（SERVER.md §1 と実装の既知差分は Requirement 4 で「承認済み逸脱」として明文化する。
+  整合確認中に未承認の差分が発見された場合は AC 4.5 に従い Issue コメントで人間判断を仰ぐ）
+
+## 関連
+
+- Parent: #163
+- Depends on: #165 #166 #167 #168 #169 #170 #171
+- Sibling: #164

--- a/docs/specs/172-native-auth-contract-tests/tasks.md
+++ b/docs/specs/172-native-auth-contract-tests/tasks.md
@@ -1,0 +1,139 @@
+# Implementation Plan
+
+本 spec はテストおよび文書追加のみで production code を変更しない。タスクは「契約観点の
+追加テスト」「DB-backed E2E テスト」「SERVER.md 同期文書」の 3 系統を独立コミット単位で
+完成させる順序で並べる。各タスクは追加後に `go test ./internal/handler/...`（および E2E
+タスクでは `TEST_DATABASE_URL` 接続時のみ実行されるサブテスト）が green であることを
+確認してから次タスクへ進む。
+
+- [ ] 1. JSON 応答契約テスト（token / refresh / revoke）を追加する
+  - `internal/handler/integration_test.go` の末尾に以下 3 ケースを追加する
+  - `TestContract_TokenResponse_ExactJSONShape`: 既存 `createNativeAuthIntegrationRouter`
+    + 既存 `runNativeLoginCallbackAndExchange` を用いて 200 を取得し、レスポンス JSON
+    を `map[string]any` にデコードして {access_token, refresh_token, token_type:"Bearer",
+    expires_in:900} の 4 フィールド一致と **総キー数 4**（余剰キー混入なし）をアサート
+  - `TestContract_RefreshResponse_ExactJSONShape`: 同様に refresh 200 応答で 4 フィールド
+    厳密集合を固定。`token_type` / `expires_in` の値も同時にアサート
+  - `TestContract_RevokeResponse_204AndEmptyBody`: revoke 成功時の `StatusNoContent` +
+    `w.Body.Len() == 0` を直接固定
+  - 既存テスト群（`TestIntegration_NativeAuthFlow_*` / `TestIntegration_RefreshFlow_*` /
+    `TestIntegration_RevokeFlow_*`）は変更しない（NFR 2.2）
+  - `_Requirements: 2.1, 2.2, 2.3, 2.4, 2.5_`
+
+- [ ] 2. native callback の Location 契約テストを追加する
+  - `internal/handler/integration_test.go` の末尾に
+    `TestContract_NativeCallbackLocation_AppSchemeAndAuthCode` を追加する
+  - native login → callback で得た 303 応答の `Location` ヘッダが
+    `feedman://auth/callback?auth_code=` で始まり、`?auth_code=` 値部分が空でないことを
+    `url.Parse` で抽出してアサート
+  - `Location` 全体一致は既存 `TestIntegration_NativeAuthFlow_LoginCallbackReturnsAuthCode`
+    で固定値（"integration-native-auth-code"）を検証済みのため、本タスクは契約形式
+    （scheme / host / path / クエリ名）の正規表現的固定に専念する
+  - `_Requirements: 2.6_`
+
+- [ ] 3. Bearer access token が既存 API に到達し Cookie と同一ユーザーで応答する契約テストを追加する
+  - `internal/handler/integration_test.go` の末尾に
+    `TestContract_BearerAccessToken_ReachesProtectedAPI_SameUserAsCookie` を追加する
+  - 既存 `auth.NewJWTIssuer` + `auth.NewJWTVerifier` を同一 secret で生成し、
+    `IssueAccessToken("contract-user-1")` で発行した JWT を Bearer として
+    `/api/subscriptions` に提示
+  - 同じ `contract-user-1` を `UserID` に持つ `model.Session` を Cookie 経由でも提示する
+    ケースを別途送り、両者で **同じ subscription 一覧 JSON** が返ることをアサート
+    （注入する `SubscriptionService` を `userID` 引数で固定 fixture を返すモックにする）
+  - 既存 `TestNewRouter_BearerAuth_IssuerVerifierRoundTrip` との重複を避けるため、本テスト
+    は「JWT sub と Cookie UserID が同じ場合に **応答内容まで等価**」までを契約として
+    固定する（既存 round-trip は 200 status 到達のみ）
+  - `_Requirements: 1.5_`
+
+- [ ] 4. Bearer 拒否 4 区分の uniform 契約テストを追加する
+  - `internal/handler/integration_test.go` の末尾に
+    `TestContract_BearerToken_RejectionUniformity_AllRejectionShapes` を追加する
+  - 同一 secret の `JWTVerifier` を `RouterDeps.JWTVerifier` に注入した router を構築し、
+    以下 4 サブケースを table-driven で `/api/subscriptions` に提示:
+    a. 署名不正（別 secret で sign した token）
+    b. 期限切れ（`exp` が過去の token、既存 `TestNewRouter_BearerAuth_ExpiredTokenWithValidCookie_Returns401`
+       と同手法）
+    c. `token_use` 不一致（`"refresh"` または欠落）
+    d. 形式不正（`Bearer not-a-jwt` 等）
+  - 各ケースで 401 status と **完全同一の response body**（`BearerOrSessionMiddleware` は
+    `http.Error(w, "unauthorized", 401)` 固定）が返ることをアサート。Cookie 併送時にも
+    fallback しないことを 1 ケースだけ追加検証する
+  - `_Requirements: 3.5, 3.6_`
+
+- [ ] 5. E2E DB-backed full-flow テストを追加する
+  - 新規ファイル `internal/handler/native_auth_e2e_db_test.go` を作成し、以下を実装する
+  - `TEST_DATABASE_URL` 接続セットアップ（既存 `setupRefreshTokenTestDB` / `setupWithdrawTestDB`
+    と同型）を関数 `setupNativeAuthE2EDB(t *testing.T) *sql.DB` として配置。DB 未到達時は
+    `t.Skipf` で silent skip（NFR 1.1）
+  - real `PostgresAuthCodeRepo` + real `PostgresRefreshTokenRepo` + real `JWTIssuer`
+    （固定 secret `[]byte("e2e-contract-test-secret-32bytes!")`） + real `JWTVerifier`
+    （同 secret）+ real `TokenService` を組み立て、real `Service`（fake `OAuthProvider`
+    を注入）と共に `RouterDeps` に wire して `NewRouter` を起動
+  - `fakeOAuthProviderForE2E` を本ファイル内で 30 行未満で定義し、`ExchangeCode` が固定
+    `OAuthUserInfo{ProviderUserID:"google-sub-e2e", Email:"e2e@example.com", Name:"E2E"}` を
+    返すよう実装
+  - 関数 `TestE2E_NativeAuthFullFlow_DBBacked` を 1 件追加し、design.md「State transitions
+    checked」の step1〜6 を逐次実行。各 step 後に 200/303/204 status と JSON 応答契約
+    （token_type:"Bearer", expires_in:900 等）をアサート
+  - 拒否サブケース（step3-reject / step4-reject / revoke 不明 token）も同テスト内に組み込み、
+    `code:INVALID_GRANT` / `code:INVALID_REFRESH_TOKEN` / 204 を固定。応答 `message` に
+    "used" / "expired" / "rotated" / "revoked" 等の原因区別語が含まれないことを既存
+    `TestIntegration_*` と同方針で `strings.Contains` 否定アサート
+  - step6 では step3 で発行された **real JWT** を Bearer として `/api/subscriptions` に
+    提示し、200 を取得する。`SubscriptionService` には real impl ではなく fake を注入し、
+    context に注入された userID が fake `OAuthProvider` の `ProviderUserID` から解決された
+    user.ID と一致する応答を返すように設定
+  - DB 検証クエリ（auth_codes.used / refresh_tokens.rotated_at / refresh_token_families.revoked_at）
+    を最小限差し込み、`DB の永続化状態が API 応答と整合する` ことまで検証
+  - `_Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 3.1, 3.2, 3.3, 3.4_`
+
+- [ ] 6. SERVER.md §1 ↔ 実装の契約同期文書を作成する
+  - 新規ファイル `docs/specs/172-native-auth-contract-tests/contract-notes.md` を作成
+  - design.md「Contract Notes Document」の `Structure` に従い、以下のセクションを記述:
+    a. `## §1.3 Endpoint contracts` — `/token` / `/refresh` / `/revoke` 各エンドポイント
+       について Request / Response / Error の対照表
+    b. `## §1.4 Token design` — access JWT 15 分 / refresh opaque 30 日 / kid 付与の対照
+    c. `## §1.5 DB schema` — auth_codes / refresh_token_families / refresh_tokens のスキーマ
+       と SERVER.md 例との差分
+    d. `## §1.8 受け入れ基準 ↔ テスト ID` — 各受け入れ基準を本 spec および既存テストの
+       関数名にマッピング
+    e. `## 承認済み逸脱` — 4.3 revoke 未認証化（#168 / RFC 7009 §2.1 public client 慣行）
+       と 4.4 DB スキーマ分離（#164 で `refresh_token_families` 追加）を明文化
+    f. `## 未承認差分エスカレーション方針` — 整合確認の過程で未承認差分を発見した場合は
+       本 spec で確定させず Issue コメントで人間判断を仰ぐ旨を明記
+  - 整合確認の作業として、SERVER.md §1.3 / §1.4 / §1.5 / §1.8 を 1 章ずつ精読し、実装
+    （`internal/handler/native_auth_handler.go` / `internal/auth/token_service.go` /
+    マイグレーション SQL）との差分を全て抽出。**承認済み逸脱の 2 件以外に未承認差分が
+    見つかった場合は本タスクを完了させず**、PR 本文「確認事項」に列挙して人間判断を仰ぐ
+    （Req 4.5）
+  - `_Requirements: 4.1, 4.2, 4.3, 4.4, 4.5_`
+
+- [ ] 7. 既存テストとの非重複・既存挙動非干渉の最終確認
+  - 本タスクは独立コミット単位として 1〜6 完了後にチェックする整理タスク（diff は
+    生じない想定だが、必要に応じて重複箇所をリファクタリング）
+  - 確認事項:
+    a. 既存 `TestIntegration_NativeAuthFlow_*` / `TestIntegration_RefreshFlow_*` /
+       `TestIntegration_ReuseDetection_FamilyRevoked` / `TestIntegration_RevokeFlow_*` /
+       `TestNewRouter_BearerAuth_*` / `TestNewRouter_NativeAuthIPRateLimit_*` の関数本体
+       が変更されていないこと（NFR 2.2）
+    b. 既存ヘルパー `createIntegrationRouter` / `createNativeAuthIntegrationRouter` /
+       `runNativeLoginCallbackAndExchange` / `mockNativeTokenExchangeService` の関数本体が
+       変更されていないこと
+    c. `go test ./...` を full pass（CI 同条件の `-p 1`）で実行
+    d. `TEST_DATABASE_URL` 未設定環境（DB 不在）で本 spec 追加テスト群が `TestE2E_*`
+       のみ skip され、それ以外は green になること
+    e. リポジトリの既存 spec の `tasks.md` / `requirements.md` / `design.md` を本 spec から
+       書き換えていないこと（impl spec の責務境界）
+  - `_Requirements: NFR 2.1, NFR 2.2, NFR 3.1_`
+
+## Verify
+
+本 spec の実装後、watcher（stage-a-verify gate）が再実行すべき verify コマンドを構造化
+ブロックで宣言する。CI の `backend` ジョブと同条件で go test を回し、加えて handler
+パッケージのみを `-run` 絞り込みで明示再実行することで、本 spec の追加テストが新規に
+存在することを担保する。
+
+<!-- stage-a-verify -->
+```sh
+go vet ./... && go test -p 1 ./...
+```


### PR DESCRIPTION
## 概要

Issue #172（umbrella #163 の最終子 Issue）の設計 PR です。`docs/specs/172-native-auth-contract-tests/` に requirements.md（EARS）/ design.md / tasks.md を追加します。実装は本 PR には含まれません（実装 PR を別途作成する 2 PR フロー）。

関連 Issue: #172（Closes は実装 PR 側で行います）

## 成果物

- **requirements.md**: 機能要件 4（OAuth フロー全体の契約検証 / JSON 応答契約 / エラー契約 / SERVER.md との同期確認）+ NFR 3、AC 計 29 件（EARS / numeric ID）。PM 自己レビューゲート（Mechanical Checks + 判断レビュー）1 パス通過
- **design.md**: 既存テスト資産（stateful mock 通し / JWT round-trip / repo DB 結合）と重複しない 2 レイヤー構成 + 文書化:
  1. 契約観点の追加（外部依存なし）: JSON 厳密 shape（余剰キー検出）/ callback Location 契約 / Bearer→既存 API の Cookie 等価応答 / Bearer 拒否 4 区分の uniform 検証
  2. 実物 service 経路 E2E（`TEST_DATABASE_URL` 必須・未設定 skip）: real TokenService + real repo + real JWTIssuer/Verifier + fake OAuthProvider で callback → exchange → refresh → revoke → Bearer API の通し
  3. `contract-notes.md`（SERVER.md §1 対照表 + 承認済み逸脱 2 件の明文化: revoke 未認証化（#168）/ DB スキーマ分離（#164））
- **tasks.md**: 最上位 7 タスク（checkbox 形式 / `_Requirements:_` 注釈 / stage-a-verify 構造化 verify ブロック付き）

## 自己レビューゲート結果

- Requirements traceability: 全 29 numeric ID が design.md に出現
- File Structure Plan 充填 / orphan component なし / Budget overflow check（7 件 ≤ 10 で pass）/ checkbox enforcement / verify block well-formed: すべて pass

## 確認事項（レビュワー判断ポイント）

- E2E テストを実 DB（CI の postgres / `TEST_DATABASE_URL`）必須とし、未設定環境では skip する設計です（既存 repository DB テストと同じ縮退規約）
- SERVER.md との既知の差分 2 件（revoke の未認証 + token 所持 = 権限 / DB スキーマの families テーブル分離）は「承認済み逸脱」として contract-notes.md に明文化する方針です。新規の未承認差分が実装中に見つかった場合は Issue コメントでエスカレーションします

🤖 Generated with [Claude Code](https://claude.com/claude-code)