### PR TITLE
fix(compose): NATIVE_AUTH_JWT_SECRET を api コンテナへ受け渡す

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,10 @@ services:
       - BASE_URL=${BASE_URL:-http://localhost:3000}
       - CORS_ALLOWED_ORIGIN=${CORS_ALLOWED_ORIGIN:-http://localhost:3000}
       - COOKIE_DOMAIN=${COOKIE_DOMAIN:-}
+      # Native Auth（iOS token 認証 / #163）。未設定なら token / refresh / revoke と
+      # Bearer 認証は無効化される（fail-closed。.env.sample の NATIVE_AUTH_JWT_SECRET 参照）。
+      - NATIVE_AUTH_JWT_SECRET=${NATIVE_AUTH_JWT_SECRET:-}
+      - NATIVE_AUTH_JWT_KID=${NATIVE_AUTH_JWT_KID:-v1}
       - SERVER_PORT=8080
       - LOG_RETENTION_DAYS=14
     logging:


### PR DESCRIPTION
## 概要

staging デプロイ（develop 検証環境）で顕在化した compose 配線の欠落修正です。
`.env.sample` には `NATIVE_AUTH_JWT_SECRET` / `NATIVE_AUTH_JWT_KID` の記載がありますが、`docker-compose.yml` の api service に environment 受け渡しが無く、`.env` に設定しても native auth（`/api/auth/token|refresh|revoke` と Bearer 認証）が有効化されませんでした（api 起動ログ: `NATIVE_AUTH_JWT_SECRET is not set; ... disabled`）。

Refs #163（native auth umbrella）

## 変更内容

- api service の environment に 2 行追加:
  - `NATIVE_AUTH_JWT_SECRET=${NATIVE_AUTH_JWT_SECRET:-}`（未設定時は空 = 従来どおり fail-closed で native auth 無効。後方互換）
  - `NATIVE_AUTH_JWT_KID=${NATIVE_AUTH_JWT_KID:-v1}`（config 側既定と同じ v1 を補完）

## 検証

- `docker compose config` クリーン
- staging 環境（`~/deploys/feedman-staging`）で同内容を override により適用し、api 起動ログ `native token exchange enabled (kid=v1)` と `/api/auth/token` の契約応答（400 INVALID_REQUEST）を確認済み

## 確認事項（レビュワー判断ポイント）

- worker service には追加していません（native auth は api の HTTP 経路のみで使用）
- 未設定環境の挙動は不変です（空文字 → config 側で未設定扱い → fail-closed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)