### PR TITLE
spec(#207): v1 モバイル API 契約とサーバ補正の設計

### DIFF
--- a/docs/specs/207--mobile-api-v1-api/design.md
+++ b/docs/specs/207--mobile-api-v1-api/design.md
@@ -1,0 +1,724 @@
+# Design Document
+
+## Overview
+
+**Purpose**: 本機能は Feedman の v1 モバイルクライアント（iOS / Android）に対して、(1)
+依存する全エンドポイントを独立した契約文書として明文化し、(2) 現状応答に欠けている 2 項目
+（モバイル向け統一ユーザー情報取得エンドポイント・記事詳細応答のフィード表示メタデータ）を
+サーバー応答に追加することで、サーバー実装ソースを参照せずにクライアント単独で実装・検証
+可能な共通動線を提供する。
+
+**Users**: Feedman の **モバイルクライアント実装者**（iOS / Android）が実装時の参照点として
+契約文書を使用し、**モバイル / Web 各クライアント**が認証済み API を呼び出す共通動線として
+新規 `GET /api/users/me` と拡張済み `GET /api/items/{id}` を利用する。
+
+**Impact**: 既存 Web Cookie 経路は **完全に非破壊**で維持する（`/auth/me` の URL・応答形状・
+認証方式は無変更、既存 `GET /api/items/{id}` の既存応答フィールドはフィールド名・型・null
+表現を含めて無変更）。新規エンドポイントと記事詳細応答の新フィールド追加は **加算的変更**
+（adding-only）であり、既存テストスイートは追加修正なしに通過する状態を維持する（NFR 1.3）。
+
+### Goals
+
+- モバイル向け統一ユーザー情報取得エンドポイント `GET /api/users/me` を新設し、Bearer
+  access token / Web Cookie のいずれの認証経路でも current user 情報を取得可能にする
+  （Req 2.1〜2.5）
+- 記事詳細エンドポイント `GET /api/items/{id}` 応答に `feed_title` / `feed_favicon_url` の
+  2 フィールドを追加する（Req 3.1, 3.2, 3.4）
+- 上記 2 点を含む v1 モバイル API 契約を `docs/specs/207--mobile-api-v1-api/mobile-api-contract.md`
+  として明文化する（Req 1.1〜1.5 / NFR 2.1, 2.2）
+- README の API 一覧に新規エンドポイントと契約文書への参照を追記する（Req 1.6）
+- 上記 3 点を Mobile API Contract Test Suite として handler 層の test ファイルに追加する
+  （Req 4.1〜4.5 / NFR 3.1）
+- 既存 Web Cookie 動線・既存契約フィールドの後方互換を維持する（Req 2.6 / Req 3.3, 3.5 /
+  NFR 1.1〜1.3）
+
+### Non-Goals
+
+- Native auth 系エンドポイント（token 発行 / refresh / revoke / native callback）の実装変更
+  および契約テストの新規整備（#163 配下 #164〜#171 で実装済み、#172 で end-to-end 契約テスト
+  整備済み）。本 spec では契約文書のサマリ記載のみ
+- `/api/devices`（デバイス登録）・`/api/keywords`（キーワード通知）の実装。これらは
+  キーワードプッシュ通知の次フェーズに該当し、v1 接続確認の必須契約に含めない
+- モバイルクライアント（iOS / Android）側の実装変更
+- 既存記事一覧 / 検索 / 購読操作 / クロスフィード閲覧エンドポイントの新規フィールド追加
+  （契約文書としての固定のみ。応答拡張は本 spec のスコープ外）
+- Web フロントエンドの実装変更（モバイル統一ユーザー情報取得エンドポイントを Web からも
+  呼び出すかは別 Issue で判断）
+- **`users` テーブルへの `avatar_url` カラム追加 / Google OAuth `picture` claim 取得 /
+  identities テーブル拡張**。requirement 2.3 / 2.4 は「`avatar_url` を成功応答に含める /
+  値がなければ null または省略」を要求するため、本 spec ではフィールドを応答 schema に含め
+  当面 `null` を返す（DB 拡張は次フェーズ。詳細は「データモデル / 設計判断」節を参照）
+
+## Architecture
+
+### Existing Architecture Analysis
+
+本 spec は既存 architecture の **延長線上**で動作し、新たなアーキテクチャパターン・新規
+ドメイン境界を導入しない。尊重すべき既存規約と取り込み済み前提:
+
+- **handler → service → repository → model の一方向依存**（CLAUDE.md「アーキテクチャと
+  機能追加ガイド」§1）。本 spec の追加・変更は全てこの境界を守る
+- **認可はサービス層に集約**（同 §1）。`GET /api/users/me` は middleware が解決した
+  `userID` を直接利用するためビジネス認可は不要、`GET /api/items/{id}` 拡張は既存
+  `item.ItemService.GetItem` 内の `SubscriptionChecker` 認可を **そのまま流用** する
+- **BearerOrSession middleware**（Issue #169 / `internal/middleware/bearer_or_session.go`）
+  は既に `/api/*` 認証必須グループに適用済み（router.go L237）。`/api/users/me` を同グループ
+  配下に置くだけで Bearer / Cookie 両経路が自動で機能する（middleware 改変不要）
+- **`/auth/me`** は `SetupAuthRoutes` / NewRouter L193 で「認証不要グループ」配下に置かれ、
+  AuthHandler.Me が Cookie 経路のみを評価する。本 spec ではここに一切手を入れない（Req 2.6 /
+  NFR 1.1）
+- **既存共有ヘルパー**: `model.FaviconDataURL`（生バイト + MIME → data URL）/
+  `middleware.UserIDFromContext` / `middleware.WriteErrorResponse` / `handleServiceError` /
+  `model.APIError` を再利用し、独自実装を増やさない（CLAUDE.md §4 / §7）
+- **interface segregation**: 既存 `item.SubscriptionChecker`（1 メソッドのみの最小
+  interface）と同パターンで、本 spec で必要な repository 依存は最小 interface で受ける
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+flowchart LR
+    subgraph "認証不要 group"
+        AuthMe["GET /auth/me<br/>(AuthHandler.Me)"]
+    end
+    subgraph "認証必須 group (BearerOrSession)"
+        UsersMe["GET /api/users/me<br/>(新規 / UserHandler.GetCurrent)"]
+        ItemsGet["GET /api/items/:id<br/>(既存 / 拡張)"]
+        OtherAPIs["その他既存 /api/*"]
+    end
+    subgraph "Service Layer"
+        AuthSvc[AuthService]
+        UserSvc[user.Service]
+        ItemSvc[item.ItemService]
+    end
+    subgraph "Repository Layer"
+        UserRepo[UserRepository]
+        ItemRepo[ItemRepository]
+        FeedRepo[FeedRepository]
+        SubRepo[SubscriptionRepository]
+        SessionRepo[SessionRepository]
+    end
+
+    AuthMe -->|Cookie のみ| AuthSvc -->|GetCurrentUser| SessionRepo
+    AuthSvc --> UserRepo
+    UsersMe -->|userID from ctx| UserSvc -->|GetByID 新設| UserRepo
+    ItemsGet --> ItemSvc
+    ItemSvc -->|FindByID 既存| ItemRepo
+    ItemSvc -->|FindByUserAndFeed 既存| SubRepo
+    ItemSvc -.->|FindByID 新規依存| FeedRepo
+```
+
+**Architecture Integration**:
+
+- 採用パターン: 既存 Hexagonal-like layered architecture を維持。ドメインサービス層に最小
+  inbound interface を追加し、handler は既存 adapter パターンで service を呼ぶ
+- ドメイン境界: `user` ドメインに current user 取得責務を追加（既存 `Withdraw` と同一サービス
+  上に同居）。`item` ドメインに feed メタデータ取得依存（`FeedRepository` の `FindByID`
+  のみを呼ぶ最小 interface）を追加
+- 既存パターンの維持: handler の `UserServiceInterface` / `ItemServiceInterface` 拡張は
+  既存 adapter パターン（`service_adapter.go`）に同居させる。`/api/users/me` のルーティング
+  登録は既存 `r.Route("/api/users", ...)` ブロック内に追加するだけで完結する
+- 新規コンポーネントの根拠: 既存 `AuthHandler.Me` は Cookie 専用かつ `AuthServiceInterface`
+  への依存を持ち、Bearer 経路（`UserIDFromContext` 経由）と認証契約が異なる。`/auth/me` を
+  そのまま二経路化すると（a）AuthHandler を認証必須グループに移す全面構造変更が必要、
+  （b）`/auth/me` の応答契約を変更してしまう、の 2 点で NFR 1.1 / Req 2.6 を破る。よって
+  新規ハンドラ `UserHandler.GetCurrent` を `/api/users` route 配下に追加する
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| HTTP Router | chi/v5（既存） | 新規ルート `GET /api/users/me` 登録 | router.go の認証必須グループ既存 `r.Route("/api/users", ...)` ブロックを拡張 |
+| Auth Middleware | `middleware.BearerOrSession`（既存 Issue #169） | Bearer / Cookie 両経路を統一処理 | 改変なし。既存配線をそのまま利用 |
+| Service Layer | `user.Service` / `item.ItemService`（既存 Go パッケージ） | current user 取得 / 記事詳細での feed メタ取得 | 各サービスに最小メソッド追加 |
+| Repository Layer | `lib/pq` + 既存 `PostgresUserRepo` / `PostgresFeedRepo`（既存） | DB アクセス | 新規クエリ追加なし（既存 `FindByID` を再利用） |
+| Domain Helper | `model.FaviconDataURL`（既存） | favicon バイト → data URL 整形 | 再利用（`subscription` / `crossfeed` / `itemsearch` と同パターン） |
+| Test Framework | 標準 `testing` パッケージ + 既存 `withUserID` / `withChiURLParam` ヘルパー | 契約テスト追加 | 既存テスト規約と同型 |
+| Docs | Markdown | mobile-api-contract.md / README 追記 | 既存 spec markdown スタイル |
+
+## File Structure Plan
+
+### Directory Structure
+
+```
+internal/
+├── handler/
+│   ├── user_handler.go             # 変更: UserServiceInterface に GetCurrent 追加 /
+│   │                               # UserHandler に GetCurrent メソッド追加 / SetupUserRoutes に GET /me 追加
+│   ├── user_handler_test.go        # 変更: GetCurrent 単体テスト追加（Bearer/Cookie 経路で挙動同一 / 401）
+│   ├── service_adapter.go          # 変更: UserServiceAdapter.GetCurrent / ItemServiceAdapterFromDomain.GetItem 拡張
+│   ├── item_handler.go             # 変更: itemDetailResponse に FeedTitle / FeedFaviconURL 追加
+│   ├── item_handler_test.go        # 変更: GetItem 契約テスト（feed_title / feed_favicon_url 含む）
+│   ├── router.go                   # 変更: r.Route("/api/users") 配下に GET /me 登録
+│   ├── router_full_test.go         # 変更: /api/users/me が認証必須 group に乗っていることの確認 1 件
+│   ├── auth_handler.go             # 変更なし
+│   └── auth_handler_test.go        # 変更: /auth/me non-regression test を 1 件追加（既存 Cookie 動線維持）
+├── user/
+│   ├── service.go                  # 変更: user.Service に GetByID(ctx, userID) を追加
+│   └── service_test.go             # 変更: GetByID の単体テスト追加
+├── item/
+│   ├── service.go                  # 変更: item.ItemService に FeedMetaProvider 依存追加 / GetItem で feed メタ取得
+│   └── service_test.go             # 変更: GetItem の feed メタ取得を mock した単体テスト追加
+├── repository/
+│   └── interfaces.go               # 変更なし（既存 UserRepository.FindByID / FeedRepository.FindByID を再利用）
+└── app/
+    └── app.go                      # 変更: item.NewItemService 呼び出しに feedRepo を追加（最小 interface）
+
+docs/specs/207--mobile-api-v1-api/
+├── requirements.md                 # 既存（変更なし）
+├── design.md                       # 本ファイル
+├── tasks.md                        # 本 spec タスク
+└── mobile-api-contract.md          # 新規: v1 モバイル API 契約文書
+
+README.md                           # 変更: API 一覧に GET /api/users/me / native auth / cross-feed / search 追記
+```
+
+### Modified Files
+
+| ファイル | 変更内容 | 根拠 |
+|---|---|---|
+| `internal/handler/user_handler.go` | `UserServiceInterface` に `GetCurrent(ctx, userID) (*currentUserResponse, error)` を追加。`UserHandler.GetCurrent` 実装（`UserIDFromContext` 取得 → service 呼出 → JSON 応答 / 401・404・500）。`SetupUserRoutes` に `GET /me` 登録 | Req 2.1, 2.2, 2.3, 2.4, 2.5 |
+| `internal/handler/service_adapter.go` | `UserServiceAdapter.GetCurrent` を追加（`user.Service.GetByID` を呼び `currentUserResponse` に変換）。`ItemServiceAdapterFromDomain.GetItem` の戻り型に `FeedTitle` / `FeedFaviconURL` を populate | Req 2.3, 3.1, 3.2, 3.4 |
+| `internal/handler/item_handler.go` | `itemDetailResponse` に `FeedTitle string` (`feed_title`) と `FeedFaviconURL *string` (`feed_favicon_url,omitempty`) を追加。`GetItem` のハンドラロジック自体は変更なし（adapter で populate） | Req 3.1, 3.2, 3.4 |
+| `internal/handler/router.go` | 認証必須 group 内 `r.Route("/api/users", ...)` ブロックの先頭に `r.Get("/me", userHandler.GetCurrent)` を追加 | Req 2.1, 2.2 |
+| `internal/user/service.go` | `Service` に `GetByID(ctx context.Context, userID string) (*model.User, error)` を追加。実装は `s.userRepo.FindByID(ctx, userID)` を呼ぶだけ。txBeginner パス時は `s.txUserDeleter.FindByID(ctx, userID)` を使う（既存 withdraw と同パターン） | Req 2.1, 2.2 |
+| `internal/item/service.go` | `FeedMetaProvider` interface を追加（`FindByID(ctx context.Context, id string) (*model.Feed, error)` のみ）。`ItemService` に `feedRepo FeedMetaProvider` フィールドを追加し、`NewItemService` シグネチャに追加。`ItemDetail` 構造体に `FeedTitle string` / `FeedFaviconURL *string` を追加し、`GetItem` 内で feed 取得 → `model.FaviconDataURL` 整形 | Req 3.1, 3.2, 3.4 |
+| `internal/app/app.go` | `item.NewItemService` 呼出しに `feedRepo` を追加（既存変数を渡すだけ） | 新規 service 依存の配線 |
+| `internal/handler/user_handler_test.go` | `mockUserService.GetCurrent` 追加。`TestUserHandler_GetCurrent_Success` / `..._NoUserID_ReturnsUnauthorized` / `..._UserNotFound` / `..._OmitsSecrets`（password 等を JSON に含めない） を追加 | Req 4.1, 4.2 |
+| `internal/handler/item_handler_test.go` | `TestItemHandler_GetItem_ReturnsFeedMetadata`（feed_title / feed_favicon_url が含まれる）、`TestItemHandler_GetItem_PreservesExistingFields`（既存フィールド全保持）、`TestItemHandler_GetItem_NullFaviconWhenMissing`（favicon 無し → null/省略）を追加 | Req 4.4, 4.5 |
+| `internal/handler/auth_handler_test.go` | `TestAuthHandler_Me_CookiePathUnchanged`（`/auth/me` non-regression: Cookie 経路 / 応答形状 `{id, email, name}` のまま）を 1 件追加 | Req 4.3 |
+| `internal/handler/router_full_test.go` | `GET /api/users/me` が認証必須 group に乗り、認証情報なしで 401 を返すことを確認する 1 件を追加 | Req 2.1, 2.2, 2.5 |
+| `internal/user/service_test.go` | `TestService_GetByID_*`（正常 / NotFound）の単体テストを追加 | Req 4.1, 4.2 |
+| `internal/item/service_test.go` | `TestItemService_GetItem_PopulatesFeedMetadata` / `..._NullFaviconWhenFeedHasNone` を追加 | Req 4.4 |
+| `docs/specs/207--mobile-api-v1-api/mobile-api-contract.md` | 新規作成（後述「Mobile API Contract Document の構成」） | Req 1.1〜1.5 |
+| `README.md` | `## API エンドポイント` 配下の表に `GET /api/users/me` を新設項として記載、Native auth 系（`POST /api/auth/token` / `/refresh` / `/revoke`） / `GET /api/items/cross-feed` / `GET /api/items/search` / `GET /api/feeds/starred/items` / `PUT /api/users/me/cross-feed-last-seen` を一覧に追記、契約文書 `docs/specs/207--mobile-api-v1-api/mobile-api-contract.md` への参照リンクを追加 | Req 1.6 |
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Tests |
+|-------------|---------|------------|------------|-------|
+| 1.1 | 共通方針記載 | mobile-api-contract.md | — | （文書） |
+| 1.2 | native auth サマリ + 既存 spec 参照 | mobile-api-contract.md | — | （文書） |
+| 1.3 | 統一ユーザー情報 URL/認証/応答 | mobile-api-contract.md / UserHandler.GetCurrent | currentUserResponse | （文書 + Test 4.1, 4.2） |
+| 1.4 | 一覧/詳細/検索/購読/クロスフィード契約 | mobile-api-contract.md | 既存各 handler のレスポンス型 | （文書） |
+| 1.5 | v1 スコープ外明示 | mobile-api-contract.md「v1 スコープ外」節 | — | （文書） |
+| 1.6 | README 追記 | README.md | — | — |
+| 2.1 | Bearer で current user 返却 | UserHandler.GetCurrent + BearerOrSession | UserServiceInterface.GetCurrent | Test 4.1 |
+| 2.2 | Cookie で current user 返却 | UserHandler.GetCurrent + BearerOrSession (Cookie 委譲) | 同上 | Test 4.2 |
+| 2.3 | id/email/name/avatar_url を含む | currentUserResponse | currentUserResponse JSON tags | Test 4.1, 4.2 |
+| 2.4 | avatar_url 欠落時 null/省略 | currentUserResponse (`*string` + `omitempty`) | 同上 | Test 4.1, 4.2 |
+| 2.5 | 未認証時拒否 | BearerOrSession middleware（既存）+ UserIDFromContext 失敗 401 | — | router_full_test の認証 group 確認 + handler test の no-userID 401 |
+| 2.6 | /auth/me 不変 | AuthHandler.Me（変更なし） | 既存 `{id, email, name}` | Test 4.3 |
+| 3.1 | feed_title 含む | itemDetailResponse + ItemServiceAdapter | itemDetailResponse | Test 4.4 |
+| 3.2 | feed_favicon_url 含む | 同上 + model.FaviconDataURL | itemDetailResponse | Test 4.4 |
+| 3.3 | 既存フィールド維持 | itemDetailResponse 既存フィールド | itemDetailResponse | Test 4.5 |
+| 3.4 | favicon 無し → null/省略 | `FeedFaviconURL *string` + `omitempty` | itemDetailResponse | item_handler_test の null ケース |
+| 3.5 | 購読外時の拒否応答不変 | item.ItemService.GetItem の既存 SubscriptionChecker 認可 | 既存 ITEM_NOT_FOUND | item_handler_test の既存 fixture 流用 |
+| 4.1 | Bearer で current user テスト | user_handler_test | — | TestUserHandler_GetCurrent_Bearer |
+| 4.2 | Cookie で current user テスト | user_handler_test（ハンドラレベルでは同一経路 / withUserID 共通） | — | TestUserHandler_GetCurrent_Cookie |
+| 4.3 | /auth/me 不変テスト | auth_handler_test | — | TestAuthHandler_Me_CookiePathUnchanged |
+| 4.4 | 記事詳細 feed メタ含むテスト | item_handler_test | — | TestItemHandler_GetItem_ReturnsFeedMetadata |
+| 4.5 | 既存フィールド維持テスト | item_handler_test | — | TestItemHandler_GetItem_PreservesExistingFields |
+| NFR 1.1 | 既存 URL/認証/応答不変 | 全変更箇所が加算のみ | — | 既存テスト全通過 |
+| NFR 1.2 | 既存フィールド不変 | itemDetailResponse 既存フィールド名・型・null 表現不変 | — | Test 4.5 |
+| NFR 1.3 | 既存テスト追加修正なし | — | — | `go test ./...` で確認 |
+| NFR 2.1 | 文書独立可読性 | mobile-api-contract.md 全節 | — | — |
+| NFR 2.2 | v1 内 / 次フェーズ明示区別 | 同 v1 / 次フェーズ節 | — | — |
+| NFR 3.1 | 標準コマンド実行可能 | 全テストは `go test ./...` 対象 | — | — |
+
+## Components and Interfaces
+
+### Handler Layer
+
+#### UserHandler.GetCurrent（新規）
+
+| Field | Detail |
+|-------|--------|
+| Intent | モバイル / Web の両クライアント向けに current user 情報を JSON で返す |
+| Requirements | 2.1, 2.2, 2.3, 2.4, 2.5 |
+
+**Responsibilities & Constraints**
+
+- `middleware.UserIDFromContext` で `userID` を取得（失敗 → 401 `UNAUTHORIZED`、既存
+  `UserHandler.Withdraw` と完全同一の error pattern）
+- `UserServiceInterface.GetCurrent(ctx, userID)` を呼び、結果を `currentUserResponse` として
+  JSON 出力
+- 認証ヘッダ / Cookie の判別は middleware 側（BearerOrSession）の責務であり handler は意識
+  しない（Req 2.1 / 2.2 を「同一 handler で両経路」として実現する）
+
+**Dependencies**
+
+- Inbound: chi router（`/api/users/me`）
+- Outbound: `UserServiceInterface.GetCurrent` — current user 取得（Critical）
+- External: なし
+
+**Contracts**: Service [x] / API [x]
+
+##### API Contract
+
+| Method | Endpoint | Request | Response | Errors |
+|--------|----------|---------|----------|--------|
+| GET | `/api/users/me` | （body なし。Authorization: Bearer または Cookie session_id を提示） | `200 {"id":string,"email":string,"name":string,"avatar_url":string\|null}` | `401` 未認証 / `404 USER_NOT_FOUND`（DB 上 user が消失している例外時） / `500` 内部エラー |
+
+##### Service Interface（handler 内）
+
+```go
+// UserServiceInterface（既存）に追加するメソッド:
+type UserServiceInterface interface {
+    Withdraw(ctx context.Context, userID string) error
+    // GetCurrent は当該 userID の current user 情報を返す。
+    // userID は middleware が解決したものを渡す。userID 不正・未存在は
+    // model.NewUserNotFoundError() を返す。
+    GetCurrent(ctx context.Context, userID string) (*currentUserResponse, error)
+}
+
+type currentUserResponse struct {
+    ID        string  `json:"id"`
+    Email     string  `json:"email"`
+    Name      string  `json:"name"`
+    AvatarURL *string `json:"avatar_url,omitempty"` // 値不在時は省略（Req 2.4）
+}
+```
+
+- Preconditions: `ctx` 内に `userID` が注入済み（BearerOrSession 通過後）
+- Postconditions: 成功時は当該 userID の `User` を返す。secret（hashed token・session_id 等）
+  をレスポンスに含めない（CLAUDE.md「機能追加チェックリスト」）
+- Invariants: 応答 JSON のキー集合は `{id, email, name}` ⊆ X ⊆ `{id, email, name, avatar_url}`
+  （avatar_url は `null` 値時に省略可、他 3 フィールドは必須）
+
+#### ItemHandler.GetItem（拡張）
+
+| Field | Detail |
+|-------|--------|
+| Intent | 記事詳細応答に feed メタデータ（title / favicon）を含めて返す |
+| Requirements | 3.1, 3.2, 3.3, 3.4, 3.5 |
+
+**Responsibilities & Constraints**
+
+- handler 本体（`item_handler.go` の `GetItem` メソッド）のフロー・認可は不変。応答型の
+  `itemDetailResponse` に 2 フィールドを追加するだけ
+- 認可（購読確認）と存在秘匿は既存 `item.ItemService.GetItem` の `SubscriptionChecker` で
+  実施済み。本拡張で挙動を変えない（Req 3.5）
+
+**Dependencies**
+
+- Inbound: chi router（`/api/items/{id}`）
+- Outbound: `ItemServiceInterface.GetItem`（既存 / 拡張）— 戻り型に feed メタを含めて返す
+- External: なし
+
+**Contracts**: API [x]
+
+##### API Contract（既存 + 拡張）
+
+| Method | Endpoint | Request | Response（拡張） | Errors |
+|--------|----------|---------|------------------|--------|
+| GET | `/api/items/{id}` | （path: item ID） | 既存 itemDetailResponse + `feed_title:string`, `feed_favicon_url:string\|null` | 既存と同一: `401` / `404 ITEM_NOT_FOUND`（購読外 or 不在） / `500` |
+
+##### Service Interface（handler 内）
+
+```go
+// itemDetailResponse の拡張:
+type itemDetailResponse struct {
+    itemSummaryResponse              // 既存。id / feed_id / title / link / summary / published_at / is_date_estimated / is_read / is_starred / hatebu_count
+    Content        string  `json:"content"`
+    Summary        string  `json:"summary"`
+    Author         string  `json:"author"`
+    FeedTitle      string  `json:"feed_title"`               // 追加 (Req 3.1)
+    FeedFaviconURL *string `json:"feed_favicon_url,omitempty"` // 追加 (Req 3.2 / 3.4: null or 省略)
+}
+```
+
+- Preconditions: 既存と同一
+- Postconditions: 既存フィールドの値・型・null 表現は無変更（NFR 1.2 / Req 3.3）
+- Invariants: feed が削除された場合は本 spec のスコープ外（item の `FindByID` が成功した時点
+  で feed_id は valid 前提。FK 制約により孤立 item は存在しない）
+
+#### AuthHandler.Me（不変 / non-regression）
+
+| Field | Detail |
+|-------|--------|
+| Intent | 既存 Web Cookie 経路の current user 取得を従来通り維持 |
+| Requirements | 2.6 / NFR 1.1 |
+
+**Responsibilities & Constraints**: 一切変更しない。`GET /auth/me` の URL・Cookie 認証方式・
+応答形状 `{id, email, name}` を本 spec 導入前と同一に保つ。non-regression test 1 件を追加し、
+将来の改修で外れたら即検出する。
+
+### Service Layer
+
+#### user.Service.GetByID（新規）
+
+| Field | Detail |
+|-------|--------|
+| Intent | userID から current user を取得する純粋な lookup |
+| Requirements | 2.1, 2.2 |
+
+**Responsibilities & Constraints**
+
+- `s.userRepo.FindByID(ctx, userID)` を呼ぶ薄い wrapper（既存 `Withdraw` がレガシーパスで
+  実施しているのと同一形）
+- `txBeginner` が設定されている場合は `s.txUserDeleter.FindByID(ctx, userID)` を使い、トランザクション
+  なしで lookup する（既存 withdraw の `txUserDeleter.FindByID` と同一 interface を再利用）
+- 見つからない / nil の場合は `model.NewUserNotFoundError()` を返す（既存 `Withdraw` と同パターン）
+- ビジネス認可は実施しない（caller userID = lookup userID であり middleware で済んでいる）
+
+**Dependencies**
+
+- Inbound: `UserServiceAdapter.GetCurrent`
+- Outbound: `repository.UserRepository.FindByID` / `TxUserDeleter.FindByID` — DB lookup（Critical）
+
+**Contracts**: Service [x]
+
+```go
+// user.Service に追加:
+// GetByID は指定 userID の current user を返す。
+// 認可は呼び出し側（middleware）が担保しており、本メソッドは認可を行わない。
+// userID が DB 上に存在しない場合は model.NewUserNotFoundError を返す。
+func (s *Service) GetByID(ctx context.Context, userID string) (*model.User, error)
+```
+
+#### item.ItemService.GetItem（拡張）
+
+| Field | Detail |
+|-------|--------|
+| Intent | 既存の認可 + 状態取得に加えて、所属 feed のメタデータ（title / favicon）を併せて返す |
+| Requirements | 3.1, 3.2, 3.3, 3.4, 3.5 |
+
+**Responsibilities & Constraints**
+
+- 既存の認可フロー（FindByID → SubscriptionChecker → FindByUserAndItem）は **完全に不変**。
+  ITEM_NOT_FOUND を返す条件も不変（Req 3.5）
+- 既存処理通過後に `feedRepo.FindByID(ctx, item.FeedID)` を呼び、`Feed.Title` を `FeedTitle`、
+  `model.FaviconDataURL(feed.FaviconData, feed.FaviconMime)` を `FeedFaviconURL` として
+  `ItemDetail` に populate する
+- `feedRepo` は `FeedMetaProvider` 最小 interface（`FindByID` のみ）で受ける（interface
+  segregation。既存 `SubscriptionChecker` と同パターン）
+- feed が見つからない（NULL）場合は内部不整合とみなし `feedRepo.FindByID` が nil を返したら
+  500 を返す方が安全だが、items.feed_id は FK 制約により孤立しないため実運用では発生しない。
+  防御的に「nil → FeedTitle 空 / FeedFaviconURL nil」とする選択肢もあるが、本 spec では
+  「FindByID が nil なら error として上位に返す」とする（fail-fast / 内部状態の検出）
+
+**Dependencies**
+
+- Inbound: `ItemServiceAdapterFromDomain.GetItem`
+- Outbound:
+  - `repository.ItemRepository.FindByID` / `ItemStateRepository.FindByUserAndItem`（既存 / Critical）
+  - `SubscriptionChecker.FindByUserAndFeed`（既存 / Critical）
+  - `FeedMetaProvider.FindByID`（新規 / Critical for メタ取得）
+- External: なし
+
+**Contracts**: Service [x]
+
+```go
+// item パッケージに新設する最小 interface:
+type FeedMetaProvider interface {
+    // FindByID は指定 ID のフィードを返す。見つからない場合は nil。
+    FindByID(ctx context.Context, id string) (*model.Feed, error)
+}
+
+// 既存 ItemService のフィールド + コンストラクタを拡張:
+type ItemService struct {
+    itemRepo      repository.ItemRepository
+    itemStateRepo repository.ItemStateRepository
+    subChecker    SubscriptionChecker
+    feedRepo      FeedMetaProvider // 新規追加
+}
+
+func NewItemService(
+    itemRepo repository.ItemRepository,
+    itemStateRepo repository.ItemStateRepository,
+    subChecker SubscriptionChecker,
+    feedRepo FeedMetaProvider, // 新規追加
+) *ItemService
+
+// ItemDetail の拡張:
+type ItemDetail struct {
+    ItemSummary
+    Content        string
+    Summary        string
+    Author         string
+    FeedTitle      string  // 新規 (Req 3.1)
+    FeedFaviconURL *string // 新規 (Req 3.2 / 3.4)
+}
+```
+
+- Preconditions: 既存 GetItem と同一
+- Postconditions: 認可 / 存在秘匿挙動は不変。成功時のみ feed メタを返す
+- Invariants: feed メタ取得失敗時はリクエスト全体を error として返し、レスポンスは送らない
+  （部分応答を生成しない）
+
+### Adapter Layer
+
+#### UserServiceAdapter.GetCurrent（新規）
+
+```go
+// 既存 UserServiceAdapter（service_adapter.go）にメソッド追加:
+func (a *UserServiceAdapter) GetCurrent(ctx context.Context, userID string) (*currentUserResponse, error) {
+    u, err := a.svc.GetByID(ctx, userID)
+    if err != nil {
+        return nil, err
+    }
+    return &currentUserResponse{
+        ID:        u.ID,
+        Email:     u.Email,
+        Name:      u.Name,
+        AvatarURL: nil, // 当面 nil 固定（DB 未拡張 / 詳細は「データモデル」節 / Req 2.4）
+    }, nil
+}
+```
+
+#### ItemServiceAdapterFromDomain.GetItem（拡張）
+
+既存実装に `FeedTitle` / `FeedFaviconURL` のコピーを追加するのみ:
+
+```go
+return &itemDetailResponse{
+    itemSummaryResponse: itemSummaryResponse{ /* 既存 */ },
+    Content:        detail.Content,
+    Summary:        detail.Summary,
+    Author:         detail.Author,
+    FeedTitle:      detail.FeedTitle,      // 追加
+    FeedFaviconURL: detail.FeedFaviconURL, // 追加（*string なので nil で省略）
+}, nil
+```
+
+## Data Models
+
+### Domain Model
+
+#### User（既存。変更なし）
+
+```go
+type User struct {
+    ID        string
+    Email     string
+    Name      string
+    CreatedAt time.Time
+    UpdatedAt time.Time
+}
+```
+
+#### Feed（既存。再利用）
+
+```go
+type Feed struct {
+    ID              string
+    Title           string
+    FaviconData     []byte
+    FaviconMime     string
+    // ... 既存フィールド
+}
+```
+
+`Feed.Title` を `feed_title`、`(FaviconData, FaviconMime)` を `model.FaviconDataURL` で
+`feed_favicon_url` に変換する。
+
+### Response DTO
+
+#### currentUserResponse（新規 / handler 内 private 型）
+
+| JSON Field | Go Type | Source | Req |
+|---|---|---|---|
+| `id` | `string` | `User.ID` | 2.3 |
+| `email` | `string` | `User.Email` | 2.3 |
+| `name` | `string` | `User.Name` | 2.3 |
+| `avatar_url` | `*string` (omitempty) | nil 固定（後述設計判断） | 2.3, 2.4 |
+
+#### itemDetailResponse（既存 + 拡張）
+
+| JSON Field | 種別 | Source | Req |
+|---|---|---|---|
+| 既存 11 フィールド（`id` 〜 `author`） | 既存 | 既存 | 3.3 |
+| `feed_title` | 追加 / `string` | `Feed.Title` | 3.1 |
+| `feed_favicon_url` | 追加 / `string\|null` (omitempty) | `model.FaviconDataURL(Feed.FaviconData, Feed.FaviconMime)` | 3.2, 3.4 |
+
+### 設計判断: `avatar_url` を当面 nil 固定で返す
+
+**判断**: `users` テーブルへの `avatar_url` カラム追加・Google OAuth `picture` claim 取得・
+identities テーブル拡張は本 spec のスコープに **含めない**。`currentUserResponse.AvatarURL`
+は `*string` 型として schema には常に存在し、当面 `nil` を返す（JSON では `omitempty` により
+省略される）。
+
+**根拠**:
+
+- requirement 2.4 が「JSON null または応答からの省略」を明示的に許容しているため、`nil` 固定
+  でも要件は満たされる
+- DB スキーマ拡張 / OAuth callback 改修は影響範囲が広く、本 spec の「契約明文化 + サーバ補正」
+  というスコープを超える
+- 将来 `avatar_url` を実値で返す改修を行う際、`*string` 型と JSON schema は既に確保済みで、
+  値を populate する箇所（`UserServiceAdapter.GetCurrent`）のみ変更すれば後方互換に追加できる
+
+**代替案（不採用）**:
+
+- (a) 本 spec で users.avatar_url カラム追加 + OAuth callback で picture claim 保存 →
+  影響範囲拡大により Issue 分割の方が健全
+- (b) avatar_url を一切応答に含めない → requirement 2.3 違反
+- (c) `email` のドメイン部から Gravatar URL を生成 → ユーザー同意なき外部送信であり
+  プライバシー方針上不可
+
+**確認事項として PjM に申し送る**: 「将来 `avatar_url` を実値で返す改修を別 Issue として
+切るかどうか（OAuth callback で `picture` を保存する設計）」を設計 PR の「確認事項」に
+記載する。本 spec では要件 2.4 の「null/省略」を採用する。
+
+### Logical / Physical Data Model
+
+本 spec での DB スキーマ変更・新規テーブル追加・新規カラム追加は **なし**。
+
+## Error Handling
+
+### Error Strategy
+
+既存 `model.APIError` + `middleware.WriteErrorResponse` + `handleServiceError` のパターンを
+そのまま踏襲する。新規エラーコードは追加しない（`UNAUTHORIZED` / `USER_NOT_FOUND` /
+`ITEM_NOT_FOUND` を再利用）。
+
+### Error Categories and Responses
+
+- **User Errors (4xx)**:
+  - `401 UNAUTHORIZED` — `/api/users/me` で `UserIDFromContext` 失敗時（BearerOrSession
+    middleware を通過しても context に userID がない異常時のセーフネット）。既存
+    `UserHandler.Withdraw` と完全同一のレスポンス
+  - `404 USER_NOT_FOUND` — `/api/users/me` で middleware 認証通過後に DB 上の user が
+    消失している例外時。`model.NewUserNotFoundError()` → `handleServiceError` → 既存
+    パターン
+  - `404 ITEM_NOT_FOUND` — `/api/items/{id}` の既存挙動。未購読・不在の両方を同一応答に
+    まとめ存在を秘匿する（NFR 1.1 / Req 3.5、既存挙動を変えない）
+- **System Errors (5xx)**:
+  - `500` — feedRepo の予期せぬ DB エラー / item 詳細取得中の feed lookup 失敗
+  - 既存 `handleServiceError` がエラーを `model.APIError` 以外なら 500 に集約する経路を
+    そのまま利用
+- **Business Logic Errors**: 本 spec の新規ロジックは認可境界を新設しないため、ビジネス
+  ルール違反は発生しない
+
+### 認証層のエラー応答
+
+`BearerOrSession` middleware（既存）が以下を返す:
+
+- Authorization 無し + Cookie 無し → 既存 `SessionMiddleware` 経路で 401（`"unauthorized"` plain text）
+- Bearer 検証失敗 → 401（`"unauthorized"` plain text、Cookie へ fallback しない）
+
+これらは本 spec の handler に到達する前に処理される（Req 2.5）。本 spec で middleware を
+改変しない。
+
+## Testing Strategy
+
+### Unit Tests
+
+- `user.Service.GetByID` 正常系（userID から `*model.User` を返す）
+- `user.Service.GetByID` UserNotFound 系（FindByID nil → `model.NewUserNotFoundError()`）
+- `item.ItemService.GetItem` 正常系で feed メタが populate されることを mock `FeedMetaProvider`
+  で検証
+- `item.ItemService.GetItem` favicon なし feed → `FeedFaviconURL` が nil（Req 3.4）
+- `item.ItemService.GetItem` 既存認可（購読外 / item 不在）応答が不変であることを確認
+
+### Integration Tests（handler レベル / 既存 fixture 流用）
+
+- `TestUserHandler_GetCurrent_Success`（withUserID で userID 注入 → 200 + JSON）
+- `TestUserHandler_GetCurrent_NoUserID_ReturnsUnauthorized`（userID 注入無し → 401）
+- `TestUserHandler_GetCurrent_UserNotFound`（service が NewUserNotFoundError → 404）
+- `TestUserHandler_GetCurrent_OmitsSecrets`（応答 JSON のキーが `{id, email, name}` ⊆
+  X ⊆ `{id, email, name, avatar_url}` であることを assert / NFR セキュリティ）
+- `TestItemHandler_GetItem_ReturnsFeedMetadata`（mock service が feed_title / favicon URL を
+  返し、JSON に出現する / Req 3.1, 3.2）
+- `TestItemHandler_GetItem_PreservesExistingFields`（既存 11 フィールドが全て出現し型不変 / Req 3.3）
+- `TestItemHandler_GetItem_NullFaviconWhenMissing`（FeedFaviconURL nil → 応答から省略 / Req 3.4）
+- `TestAuthHandler_Me_CookiePathUnchanged`（既存 Cookie 経路で `{id, email, name}` 応答が維持 /
+  Req 2.6）
+- `TestRouter_GetUsersMe_RequiresAuth`（`router_full_test.go` 追加。`GET /api/users/me` が
+  認証必須 group に乗り、Authorization / Cookie 無しで 401 / Req 2.5）
+
+### E2E / Contract Tests
+
+本 spec ではフル E2E は追加せず、handler 統合テストでカバーする（NFR 3.1: 外部接続を要さない /
+標準コマンドで実行）。Bearer 経路と Cookie 経路は middleware 層で既に検証済み（#172 で
+end-to-end 契約テスト整備済）であり、`/api/users/me` 自体の handler は両経路で同一の
+`UserIDFromContext` 経路を通るため二経路のハンドラレベル分岐テストは不要。
+
+### Performance / Load Tests
+
+本 spec の変更は既存クエリの追加（feed FindByID 1 件追加 / user FindByID 1 件追加）に留まり、
+性能影響は無視可能。専用負荷テストは追加しない。
+
+## Mobile API Contract Document の構成（`docs/specs/207--mobile-api-v1-api/mobile-api-contract.md`）
+
+本文書は **クライアント実装者がサーバ実装ソースを参照せずに v1 動線を実装可能**な粒度で
+記述する（NFR 2.1）。構成案:
+
+1. **概要** — v1 のスコープ・対象クライアント・対象サーバ実装 commit / 日付
+2. **共通方針**（Req 1.1）
+   - 認証方式: Bearer access token（モバイル） / Cookie session_id（Web）
+   - エラー応答形式: `model.APIError` の JSON shape（code / message / category / action）
+   - 命名規約: snake_case JSON フィールド / RFC3339 タイムスタンプ / cursor pagination
+   - 共通エラーステータス: 400 / 401 / 404 / 422 / 429 / 500
+3. **Native Auth エンドポイント**（Req 1.2 / サマリ + 既存 spec 参照）
+   - `POST /api/auth/token` — auth_code 交換（詳細 #166 / #172 spec）
+   - `POST /api/auth/refresh` — token rotation（詳細 #167 / #172 spec）
+   - `POST /api/auth/revoke` — token 無効化（詳細 #168 / #172 spec）
+   - `GET /auth/google/login?flow=native&code_challenge=...` — PKCE login（#165）
+   - `feedman://auth/callback?auth_code=...` — native callback（#165）
+4. **モバイル統一ユーザー情報取得**（Req 1.3）
+   - `GET /api/users/me` — URL / 認証方式（Bearer or Cookie）/ 成功応答スキーマ / エラー応答
+5. **v1 共通動線エンドポイント**（Req 1.4）
+   - `GET /api/feeds/{id}/items` — 記事一覧（cursor / filter）
+   - `GET /api/feeds/starred/items` — 全フィード横断スター記事一覧
+   - `GET /api/items/{id}` — 記事詳細（**feed_title / feed_favicon_url 含む**）
+   - `GET /api/items/search?q=...` — 記事検索
+   - `GET /api/items/cross-feed` — 横断新着一覧
+   - `GET /api/subscriptions` — 購読一覧
+   - `DELETE /api/subscriptions/{id}` — 購読解除
+   - `PUT /api/subscriptions/{id}/settings` — フェッチ間隔設定
+   - `POST /api/subscriptions/{id}/resume` — 停止フィード再開
+   - `POST /api/subscriptions/{id}/fetch` — 手動フェッチ
+   - `PUT /api/items/{id}/state` — 既読 / スター状態更新
+   - `PUT /api/users/me/cross-feed-last-seen` — 横断一覧の最終閲覧時刻更新
+6. **v1 スコープ外（次フェーズ）**（Req 1.5 / NFR 2.2）
+   - `/api/devices` — デバイス登録（次フェーズ）
+   - `/api/keywords` — キーワード通知（次フェーズ）
+   - 上記は v1 クライアントが呼び出さない旨を明示
+7. **後方互換ポリシー** — 既存フィールドの削除・改名・型変更を行わない / 追加フィールドの
+   みで進化させる旨
+
+## Security Considerations
+
+- **認証スコープ**: `/api/users/me` は `BearerOrSession` middleware を必ず通過させ、未認証
+  要求は handler 到達前に 401 で拒否する（Req 2.5）
+- **secret 非露出**: `currentUserResponse` には `id` / `email` / `name` / `avatar_url` のみ
+  を含め、session_id / refresh_token / hashed token 等は **絶対に含めない**（CLAUDE.md
+  「機密情報の扱い」/「機能追加チェックリスト」）
+- **エラー応答の最小化**: 内部エラー詳細（SQL エラー / スタックトレース / 内部 URL）を
+  レスポンスに含めない。既存 `handleServiceError` の挙動を変えない
+- **`/auth/me` の Cookie 動線**: 一切変更しない。HttpOnly / Secure / SameSite=Lax の Cookie
+  属性は無変更（Req 2.6 / NFR 1.1）
+- **記事詳細の favicon**: 既存 `model.FaviconDataURL` 経由で data URL 化する。生バイトを
+  そのまま返さないため、Content-Security-Policy 違反は発生しない（既存 `subscription` /
+  `crossfeed` / `itemsearch` と同パターン）
+
+## Migration Strategy
+
+本 spec は **追加のみ**であり破壊的変更を含まない。マイグレーションは不要。クライアント側
+の移行（`/auth/me` から `/api/users/me` への切り替え）はモバイルクライアント実装側の別 Issue
+で実施する。サーバ側は両エンドポイントを並行提供し続けるため、移行期間中の非対称も問題に
+ならない。
+
+## Open Questions / 設計 PR レビュー時の確認事項
+
+設計 PR 本文「確認事項」セクションに以下を記載するよう Project Manager / 運用者に申し送る:
+
+1. **`avatar_url` の実値返却タイミング**: 本 spec では `null` 固定。将来 `users.avatar_url`
+   カラム追加 + OAuth callback で `picture` claim 保存を行う改修を別 Issue で起票するか、
+   v1 リリースでは null のまま放置するかを決定すること
+2. **`/api/users/me` を Web フロントエンドからも呼ぶか**: Web 側は既存 `/auth/me` で動作中。
+   モバイル / Web の双方が `/api/users/me` を使う形に統一するかどうかは別 Issue で決定（本
+   spec では決定しない / requirements.md Out of Scope）
+3. **mobile-api-contract.md の配置場所**: 本 spec では `docs/specs/207--mobile-api-v1-api/`
+   配下に配置する案。クライアント実装者が永続参照する文書として `docs/contracts/` のような
+   永続的な場所に置くべきかは PjM 判断（本 spec では spec 配下で起票し、必要なら別 PR で
+   移動を検討）
+
+## Supporting References
+
+- [chi router v5 - Routing patterns](https://github.com/go-chi/chi#routing-patterns)
+  — `r.Route("/api/users", ...)` 配下に `r.Get("/me", ...)` を追加する記法の確認
+- 関連 spec:
+  - `docs/specs/172-native-auth-contract-tests/design.md` — native auth 契約テストの記述
+    パターンを参照
+  - Issue #163 / #169 — BearerOrSession middleware の判定フロー

--- a/docs/specs/207--mobile-api-v1-api/requirements.md
+++ b/docs/specs/207--mobile-api-v1-api/requirements.md
@@ -1,0 +1,118 @@
+# Requirements Document
+
+## Introduction
+
+Feedman の v1 モバイルクライアント（Android / iOS）は、Web フロントエンドと共通のサーバー
+API を利用してログイン後の主要機能（ユーザー情報取得・記事一覧・記事詳細・検索・購読操作）
+を実現する。しかし現状はサーバー実装と Web フロント実装の暗黙の合意で動いており、
+モバイル側が独立して参照できる「v1 共通 API 契約ドキュメント」が存在しない。また現行
+サーバー応答にはモバイルクライアントが期待する一部情報（モバイル向け統一ユーザー情報
+エンドポイント・記事詳細のフィード表示メタデータ）が欠けている。
+
+本 spec は、(1) v1 モバイル API 契約を独立した文書として明文化し、(2) モバイルクライアントが
+依存する 2 点（統一ユーザー情報エンドポイント・記事詳細のフィードメタデータ）をサーバー応答
+として追加し、(3) 既存 Web Cookie 動線および既存契約フィールドの後方互換を維持することを
+対象とする。Native auth の token 発行・rotation・revoke 契約は別 spec（#172 / #163 配下）で
+扱い済みであり、本 spec では発行済み access token を用いて認証済み API を呼び出すクライアント
+共通動線のみを扱う。
+
+## Requirements
+
+### Requirement 1: v1 モバイル API 契約ドキュメントの明文化
+
+**Objective:** As a Feedman モバイルクライアント実装者, I want v1 で利用するサーバー API
+契約を独立した文書として参照したい, so that Android / iOS の各クライアントがサーバー実装
+コードを読まずに独立して実装・検証できる
+
+#### Acceptance Criteria
+
+1. The Mobile API Contract Document shall v1 モバイルクライアントが利用する共通方針（認証ヘッダ・エラー応答形式・JSON フィールド命名規約）を記載する
+2. The Mobile API Contract Document shall native auth 系エンドポイント（token 発行・refresh・revoke・native callback）の契約サマリを記載し、詳細は既存 spec を参照する形で明示する
+3. The Mobile API Contract Document shall 統一ユーザー情報取得エンドポイントの URL・認証方式・成功応答 JSON フィールド・エラー応答を記載する
+4. The Mobile API Contract Document shall 記事一覧・記事詳細・検索・購読操作・クロスフィード閲覧の各エンドポイントについて、URL・認証方式・主要クエリ／パスパラメータ・成功応答 JSON フィールド・エラー応答を記載する
+5. The Mobile API Contract Document shall v1 スコープ外として除外するエンドポイント（デバイス登録・キーワード通知）を「次フェーズ」として明示し、v1 では呼び出さない旨を記録する
+6. The README shall モバイル統一ユーザー情報取得エンドポイント・native auth 系エンドポイント・クロスフィード閲覧・検索の各 API を一覧に追記し、契約文書への参照を含める
+
+### Requirement 2: 統一ユーザー情報取得エンドポイントの新設
+
+**Objective:** As a Feedman モバイルクライアント, I want Bearer token と Web Cookie の
+いずれでも同一の URL で current user 情報を取得したい, so that モバイルと Web が同じ
+クライアントコードパスで認証済みユーザー情報を扱える
+
+#### Acceptance Criteria
+
+1. When 有効な Bearer access token を Authorization ヘッダで提示した状態でモバイル統一ユーザー情報取得エンドポイントが要求されたとき, the Feedman API shall 当該 token の主体である current user の情報を JSON で応答する
+2. When 有効な Web Cookie セッションを提示した状態でモバイル統一ユーザー情報取得エンドポイントが要求されたとき, the Feedman API shall 当該セッションの主体である current user の情報を JSON で応答する
+3. The モバイル統一ユーザー情報取得エンドポイント shall 成功応答に `id`, `email`, `name`, `avatar_url` のフィールドを含める
+4. Where current user に `avatar_url` 値が存在しないとき, the モバイル統一ユーザー情報取得エンドポイント shall `avatar_url` を JSON null または応答からの省略として表現する
+5. If 認証ヘッダもセッションも提示されない、または提示された認証情報が無効である状態でモバイル統一ユーザー情報取得エンドポイントが要求されたとき, the Feedman API shall 未認証として要求を拒否する
+6. The 既存 Web 専用ユーザー情報取得エンドポイント `/auth/me` shall 本 spec 導入前と同一の URL・同一の Web Cookie 認証方式・同一の応答形状で動作する
+
+### Requirement 3: 記事詳細応答へのフィード表示メタデータ追加
+
+**Objective:** As a Feedman モバイルクライアント, I want 記事詳細応答に当該記事が属する
+フィードの表示用メタデータ（タイトル・favicon）を含めて受け取りたい, so that 記事詳細
+画面でフィードのコンテキストを表示する際に追加 API 呼び出しを必要としない
+
+#### Acceptance Criteria
+
+1. When 認証済み要求で記事詳細エンドポイントが特定の記事 ID に対して呼び出されたとき, the Feedman API shall 応答 JSON に当該記事が属するフィードの表示タイトルを示すフィールドを含める
+2. When 認証済み要求で記事詳細エンドポイントが特定の記事 ID に対して呼び出されたとき, the Feedman API shall 応答 JSON に当該記事が属するフィードの favicon を示すフィールドを含める
+3. The 記事詳細エンドポイント shall 本 spec 導入前から応答に含まれていた既存フィールド（記事 ID・フィード ID・タイトル・リンク・サマリ・本文・著者・公開日時・日時推定フラグ・既読フラグ・スター付与フラグ・はてなブックマーク件数）を引き続き同一フィールド名で含める
+4. Where フィードに favicon が登録されていないとき, the 記事詳細エンドポイント shall favicon メタデータフィールドを JSON null または応答からの省略として表現する
+5. If 要求された記事 ID が要求元ユーザーの購読範囲に存在しないとき, the 記事詳細エンドポイント shall 本 spec 導入前と同一の拒否応答を返す
+
+### Requirement 4: v1 クライアント共通動線の契約テスト
+
+**Objective:** As a Feedman 運用者, I want v1 モバイルクライアント共通動線の主要契約が
+自動テストで検証されてほしい, so that 後続変更で契約から外れた応答が混入しても CI で
+検出できる
+
+#### Acceptance Criteria
+
+1. The Mobile API Contract Test Suite shall Bearer access token 提示時にモバイル統一ユーザー情報取得エンドポイントが current user を返すことを検証する
+2. The Mobile API Contract Test Suite shall Web Cookie セッション提示時にモバイル統一ユーザー情報取得エンドポイントが current user を返すことを検証する
+3. The Mobile API Contract Test Suite shall 既存 Web 専用ユーザー情報取得エンドポイント `/auth/me` の Web Cookie 動線が本 spec 導入前と同一に動作することを検証する
+4. The Mobile API Contract Test Suite shall 記事詳細エンドポイントの応答にフィード表示タイトルとフィード favicon メタデータの両フィールドが含まれることを検証する
+5. The Mobile API Contract Test Suite shall 記事詳細エンドポイントの応答に既存フィールド一式が引き続き含まれることを検証する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The Feedman API shall 既存 Web Cookie セッション認証で利用されている全エンドポイントの URL・認証方式・応答形状を本 spec 導入により変更しない
+2. The Feedman API shall 既存記事詳細エンドポイントの既存応答フィールドのフィールド名・型・null 表現を本 spec 導入により変更しない
+3. The Feedman API shall 本 spec の変更により既存の自動テストスイートが追加の修正なしに通過する状態を維持する
+
+### NFR 2: 契約文書の独立可読性
+
+1. The Mobile API Contract Document shall モバイルクライアント実装者がサーバー実装ソースコードを参照せずに、文書のみで v1 で呼び出す全エンドポイントの URL・認証方式・要求／応答 JSON 形状を特定できる粒度で記載する
+2. The Mobile API Contract Document shall v1 スコープに含まれるエンドポイントと v1 スコープ外として次フェーズに延期するエンドポイントを明示的に区別して記載する
+
+### NFR 3: テストの自動実行性
+
+1. The Mobile API Contract Test Suite shall 標準のリポジトリテスト実行コマンドで他テストと併せて実行可能な配置とし、外部ネットワーク・実 OAuth プロバイダ・実フィード取得への接続を必要としない
+
+## Out of Scope
+
+- Native auth 系エンドポイント（token 発行・refresh・revoke・native callback）の実装変更
+  および契約テストの新規整備（#163 配下の #164〜#171 で実装済み、#172 spec で end-to-end
+  契約テストを整備済み。本 spec では契約文書サマリ記載のみ）
+- `/api/devices`（デバイス登録）および `/api/keywords`（キーワード通知）の実装。これらは
+  キーワードプッシュ通知の次フェーズに該当し、v1 接続確認の必須契約に含めない
+- モバイルクライアント（Android / iOS）側の実装変更
+- 既存記事一覧 / 検索 / 購読操作 / クロスフィード閲覧エンドポイントの新規フィールド追加。
+  本 spec では既存挙動を契約文書として固定するに留め、応答拡張は行わない（記事詳細応答への
+  フィードメタデータ追加のみ例外として本 spec で扱う）
+- Web フロントエンドの実装変更（モバイル統一ユーザー情報取得エンドポイントを Web からも
+  呼び出すかは本 spec では決定しない）
+
+## Open Questions
+
+- なし（v1 スコープ外項目・後方互換維持方針・既存 `/auth/me` の保持方針は Issue #207 本文で
+  決着済み。`avatar_url` の null 表現可否および favicon メタデータの null 表現可否は
+  Requirement 2.4 / Requirement 3.4 で「JSON null または応答からの省略」を許容として明示）
+
+## 関連
+
+- Related: #163 #169 #172

--- a/docs/specs/207--mobile-api-v1-api/tasks.md
+++ b/docs/specs/207--mobile-api-v1-api/tasks.md
@@ -1,0 +1,161 @@
+# Implementation Plan
+
+- [ ] 1. Mobile API Contract Document を新規作成する (P)
+  - `docs/specs/207--mobile-api-v1-api/mobile-api-contract.md` を新規作成
+  - 構成は design.md「Mobile API Contract Document の構成」節に従う:
+    概要 / 共通方針（認証ヘッダ・エラー応答形式・JSON 命名規約）/ Native Auth サマリ /
+    モバイル統一ユーザー情報取得 / v1 共通動線エンドポイント（記事一覧・記事詳細・検索・
+    購読操作・クロスフィード）/ v1 スコープ外（次フェーズ）/ 後方互換ポリシー
+  - 各エンドポイントについて URL / 認証方式 / 主要クエリ・パスパラメータ / 成功応答 JSON
+    フィールド / エラー応答を記載し、サーバ実装ソースを参照せずに実装可能な粒度にする
+  - native auth 系（`POST /api/auth/token` / `/refresh` / `/revoke` / `feedman://auth/callback`）は
+    既存 spec（#163 / #165〜#171 / #172）へのリンクを含めたサマリ記載に留める
+  - v1 スコープ外として `/api/devices` / `/api/keywords` を明示し、次フェーズ予定として記録
+  - 記事詳細の応答フィールドには本 spec で追加する `feed_title` / `feed_favicon_url` を
+    必ず含める（Task 7 と整合）
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.3, 2.4, 3.1, 3.2, 3.4, NFR 2.1, NFR 2.2_
+  - _Boundary: mobile-api-contract.md_
+
+- [ ] 2. README の API エンドポイント一覧を更新する (P)
+  - `README.md` の `## API エンドポイント` 配下の表を以下の通り更新:
+    - 「ユーザー管理（認証必須）」に `GET /api/users/me`（モバイル / Web 共通の current
+      user 取得）を新設項として追加
+    - Native Auth 系（`POST /api/auth/token` / `POST /api/auth/refresh` /
+      `POST /api/auth/revoke`）を追記（認証不要グループとして区別）
+    - 既存表に未掲載の項目を追加: `GET /api/feeds/starred/items` / `GET /api/items/search` /
+      `GET /api/items/cross-feed` / `POST /api/subscriptions/{id}/fetch` /
+      `PUT /api/users/me/cross-feed-last-seen`
+    - 表の直後に Mobile API Contract Document
+      （`docs/specs/207--mobile-api-v1-api/mobile-api-contract.md`）への参照リンクを追加
+  - 既存表の他項目（フィード管理 / 記事管理 / 監視 / ミドルウェアスタック / データベース
+    スキーマ等）の記述は変更しない
+  - _Requirements: 1.6_
+  - _Boundary: README.md_
+
+- [ ] 3. user.Service に GetByID を追加し単体テストを通す
+  - `internal/user/service.go` に `func (s *Service) GetByID(ctx context.Context, userID string) (*model.User, error)`
+    を追加。実装は `s.userRepo.FindByID` を呼ぶ（レガシーパス）、または
+    `s.txUserDeleter.FindByID` を呼ぶ（txBeginner パス）薄い wrapper
+  - 見つからない / nil の場合は `model.NewUserNotFoundError()` を返す（既存 `Withdraw` と
+    同パターン）
+  - 認可は行わない（caller userID = lookup userID であり middleware で済んでいる旨を
+    doc comment に記述）
+  - `internal/user/service_test.go` に以下の単体テストを追加:
+    - `TestService_GetByID_Success`（mock UserRepository が user を返し、それがそのまま返る）
+    - `TestService_GetByID_NotFound_ReturnsUserNotFoundError`（mock が nil を返したとき
+      `model.NewUserNotFoundError` が返る）
+    - `TestService_GetByID_RepoError_PropagatesError`（mock がエラーを返したとき wrap されて
+      返ることを確認）
+    - レガシーパスと txBeginner パスの両方で挙動が同一であることを確認（既存 service_test
+      の構築パターンを踏襲）
+  - _Requirements: 2.1, 2.2, 2.3_
+  - _Boundary: user.Service_
+
+- [ ] 4. GET /api/users/me ハンドラ・アダプタ・ルーティング配線を追加し契約テストを通す
+  - `internal/handler/user_handler.go` に以下を追加:
+    - `UserServiceInterface` に `GetCurrent(ctx context.Context, userID string) (*currentUserResponse, error)`
+      メソッド追加
+    - `currentUserResponse` 構造体（`id` / `email` / `name` / `avatar_url *string omitempty`）追加
+    - `UserHandler.GetCurrent(w, r)` 実装（`UserIDFromContext` 失敗 → 401 UNAUTHORIZED /
+      service 呼出 / `handleServiceError` で USER_NOT_FOUND → 404 / 成功 → JSON 200）
+    - `SetupUserRoutes` 内の `r.Route("/api/users", ...)` ブロックに `r.Get("/me", h.GetCurrent)` を追加
+  - `internal/handler/service_adapter.go` に `UserServiceAdapter.GetCurrent` を実装:
+    `a.svc.GetByID(ctx, userID)` を呼び `currentUserResponse` に変換。`avatar_url` は
+    当面 `nil` 固定（design.md「設計判断」節）
+  - `internal/handler/router.go` の認証必須 group 内 `r.Route("/api/users", ...)` ブロックに
+    `r.Get("/me", userHandler.GetCurrent)` を追加（既存 `r.Delete("/me", ...)` の前後どちらでも可）
+  - `internal/handler/user_handler_test.go` に以下のテストを追加:
+    - `mockUserService` に `getCurrentFn` フィールドと `GetCurrent` メソッド追加
+    - `TestUserHandler_GetCurrent_Success_ReturnsCurrentUser`（withUserID で注入 → 200 +
+      `{id, email, name}` を含む JSON / Req 4.1, 4.2: BearerOrSession 通過後の handler は
+      経路非依存で同一動作するため両経路を 1 つのテストで担保）
+    - `TestUserHandler_GetCurrent_NoUserID_ReturnsUnauthorized`（withUserID 未注入 → 401）
+    - `TestUserHandler_GetCurrent_UserNotFound_Returns404`（service が NewUserNotFoundError → 404）
+    - `TestUserHandler_GetCurrent_OmitsSecrets`（応答 JSON のキー集合が
+      `{id, email, name}` ⊆ X ⊆ `{id, email, name, avatar_url}` であり session_id /
+      refresh_token 等を含まないことを assert）
+    - `TestUserHandler_GetCurrent_OmitsAvatarWhenNil`（avatar_url が nil なら JSON から省略
+      されること / Req 2.4）
+  - `internal/handler/router_full_test.go` に
+    `TestRouter_GetUsersMe_RequiresAuth`（`GET /api/users/me` が認証必須グループに乗り、
+    Authorization / Cookie のいずれも無しで 401 を返すことを確認 / Req 2.5）を追加
+  - `internal/app/app.go` の wiring は `UserServiceAdapter` 既存生成箇所のままで GetCurrent
+    が追加で見えるようになる（adapter 拡張のみで配線変更不要）
+  - _Requirements: 1.3, 2.1, 2.2, 2.3, 2.4, 2.5, 4.1, 4.2_
+  - _Boundary: UserHandler, UserServiceAdapter, router.go_
+  - _Depends: 3_
+
+- [ ] 5. /auth/me の Cookie 経路 non-regression テストを追加する
+  - `internal/handler/auth_handler_test.go` に
+    `TestAuthHandler_Me_CookiePathUnchanged` を追加:
+    - 既存 `mockAuthService` パターンを踏襲し、Cookie `session_id` を持つリクエストで
+      `AuthHandler.Me` を呼ぶ
+    - 応答 200 / `Content-Type: application/json` / JSON が **既存形** `{id, email, name}`
+      を含み、本 spec 導入前と同一であることを assert
+    - `avatar_url` のような新フィールドが `/auth/me` から漏れて返らないことも合わせて assert
+    - Cookie 不在時の 401 挙動の non-regression も同 test で確認
+  - `internal/handler/auth_handler.go` および `SetupAuthRoutes` は **変更しない**（このタスク
+    はテスト追加のみで既存挙動の保護を目的とする）
+  - _Requirements: 2.6, 4.3, NFR 1.1_
+  - _Boundary: AuthHandler_
+
+- [ ] 6. item.ItemService.GetItem を拡張し FeedMetaProvider 依存を導入する
+  - `internal/item/service.go` に以下を追加:
+    - `FeedMetaProvider` interface（`FindByID(ctx context.Context, id string) (*model.Feed, error)`
+      の 1 メソッドのみ。既存 `SubscriptionChecker` と同じ interface segregation パターン）
+    - `ItemService` 構造体に `feedRepo FeedMetaProvider` フィールドを追加
+    - `NewItemService` シグネチャに `feedRepo FeedMetaProvider` を追加（呼出側全箇所を更新）
+    - `ItemDetail` 構造体に `FeedTitle string` / `FeedFaviconURL *string` を追加
+    - `GetItem` 内の既存認可フロー（FindByID → SubscriptionChecker → FindByUserAndItem）の
+      **後**に `feedRepo.FindByID(ctx, item.FeedID)` を呼び、`Feed.Title` を `FeedTitle`、
+      `model.FaviconDataURL(feed.FaviconData, feed.FaviconMime)` を `FeedFaviconURL` に populate
+    - feedRepo が nil を返したらエラーとして上位に伝播する（fail-fast / FK 制約により実運用
+      では発生しない想定）
+  - 既存認可フロー（ITEM_NOT_FOUND 応答条件 / SubscriptionChecker の挙動）を **絶対に変えない**
+    （Req 3.5）
+  - `internal/item/service_test.go` に以下の単体テストを追加:
+    - `TestItemService_GetItem_PopulatesFeedMetadata`（mock FeedMetaProvider が feed を返す →
+      ItemDetail.FeedTitle / FeedFaviconURL が populate される）
+    - `TestItemService_GetItem_NullFaviconWhenFeedHasNone`（mock が FaviconData/Mime 空の feed
+      を返す → FeedFaviconURL が nil / Req 3.4）
+    - `TestItemService_GetItem_FeedRepoError_PropagatesError`（mock feedRepo がエラーを返す →
+      error が上位に伝播し ItemDetail nil）
+    - 既存 GetItem のテスト（未購読 → ITEM_NOT_FOUND 等）が **変更なしで通過する**ことを確認
+      （Req 3.5 / NFR 1.3）
+  - `internal/app/app.go` の `item.NewItemService(...)` 呼出しに既存 `feedRepo` 変数を追加引数
+    として渡す（変数は同一スコープに既に存在 / 配線追加 1 行）
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 4.4_
+  - _Boundary: item.ItemService, app.go wiring_
+
+- [ ] 7. itemDetailResponse を拡張し記事詳細契約テストを通す
+  - `internal/handler/item_handler.go` の `itemDetailResponse` に以下を追加:
+    - `FeedTitle string \`json:"feed_title"\``
+    - `FeedFaviconURL *string \`json:"feed_favicon_url,omitempty"\``
+  - 既存フィールド（`itemSummaryResponse` 経由の 9 フィールド + `Content` / `Summary` /
+    `Author`）の **フィールド名・型・タグを一切変更しない**（NFR 1.2 / Req 3.3）
+  - `internal/handler/service_adapter.go` の `ItemServiceAdapterFromDomain.GetItem` に
+    `FeedTitle: detail.FeedTitle` / `FeedFaviconURL: detail.FeedFaviconURL` の 2 行を追加
+  - `internal/handler/item_handler_test.go` に以下を追加（既存 `mockItemService.getItemFn` を
+    流用）:
+    - `TestItemHandler_GetItem_ReturnsFeedMetadata`（mock が feed_title / favicon URL 入りの
+      itemDetailResponse を返す → JSON に `feed_title` と `feed_favicon_url` が出現 / Req 4.4）
+    - `TestItemHandler_GetItem_PreservesExistingFields`（既存 11 フィールド全てが出現し、
+      フィールド名・型が不変であることを assert / Req 3.3 / 4.5 / NFR 1.2）
+    - `TestItemHandler_GetItem_OmitsFaviconWhenNil`（FeedFaviconURL nil → JSON から省略 /
+      Req 3.4）
+    - `TestItemHandler_GetItem_NotFound_PreservesExistingBehavior`（既存 ITEM_NOT_FOUND 応答
+      が変わらないことを assert / Req 3.5）
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 4.4, 4.5, NFR 1.2_
+  - _Boundary: ItemHandler, ItemServiceAdapter_
+  - _Depends: 6_
+
+## Verify
+
+本 spec の実装後、watcher（stage-a-verify gate）が再実行すべき verify コマンドを
+構造化ブロックで宣言する。Go バックエンドのみが本 spec の変更対象であるため、Go の
+test + vet を実行する（lint は CI 既定の `go vet` で代替し、本 spec 専用追加なし）。
+
+<!-- stage-a-verify -->
+```sh
+go test ./... && go vet ./...
+```


### PR DESCRIPTION
## 概要

この PR は **設計レビュー専用** です。実装コードは含まれません。
`docs/specs/207--mobile-api-v1-api/` 配下の requirements / design / tasks を merge するためのゲートです。

## 対応 Issue

Refs #207

## 含まれる成果物

- `docs/specs/207--mobile-api-v1-api/requirements.md` — 要件定義（EARS / numeric ID 形式）
- `docs/specs/207--mobile-api-v1-api/design.md` — 設計書（モジュール構成・公開 IF・ファイル配置プラン・要件トレーサビリティ）
- `docs/specs/207--mobile-api-v1-api/tasks.md` — 実装タスク分割（最上位 7 件、Budget overflow check pass）

## 関連 Issue / PR

なし

## レビュー観点

- requirements.md の FR / NFR / AC に過不足はないか
- design.md のモジュール構成・公開 IF が FR をカバーしているか
- 既存コードの再利用が検討されているか、重複実装が混じっていないか
- tasks.md の分割粒度が独立コミット可能か

## 次のステップ

- この PR を **merge** したら、Issue から `awaiting-design-review` ラベルを外してください。次回ポーリングで Developer が自動起動し、実装 PR が別途作られます
- 設計に問題があれば、直接この PR で commit / suggest-edit / line comment して修正してください
- やり直したい場合は PR を close して、Issue の `awaiting-design-review` ラベルを外してください

## 確認事項

design.md 末尾「Open Questions / 設計 PR レビュー時の確認事項」より重要な確認ポイントを抜粋します（詳細は design.md を参照）:

1. **`avatar_url` の実値返却タイミング**: 本 spec では `null` 固定。将来 `users.avatar_url` カラム追加 + OAuth callback で `picture` claim 保存を行う改修を別 Issue で起票するか、v1 リリースでは null のまま放置するかを決定すること
2. **`/api/users/me` を Web フロントエンドからも呼ぶか**: Web 側は既存 `/auth/me` で動作中。モバイル / Web の双方が `/api/users/me` を使う形に統一するかどうかは別 Issue で決定（本 spec では決定しない）
3. **mobile-api-contract.md の配置場所**: 本 spec では `docs/specs/207--mobile-api-v1-api/` 配下に配置する案。クライアント実装者が永続参照する文書として `docs/contracts/` のような永続的な場所に置くべきかは PjM 判断

base 整合性検証: --base develop 指定 / baseRefName: develop / OK（一致確認済）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
設計レビューゲート: PM → Architect が完了した段階です。merge 後に Issue から `awaiting-design-review` ラベルを外すと実装が自動開始します。
