### PR TITLE
test(auth): JWTIssuer テストの時限切れ（token is expired）を解消

### DIFF
--- a/internal/auth/jwt_issuer_test.go
+++ b/internal/auth/jwt_issuer_test.go
@@ -67,7 +67,7 @@ func TestIssueAccessToken_SuccessfulIssuance(t *testing.T) {
 			t.Errorf("unexpected signing method: %v", token.Method)
 		}
 		return fixedJWTSecret, nil
-	})
+	}, jwt.WithTimeFunc(func() time.Time { return fixedJWTIssuedAt }))
 	if err != nil {
 		t.Fatalf("jwt.Parse returned error: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestIssueAccessToken_KidPropagation(t *testing.T) {
 			// Assert: parse して header.kid を確認
 			parsed, err := jwt.Parse(tokenString, func(*jwt.Token) (interface{}, error) {
 				return fixedJWTSecret, nil
-			})
+			}, jwt.WithTimeFunc(func() time.Time { return fixedJWTIssuedAt }))
 			if err != nil {
 				t.Fatalf("jwt.Parse: %v", err)
 			}
@@ -196,7 +196,7 @@ func TestIssueAccessToken_DifferentJtisAcrossInvocations(t *testing.T) {
 		}
 		parsed, err := jwt.Parse(tokenString, func(*jwt.Token) (interface{}, error) {
 			return fixedJWTSecret, nil
-		})
+		}, jwt.WithTimeFunc(func() time.Time { return fixedJWTIssuedAt }))
 		if err != nil {
 			t.Fatalf("jwt.Parse[%d]: %v", i, err)
 		}


### PR DESCRIPTION
## 概要

`internal/auth` の Backend Tests が `token is expired` で恒常的に失敗していた時限テストバグを修正する。develop 上で全 PR の Backend Tests を赤にしていた原因（PR#208 の CI failure 調査で発見）。

## 原因

[jwt_issuer_test.go](../blob/develop/internal/auth/jwt_issuer_test.go) は固定発行時刻でトークンを発行する一方、`jwt.Parse` に時刻関数を渡していなかった。

- `fixedJWTIssuedAt = 2026-06-12 12:00 UTC` で発行 → `exp = iat + 15分 = 2026-06-12 12:15 UTC`
- `jwt.Parse(...)` は時刻関数未指定のため golang-jwt v5 が `exp` を**実時刻**で検証
- → 2026-06-12 12:15 UTC を過ぎると常に `token is expired`

`feat(auth): JWTIssuer ... (#166)` で混入。これまで埋もれていたのは、全 PR CI が依存脆弱性スキャンで既に赤だったため。

## 修正

本番の検証側 `jwt_verifier.go` は既に `jwt.WithTimeFunc` で時刻を注入している。テスト側の各 `jwt.Parse`（SuccessfulIssuance / KidPropagation / DifferentJtis）にも同じ `jwt.WithTimeFunc(func() time.Time { return fixedJWTIssuedAt })` を渡し、固定発行時刻を基準に `exp` を検証するよう揃えた。固定時刻の決定論性を保ったまま時限切れを解消する。

実装挙動の変更はなく、テスト側のみの修正。

## 検証

- `gofmt -l` 差分なし / `go vet ./internal/auth/` クリーン
- `go test ./internal/auth/` → `ok`（修正前は4テストが `token is expired` で FAIL）

## 確認事項

- 別解として「署名検証失敗を見る `WrongSecretFailsVerification`」は署名段階で先に失敗するため `exp` 検証に到達せず、本 PR では変更していません（diff を最小化）。一貫性のため同 option を付けるべきか要判断。
- 依存脆弱性スキャン（npm audit）の赤は別原因のため別 PR で対応します（本 PR のスコープ外）。