### PR TITLE
feat(#207): v1 クライアント共通 API 契約を明文化しサーバ応答を補正する

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,14 @@ Docker Compose は 2 つのネットワークを定義:
 
 | メソッド | パス | 説明 |
 |---------|------|------|
-| GET | `/auth/google/login` | OAuth フロー開始 |
+| GET | `/auth/google/login` | OAuth フロー開始（Web Cookie / Native PKCE 両対応） |
 | GET | `/auth/google/callback` | OAuth コールバック |
 | POST | `/auth/logout` | ログアウト |
-| GET | `/auth/me` | 現在のユーザー情報 |
+| GET | `/auth/me` | 現在のユーザー情報（Web Cookie 専用） |
+| POST | `/api/auth/token` | Native auth: auth_code 交換による access token / refresh token 発行 |
+| POST | `/api/auth/refresh` | Native auth: refresh token rotation による新規 access token 発行 |
+| POST | `/api/auth/revoke` | Native auth: refresh token 無効化 |
+
 ### フィード管理（認証必須）
 
 | メソッド | パス | 説明 |
@@ -245,13 +249,16 @@ Docker Compose は 2 つのネットワークを定義:
 | PATCH | `/api/feeds/{id}` | フィード URL 変更 |
 | DELETE | `/api/feeds/{id}` | フィード削除 |
 | GET | `/api/feeds/{id}/items` | 記事一覧（カーソルページネーション） |
+| GET | `/api/feeds/starred/items` | 全フィード横断のスター記事一覧 |
 
 ### 記事管理（認証必須）
 
 | メソッド | パス | 説明 |
 |---------|------|------|
-| GET | `/api/items/{id}` | 記事詳細 |
+| GET | `/api/items/{id}` | 記事詳細（`feed_title` / `feed_favicon_url` を含む） |
 | PUT | `/api/items/{id}/state` | 既読/スター状態更新 |
+| GET | `/api/items/search` | 記事検索（全購読横断 / フィード内検索） |
+| GET | `/api/items/cross-feed` | 横断新着記事一覧 |
 
 ### 購読管理（認証必須）
 
@@ -261,12 +268,20 @@ Docker Compose は 2 つのネットワークを定義:
 | DELETE | `/api/subscriptions/{id}` | 購読解除 |
 | PUT | `/api/subscriptions/{id}/settings` | フェッチ間隔設定 |
 | POST | `/api/subscriptions/{id}/resume` | 停止フィードの再開 |
+| POST | `/api/subscriptions/{id}/fetch` | 手動フェッチ（10 分クールダウン） |
 
 ### ユーザー管理（認証必須）
 
 | メソッド | パス | 説明 |
 |---------|------|------|
+| GET | `/api/users/me` | 現在のユーザー情報（モバイル / Web 共通。Bearer または Cookie で認証） |
 | DELETE | `/api/users/me` | 退会（アカウント削除） |
+| PUT | `/api/users/me/cross-feed-last-seen` | 横断新着一覧の最終閲覧時刻を更新 |
+
+> **モバイル API 契約**: v1 モバイルクライアント（iOS / Android）が依存する API の詳細契約
+> （URL / 認証方式 / 要求・応答 JSON 形状 / エラー応答）は
+> [`docs/specs/207--mobile-api-v1-api/mobile-api-contract.md`](docs/specs/207--mobile-api-v1-api/mobile-api-contract.md)
+> を参照すること。
 
 ### 監視
 

--- a/docs/specs/207--mobile-api-v1-api/impl-notes.md
+++ b/docs/specs/207--mobile-api-v1-api/impl-notes.md
@@ -59,3 +59,42 @@
     repository ルート相対パスでマークダウンリンクとして記述（GitHub UI でも閲覧可能）。
 - 残存課題: なし（README のみの変更で Go コード / テストは未変更。`go test` / `go vet` は
   挙動を変えないため本 task では実行不要。後続 task 3〜7 で実装変更時に verify される）。
+
+### Task 3
+- 採用方針: design.md L348-377「user.Service.GetByID（新規）」節と既存 `Withdraw` の
+  lookup ロジック（service.go L171 / L252 / L425-428）を踏襲し、`txBeginner != nil` ⇒
+  `txUserDeleter.FindByID`、それ以外 ⇒ `userRepo.FindByID` の二択で薄い wrapper として
+  実装した。nil ユーザーは `model.NewUserNotFoundError()`、repository error は
+  `fmt.Errorf("ユーザーの取得に失敗しました: %w", err)` で wrap して返す（既存
+  `withdrawLegacy` / `withdrawTx` の文言と完全一致）。
+- 重要な判断:
+  - **`Withdraw` の選択ロジックを `if s.txBeginner != nil` 単独で判定**: 既存 `Withdraw` は
+    `withdrawTx` / `withdrawLegacy` の 2 メソッドへ分岐するが、`GetByID` は分岐先のロジック
+    が「FindByID を 1 回呼ぶだけ」なので、別関数に分けずに 1 メソッド内で if-else 分岐する形に
+    した。コード重複を避けつつ「同パターン」を保つ最小実装。design.md「実装は `s.userRepo.FindByID`
+    を呼ぶだけ」「txBeginner パス時は `s.txUserDeleter.FindByID` を使う」の指針と整合。
+  - **error wrap 文言は既存 `Withdraw` の "ユーザーの取得に失敗しました" を再利用**: 既存
+    `withdrawLegacy` L173 / `withdrawTx` L173 と同一文言を採用し、運用ログ上で `Withdraw`
+    と `GetByID` の lookup error が同じ書式で出るようにした。新しい文言を発明しない。
+  - **doc comment で「認可を行わない理由」を明示**: design.md L362「ビジネス認可は実施しない
+    （caller userID = lookup userID であり middleware で済んでいる）」をそのまま採用し、
+    将来読者が「サービス層認可漏れではないか？」と疑わないようにした。CLAUDE.md「Backend §1.
+    レイヤリングと依存方向」の「認可はサービス層に集約」の例外条件（middleware が解決した
+    userID をそのまま使う read endpoint）を doc comment で説明する形。
+  - **テストは subtest で「レガシー / tx 両パス」を 1 つの top-level test 関数に集約**:
+    tasks.md L49「レガシーパスと txBeginner パスの両方で挙動が同一であることを確認」を、
+    `t.Run` で 2 subtest に分離する形で実装。`TestService_GetByID_Success` /
+    `_NotFound_ReturnsUserNotFoundError` / `_RepoError_PropagatesError` の 3 関数 ×
+    レガシー・tx の 2 subtest = 計 6 ケース。既存 `TestService_Withdraw_Tx_*` が並列に並ぶ
+    既存パターンと一貫させた。
+  - **tx パスの subtest で `beginCalled` を assert**: `GetByID` は read-only lookup なので
+    `txBeginner.BeginTx` を呼ばない（既存 `Withdraw` は `withdrawTx` でも user 存在確認は
+    トランザクション外で実施するパターン / service.go L171）。本 task ではさらに lookup のみ
+    なので一切 tx を開始しないことを `if beginner.beginCalled` で明示的に検証した。回帰防止。
+  - **`mockUserRepo.findByIDFn` 内で受け取った id を assert**: 「caller userID = lookup userID」
+    の前提が崩れないよう、subtest 内で `id != want.ID` のときに `t.Errorf` を発火させる
+    軽い contract check を加えた（design.md「認可」節の前提が裏で破られないよう保護）。
+- 残存課題: なし。後続 task 4 で `UserServiceInterface` 経由で `GetCurrent` adapter から
+  本メソッドを呼び出す配線が入る（adapter は `a.svc.GetByID(ctx, userID)` を呼んで
+  `currentUserResponse` に変換 / tasks.md L62-64）。本 task では service 層に閉じた追加のみで
+  外部公開 / 配線は触っていない。

--- a/docs/specs/207--mobile-api-v1-api/impl-notes.md
+++ b/docs/specs/207--mobile-api-v1-api/impl-notes.md
@@ -28,3 +28,34 @@
     「1 commit = 1 task ID」契約に従い分離。
 - 残存課題: なし（後続 task 2〜7 は本契約文書を参照しながら実装される想定。本 task では
   Go コード変更は一切なし、`go vet` 等の verify も実装変更を含む後続 task で実行される）。
+
+### Task 2
+- 採用方針: tasks.md task 2 本文に列挙された 5 種類の追記項目（Native auth / starred items /
+  search / cross-feed / 手動フェッチ / `GET /api/users/me` / cross-feed-last-seen）を
+  既存の責務別 h3 セクション（認証 / フィード管理 / 記事管理 / 購読管理 / ユーザー管理）に
+  そのまま追記し、ユーザー管理表の直後に Mobile API Contract Document への参照リンクを
+  blockquote 形式で追加した。
+- 重要な判断:
+  - **`POST /api/auth/token` / `/refresh` / `/revoke` は「認証（認証不要）」表に追記**:
+    design.md「Architecture Pattern & Boundary Map」と router.go の認証グループ配線では
+    native auth 系は `BearerOrSession` の **外側**（認証不要グループ）に配置されるため、
+    README 上も既存 `/auth/google/login` / `/auth/logout` 等と同じ「認証（認証不要）」表に
+    束ねる方が境界の説明と整合する。mobile-api-contract.md §3 とも整合（「認証 不要（auth_code
+    or refresh_token を body で提示）」と記載）。
+  - **`GET /api/users/me` の説明文に「モバイル / Web 共通。Bearer または Cookie で認証」と
+    明記**: 既存 `DELETE /api/users/me` と並べた際、両エンドポイントの認証境界が同じ
+    （BearerOrSession 必須）であり、`GET /api/users/me` が `/auth/me` とは別の新規モバイル/Web
+    共通エンドポイントである旨を 1 行で示せるようにした。
+  - **`GET /auth/me` の説明文を「Web Cookie 専用」に補足**: 本 spec の Req 2.6 / NFR 1.1 で
+    `/auth/me` の Cookie 動線を保持する方針なので、README 上で `GET /api/users/me` との
+    棲み分け（モバイルクライアントは `/auth/me` を呼ばず `/api/users/me` を使う）が読者に
+    伝わるよう補足した。
+  - **`GET /api/items/{id}` の説明文に `feed_title` / `feed_favicon_url` の追加を補足**:
+    task 7 で実装する記事詳細応答の拡張内容を README 上でも示し、mobile-api-contract.md §5.3
+    と整合させた。
+  - **Mobile API Contract Document への参照は blockquote 形式**: 既存 README のスタイル
+    （`NEXT_PUBLIC_API_URL は廃止しました。` のような注釈が blockquote で記述されている）と
+    揃え、API エンドポイント全体に対する補足説明としての位置付けを明示。リンク文字列は
+    repository ルート相対パスでマークダウンリンクとして記述（GitHub UI でも閲覧可能）。
+- 残存課題: なし（README のみの変更で Go コード / テストは未変更。`go test` / `go vet` は
+  挙動を変えないため本 task では実行不要。後続 task 3〜7 で実装変更時に verify される）。

--- a/docs/specs/207--mobile-api-v1-api/impl-notes.md
+++ b/docs/specs/207--mobile-api-v1-api/impl-notes.md
@@ -1,0 +1,30 @@
+# Implementation Notes
+
+本 spec（#207 v1 モバイル API 契約）の実装に関する補足ノート。
+
+## Implementation Notes
+
+### Task 1
+- 採用方針: design.md「Mobile API Contract Document の構成」節（L641-678）の章立て（1〜7）を
+  そのまま採用し、各エンドポイントを表形式（URL / 認証 / クエリ / 成功応答 / エラー）+
+  応答スキーマ JSON ブロック + フィールド説明表の 3 段構成で記述した。
+- 重要な判断:
+  - **既存サーバ実装の応答形を直接観察してから記述**: `internal/handler/*_handler.go` の
+    `json:"..."` タグを `grep` で確認し、契約文書に書く応答スキーマが実装と乖離しないよう
+    にした。特に search の `favicon_url`、cross-feed の `feed_favicon_url` / `since_time`、
+    subscriptions の `favicon_url` といった命名の非対称を §7.4 で明示。
+  - **`/api/items/{id}` の応答スキーマは「拡張後の形」で記述**: 本 spec の後続 task 6 / 7 で
+    handler / service に `feed_title` / `feed_favicon_url` を追加する想定なので、契約文書
+    側は task 完了後の最終形（拡張後）で記述し、task 7 と整合させた（design.md「設計判断」
+    と一致）。
+  - **`avatar_url` は v1 では常に null / 省略**: design.md「設計判断: avatar_url を当面 nil
+    固定で返す」節に従い、契約文書では「v1 時点では常に null / 省略される。将来 OAuth
+    `picture` claim 保存が入れば実値で返る」と明記。クライアント実装者が両表現を等価と
+    扱う前提を文書化した。
+  - **エラー応答 401 の text/plain 例外を明記**: `BearerOrSession` middleware が 401 で
+    `unauthorized` plain text を返す（JSON 形式ではない）という既存仕様を §2.2 末尾で
+    明示。クライアントが 401 を JSON パース失敗で検出しない実装にするため。
+  - **commit を 3 つに分割**: 文書本体 / impl-notes 追記 / tasks.md marker を Issue #164
+    「1 commit = 1 task ID」契約に従い分離。
+- 残存課題: なし（後続 task 2〜7 は本契約文書を参照しながら実装される想定。本 task では
+  Go コード変更は一切なし、`go vet` 等の verify も実装変更を含む後続 task で実行される）。

--- a/docs/specs/207--mobile-api-v1-api/impl-notes.md
+++ b/docs/specs/207--mobile-api-v1-api/impl-notes.md
@@ -98,3 +98,51 @@
   本メソッドを呼び出す配線が入る（adapter は `a.svc.GetByID(ctx, userID)` を呼んで
   `currentUserResponse` に変換 / tasks.md L62-64）。本 task では service 層に閉じた追加のみで
   外部公開 / 配線は触っていない。
+
+### Task 4
+- 採用方針: design.md「Components and Interfaces」節 UserHandler.GetCurrent / UserServiceAdapter.GetCurrent
+  / router.go の認証必須グループ配下 `r.Route("/api/users", ...)` 追加の 4 箇所の変更指針を
+  そのまま採用。`currentUserResponse` を `user_handler.go` 内 private 型として宣言し、
+  既存 `UserHandler.Withdraw` の error pattern（`middleware.UserIDFromContext` 失敗 → 401
+  UNAUTHORIZED / service エラー → `handleServiceError`）と完全同型で実装した。
+- 重要な判断:
+  - **`currentUserResponse` の宣言場所を `user_handler.go` 内に集約**: design.md L274-280 の
+    interface 定義例と一致させ、handler package 内 private 型として 1 箇所に置いた。
+    `service_adapter.go` の `UserServiceAdapter.GetCurrent` も同 package 内で型を参照
+    できるため、`*currentUserResponse` を返り値型として直接利用できる（package 境界を跨がない）。
+  - **`AvatarURL *string` で `omitempty` 採用 + adapter で常時 nil 固定**: Req 2.4「JSON null
+    または応答からの省略」を「省略」側で実装した（design.md「設計判断」節と一致）。
+    `*string` + `omitempty` の Go 標準挙動として nil なら JSON から省略され、非 nil
+    （将来 OAuth `picture` claim 保存実装後）なら値が出力される。テストでは
+    `TestUserHandler_GetCurrent_OmitsAvatarWhenNil` で nil ケースの省略を、
+    `TestUserHandler_GetCurrent_OmitsSecrets` で非 nil ケース（`avatar_url` キーが
+    出現する場合でも許可キー集合内）を担保した。
+  - **既存 `TestUserHandler_Withdraw_*` パターンとテスト名・テスト構造を厳密に揃える**:
+    Success / NoUserID_ReturnsUnauthorized / UserNotFound / InternalError の 4 パターンを
+    Withdraw と同型で並べ、レビュワーが「対応する Withdraw 系テストを引き写した」と
+    一目で理解できるようにした。追加分は OmitsSecrets と OmitsAvatarWhenNil の 2 件で、
+    本 spec 固有の Req 2.3 / 2.4 / Security Considerations 検証として独立配置。
+  - **OmitsSecrets テストの構造**: 「許可キー集合 {id, email, name, avatar_url} 以外は出ない」
+    形で集合演算的に検査し、将来 currentUserResponse に追加フィールドが入った場合に
+    レビュワーが当該テストを意識せざるを得ない gate を作った（CLAUDE.md「機能追加
+    チェックリスト」の secret 露出禁止の運用上の保護線）。明示的な `forbidden` リスト
+    （session_id / refresh_token / password / password_hash / access_token）の検査も
+    別途追加し、grep でも検出可能な regression net を二重化。
+  - **`router_full_test.go` で `TestRouter_GetUsersMe_RequiresAuth` と
+    `TestNewRouter_UserRoutes_GetCurrentEndpoint` の 2 件を追加**: tasks.md L80-81 が指定する
+    認証必須グループ確認（401）に加え、session 経路で 200 が返ることも同様の既存
+    `TestNewRouter_UserRoutes_WithdrawEndpoint` パターンに揃えて追加した。createTestRouter の
+    `mockAuthService.getCurrentUserFn` が既に user-test-1 を返すモック構成なので、新規モック
+    を追加せずに動作する（`UserService: &mockUserService{}` の default `getCurrentFn`
+    が `&currentUserResponse{ID: userID}` を返すよう mock 側を実装したため、Cookie 経路でも
+    200 を返す）。
+  - **`SetupUserRoutes` で `r.Get("/me", h.GetCurrent)` を `r.Delete("/me", h.Withdraw)`
+    より前に登録**: chi は同一 path で method 別 handler を持つため順序は意味的に問題に
+    ならないが、design.md File Structure Plan の記述順序（GetCurrent → Withdraw）に
+    合わせ、可読性のため `r.Get` を先頭に置いた。`router.go` の認証必須グループ内も
+    同様の順序にした。
+- 残存課題: なし。本 task は handler / adapter / router の追加のみで `app.go` の wiring は
+  既存 `UserServiceAdapter` の生成箇所のままで GetCurrent メソッドが追加で見える
+  （adapter 拡張のみで配線変更不要）。`go test ./...` と `go vet ./...` は全て pass。
+  後続 task 5（`/auth/me` Cookie 経路 non-regression テスト）/ task 6 / 7（記事詳細応答の
+  feed_title / feed_favicon_url 追加）に本 task は影響を与えない。

--- a/docs/specs/207--mobile-api-v1-api/impl-notes.md
+++ b/docs/specs/207--mobile-api-v1-api/impl-notes.md
@@ -234,3 +234,53 @@
   `feed_favicon_url` フィールドに転写される配線が入る。本 task は service 層に閉じた拡張と
   app.go wiring の 1 行追加のみで handler 層は触っていない（_Boundary: item.ItemService,
   app.go wiring_ 制約と一致）。`go test ./...` / `go vet ./...` は全て pass。
+
+### Task 7
+- 採用方針: design.md「Components and Interfaces - Handler Layer - ItemHandler.GetItem（拡張）」
+  節 L288-328 の指針（handler 本体の認可フロー / 既存 itemDetailResponse 既存フィールド不変 /
+  追加 2 フィールドのみ加算）をそのまま採用。`itemDetailResponse` に `FeedTitle string`（タグ
+  `feed_title`）と `FeedFaviconURL *string`（タグ `feed_favicon_url,omitempty`）を追加し、
+  `ItemServiceAdapterFromDomain.GetItem` で task 6 で導入済みの `detail.FeedTitle` /
+  `detail.FeedFaviconURL` をそのまま pass-through する 2 行を追加した。handler の
+  `GetItem` メソッド本体（認可 / 404 fallback / Content-Type set / JSON encode）は一切変更
+  しない（design.md L297「フロー・認可は不変」と一致）。
+- 重要な判断:
+  - **`itemDetailResponse` 構造体のフィールド順序は「既存末尾追加」を採用**: 既存 3 フィールド
+    （Content / Summary / Author）の後ろに FeedTitle → FeedFaviconURL を並べた。Go の struct
+    フィールド順序は JSON エンコード順序に影響するため、既存 JSON 出力順の前半部分（既存 11
+    フィールド）が完全に温存される（NFR 1.2 の「フィールド名・型・null 表現を変更しない」を
+    超え、出力順序まで保護することで snapshot test 等にも regression を発生させない）。
+  - **`FeedFaviconURL` を `*string` + `omitempty` で「省略」側に統一**: Req 3.4 の「JSON null
+    または応答からの省略」のうち、本 spec では一貫して「省略」側を選択（task 4 の
+    `avatar_url`、cross-feed の `feed_favicon_url` などと同パターン）。`*string` 型のため
+    将来 favicon を実値で返す場合も schema 変更なしで populate 可能。
+  - **テストは「正常 / 既存温存 / 境界 / 異常」の 4 観点で AC を直接担保**: tasks.md L138-147 の
+    4 テスト要件を 1:1 で実装した。`TestItemHandler_GetItem_ReturnsFeedMetadata`（Req 3.1, 3.2 /
+    4.4 正常）/ `_PreservesExistingFields`（Req 3.3 / 4.5 / NFR 1.2 既存温存）/
+    `_OmitsFaviconWhenNil`（Req 3.4 境界）/ `_NotFound_PreservesExistingBehavior`（Req 3.5
+    異常）。既存テスト `TestItemHandler_GetItem_NotFound_ReturnsNotFound` は status / code
+    のみ検査するため、本 spec 専用の non-regression 観点（404 応答に新フィールドが紛れ込ま
+    ないこと）として `_PreservesExistingBehavior` を別途追加した。
+  - **既存 11 フィールド enum 列挙の正典化**: `_PreservesExistingFields` テストで既存 11
+    フィールド（id / feed_id / title / link / summary / published_at / is_date_estimated /
+    is_read / is_starred / hatebu_count / content / author）を `wantExistingFields` map
+    として明示列挙し、将来既存フィールドが改名 / 削除 / 型変更された場合に本テストが
+    落ちることで NFR 1.2 を機械的に保護する gate にした。`published_at` のみ時刻形式のため
+    値比較せず存在確認のみ。テストコード上が contract document として機能する。
+  - **`_OmitsFaviconWhenNil` の二重検査（bytes + map）**: `omitempty` の省略を bytes
+    レベル（`bytes.Contains(bodyBytes, []byte("feed_favicon_url"))` が false）と map
+    decode 後の `_, ok := result["feed_favicon_url"]` の二重で確認した。前者は厳密な
+    JSON 出力検査、後者は decode 後の存在確認で、JSON 整形ロジックの将来変更
+    （indent 化等）に対する堅牢性を確保。
+  - **`_NotFound_PreservesExistingBehavior` の regression net**: 404 応答 body に
+    `feed_title` / `feed_favicon_url` / `"content"` / `"author"` 等の記事詳細フィールドが
+    含まれないことを `forbidden` リストで明示 enum 検査。`handleServiceError` の APIError
+    JSON shape が将来変わって新フィールドが漏れ出るような regression を grep 可能な形で
+    保護する。
+  - **commit を 3 つに分割**: 実装 + テスト / impl-notes 追記 / tasks.md marker を Issue #164
+    「1 commit = 1 task ID」契約に従い分離。task 7 は子タスクを持たないため、marker commit
+    は `mark 7 as done` の単記。
+- 残存課題: なし。本 spec の全 7 task が完了し、Req 1.x（契約文書） / Req 2.x（統一ユーザー情報
+  エンドポイント） / Req 3.x（記事詳細フィードメタ）/ Req 4.x（契約テスト）/ NFR 1.x（後方互換）/
+  NFR 2.x（文書可読性）/ NFR 3.x（テスト自動実行性）の全 AC が対応テスト・ドキュメントで
+  担保された。`go test ./...`（22 パッケージ全 pass）/ `go vet ./...`（クリーン）も確認済み。

--- a/docs/specs/207--mobile-api-v1-api/impl-notes.md
+++ b/docs/specs/207--mobile-api-v1-api/impl-notes.md
@@ -185,3 +185,52 @@
   `/auth/me`（本 task の保護対象）と `/api/items/{id}`（task 7 の拡張対象）は完全に異なる
   endpoint であり、本 task の non-regression gate は互いに干渉しない。`go test ./internal/handler/...`
   と `go vet ./...` は全て pass。
+
+### Task 6
+- 採用方針: design.md L379-447「item.ItemService.GetItem（拡張）」節と
+  「Components and Interfaces - Service Layer」の interface segregation 指針をそのまま採用し、
+  `FeedMetaProvider` 1 メソッド interface（既存 `SubscriptionChecker` と同パターン）を新設して
+  `NewItemService` を 4 引数化、既存認可フロー（FindByID → SubscriptionChecker →
+  FindByUserAndItem）の **後** に feed lookup → `model.FaviconDataURL` で整形して `ItemDetail` に
+  populate する形で実装した。
+- 重要な判断:
+  - **feed lookup を認可後に配置**: design.md L388 / L444-447 が要求する通り、認可フロー（購読確認 /
+    存在秘匿）を完全に通過した後にのみ feed メタを取得する形にした。これにより未購読 user に対して
+    feed が引き当てられること自体を秘匿でき、`ITEM_NOT_FOUND` 応答条件（Req 3.5）が完全に不変
+    となる。既存 `TestItemService_GetItem_Unsubscribed_ReturnsNotFound` /
+    `TestItemService_GetItem_NotFound` が変更なしで pass することで保証。
+  - **`feedRepo` が nil を返したときの応答は汎用 error**: design.md L396-398 が「FindByID が nil
+    なら error として上位に返す（fail-fast）」と指定しているため、`model.NewItemNotFoundError`
+    ではなく汎用 `fmt.Errorf("記事所属フィードの取得に失敗しました: feed_id=%s が見つかりません", ...)` を
+    返す形にした。`ItemNotFoundError` を返すと「存在しない item」と「内部不整合（孤立 item）」が
+    handler 層で同じ 404 に集約され、内部不整合の検出能力が落ちるため。汎用 error は上位
+    `handleServiceError` で 500 に集約され、運用ログから孤立 item を発見可能になる。FK 制約により
+    実運用では発生しないが、防御的に 500 に倒す側を採用。
+  - **既存 19 テストの mock 互換性確保のため `defaultFeedProvider()` ヘルパーを導入**:
+    `NewItemService` シグネチャ変更で全テストの呼び出し側に 4 引数目を追加する必要が
+    あったが、既存テストは `FeedTitle` / `FeedFaviconURL` を検査しないため、空 `Feed{ID: id}`
+    を返す `defaultFeedProvider()` ヘルパーで一括対応した。既存テストロジック自体は一切変更
+    せず、引数追加のみで互換性を確保。既存 `subscribedChecker()` / `unsubscribedChecker()`
+    と同型の命名で読みやすさを揃えた。
+  - **3 つの新規テストを既存 `GetItem` テストクラスタの末尾にまとめて配置**:
+    `TestItemService_GetItem_PopulatesFeedMetadata`（正常系 / Req 3.1, 3.2）→
+    `_NullFaviconWhenFeedHasNone`（境界 / Req 3.4）→ `_FeedRepoError_PropagatesError`
+    （異常系 / fail-fast）の順で、AC との対応を test 名と doc コメントに明示。
+    AC 起点 + 正常 / 境界 / 異常の網羅（CLAUDE.md「テスト規約」）。
+  - **`FeedMetaProvider.FindByID` の id 引数 contract check**: 正常系テスト
+    `_PopulatesFeedMetadata` の mock 内で `id != "feed-1"` のときに `t.Errorf` を発火させ、
+    「feed lookup が item.FeedID と一致する id で呼ばれること」を contract として保護した。
+    task 7 で adapter / handler 拡張時に id 渡しが壊れても本 service テストで検出可能になる。
+  - **`model.FaviconDataURL` 出力フォーマットの厳密一致**: `_PopulatesFeedMetadata` の assert
+    で `*detail.FeedFaviconURL == "data:image/png;base64,YWJj"` を厳密一致で検査
+    （base64("abc") = "YWJj"）。`model.FaviconDataURL` の出力契約が将来変わった場合に本テストが
+    落ちることで `subscription` / `crossfeed` / `itemsearch` 等の既存利用箇所と一貫した
+    favicon 整形ロジックが保たれることを担保する。
+  - **commit を 3 つに分割**: 実装 + テスト + wiring / impl-notes 追記 / tasks.md marker を
+    Issue #164「1 commit = 1 task ID」契約に従い分離。
+- 残存課題: なし。後続 task 7（itemDetailResponse JSON 拡張と handler 契約テスト）で本 task の
+  `ItemDetail.FeedTitle` / `FeedFaviconURL` が `service_adapter.go` の
+  `ItemServiceAdapterFromDomain.GetItem` 経由で `itemDetailResponse` の `feed_title` /
+  `feed_favicon_url` フィールドに転写される配線が入る。本 task は service 層に閉じた拡張と
+  app.go wiring の 1 行追加のみで handler 層は触っていない（_Boundary: item.ItemService,
+  app.go wiring_ 制約と一致）。`go test ./...` / `go vet ./...` は全て pass。

--- a/docs/specs/207--mobile-api-v1-api/impl-notes.md
+++ b/docs/specs/207--mobile-api-v1-api/impl-notes.md
@@ -146,3 +146,42 @@
   （adapter 拡張のみで配線変更不要）。`go test ./...` と `go vet ./...` は全て pass。
   後続 task 5（`/auth/me` Cookie 経路 non-regression テスト）/ task 6 / 7（記事詳細応答の
   feed_title / feed_favicon_url 追加）に本 task は影響を与えない。
+
+### Task 5
+- 採用方針: 既存 `mockAuthService` パターン + `json.NewDecoder(...).Decode(&body)` で応答を
+  `map[string]interface{}` に decode し、サブテスト 2 件（`Cookie_Present_ReturnsExistingShape`
+  / `NoCookie_ReturnsUnauthorized`）で `/auth/me` の Cookie 経路応答が本 spec 導入で
+  変化していないことを保護する non-regression test を追加。`auth_handler.go` /
+  `SetupAuthRoutes` は一切変更しない（task 本文の制約）。
+- 重要な判断:
+  - **キー集合の「厳密一致」を採用**: 既存 `TestAuthHandler_Me_Authenticated_ReturnsUserJSON`
+    は status と Content-Type のみを検査するが、本テストでは `len(body) != len(allowed)`
+    によって応答キー集合が **厳密に** `{id, email, name}` のみであることを assert する。
+    将来 `model.User` に `AvatarURL` フィールドが追加されたり、`/auth/me` handler の
+    map literal に新フィールドが紛れ込んだ場合に、本テストが落ちることで mobile-api-contract.md
+    §2.2「`GET /api/users/me`（モバイル/Web 共通）と `GET /auth/me`（Web Cookie 専用）の
+    棲み分け」が壊れる regression を機械的に検出できる gate になる。
+  - **既存 `TestAuthHandler_Me_Authenticated_ReturnsUserJSON` との重複を許容**: 両テストの
+    観点は分離している（既存 = status/Content-Type のみ・本テスト = 応答本文のキー集合まで踏み込む
+    non-regression）。task 5 本文「**既存形** `{id, email, name}` を含み、本 spec 導入前と
+    同一であることを assert」「`avatar_url` のような新フィールドが `/auth/me` から漏れて
+    返らないことも合わせて assert」が要求する 2 つの観点は、既存テストでは満たせないため
+    新規追加が必要だった。
+  - **禁止キーの明示 enum 列挙で grep 可能な regression net を二重化**: `len(body)` ベースの
+    集合演算的検査に加え、`forbidden := []string{"avatar_url", "session_id", "refresh_token",
+    "password", "password_hash", "access_token"}` の明示 enum を追加 assert。前者は厳密一致で
+    確実に検出するが、後者は `grep -r 'session_id\|refresh_token\|avatar_url' internal/handler`
+    で「secret 漏出 / 新フィールド漏出を検知する gate がどこにあるか」を運用者が grep で
+    見つけられるようにする目的（task 4 の `TestUserHandler_GetCurrent_OmitsSecrets` と
+    同じ二重化パターン）。
+  - **`keysOf` ヘルパーは既存 `integration_test.go` のものを再利用**: 同 package 内に既存の
+    `keysOf(m map[string]any) []string`（integration_test.go:2040）が存在するため、新規定義は
+    重複宣言コンパイルエラーになる。私が一旦追加した重複定義を削除し、既存ヘルパーを利用する
+    形に修正した（`any` は `interface{}` のエイリアスなので `map[string]interface{}` を渡せる）。
+  - **`session_id` Cookie 値の assert**: mock `getCurrentUserFn` 内で受け取った `sessionID` が
+    request Cookie 値 `"valid-session"` と一致することを軽い contract check として確認。Cookie
+    の値が service 層に正しく渡される配線も併せて保護する。
+- 残存課題: なし。task 6 / 7 は記事詳細応答の `feed_title` / `feed_favicon_url` 追加だが、
+  `/auth/me`（本 task の保護対象）と `/api/items/{id}`（task 7 の拡張対象）は完全に異なる
+  endpoint であり、本 task の non-regression gate は互いに干渉しない。`go test ./internal/handler/...`
+  と `go vet ./...` は全て pass。

--- a/docs/specs/207--mobile-api-v1-api/mobile-api-contract.md
+++ b/docs/specs/207--mobile-api-v1-api/mobile-api-contract.md
@@ -1,0 +1,763 @@
+# Feedman Mobile API Contract (v1)
+
+本文書は Feedman v1 モバイルクライアント（iOS / Android）が依存するサーバー API の
+契約を、サーバー実装ソースを参照せずにクライアント側だけで実装・検証できる粒度で
+明文化したものである（NFR 2.1）。
+
+- 対象クライアント: iOS（feedman-ios） / Android
+- 対象サーバー実装: 本リポジトリの当該 spec branch（`claude/issue-207-impl--mobile-api-v1-api`）
+  を含む `develop` ブランチ以降
+- 文書スコープ: v1 で接続確認対象とする全エンドポイントの契約（URL / 認証方式 /
+  要求・応答 JSON / エラー応答）
+- 文書非対象: モバイルクライアント実装内部、Web フロントエンドの UI 仕様、
+  サーバー実装の内部詳細（DB スキーマ・middleware 配線等）
+
+---
+
+## 1. 概要
+
+### 1.1 v1 の位置付け
+
+v1 は「ログイン後の認証済み API を呼び出して主要動線（記事一覧・記事詳細・検索・
+購読操作・横断新着）を完成させる」フェーズである。Native auth（PKCE による access /
+refresh token 発行・rotation・revoke）は別 spec 群（#163 配下 #165〜#171 / #172）で
+**既に実装完了済み** であり、本文書ではそのサマリと参照のみを記載する。
+
+### 1.2 スコープ境界
+
+- **v1 で呼び出す API**: 本文書の §3, §4, §5 に記載
+- **v1 で呼び出さない API**: §6「v1 スコープ外（次フェーズ）」に記載
+
+### 1.3 既存 Web 動線との関係
+
+既存 Web フロントエンド（Cookie セッション）が利用する API はすべて維持され、本 spec
+で URL・認証方式・応答形状の破壊的変更は一切行わない（NFR 1.1, 1.2, 1.3）。詳細は
+§7「後方互換ポリシー」を参照。
+
+---
+
+## 2. 共通方針
+
+### 2.1 認証方式
+
+| クライアント種別 | 認証ヘッダ / Cookie | 取得経路 |
+|---|---|---|
+| モバイル（iOS / Android） | `Authorization: Bearer <access_token>` HTTP ヘッダ | §3 native auth の `POST /api/auth/token` で発行 |
+| Web フロントエンド | `Cookie: session_id=<sid>` | `/auth/google/login` → `/auth/google/callback` で HttpOnly Cookie として設定 |
+
+`/api/*` 配下の認証必須エンドポイントは Bearer / Cookie の **両経路** を統一的に受け付ける
+（BearerOrSession middleware により判別）。クライアントは自分の経路のいずれか 1 つだけを
+提示すればよい。両方を同時に提示した場合の挙動はサーバー側で `Authorization` ヘッダが
+優先されるが、モバイルクライアントは Bearer のみ提示する想定であり Cookie の併用は不要。
+
+未認証時（Authorization 無し + Cookie 無し / どちらも無効）は 401 `unauthorized`
+が返る（応答ボディは text/plain `unauthorized`）。
+
+`/auth/me`（Web 専用 current user 取得）は本文書のスコープ外の **既存 Web 動線** であり、
+モバイルクライアントは利用しない。詳細は §7「後方互換ポリシー」を参照。
+
+### 2.2 エラー応答形式
+
+`/api/*` 配下のエンドポイントは、4xx / 5xx エラー時に統一フォーマット JSON を返す
+（`Content-Type: application/json`）:
+
+```json
+{
+  "code": "ITEM_NOT_FOUND",
+  "message": "指定された記事が見つかりません: <item-id>",
+  "category": "feed",
+  "action": "記事IDを確認してください。",
+  "details": { "retry_after_seconds": 600 }
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `code` | string | 必須 | エラーコード（後述 §2.3 に主要コード一覧） |
+| `message` | string | 必須 | エンドユーザー向けの日本語メッセージ |
+| `category` | string | 必須 | 原因カテゴリ。`auth` / `validation` / `feed` / `system` / `authorization` のいずれか |
+| `action` | string | 必須 | ユーザーが取るべき次の行動を示す文言 |
+| `details` | object | 任意 | 追加情報。例: 429 のクールダウン応答で `retry_after_seconds`（int 秒）を載せる。値不在時はフィールド自体が JSON から省略される（`omitempty` 相当） |
+
+例外: `BearerOrSession` middleware が拒否する 401 応答（認証情報無し / Bearer 検証失敗）は
+**text/plain `unauthorized`** を返す（上記 JSON 形式ではない）。これは middleware が
+handler 到達前に短絡応答するためで、本文書でも以後特に明記しない限り 401 はこの形である。
+
+### 2.3 主要エラーコード一覧
+
+| HTTP Status | code | 発生場面 |
+|---|---|---|
+| 400 | `INVALID_URL` | フィード登録時の URL 形式不正 |
+| 400 | `INVALID_FILTER` | 記事一覧 `filter` パラメータが不正 |
+| 400 | `INVALID_FETCH_INTERVAL` | フェッチ間隔が範囲外 |
+| 400 | `INVALID_SEARCH_QUERY` | 検索 `cursor` / `feed_id` / `limit` の形式不正 |
+| 400 | `INVALID_REQUEST` | クエリパラメータの一般的な形式不正（cross-feed の `since` 等） |
+| 401 | （text/plain `unauthorized`） | 未認証（Authorization / Cookie 不在 or 無効） |
+| 403 | `FEED_NOT_SUBSCRIBED` | 検索 `feed_id` 指定先を当該ユーザーが未購読 |
+| 404 | `ITEM_NOT_FOUND` | 記事が当該ユーザーの購読範囲に存在しない（未購読時の存在秘匿を含む） |
+| 404 | `SUBSCRIPTION_NOT_FOUND` | 購読が見つからない（解除・設定更新・再開・手動フェッチ時） |
+| 404 | `USER_NOT_FOUND` | 認証通過後に DB 上の user が消失している例外時 |
+| 409 | `FEED_FETCH_IN_PROGRESS` | 手動フェッチ時、別トランザクションがフェッチ中 |
+| 422 | `FEED_NOT_DETECTED` / `PARSE_FAILED` / `SSRF_BLOCKED` / `FETCH_FAILED` / `FEED_HTTP_ERROR` | フィード登録時の検出・取得・解析失敗 |
+| 429 | `FEED_COOLDOWN` | 手動フェッチが 10 分クールダウン中。`details.retry_after_seconds` に残り秒数（int） |
+| 500 | `INTERNAL_ERROR` | 内部エラー（DB エラー等） |
+
+新しいエラーコードは将来追加され得る。クライアントは未知の `code` を受け取った場合でも
+`category` / `message` を用いて汎用的にハンドリングできるよう実装すること。
+
+### 2.4 JSON 命名規約
+
+- フィールド名は **snake_case**（例: `next_cursor` / `is_read` / `feed_title`）
+- タイムスタンプは **RFC3339** 文字列（例: `2025-06-23T10:00:00Z`）
+- ID は文字列（UUID v4 形式が多いが、クライアントは不透明な文字列として扱う）
+- nullable な値は `string | null` または `omitempty` でフィールド自体が省略される。
+  どちらの表現になるかは本文書の各エンドポイント節で個別に明記する
+
+### 2.5 Cursor pagination 形式
+
+記事一覧系（`/api/feeds/{id}/items`, `/api/feeds/starred/items`, `/api/items/search`,
+`/api/items/cross-feed`）は共通の cursor pagination 形式を採用する:
+
+**応答**:
+
+```json
+{
+  "items": [ /* 当該ページの記事配列 */ ],
+  "next_cursor": "2025-06-23T10:00:00.000Z|abcdef...",
+  "has_more": true
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `items` | array | 必須 | 当該ページの記事配列 |
+| `next_cursor` | string | 末尾ページでは省略（`omitempty`） | 次ページ取得用のカーソル文字列。形式 `<RFC3339Nano>\|<id>`（不透明文字列としてそのまま再送する） |
+| `has_more` | bool | 必須 | 次ページが存在するか |
+
+**次ページ取得**: `cursor=<next_cursor 文字列>` と `limit=<件数>` をクエリで送る。
+`next_cursor` を発行できない末尾項目（PublishedAt がゼロ値等）でも `has_more=true` が
+返ることがあるため、クライアントは `next_cursor` の空判定だけでなく `has_more` も
+参照すること。
+
+**`limit` の上限**: 各エンドポイント節で個別に記載する。共通の既定値は概ね 50 件、
+最大は 200 件（cross-feed）/ 100 件（search）等エンドポイントごとに異なる。
+
+### 2.6 リクエストボディの形式
+
+`POST` / `PUT` は `Content-Type: application/json` で JSON ボディを送る。
+ボディサイズは middleware により上限が設定されており、超過時は 413 が返る
+（具体値は本文書のスコープ外）。
+
+---
+
+## 3. Native Auth エンドポイント（サマリ）
+
+Native auth 系（access token 発行 / refresh / revoke / native callback）は本文書の
+**契約レベルでのサマリのみ** を記載する。詳細仕様（PKCE パラメータ規約・JWT claim
+構造・token rotation 規約・end-to-end 契約テスト）は以下の既存 spec を参照すること
+（Req 1.2）:
+
+- **Native Auth 全体設計**: Issue #163
+- **PKCE login**: Issue #165
+- **`POST /api/auth/token`**: Issue #166 / #172
+- **`POST /api/auth/refresh`**: Issue #167 / #172
+- **`POST /api/auth/revoke`**: Issue #168 / #172
+- **`BearerOrSession` middleware**: Issue #169
+- **JWT 署名鍵 rotation**: Issue #170, #171
+- **End-to-end 契約テスト**: Issue #172
+
+### 3.1 `GET /auth/google/login` — PKCE login 開始
+
+| 項目 | 内容 |
+|---|---|
+| URL | `GET /auth/google/login?flow=native&code_challenge=<S256>&code_challenge_method=S256` |
+| 認証 | 不要（OAuth フロー開始） |
+| クエリ | `flow=native`（必須）／`code_challenge`（PKCE S256 challenge、Base64URL）／`code_challenge_method=S256`（必須） |
+| 応答 | 302 redirect to Google OAuth consent screen。サーバ側 Cookie に PKCE challenge を保存（HttpOnly） |
+| エラー | 400 `invalid pkce parameters`（PKCE パラメータ不正） |
+
+詳細仕様は #165 を参照。
+
+### 3.2 `feedman://auth/callback` — Native callback
+
+| 項目 | 内容 |
+|---|---|
+| URL | `feedman://auth/callback?auth_code=<one-time code>` |
+| 認証 | 不要（callback redirect の受け取り側） |
+| 説明 | Google OAuth consent 完了後、サーバが上記アプリスキームにリダイレクトする。`auth_code` は短寿命の一回限り使い捨てコード |
+
+詳細仕様は #165 を参照。
+
+### 3.3 `POST /api/auth/token` — Access token 発行
+
+| 項目 | 内容 |
+|---|---|
+| URL | `POST /api/auth/token` |
+| 認証 | 不要（auth_code 交換） |
+| リクエスト | `{"auth_code": "<callback で受領した auth_code>", "code_verifier": "<PKCE verifier>"}` |
+| 成功応答 | 200 `{"access_token": "<JWT>", "refresh_token": "<opaque>", "token_type": "Bearer", "expires_in": <int 秒>}` |
+| エラー | 400 / 401（auth_code 無効 / PKCE 検証失敗 / 期限切れ）。詳細は #166 / #172 |
+
+### 3.4 `POST /api/auth/refresh` — Token rotation
+
+| 項目 | 内容 |
+|---|---|
+| URL | `POST /api/auth/refresh` |
+| 認証 | 不要（refresh_token を body で提示） |
+| リクエスト | `{"refresh_token": "<現行の refresh_token>"}` |
+| 成功応答 | 200 `{"access_token": "<新 JWT>", "refresh_token": "<新 opaque>", "token_type": "Bearer", "expires_in": <int 秒>}`。古い refresh_token は **無効化される**（rotation） |
+| エラー | 400 / 401（refresh_token 無効 / 既に rotation 済 / 期限切れ）。詳細は #167 / #172 |
+
+### 3.5 `POST /api/auth/revoke` — Refresh token 無効化
+
+| 項目 | 内容 |
+|---|---|
+| URL | `POST /api/auth/revoke` |
+| 認証 | 不要（refresh_token を body で提示） |
+| リクエスト | `{"refresh_token": "<無効化したい refresh_token>"}` |
+| 成功応答 | 204 No Content |
+| エラー | 400 / 401（refresh_token 形式不正 / 既に無効）。詳細は #168 / #172 |
+
+---
+
+## 4. モバイル統一ユーザー情報取得
+
+### 4.1 `GET /api/users/me` — Current user 取得
+
+| 項目 | 内容 |
+|---|---|
+| URL | `GET /api/users/me` |
+| 認証 | **必須**。Bearer（モバイル）または Cookie session_id（Web）のいずれか |
+| リクエスト | （body なし） |
+| 成功応答 | 200 `application/json`（後述） |
+| エラー | 401（未認証）/ 404 `USER_NOT_FOUND`（認証通過後に DB 上 user が消失している例外時）/ 500 |
+
+**成功応答スキーマ**:
+
+```json
+{
+  "id": "<user id>",
+  "email": "<user email>",
+  "name": "<display name>",
+  "avatar_url": null
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `id` | string | 必須 | ユーザー識別子 |
+| `email` | string | 必須 | ログイン時のメールアドレス |
+| `name` | string | 必須 | 表示名 |
+| `avatar_url` | `string \| null` | 任意（v1 では常に null または省略） | アバター画像 URL。v1 時点では DB 未拡張のため常に null / 省略される。将来 OAuth プロフィール画像を保存する改修が入った場合、JSON 文字列として実値が返るようになる |
+
+**注意事項**:
+
+- `avatar_url` が **JSON null として返る** か **応答から省略される** かは実装側の選択であり、
+  クライアントは両表現を等価として扱うこと（要件 2.4 で許容されている）
+- 本エンドポイントは secret（session_id / refresh_token / hashed token 等）を一切応答に
+  含めない
+- 既存 Web 動線の `GET /auth/me` は本エンドポイントとは別物として **維持される**
+  （§7 参照）。モバイルクライアントは `/auth/me` を呼ばない
+
+---
+
+## 5. v1 共通動線エンドポイント
+
+本節に記載する全エンドポイントは `/api/*` 配下にあり、Bearer または Cookie 認証が
+**必須** である。認証情報なしのアクセスはすべて 401 で拒否される。
+
+### 5.1 `GET /api/feeds/{id}/items` — フィード内記事一覧
+
+| 項目 | 内容 |
+|---|---|
+| URL | `GET /api/feeds/{id}/items` |
+| 認証 | 必須 |
+| パスパラメータ | `id`: 購読フィードの UUID |
+| クエリ | `filter` (`all` / `unread` / `starred`、既定 `all`) ／ `cursor`（前回 next_cursor、空文字で先頭ページ） ／ `limit`（既定 50、上限はサーバ側で制限） |
+| 成功応答 | 200 `application/json`（後述） |
+| エラー | 400 `INVALID_FILTER` / 401 / 404（未購読 / 不在のフィード） / 500 |
+
+**成功応答スキーマ**:
+
+```json
+{
+  "items": [
+    {
+      "id": "<item id>",
+      "feed_id": "<feed id>",
+      "title": "<title>",
+      "link": "<https://...>",
+      "summary": "<sanitized summary>",
+      "published_at": "2025-06-23T10:00:00Z",
+      "is_date_estimated": false,
+      "is_read": false,
+      "is_starred": false,
+      "hatebu_count": 42
+    }
+  ],
+  "next_cursor": "2025-06-23T10:00:00.000Z|abcdef...",
+  "has_more": true
+}
+```
+
+各 item フィールドの意味:
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `id` | string | 必須 | 記事 ID |
+| `feed_id` | string | 必須 | 所属フィード ID |
+| `title` | string | 必須 | 記事タイトル |
+| `link` | string | 必須 | 元記事の URL |
+| `summary` | string | 必須 | サニタイズ済み概要（空文字列もあり得る） |
+| `published_at` | string (RFC3339) | 必須 | 公開日時 |
+| `is_date_estimated` | bool | 必須 | 公開日時が推定値かどうか |
+| `is_read` | bool | 必須 | 既読フラグ |
+| `is_starred` | bool | 必須 | スター付与フラグ |
+| `hatebu_count` | int | 必須 | はてなブックマーク件数 |
+
+**フィード表示メタデータ（`feed_title` / `feed_favicon_url`）について**: 本一覧はクライアントが
+「現在選択中のフィード」のコンテキストで呼び出すため、各 item に `feed_title` /
+`feed_favicon_url` は **含まれない**。クライアントは選択中フィードのメタデータ（§5.7 の
+購読一覧から取得）で補うこと。
+
+### 5.2 `GET /api/feeds/starred/items` — 全フィード横断スター記事一覧
+
+| 項目 | 内容 |
+|---|---|
+| URL | `GET /api/feeds/starred/items` |
+| 認証 | 必須 |
+| クエリ | `cursor` / `limit`（§2.5 共通形式に従う） |
+| 成功応答 | 200 `application/json`（後述） |
+| エラー | 401 / 500 |
+
+**成功応答スキーマ**: items 配列の各要素が `feed_title` を **追加** で含む（複数フィードを
+横断するため、UI 側で「どのフィードの記事か」を表示する必要があるため）:
+
+```json
+{
+  "items": [
+    {
+      "id": "<item id>",
+      "feed_id": "<feed id>",
+      "feed_title": "<フィード表示名>",
+      "title": "<title>",
+      "link": "<https://...>",
+      "summary": "<sanitized summary>",
+      "published_at": "2025-06-23T10:00:00Z",
+      "is_date_estimated": false,
+      "is_read": false,
+      "is_starred": true,
+      "hatebu_count": 12
+    }
+  ],
+  "next_cursor": "...",
+  "has_more": false
+}
+```
+
+`feed_favicon_url` は本エンドポイントの応答には **含まれない**（v1 スコープ。将来必要に
+なれば加算的に追加される）。
+
+### 5.3 `GET /api/items/{id}` — 記事詳細
+
+| 項目 | 内容 |
+|---|---|
+| URL | `GET /api/items/{id}` |
+| 認証 | 必須 |
+| パスパラメータ | `id`: 記事 UUID |
+| クエリ | （なし） |
+| 成功応答 | 200 `application/json`（後述） |
+| エラー | 401 / 404 `ITEM_NOT_FOUND`（記事が当該ユーザーの購読範囲に存在しない。**未購読 / 不在の両方を同一応答にまとめ存在を秘匿する**）/ 500 |
+
+**成功応答スキーマ**（本 spec で `feed_title` / `feed_favicon_url` を追加した拡張後の形）:
+
+```json
+{
+  "id": "<item id>",
+  "feed_id": "<feed id>",
+  "title": "<title>",
+  "link": "<https://...>",
+  "summary": "<sanitized summary>",
+  "published_at": "2025-06-23T10:00:00Z",
+  "is_date_estimated": false,
+  "is_read": true,
+  "is_starred": false,
+  "hatebu_count": 42,
+  "content": "<sanitized HTML 本文>",
+  "author": "<著者名 or 空文字>",
+  "feed_title": "<フィード表示名>",
+  "feed_favicon_url": "data:image/png;base64,..."
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| 既存 11 フィールド（`id` 〜 `hatebu_count`） | （§5.1 と同型） | 必須 | §5.1 のサマリと同一スキーマ |
+| `content` | string | 必須 | サニタイズ済み HTML 本文 |
+| `summary` | string | 必須 | サマリ（記事一覧の `summary` と重複する。v1 でも両方含める） |
+| `author` | string | 必須 | 著者名（不明時は空文字） |
+| `feed_title` | string | **追加 / 必須** | 所属フィードの表示タイトル（本 spec で追加） |
+| `feed_favicon_url` | `string \| null` | **追加 / 任意（null 時は省略）** | 所属フィードの favicon。`data:image/...;base64,...` 形式の data URL。favicon が登録されていない場合は **JSON から省略される**（要件 3.4 で「null または省略」が許容） |
+
+**注意事項**:
+
+- 既存フィールド名・型は本 spec 導入により **一切変更されない**（要件 3.3 / NFR 1.2）
+- `feed_favicon_url` の data URL は HTML / CSP 安全な形式に整形済（生バイトを返さない）
+- 未購読記事へのアクセスは「記事が存在しない」と同じ 404 `ITEM_NOT_FOUND` を返す
+  （存在秘匿 / 要件 3.5）
+
+### 5.4 `GET /api/items/search` — 記事検索
+
+| 項目 | 内容 |
+|---|---|
+| URL | `GET /api/items/search` |
+| 認証 | 必須 |
+| クエリ | `q`（検索キーワード、必須）／ `feed_id`（UUID、任意。指定時はフィード内検索、省略時は全購読フィード横断検索）／ `cursor` / `limit`（§2.5 共通形式） |
+| 成功応答 | 200 `application/json`（後述） |
+| エラー | 400 `INVALID_SEARCH_QUERY`（`cursor` / `feed_id` / `limit` の形式不正） / 401 / 403 `FEED_NOT_SUBSCRIBED`（`feed_id` 指定先が当該ユーザー未購読） / 500 |
+
+**成功応答スキーマ**: items 配列の各要素が `feed_title` を含む（横断検索でも feed 内検索でも
+共通の応答形）。また検索結果固有のオプションフィールド `favicon_url` / `hatebu_fetched_at`
+が含まれる:
+
+```json
+{
+  "items": [
+    {
+      "id": "<item id>",
+      "feed_id": "<feed id>",
+      "feed_title": "<フィード表示名>",
+      "favicon_url": "data:image/png;base64,...",
+      "title": "<title>",
+      "link": "<https://...>",
+      "summary": "<sanitized summary>",
+      "published_at": "2025-06-23T10:00:00Z",
+      "is_date_estimated": false,
+      "is_read": false,
+      "is_starred": false,
+      "hatebu_count": 5,
+      "hatebu_fetched_at": "2025-06-23T09:00:00Z"
+    }
+  ],
+  "next_cursor": "...",
+  "has_more": true
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| 既存 11 フィールド（`id` 〜 `hatebu_count`） | （§5.1 と同型） | 必須 | §5.1 のサマリと同一スキーマ |
+| `feed_title` | string | 必須 | 所属フィード表示名 |
+| `favicon_url` | `string \| null` | 任意（null 時は省略） | 所属フィード favicon の data URL。**`feed_favicon_url` ではなく `favicon_url`** である点に注意（記事詳細 §5.3 の命名と異なる。これは検索 API 固有の歴史的経緯による既存契約） |
+| `hatebu_fetched_at` | string (RFC3339) | 任意（null 時は省略） | はてなブックマーク件数の取得時刻 |
+
+**注意事項**:
+
+- `scope=global|feed` のような明示的なスコープ切り替えパラメータは **契約に含まれない**。
+  `feed_id` の有無で挙動が決まる（指定時 = feed 内検索 / 省略時 = 全購読横断検索）
+- `feed_id` を未購読のフィード ID で送ると 403 `FEED_NOT_SUBSCRIBED` を返す
+- 検索キーワード `q` の長さ・特殊文字の扱いはサーバー側で正規化される
+
+### 5.5 `GET /api/items/cross-feed` — 横断新着記事一覧
+
+| 項目 | 内容 |
+|---|---|
+| URL | `GET /api/items/cross-feed` |
+| 認証 | 必須 |
+| クエリ | `cursor` / `limit`（既定 50、上限 200） ／ `since`（任意、RFC3339）— **request では `since` という名前** |
+| 成功応答 | 200 `application/json`（後述） |
+| エラー | 400 `INVALID_REQUEST`（`limit` / `since` の形式不正） / 401 / 500 |
+
+**成功応答スキーマ**: items 配列の各要素が `feed_title` / `feed_favicon_url` を含む。
+また baseline として採用した時刻が `since_time` フィールド（**response では `since_time` という
+名前**）で返る:
+
+```json
+{
+  "items": [
+    {
+      "id": "<item id>",
+      "feed_id": "<feed id>",
+      "feed_title": "<フィード表示名>",
+      "feed_favicon_url": "data:image/png;base64,...",
+      "title": "<title>",
+      "link": "<https://...>",
+      "summary": "<sanitized summary>",
+      "published_at": "2025-06-23T10:00:00Z",
+      "is_date_estimated": false,
+      "is_read": false,
+      "is_starred": false,
+      "hatebu_count": 0
+    }
+  ],
+  "next_cursor": "...",
+  "has_more": true,
+  "since_time": "2025-06-23T09:00:00Z"
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| 既存 11 フィールド（`id` 〜 `hatebu_count`） | （§5.1 と同型） | 必須 | §5.1 のサマリと同一スキーマ |
+| `feed_title` | string | 必須 | 所属フィード表示名 |
+| `feed_favicon_url` | `string \| null` | 任意（null 時は応答に含まれるが `null` 値） | 所属フィード favicon の data URL |
+| `since_time` | string (RFC3339) | 必須 | サーバが採用した新着判定基準時刻。クライアントは次回 `since` パラメータとしてこれを再利用できる |
+
+**`since` ↔ `since_time` の対称性に関する注意**: リクエストパラメータ名は **`since`**、
+レスポンスフィールド名は **`since_time`** で **非対称** である。これは v1 時点の既存契約で
+あり、本文書でも将来的にも維持される（後方互換）。
+
+**新着判定の動き**:
+
+- `since` を指定しない場合、サーバ側の `user_cross_feed_views.last_seen_at`（ユーザーが
+  最後に横断新着を閲覧した時刻）を baseline として用いる
+- `since` を指定した場合、サーバ側 baseline を無視して当該値を用いる
+- `PUT /api/users/me/cross-feed-last-seen`（§5.13）で baseline を進められる
+
+### 5.6 `GET /api/subscriptions` — 購読一覧
+
+| 項目 | 内容 |
+|---|---|
+| URL | `GET /api/subscriptions` |
+| 認証 | 必須 |
+| クエリ | （なし） |
+| 成功応答 | 200 `application/json` — 配列を直接返す |
+| エラー | 401 / 500 |
+
+**成功応答スキーマ**:
+
+```json
+[
+  {
+    "id": "<subscription id>",
+    "user_id": "<user id>",
+    "feed_id": "<feed id>",
+    "feed_title": "<フィード表示名>",
+    "feed_url": "<https://example.com/feed.xml>",
+    "favicon_url": "data:image/png;base64,...",
+    "fetch_interval_minutes": 60,
+    "feed_status": "active",
+    "error_message": null,
+    "unread_count": 12,
+    "created_at": "2025-06-23T10:00:00Z"
+  }
+]
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `id` | string | 必須 | 購読 ID |
+| `user_id` | string | 必須 | 当該ユーザー ID |
+| `feed_id` | string | 必須 | フィード ID |
+| `feed_title` | string | 必須 | フィード表示名 |
+| `feed_url` | string | 必須 | フィード URL |
+| `favicon_url` | `string \| null` | 任意（null 時は省略） | favicon の data URL（**`feed_favicon_url` ではなく `favicon_url`** である点に注意。§5.4 と同じ命名） |
+| `fetch_interval_minutes` | int | 必須 | フェッチ間隔（30〜720 分、30 分刻み） |
+| `feed_status` | string | 必須 | フィード状態（`active` / `stopped` 等） |
+| `error_message` | `string \| null` | 任意（null 時は省略） | 最新のフェッチエラーメッセージ |
+| `unread_count` | int | 必須 | 未読件数 |
+| `created_at` | string (RFC3339) | 必須 | 購読開始時刻 |
+
+### 5.7 `POST /api/feeds` — 新規購読登録
+
+| 項目 | 内容 |
+|---|---|
+| URL | `POST /api/feeds` |
+| 認証 | 必須 |
+| リクエスト | `{"url": "<https://example.com/feed.xml or トップページ URL>"}` |
+| 成功応答 | 201 `application/json` |
+| エラー | 400 `INVALID_URL` / 422 `FEED_NOT_DETECTED` / `PARSE_FAILED` / `SSRF_BLOCKED` / `FETCH_FAILED` / `FEED_HTTP_ERROR`（`details.status_code`）／ 409 `DUPLICATE_SUBSCRIPTION` / 401 / 500 |
+
+**成功応答スキーマ**:
+
+```json
+{
+  "id": "<feed id>",
+  "feed_url": "<最終検出された feed URL>",
+  "site_url": "<サイトのトップ URL>",
+  "title": "<フィードタイトル>",
+  "fetch_status": "active"
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `id` | string | 必須 | フィード ID |
+| `feed_url` | string | 必須 | サーバ側で検出した最終的なフィード URL |
+| `site_url` | string | 必須 | フィードに紐付くサイト URL |
+| `title` | string | 必須 | フィード表示名 |
+| `fetch_status` | string | 必須 | フェッチ状態 |
+
+### 5.8 `DELETE /api/subscriptions/{id}` — 購読解除
+
+| 項目 | 内容 |
+|---|---|
+| URL | `DELETE /api/subscriptions/{id}` |
+| 認証 | 必須 |
+| パスパラメータ | `id`: 購読 ID |
+| 成功応答 | 204 No Content |
+| エラー | 401 / 404 `SUBSCRIPTION_NOT_FOUND` / 500 |
+
+### 5.9 `PUT /api/subscriptions/{id}/settings` — フェッチ間隔設定
+
+| 項目 | 内容 |
+|---|---|
+| URL | `PUT /api/subscriptions/{id}/settings` |
+| 認証 | 必須 |
+| パスパラメータ | `id`: 購読 ID |
+| リクエスト | `{"fetch_interval_minutes": 60}`（30〜720 の 30 分刻み） |
+| 成功応答 | 200（更新後の購読情報。§5.6 の項目と同形） |
+| エラー | 400 `INVALID_FETCH_INTERVAL` / 401 / 404 `SUBSCRIPTION_NOT_FOUND` / 500 |
+
+### 5.10 `POST /api/subscriptions/{id}/resume` — 停止フィード再開
+
+| 項目 | 内容 |
+|---|---|
+| URL | `POST /api/subscriptions/{id}/resume` |
+| 認証 | 必須 |
+| パスパラメータ | `id`: 購読 ID |
+| リクエスト | （body なし） |
+| 成功応答 | 200（更新後の購読情報。§5.6 の項目と同形） |
+| エラー | 401 / 404 `SUBSCRIPTION_NOT_FOUND` / 409 `FEED_NOT_STOPPED`（停止中でないフィード）/ 500 |
+
+### 5.11 `POST /api/subscriptions/{id}/fetch` — 手動フェッチ
+
+| 項目 | 内容 |
+|---|---|
+| URL | `POST /api/subscriptions/{id}/fetch` |
+| 認証 | 必須 |
+| パスパラメータ | `id`: 購読 ID |
+| リクエスト | （body なし） |
+| 成功応答 | 200（更新後の購読情報。§5.6 の項目と同形） |
+| エラー | 401 / 404 `SUBSCRIPTION_NOT_FOUND` / 409 `FEED_FETCH_IN_PROGRESS` / 429 `FEED_COOLDOWN`（`details.retry_after_seconds` に残り秒数 int）/ 500 |
+
+**注意事項**: 手動フェッチは最終成功時刻から 10 分のクールダウンが課される。
+429 応答の `details.retry_after_seconds` に従って UI 側で次回フェッチ可能時刻を案内すること。
+
+### 5.12 `PUT /api/items/{id}/state` — 既読 / スター状態更新
+
+| 項目 | 内容 |
+|---|---|
+| URL | `PUT /api/items/{id}/state` |
+| 認証 | 必須 |
+| パスパラメータ | `id`: 記事 ID |
+| リクエスト | `{"is_read": true, "is_starred": false}`（両フィールド任意、nil は変更なし。部分更新） |
+| 成功応答 | 200 `application/json` |
+| エラー | 401 / 404 `ITEM_NOT_FOUND` / 500 |
+
+**成功応答スキーマ**:
+
+```json
+{
+  "item_id": "<item id>",
+  "is_read": true,
+  "is_starred": false
+}
+```
+
+### 5.13 `PUT /api/users/me/cross-feed-last-seen` — 横断一覧の最終閲覧時刻更新
+
+| 項目 | 内容 |
+|---|---|
+| URL | `PUT /api/users/me/cross-feed-last-seen` |
+| 認証 | 必須 |
+| リクエスト | （body なし。サーバ側で `now()` を採用） |
+| 成功応答 | 204 No Content |
+| エラー | 401 / 500 |
+
+**注意事項**: 本エンドポイントを呼ぶと、次回の `GET /api/items/cross-feed`（§5.5）で
+`since` パラメータを指定しなかった場合の baseline（`user_cross_feed_views.last_seen_at`）が
+`now()` に更新される。
+
+---
+
+## 6. v1 スコープ外（次フェーズ）
+
+以下のエンドポイントは v1 接続確認の **必須契約に含めない**。モバイルクライアントは
+v1 では呼び出さないこと。これらはキーワードプッシュ通知の **次フェーズ** に該当する
+（要件 1.5 / NFR 2.2）。
+
+| エンドポイント | 用途 | 位置付け |
+|---|---|---|
+| `/api/devices` | デバイス登録（push 通知トークン管理） | 次フェーズ。v1 ではサーバ側に未実装 / クライアントから呼び出さない |
+| `/api/keywords` | キーワード通知（指定キーワード一致時の push） | 次フェーズ。v1 ではサーバ側に未実装 / クライアントから呼び出さない |
+
+これらは将来の別 Issue で起票・実装される。v1 リリース時点では契約自体が存在しない。
+
+---
+
+## 7. 後方互換ポリシー
+
+### 7.1 既存フィールドの不変性
+
+本 spec 導入により、以下を **一切変更しない**:
+
+- 既存エンドポイントの URL / HTTP method
+- 既存エンドポイントの認証方式（Cookie 専用エンドポイントは Cookie のままで Bearer
+  対応を強制しない）
+- 既存応答 JSON のフィールド名・型・null 表現
+- 既存エラーコード / HTTP status の対応
+
+### 7.2 進化のルール
+
+新規機能の追加は **加算的変更（adding-only）** のみで行う:
+
+- 新しいエンドポイント / 新フィールドの追加は可
+- 既存フィールドの削除・改名・型変更は **不可**
+- nullable な追加フィールドは `omitempty` または `null` のいずれかで表現してよい
+
+本文書は v1 契約として **追加フィールド** を 2 つ含む（記事詳細応答の `feed_title` /
+`feed_favicon_url`）。これらは既存クライアントの応答パースを破壊しない（既存フィールドが
+すべて保持されているため）。
+
+### 7.3 `/auth/me` の維持
+
+既存 Web 専用エンドポイント `GET /auth/me` は本 spec で **一切変更しない**（要件 2.6 /
+NFR 1.1）:
+
+- URL: `GET /auth/me`（不変）
+- 認証: Cookie `session_id` 専用（Bearer 経路へ拡張しない）
+- 応答: `{"id":"<>", "email":"<>", "name":"<>"}` の 3 フィールド（不変。`avatar_url` を
+  追加しない）
+
+モバイルクライアントは `/auth/me` を呼ばず、`§4.1 GET /api/users/me` を利用すること。
+両エンドポイントは並行提供される。
+
+### 7.4 命名の歴史的非対称性
+
+以下は v1 時点で既存契約として存在する命名の非対称性であり、本文書および将来も
+**そのまま維持される**:
+
+| エンドポイント | favicon フィールド名 | 備考 |
+|---|---|---|
+| `GET /api/items/{id}` | `feed_favicon_url` | 本 spec で追加 |
+| `GET /api/items/cross-feed` | `feed_favicon_url` | 既存 |
+| `GET /api/items/search` | `favicon_url` | 既存（歴史的経緯） |
+| `GET /api/subscriptions` | `favicon_url` | 既存（歴史的経緯） |
+
+`/api/items/cross-feed` の request `since` ↔ response `since_time` も既存非対称（§5.5 参照）。
+
+クライアントは各エンドポイントごとに正しいフィールド名でパースすること。
+
+---
+
+## 関連 spec / 関連 Issue
+
+- **本 spec**: Issue #207 — v1 モバイル API 契約の明文化と統一ユーザー情報 / 記事詳細
+  フィードメタデータの追加
+- **Native auth 全体**: Issue #163
+- **PKCE login**: Issue #165
+- **`POST /api/auth/token`**: Issue #166
+- **`POST /api/auth/refresh`**: Issue #167
+- **`POST /api/auth/revoke`**: Issue #168
+- **`BearerOrSession` middleware**: Issue #169
+- **JWT 署名鍵 rotation**: Issue #170, #171
+- **Native auth end-to-end 契約テスト**: Issue #172
+
+---
+
+## 改訂履歴
+
+| 日付 | 改訂内容 | 関連 Issue |
+|---|---|---|
+| 2026-06-23 | 初版作成（v1 モバイル API 契約の明文化、`GET /api/users/me` 新設、記事詳細応答への `feed_title` / `feed_favicon_url` 追加） | #207 |

--- a/docs/specs/207--mobile-api-v1-api/review-notes.md
+++ b/docs/specs/207--mobile-api-v1-api/review-notes.md
@@ -1,0 +1,67 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-8 timestamp=2026-06-29T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-207-impl--mobile-api-v1-api
+- HEAD commit: 4cb6ebfb959d96de3168fa18396f1c74f0bf8a61
+- Compared to: develop..HEAD
+
+## Verified Requirements
+
+### Requirement 1（v1 モバイル API 契約ドキュメント）
+- 1.1 — `mobile-api-contract.md` §2.1 認証方式 / §2.2 エラー応答形式 / §2.4 JSON 命名規約 に共通方針を記載
+- 1.2 — 同 §3 Native Auth サマリ（token/refresh/revoke/native callback）+ 既存 spec #163/#172 参照
+- 1.3 — 同 §4.1 `GET /api/users/me`（URL/認証方式/成功応答 JSON/エラー応答）を記載
+- 1.4 — 同 §5.1〜§5.13（記事一覧・記事詳細・検索・クロスフィード・購読操作）の URL/認証/パラメータ/応答/エラーを記載
+- 1.5 — 同 §6 v1 スコープ外（`/api/devices` / `/api/keywords`）を次フェーズとして明示
+- 1.6 — `README.md` API エンドポイント一覧に `GET /api/users/me`・native auth 系・starred/search/cross-feed/manual fetch を追記し、契約文書参照リンクを追加
+
+### Requirement 2（統一ユーザー情報取得エンドポイント）
+- 2.1 — `UserHandler.GetCurrent` + `UserServiceAdapter.GetCurrent` + `user.Service.GetByID` + router.go 認証必須グループ配線。`TestUserHandler_GetCurrent_Success_ReturnsCurrentUser`
+- 2.2 — 同一 handler が BearerOrSession 通過後に経路非依存で動作。`TestNewRouter_UserRoutes_GetCurrentEndpoint`（Cookie 経路 200）
+- 2.3 — `currentUserResponse{id,email,name,avatar_url}`。`TestUserHandler_GetCurrent_OmitsSecrets`
+- 2.4 — `AvatarURL *string` + `omitempty`。`TestUserHandler_GetCurrent_OmitsAvatarWhenNil`
+- 2.5 — handler 401 + router.go 認証グループ配下。`TestUserHandler_GetCurrent_NoUserID_ReturnsUnauthorized` / `TestRouter_GetUsersMe_RequiresAuth`
+- 2.6 — `auth_handler.go` / `SetupAuthRoutes` 未変更。`TestAuthHandler_Me_CookiePathUnchanged`
+
+### Requirement 3（記事詳細フィードメタデータ）
+- 3.1 — `ItemDetail.FeedTitle` / `itemDetailResponse.feed_title`。`TestItemService_GetItem_PopulatesFeedMetadata` / `TestItemHandler_GetItem_ReturnsFeedMetadata`
+- 3.2 — `FeedFaviconURL` を `model.FaviconDataURL` で整形。同上テスト
+- 3.3 — 既存 11 フィールドのフィールド名・型・JSON タグ不変。`TestItemHandler_GetItem_PreservesExistingFields`
+- 3.4 — `*string` + `omitempty`。`TestItemService_GetItem_NullFaviconWhenFeedHasNone` / `TestItemHandler_GetItem_OmitsFaviconWhenNil`
+- 3.5 — feed lookup を既存認可フロー（SubscriptionChecker）の後に配置し ITEM_NOT_FOUND 条件不変。`TestItemService_GetItem_Unsubscribed_ReturnsNotFound`（変更なし pass）/ `TestItemHandler_GetItem_NotFound_PreservesExistingBehavior`
+
+### Requirement 4（契約テスト）
+- 4.1 — `TestUserHandler_GetCurrent_Success_ReturnsCurrentUser`（認証済み要求で current user を返す）。impl-notes に経路等価の紐付け記載あり
+- 4.2 — `TestNewRouter_UserRoutes_GetCurrentEndpoint`（Cookie 経路 200）+ handler success test
+- 4.3 — `TestAuthHandler_Me_CookiePathUnchanged`（`/auth/me` Cookie 経路の shape 非回帰）
+- 4.4 — `TestItemHandler_GetItem_ReturnsFeedMetadata`（feed_title / feed_favicon_url 両出現）
+- 4.5 — `TestItemHandler_GetItem_PreservesExistingFields`（既存フィールド一式の存続）
+
+### Non-Functional Requirements
+- NFR 1.1/1.2/1.3 — `/auth/me` 未変更・既存 item フィールド温存・既存 item テスト群は `defaultFeedProvider()` 追加引数のみで全 pass（後述 verify で green 確認）
+- NFR 2.1/2.2 — 契約文書 §1〜§7 がエンドポイント詳細と v1 スコープ内外を独立記載
+- NFR 3.1 — 追加テストは標準 `go test` 配置・外部ネットワーク/実 OAuth/実フィード非依存
+
+## Verify 実行結果（reviewer 再実行）
+- `go build ./...` — OK
+- `go test ./internal/user/... ./internal/item/... ./internal/handler/...` — all ok
+- `go vet ./internal/user/... ./internal/item/... ./internal/handler/... ./internal/app/...` — clean
+
+## Boundary 確認
+- 全変更ファイルが tasks.md の各 `_Boundary:_` に収まる（user.Service / UserHandler / UserServiceAdapter / router.go / AuthHandler[test] / item.ItemService / app.go wiring / ItemHandler / ItemServiceAdapter / mobile-api-contract.md / README.md）
+- `tasks.md` は `- [ ]`→`- [x]` の進捗 checkbox 編集のみ（spec 本文・アノテーション不変）
+- `docs/openapi/mobile-v1.yaml` の削除表示は本ブランチの変更ではなく develop 側の追加に対する two-dot diff 上の見かけ（merge-base..HEAD の three-dot diff では非該当を確認）。boundary 逸脱に当たらない
+- Feature Flag Protocol は CLAUDE.md で `opt-out`。flag 観点の細目は適用せず通常 3 カテゴリ判定
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric AC（Req 1.x / 2.x / 3.x / 4.x / NFR 1.x / 2.x / 3.x）が実装・テスト・契約文書で観測可能にカバーされ、boundary 逸脱なし。build / test / vet を reviewer 側でも再実行し green を確認した。
+
+RESULT: approve

--- a/docs/specs/207--mobile-api-v1-api/tasks.md
+++ b/docs/specs/207--mobile-api-v1-api/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. Mobile API Contract Document を新規作成する (P)
+- [x] 1. Mobile API Contract Document を新規作成する (P)
   - `docs/specs/207--mobile-api-v1-api/mobile-api-contract.md` を新規作成
   - 構成は design.md「Mobile API Contract Document の構成」節に従う:
     概要 / 共通方針（認証ヘッダ・エラー応答形式・JSON 命名規約）/ Native Auth サマリ /

--- a/docs/specs/207--mobile-api-v1-api/tasks.md
+++ b/docs/specs/207--mobile-api-v1-api/tasks.md
@@ -16,7 +16,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.3, 2.4, 3.1, 3.2, 3.4, NFR 2.1, NFR 2.2_
   - _Boundary: mobile-api-contract.md_
 
-- [ ] 2. README の API エンドポイント一覧を更新する (P)
+- [x] 2. README の API エンドポイント一覧を更新する (P)
   - `README.md` の `## API エンドポイント` 配下の表を以下の通り更新:
     - 「ユーザー管理（認証必須）」に `GET /api/users/me`（モバイル / Web 共通の current
       user 取得）を新設項として追加

--- a/docs/specs/207--mobile-api-v1-api/tasks.md
+++ b/docs/specs/207--mobile-api-v1-api/tasks.md
@@ -99,7 +99,7 @@
   - _Requirements: 2.6, 4.3, NFR 1.1_
   - _Boundary: AuthHandler_
 
-- [ ] 6. item.ItemService.GetItem を拡張し FeedMetaProvider 依存を導入する
+- [x] 6. item.ItemService.GetItem を拡張し FeedMetaProvider 依存を導入する
   - `internal/item/service.go` に以下を追加:
     - `FeedMetaProvider` interface（`FindByID(ctx context.Context, id string) (*model.Feed, error)`
       の 1 メソッドのみ。既存 `SubscriptionChecker` と同じ interface segregation パターン）

--- a/docs/specs/207--mobile-api-v1-api/tasks.md
+++ b/docs/specs/207--mobile-api-v1-api/tasks.md
@@ -32,7 +32,7 @@
   - _Requirements: 1.6_
   - _Boundary: README.md_
 
-- [ ] 3. user.Service に GetByID を追加し単体テストを通す
+- [x] 3. user.Service に GetByID を追加し単体テストを通す
   - `internal/user/service.go` に `func (s *Service) GetByID(ctx context.Context, userID string) (*model.User, error)`
     を追加。実装は `s.userRepo.FindByID` を呼ぶ（レガシーパス）、または
     `s.txUserDeleter.FindByID` を呼ぶ（txBeginner パス）薄い wrapper

--- a/docs/specs/207--mobile-api-v1-api/tasks.md
+++ b/docs/specs/207--mobile-api-v1-api/tasks.md
@@ -85,7 +85,7 @@
   - _Boundary: UserHandler, UserServiceAdapter, router.go_
   - _Depends: 3_
 
-- [ ] 5. /auth/me の Cookie 経路 non-regression テストを追加する
+- [x] 5. /auth/me の Cookie 経路 non-regression テストを追加する
   - `internal/handler/auth_handler_test.go` に
     `TestAuthHandler_Me_CookiePathUnchanged` を追加:
     - 既存 `mockAuthService` パターンを踏襲し、Cookie `session_id` を持つリクエストで

--- a/docs/specs/207--mobile-api-v1-api/tasks.md
+++ b/docs/specs/207--mobile-api-v1-api/tasks.md
@@ -127,7 +127,7 @@
   - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 4.4_
   - _Boundary: item.ItemService, app.go wiring_
 
-- [ ] 7. itemDetailResponse を拡張し記事詳細契約テストを通す
+- [x] 7. itemDetailResponse を拡張し記事詳細契約テストを通す
   - `internal/handler/item_handler.go` の `itemDetailResponse` に以下を追加:
     - `FeedTitle string \`json:"feed_title"\``
     - `FeedFaviconURL *string \`json:"feed_favicon_url,omitempty"\``

--- a/docs/specs/207--mobile-api-v1-api/tasks.md
+++ b/docs/specs/207--mobile-api-v1-api/tasks.md
@@ -51,7 +51,7 @@
   - _Requirements: 2.1, 2.2, 2.3_
   - _Boundary: user.Service_
 
-- [ ] 4. GET /api/users/me ハンドラ・アダプタ・ルーティング配線を追加し契約テストを通す
+- [x] 4. GET /api/users/me ハンドラ・アダプタ・ルーティング配線を追加し契約テストを通す
   - `internal/handler/user_handler.go` に以下を追加:
     - `UserServiceInterface` に `GetCurrent(ctx context.Context, userID string) (*currentUserResponse, error)`
       メソッド追加

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -138,7 +138,9 @@ func runServe(cfg *config.Config) error {
 
 	// itemService / itemStateService は subRepo を SubscriptionChecker として注入し、
 	// 記事詳細取得・状態更新時に購読外フィードへの越境アクセスを拒否する（#175）。
-	itemService := item.NewItemService(itemRepo, itemStateRepo, subRepo)
+	// itemService には追加で feedRepo を FeedMetaProvider として注入し、記事詳細応答に
+	// 所属フィードの表示メタデータ（タイトル / favicon）を付与する（Issue #207 / Req 3.1, 3.2）。
+	itemService := item.NewItemService(itemRepo, itemStateRepo, subRepo, feedRepo)
 	itemStateService := item.NewItemStateService(itemRepo, itemStateRepo, subRepo)
 
 	// 横断新着一覧サービス（Issue #121）。itemRepo の ListNewAcrossFeeds と

--- a/internal/handler/auth_handler_test.go
+++ b/internal/handler/auth_handler_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -829,4 +830,121 @@ func TestAuthHandler_Callback_Native_TamperedChallenge_Rejects(t *testing.T) {
 	if nativeCalled {
 		t.Error("HandleNativeCallback must not be called with tampered challenge")
 	}
+}
+
+// TestAuthHandler_Me_CookiePathUnchanged は /auth/me の Cookie 経路応答が本 spec（#207）
+// 導入で変化していないことを保護する non-regression テスト（Req 2.6 / 4.3 / NFR 1.1）。
+//
+// 既存 TestAuthHandler_Me_Authenticated_ReturnsUserJSON は status と Content-Type のみを
+// 検査するが、本テストは応答 JSON 本文のキー集合まで踏み込み:
+//
+//   - サブテスト Cookie_Present_ReturnsExistingShape:
+//     応答 200 / Content-Type: application/json / JSON のキー集合が **厳密に**
+//     {id, email, name} のみであること（avatar_url / session_id / refresh_token 等の
+//     新フィールド・secret は含まれない）と、各フィールドの値が mock の返り値と一致
+//     することを集合演算的に assert する。
+//   - サブテスト NoCookie_ReturnsUnauthorized:
+//     Cookie 不在で 401 を返す既存挙動が変化していないことを保護する。
+//
+// 本 task は実装変更を伴わない。`/api/users/me`（#207 で新設）と `/auth/me`（既存 Web Cookie 経路）の
+// 棲み分けを維持し、後者に新フィールドが漏れて返らないことを将来の変更で機械的に検出する gate。
+func TestAuthHandler_Me_CookiePathUnchanged(t *testing.T) {
+	t.Run("Cookie_Present_ReturnsExistingShape", func(t *testing.T) {
+		// Arrange: 既存 mockAuthService パターンで getCurrentUser を注入。
+		// model.User には ID/Email/Name のみ存在し、AvatarURL フィールドは無い
+		// （avatar_url が応答に漏れないことの構造的保証は handler 側の map literal にも依存）。
+		wantUser := &model.User{
+			ID:    "user-id-cookie",
+			Email: "cookie@example.com",
+			Name:  "Cookie User",
+		}
+		svc := &mockAuthService{
+			getCurrentUserFn: func(ctx context.Context, sessionID string) (*model.User, error) {
+				if sessionID != "valid-session" {
+					t.Errorf("sessionID = %q, want %q", sessionID, "valid-session")
+				}
+				return wantUser, nil
+			},
+		}
+		h := NewAuthHandler(svc, AuthHandlerConfig{
+			BaseURL: "http://localhost:3000",
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+		req.AddCookie(&http.Cookie{Name: "session_id", Value: "valid-session"})
+		w := httptest.NewRecorder()
+
+		// Act
+		h.Me(w, req)
+
+		// Assert: status / Content-Type は既存仕様通り
+		resp := w.Result()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+		}
+		if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want %q", ct, "application/json")
+		}
+
+		// JSON 本文を decode してキー集合と値を検査
+		var body map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+
+		// 1. 必須キー {id, email, name} が全て存在し、値が一致する
+		if got, ok := body["id"].(string); !ok || got != wantUser.ID {
+			t.Errorf("id = %v (ok=%v), want %q", body["id"], ok, wantUser.ID)
+		}
+		if got, ok := body["email"].(string); !ok || got != wantUser.Email {
+			t.Errorf("email = %v (ok=%v), want %q", body["email"], ok, wantUser.Email)
+		}
+		if got, ok := body["name"].(string); !ok || got != wantUser.Name {
+			t.Errorf("name = %v (ok=%v), want %q", body["name"], ok, wantUser.Name)
+		}
+
+		// 2. キー集合は **厳密に** {id, email, name} のみであること
+		//    （avatar_url や将来追加されるフィールドが /auth/me から漏れないことを保護）
+		allowed := map[string]bool{
+			"id":    true,
+			"email": true,
+			"name":  true,
+		}
+		if len(body) != len(allowed) {
+			t.Errorf("response key count = %d, want %d (keys=%v)", len(body), len(allowed), keysOf(body))
+		}
+		for k := range body {
+			if !allowed[k] {
+				t.Errorf("response contains forbidden key %q (shape regression: /auth/me should keep {id, email, name})", k)
+			}
+		}
+
+		// 3. 明示的に新フィールド / secret キーが含まれないことを assert（regression net の二重化）
+		//    grep でも検出可能にするため individual key check を残す
+		forbidden := []string{"avatar_url", "session_id", "refresh_token", "password", "password_hash", "access_token"}
+		for _, k := range forbidden {
+			if _, ok := body[k]; ok {
+				t.Errorf("response leaks forbidden key %q from /auth/me (non-regression violation)", k)
+			}
+		}
+	})
+
+	t.Run("NoCookie_ReturnsUnauthorized", func(t *testing.T) {
+		// Arrange: session_id Cookie 不在
+		h := NewAuthHandler(&mockAuthService{}, AuthHandlerConfig{
+			BaseURL: "http://localhost:3000",
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/auth/me", nil)
+		w := httptest.NewRecorder()
+
+		// Act
+		h.Me(w, req)
+
+		// Assert: 既存仕様通り 401 を返す
+		resp := w.Result()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+		}
+	})
 }

--- a/internal/handler/item_handler.go
+++ b/internal/handler/item_handler.go
@@ -88,11 +88,22 @@ type starredItemListResult struct {
 }
 
 // itemDetailResponse は記事詳細のレスポンス。
+//
+// 既存 11 フィールド（itemSummaryResponse 経由の 9 フィールド + Content / Summary / Author）の
+// フィールド名・型・JSON タグは Issue #207 以前から不変であり、後方互換のため変更しない
+// （NFR 1.2 / Req 3.3）。
+//
+// 追加フィールド:
+//   - FeedTitle: 当該記事が属するフィードの表示タイトル（Req 3.1）
+//   - FeedFaviconURL: 同フィードの favicon を data URL 化したもの。
+//     値が無い場合は nil を保持し、`omitempty` で JSON から省略される（Req 3.2 / 3.4）
 type itemDetailResponse struct {
 	itemSummaryResponse
-	Content string `json:"content"` // サニタイズ済みHTML
-	Summary string `json:"summary"`
-	Author  string `json:"author"`
+	Content        string  `json:"content"` // サニタイズ済みHTML
+	Summary        string  `json:"summary"`
+	Author         string  `json:"author"`
+	FeedTitle      string  `json:"feed_title"`                 // Req 3.1: フィード表示タイトル
+	FeedFaviconURL *string `json:"feed_favicon_url,omitempty"` // Req 3.2 / 3.4: favicon data URL（無し時は省略）
 }
 
 // itemStateRequest は記事状態更新リクエストのボディ。

--- a/internal/handler/item_handler_test.go
+++ b/internal/handler/item_handler_test.go
@@ -589,6 +589,260 @@ func TestItemHandler_GetItem_ServiceError_ReturnsInternalServerError(t *testing.
 	}
 }
 
+// TestItemHandler_GetItem_ReturnsFeedMetadata は記事詳細応答 JSON に
+// feed_title と feed_favicon_url の両フィールドが含まれることを検証する
+// （Req 3.1, 3.2, 4.4）。
+//
+// service 層が feed メタを populate した itemDetailResponse を返す前提で、
+// handler が JSON エンコード時に両フィールドをそのまま出力することを確認する。
+func TestItemHandler_GetItem_ReturnsFeedMetadata(t *testing.T) {
+	// Arrange
+	now := time.Now().UTC().Truncate(time.Second)
+	favicon := "data:image/png;base64,YWJj"
+	svc := &mockItemService{
+		getItemFn: func(ctx context.Context, userID, itemID string) (*itemDetailResponse, error) {
+			return &itemDetailResponse{
+				itemSummaryResponse: itemSummaryResponse{
+					ID:          "item-1",
+					FeedID:      "feed-1",
+					Title:       "テスト記事",
+					Link:        "https://example.com/article",
+					PublishedAt: now,
+				},
+				Content:        "<p>本文</p>",
+				Summary:        "サマリー",
+				Author:         "著者",
+				FeedTitle:      "サンプルフィード",
+				FeedFaviconURL: &favicon,
+			}, nil
+		},
+	}
+	h := NewItemHandler(svc, &mockItemStateService{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items/item-1", nil)
+	req = withUserID(req, "user-123")
+	req = withChiURLParam(req, "id", "item-1")
+	w := httptest.NewRecorder()
+
+	// Act
+	h.GetItem(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Result().StatusCode, http.StatusOK)
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if result["feed_title"] != "サンプルフィード" {
+		t.Errorf("feed_title = %v, want %q", result["feed_title"], "サンプルフィード")
+	}
+	if result["feed_favicon_url"] != favicon {
+		t.Errorf("feed_favicon_url = %v, want %q", result["feed_favicon_url"], favicon)
+	}
+}
+
+// TestItemHandler_GetItem_PreservesExistingFields は本 spec 導入前から記事詳細応答に
+// 含まれていた既存 11 フィールド全てが、フィールド名・型不変で引き続き出現することを
+// 検証する（Req 3.3 / 4.5 / NFR 1.2）。
+//
+// 「フィールド名・型・null 表現を本 spec 導入により変更しない」契約を機械的な
+// 集合検査で保護する。将来 itemDetailResponse の既存フィールドが改名 / 削除 /
+// 型変更された場合に本テストが落ちることで、後方互換の regression を検出する。
+func TestItemHandler_GetItem_PreservesExistingFields(t *testing.T) {
+	// Arrange
+	now := time.Now().UTC().Truncate(time.Second)
+	favicon := "data:image/png;base64,YWJj"
+	svc := &mockItemService{
+		getItemFn: func(ctx context.Context, userID, itemID string) (*itemDetailResponse, error) {
+			return &itemDetailResponse{
+				itemSummaryResponse: itemSummaryResponse{
+					ID:              "item-1",
+					FeedID:          "feed-1",
+					Title:           "テスト記事",
+					Link:            "https://example.com/article",
+					Summary:         "サマリーテキスト",
+					PublishedAt:     now,
+					IsDateEstimated: true,
+					IsRead:          true,
+					IsStarred:       false,
+					HatebuCount:     42,
+				},
+				Content:        "<p>サニタイズ済みコンテンツ</p>",
+				Summary:        "サマリーテキスト",
+				Author:         "著者名",
+				FeedTitle:      "サンプルフィード",
+				FeedFaviconURL: &favicon,
+			}, nil
+		},
+	}
+	h := NewItemHandler(svc, &mockItemStateService{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items/item-1", nil)
+	req = withUserID(req, "user-123")
+	req = withChiURLParam(req, "id", "item-1")
+	w := httptest.NewRecorder()
+
+	// Act
+	h.GetItem(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Result().StatusCode, http.StatusOK)
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// 本 spec 導入前から存在する既存 11 フィールドを期待値とともに enum 列挙する。
+	// フィールド名（snake_case JSON タグ）と型は本 spec で一切変更されないことを保証する
+	// （NFR 1.2 / Req 3.3）。
+	wantExistingFields := map[string]interface{}{
+		"id":                "item-1",
+		"feed_id":           "feed-1",
+		"title":             "テスト記事",
+		"link":              "https://example.com/article",
+		"summary":           "サマリーテキスト",
+		"is_date_estimated": true,
+		"is_read":           true,
+		"is_starred":        false,
+		"hatebu_count":      float64(42),
+		"content":           "<p>サニタイズ済みコンテンツ</p>",
+		"author":            "著者名",
+	}
+	for k, want := range wantExistingFields {
+		got, ok := result[k]
+		if !ok {
+			t.Errorf("expected existing field %q to be present in response", k)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s = %v (%T), want %v (%T)", k, got, got, want, want)
+		}
+	}
+
+	// published_at は時刻形式のため値比較せず、存在のみ確認（型変更がないことの保証）。
+	if _, ok := result["published_at"]; !ok {
+		t.Error("expected existing field \"published_at\" to be present in response")
+	}
+}
+
+// TestItemHandler_GetItem_OmitsFaviconWhenNil は FeedFaviconURL が nil のとき
+// 応答 JSON から feed_favicon_url キーが省略されることを検証する（Req 3.4）。
+//
+// `*string` + `omitempty` の Go 標準挙動として nil なら JSON 出力されない。
+// 「JSON null または応答からの省略」のうち「省略」側で実装した design.md 「設計判断」
+// と一致する挙動を機械的に保護する。
+func TestItemHandler_GetItem_OmitsFaviconWhenNil(t *testing.T) {
+	// Arrange
+	now := time.Now().UTC().Truncate(time.Second)
+	svc := &mockItemService{
+		getItemFn: func(ctx context.Context, userID, itemID string) (*itemDetailResponse, error) {
+			return &itemDetailResponse{
+				itemSummaryResponse: itemSummaryResponse{
+					ID:          "item-1",
+					FeedID:      "feed-1",
+					Title:       "テスト記事",
+					Link:        "https://example.com/article",
+					PublishedAt: now,
+				},
+				Content:        "<p>本文</p>",
+				FeedTitle:      "favicon 無しフィード",
+				FeedFaviconURL: nil,
+			}, nil
+		},
+	}
+	h := NewItemHandler(svc, &mockItemStateService{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items/item-1", nil)
+	req = withUserID(req, "user-123")
+	req = withChiURLParam(req, "id", "item-1")
+	w := httptest.NewRecorder()
+
+	// Act
+	h.GetItem(w, req)
+
+	// Assert
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Result().StatusCode, http.StatusOK)
+	}
+
+	// JSON 文字列に "feed_favicon_url" が出現しないことを bytes レベルで確認する
+	// （omitempty による省略の機械的検証）。
+	bodyBytes := w.Body.Bytes()
+	if bytes.Contains(bodyBytes, []byte("feed_favicon_url")) {
+		t.Errorf("expected feed_favicon_url to be omitted, got %s", string(bodyBytes))
+	}
+
+	// 念のため map decode して同観点を二重に確認する
+	var result map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if _, ok := result["feed_favicon_url"]; ok {
+		t.Errorf("expected feed_favicon_url to be absent in JSON map, got %v", result["feed_favicon_url"])
+	}
+
+	// feed_title は値の有無に関わらず必ず出現する（`omitempty` 無し）。
+	if result["feed_title"] != "favicon 無しフィード" {
+		t.Errorf("feed_title = %v, want %q", result["feed_title"], "favicon 無しフィード")
+	}
+}
+
+// TestItemHandler_GetItem_NotFound_PreservesExistingBehavior は購読外 / 不在記事 ID に
+// 対する 404 ITEM_NOT_FOUND 応答が本 spec 導入で変化しないことを検証する
+// （Req 3.5）。
+//
+// 既存テスト TestItemHandler_GetItem_NotFound_ReturnsNotFound は status / code のみ
+// 検査するが、本テストでは「feed_title / feed_favicon_url が誤って 404 応答に
+// 紛れ込まないこと」も合わせて assert することで、応答 shape が成功時の追加
+// フィールドに影響されないことを機械的に保護する。
+func TestItemHandler_GetItem_NotFound_PreservesExistingBehavior(t *testing.T) {
+	// Arrange: service 層が ITEM_NOT_FOUND を返す（購読外 / 不在のどちらかは秘匿）
+	svc := &mockItemService{
+		getItemFn: func(ctx context.Context, userID, itemID string) (*itemDetailResponse, error) {
+			return nil, model.NewItemNotFoundError(itemID)
+		},
+	}
+	h := NewItemHandler(svc, &mockItemStateService{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/items/nonexistent", nil)
+	req = withUserID(req, "user-123")
+	req = withChiURLParam(req, "id", "nonexistent")
+	w := httptest.NewRecorder()
+
+	// Act
+	h.GetItem(w, req)
+
+	// Assert
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+
+	// 応答 body は既存 APIError 形式（code = ITEM_NOT_FOUND）であり、
+	// 記事詳細フィールド（feed_title / feed_favicon_url / id / content 等）が
+	// 含まれないことを確認する。
+	errResp := parseAPIErrorResponse(t, w)
+	if errResp["code"] != model.ErrCodeItemNotFound {
+		t.Errorf("code = %q, want %q", errResp["code"], model.ErrCodeItemNotFound)
+	}
+
+	// 404 応答に詳細フィールドが漏れ込まないこと（regression net）
+	bodyBytes := w.Body.Bytes()
+	forbidden := []string{"feed_title", "feed_favicon_url", "\"content\"", "\"author\""}
+	for _, key := range forbidden {
+		if bytes.Contains(bodyBytes, []byte(key)) {
+			t.Errorf("404 response should not contain %q, got %s", key, string(bodyBytes))
+		}
+	}
+}
+
 // --- PUT /api/items/:id/state テスト ---
 
 func TestItemHandler_UpdateItemState_SetRead_Success(t *testing.T) {

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -297,6 +297,10 @@ func NewRouter(deps *RouterDeps) http.Handler {
 
 		// ユーザー管理
 		r.Route("/api/users", func(r chi.Router) {
+			// GET /api/users/me - モバイル / Web 共通の current user 取得（Issue #207）。
+			// BearerOrSession middleware を通過した後に実行されるため、Bearer / Cookie の
+			// いずれの経路でも同じ handler で current user 情報を返す（Req 2.1 / 2.2）。
+			r.Get("/me", userHandler.GetCurrent)
 			r.Delete("/me", userHandler.Withdraw)
 			// PUT /api/users/me/cross-feed-last-seen - 横断一覧の最終閲覧時刻更新（Issue #121）
 			// CrossFeedService が未配線の deps では登録しない（後方互換）。

--- a/internal/handler/router_full_test.go
+++ b/internal/handler/router_full_test.go
@@ -310,6 +310,44 @@ func TestNewRouter_SubscriptionRoutes_AllEndpoints(t *testing.T) {
 	}
 }
 
+// TestRouter_GetUsersMe_RequiresAuth は GET /api/users/me が認証必須グループに
+// 乗っていることを確認する（Req 2.5）。Authorization ヘッダも session_id Cookie も
+// 持たないリクエストは BearerOrSession middleware により 401 を返す。
+func TestRouter_GetUsersMe_RequiresAuth(t *testing.T) {
+	router, _ := createTestRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users/me", nil)
+	// Authorization ヘッダなし / Cookie なし
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Errorf("GET /api/users/me (no auth) status = %d, want %d",
+			w.Result().StatusCode, http.StatusUnauthorized)
+	}
+}
+
+// TestNewRouter_UserRoutes_GetCurrentEndpoint は GET /api/users/me が認証必須グループ内に
+// 登録され、有効な session で 200 を返すことを確認する（Req 2.1 / 2.2 のうち Cookie 経路）。
+func TestNewRouter_UserRoutes_GetCurrentEndpoint(t *testing.T) {
+	router, _ := createTestRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users/me", nil)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "valid-session"})
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode == http.StatusNotFound {
+		t.Errorf("GET /api/users/me returned 404, route not found")
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET /api/users/me status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
 // TestNewRouter_UserRoutes_WithdrawEndpoint は退会エンドポイントが登録されていることを検証する。
 func TestNewRouter_UserRoutes_WithdrawEndpoint(t *testing.T) {
 	router, _ := createTestRouter()

--- a/internal/handler/service_adapter.go
+++ b/internal/handler/service_adapter.go
@@ -218,9 +218,11 @@ func (a *ItemServiceAdapterFromDomain) GetItem(ctx context.Context, userID, item
 			IsStarred:       detail.IsStarred,
 			HatebuCount:     detail.HatebuCount,
 		},
-		Content: detail.Content,
-		Summary: detail.Summary,
-		Author:  detail.Author,
+		Content:        detail.Content,
+		Summary:        detail.Summary,
+		Author:         detail.Author,
+		FeedTitle:      detail.FeedTitle,      // Req 3.1: service 層が populate した feed タイトルを転写
+		FeedFaviconURL: detail.FeedFaviconURL, // Req 3.2 / 3.4: *string なので nil で省略される
 	}, nil
 }
 

--- a/internal/handler/service_adapter.go
+++ b/internal/handler/service_adapter.go
@@ -105,6 +105,22 @@ func (a *UserServiceAdapter) Withdraw(ctx context.Context, userID string) error 
 	return a.svc.Withdraw(ctx, userID)
 }
 
+// GetCurrent は指定 userID の current user 情報をハンドラ用 DTO で返す。
+// user.Service.GetByID を呼び、*model.User から currentUserResponse に変換する。
+// avatar_url は v1 では DB 未拡張のため常に nil を返す（design.md「設計判断」/ Req 2.4）。
+func (a *UserServiceAdapter) GetCurrent(ctx context.Context, userID string) (*currentUserResponse, error) {
+	u, err := a.svc.GetByID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	return &currentUserResponse{
+		ID:        u.ID,
+		Email:     u.Email,
+		Name:      u.Name,
+		AvatarURL: nil,
+	}, nil
+}
+
 // ItemServiceAdapterFromDomain は item.ItemService を ItemServiceInterface に適合させるアダプタ。
 type ItemServiceAdapterFromDomain struct {
 	svc *item.ItemService

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -15,6 +16,22 @@ type UserServiceInterface interface {
 	// user、identities、subscriptions、item_states、settingsを一括削除する。
 	// feeds、itemsは共有キャッシュとして残す。
 	Withdraw(ctx context.Context, userID string) error
+	// GetCurrent は指定 userID の current user 情報をレスポンス用 DTO で返す。
+	// userID は middleware（BearerOrSession）が解決したものを呼び出し側が渡す。
+	// userID が DB 上に存在しない場合は model.NewUserNotFoundError を返す。
+	GetCurrent(ctx context.Context, userID string) (*currentUserResponse, error)
+}
+
+// currentUserResponse は GET /api/users/me の応答 JSON 表現。
+// avatar_url は v1 では常に nil（DB 未拡張）であり omitempty で省略される
+// （Req 2.3 / 2.4 / design.md「設計判断: avatar_url を当面 nil 固定で返す」節）。
+// session_id / refresh_token などの secret は絶対に含めない
+// （CLAUDE.md「機能追加チェックリスト」/「機密情報の扱い」）。
+type currentUserResponse struct {
+	ID        string  `json:"id"`
+	Email     string  `json:"email"`
+	Name      string  `json:"name"`
+	AvatarURL *string `json:"avatar_url,omitempty"`
 }
 
 // UserHandler はユーザー管理のHTTPハンドラー。
@@ -51,12 +68,43 @@ func (h *UserHandler) Withdraw(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// GetCurrent は現在ログイン中のユーザー情報を JSON で返す。
+// GET /api/users/me
+//
+// BearerOrSession middleware を通過した後の経路（Authorization: Bearer / Cookie
+// session_id のいずれも）で同じ handler を呼ぶため、handler 自体は経路を区別しない
+// （Req 2.1 / 2.2）。middleware が解決した userID を context から取得して service に渡す。
+//
+// 応答キー集合は {id, email, name} ⊆ X ⊆ {id, email, name, avatar_url}（Req 2.3 / 2.4）。
+func (h *UserHandler) GetCurrent(w http.ResponseWriter, r *http.Request) {
+	userID, err := middleware.UserIDFromContext(r.Context())
+	if err != nil {
+		middleware.WriteErrorResponse(w, http.StatusUnauthorized, &model.APIError{
+			Code:     "UNAUTHORIZED",
+			Message:  "認証が必要です。",
+			Category: "auth",
+			Action:   "ログインしてください。",
+		})
+		return
+	}
+
+	resp, err := h.service.GetCurrent(r.Context(), userID)
+	if err != nil {
+		handleServiceError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
 // SetupUserRoutes はユーザー管理関連のルーティングを設定したchi.Routerを返す。
 func SetupUserRoutes(service UserServiceInterface) http.Handler {
 	r := chi.NewRouter()
 	h := NewUserHandler(service)
 
 	r.Route("/api/users", func(r chi.Router) {
+		r.Get("/me", h.GetCurrent)
 		r.Delete("/me", h.Withdraw)
 	})
 

--- a/internal/handler/user_handler_test.go
+++ b/internal/handler/user_handler_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -14,7 +15,8 @@ import (
 
 // mockUserService はUserServiceInterfaceのモック実装。
 type mockUserService struct {
-	withdrawFn func(ctx context.Context, userID string) error
+	withdrawFn   func(ctx context.Context, userID string) error
+	getCurrentFn func(ctx context.Context, userID string) (*currentUserResponse, error)
 }
 
 func (m *mockUserService) Withdraw(ctx context.Context, userID string) error {
@@ -22,6 +24,13 @@ func (m *mockUserService) Withdraw(ctx context.Context, userID string) error {
 		return m.withdrawFn(ctx, userID)
 	}
 	return nil
+}
+
+func (m *mockUserService) GetCurrent(ctx context.Context, userID string) (*currentUserResponse, error) {
+	if m.getCurrentFn != nil {
+		return m.getCurrentFn(ctx, userID)
+	}
+	return &currentUserResponse{ID: userID}, nil
 }
 
 // --- DELETE /api/users/me テスト ---
@@ -159,5 +168,242 @@ func TestUserHandler_Withdraw_VerifiesOnlyUserDataIsDeleted(t *testing.T) {
 	resp := w.Result()
 	if resp.StatusCode != http.StatusNoContent {
 		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+}
+
+// --- GET /api/users/me テスト ---
+
+// TestUserHandler_GetCurrent_Success_ReturnsCurrentUser は GET /api/users/me が
+// userID 注入済リクエストに対して 200 + {id, email, name} を含む JSON を返すことを確認する。
+// BearerOrSession middleware 通過後の handler は経路（Bearer / Cookie）非依存で同一動作する
+// ため、両経路を 1 つのテストで担保する（Req 4.1 / 4.2 / design.md「Testing Strategy」節）。
+func TestUserHandler_GetCurrent_Success_ReturnsCurrentUser(t *testing.T) {
+	getCurrentCalled := false
+	svc := &mockUserService{
+		getCurrentFn: func(ctx context.Context, userID string) (*currentUserResponse, error) {
+			getCurrentCalled = true
+			if userID != "user-123" {
+				t.Errorf("userID = %q, want %q", userID, "user-123")
+			}
+			return &currentUserResponse{
+				ID:    "user-123",
+				Email: "test@example.com",
+				Name:  "Test User",
+			}, nil
+		},
+	}
+
+	h := NewUserHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users/me", nil)
+	req = withUserID(req, "user-123")
+	w := httptest.NewRecorder()
+
+	h.GetCurrent(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", got, "application/json")
+	}
+	if !getCurrentCalled {
+		t.Error("expected GetCurrent to be called")
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["id"] != "user-123" {
+		t.Errorf("id = %v, want %q", body["id"], "user-123")
+	}
+	if body["email"] != "test@example.com" {
+		t.Errorf("email = %v, want %q", body["email"], "test@example.com")
+	}
+	if body["name"] != "Test User" {
+		t.Errorf("name = %v, want %q", body["name"], "Test User")
+	}
+}
+
+// TestUserHandler_GetCurrent_NoUserID_ReturnsUnauthorized は context に userID が
+// 注入されていない場合に 401 UNAUTHORIZED を返すことを確認する（Req 2.5）。
+func TestUserHandler_GetCurrent_NoUserID_ReturnsUnauthorized(t *testing.T) {
+	h := NewUserHandler(&mockUserService{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users/me", nil)
+	// ユーザーIDを注入しない
+	w := httptest.NewRecorder()
+
+	h.GetCurrent(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+// TestUserHandler_GetCurrent_UserNotFound_Returns404 は service が
+// model.NewUserNotFoundError を返した場合 404 を返すことを確認する。
+func TestUserHandler_GetCurrent_UserNotFound_Returns404(t *testing.T) {
+	svc := &mockUserService{
+		getCurrentFn: func(ctx context.Context, userID string) (*currentUserResponse, error) {
+			return nil, model.NewUserNotFoundError()
+		},
+	}
+
+	h := NewUserHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users/me", nil)
+	req = withUserID(req, "user-123")
+	w := httptest.NewRecorder()
+
+	h.GetCurrent(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+// TestUserHandler_GetCurrent_InternalError は service が APIError 以外のエラーを
+// 返した場合 500 を返すことを確認する（既存 handleServiceError パターンの再利用検証）。
+func TestUserHandler_GetCurrent_InternalError(t *testing.T) {
+	svc := &mockUserService{
+		getCurrentFn: func(ctx context.Context, userID string) (*currentUserResponse, error) {
+			return nil, errors.New("db connection lost")
+		},
+	}
+
+	h := NewUserHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users/me", nil)
+	req = withUserID(req, "user-123")
+	w := httptest.NewRecorder()
+
+	h.GetCurrent(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+}
+
+// TestUserHandler_GetCurrent_OmitsSecrets は応答 JSON のキー集合が
+// {id, email, name} ⊆ X ⊆ {id, email, name, avatar_url} であり、session_id /
+// refresh_token / hashed token などの secret を含まないことを確認する
+// （CLAUDE.md「機密情報の扱い」/「機能追加チェックリスト」/ design.md「Security Considerations」節）。
+func TestUserHandler_GetCurrent_OmitsSecrets(t *testing.T) {
+	avatarValue := "https://example.com/avatar.png"
+	svc := &mockUserService{
+		getCurrentFn: func(ctx context.Context, userID string) (*currentUserResponse, error) {
+			// avatar_url を返すケースでも応答キー集合が {id, email, name, avatar_url}
+			// の範囲に収まることを確認するため、ここでは avatar_url を含めて返す。
+			return &currentUserResponse{
+				ID:        "user-123",
+				Email:     "test@example.com",
+				Name:      "Test",
+				AvatarURL: &avatarValue,
+			}, nil
+		},
+	}
+
+	h := NewUserHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users/me", nil)
+	req = withUserID(req, "user-123")
+	w := httptest.NewRecorder()
+
+	h.GetCurrent(w, req)
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// 必須キー（{id, email, name}）が全て含まれる
+	requiredKeys := []string{"id", "email", "name"}
+	for _, k := range requiredKeys {
+		if _, ok := body[k]; !ok {
+			t.Errorf("response missing required key %q", k)
+		}
+	}
+
+	// 許可されたキー集合 {id, email, name, avatar_url} 以外が含まれていないこと
+	allowed := map[string]bool{
+		"id":         true,
+		"email":      true,
+		"name":       true,
+		"avatar_url": true,
+	}
+	for k := range body {
+		if !allowed[k] {
+			t.Errorf("response contains forbidden key %q (secret leak risk)", k)
+		}
+	}
+
+	// 念のため明示的に secret キーが存在しないことを確認
+	forbidden := []string{"session_id", "refresh_token", "password", "password_hash", "access_token"}
+	for _, k := range forbidden {
+		if _, ok := body[k]; ok {
+			t.Errorf("response leaks secret key %q", k)
+		}
+	}
+}
+
+// TestUserHandler_GetCurrent_OmitsAvatarWhenNil は AvatarURL が nil の場合に
+// 応答 JSON から avatar_url キーが省略されることを確認する（Req 2.4 /
+// `*string` + omitempty タグの挙動検証）。
+func TestUserHandler_GetCurrent_OmitsAvatarWhenNil(t *testing.T) {
+	svc := &mockUserService{
+		getCurrentFn: func(ctx context.Context, userID string) (*currentUserResponse, error) {
+			return &currentUserResponse{
+				ID:    "user-123",
+				Email: "test@example.com",
+				Name:  "Test User",
+				// AvatarURL は nil（v1 デフォルト挙動）
+			}, nil
+		},
+	}
+
+	h := NewUserHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users/me", nil)
+	req = withUserID(req, "user-123")
+	w := httptest.NewRecorder()
+
+	h.GetCurrent(w, req)
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if _, ok := body["avatar_url"]; ok {
+		t.Errorf("avatar_url key should be omitted when nil, but got %v", body["avatar_url"])
+	}
+}
+
+// TestSetupUserRoutes_GetCurrentEndpoint は SetupUserRoutes が GET /me を登録している
+// ことを確認する（router 配線の基本動作確認）。
+func TestSetupUserRoutes_GetCurrentEndpoint(t *testing.T) {
+	svc := &mockUserService{
+		getCurrentFn: func(ctx context.Context, userID string) (*currentUserResponse, error) {
+			return &currentUserResponse{ID: userID, Email: "x@example.com", Name: "X"}, nil
+		},
+	}
+
+	router := SetupUserRoutes(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/users/me", nil)
+	req = withUserID(req, "user-123")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET /api/users/me status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 }

--- a/internal/item/service.go
+++ b/internal/item/service.go
@@ -3,6 +3,7 @@ package item
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/hitoshi/feedman/internal/model"
@@ -17,25 +18,38 @@ type SubscriptionChecker interface {
 	FindByUserAndFeed(ctx context.Context, userID, feedID string) (*model.Subscription, error)
 }
 
+// FeedMetaProvider は記事詳細応答にフィード表示メタデータを付与するための最小インターフェース。
+// repository.FeedRepository がこれを満たす（インターフェース分離のため、全 FeedRepository
+// ではなく FindByID のみに依存する。既存 SubscriptionChecker と同パターン）。
+type FeedMetaProvider interface {
+	// FindByID は指定 ID のフィードを返す。見つからない場合は nil を返す。
+	FindByID(ctx context.Context, id string) (*model.Feed, error)
+}
+
 // ItemService は記事取得・フィルタリングのサービス。
 type ItemService struct {
 	itemRepo      repository.ItemRepository
 	itemStateRepo repository.ItemStateRepository
 	subChecker    SubscriptionChecker
+	feedRepo      FeedMetaProvider
 }
 
 // NewItemService はItemServiceの新しいインスタンスを生成する。
 // subChecker は記事詳細取得時に呼び出しユーザーが当該フィードを購読しているかを
 // 確認するために使用する（購読外フィードの記事本文への越境アクセスを防ぐ）。
+// feedRepo は GetItem で記事所属フィードの表示メタデータ（タイトル / favicon）を
+// 取得するために使用する（Issue #207 / Req 3.1, 3.2）。
 func NewItemService(
 	itemRepo repository.ItemRepository,
 	itemStateRepo repository.ItemStateRepository,
 	subChecker SubscriptionChecker,
+	feedRepo FeedMetaProvider,
 ) *ItemService {
 	return &ItemService{
 		itemRepo:      itemRepo,
 		itemStateRepo: itemStateRepo,
 		subChecker:    subChecker,
+		feedRepo:      feedRepo,
 	}
 }
 
@@ -278,6 +292,20 @@ func (s *ItemService) GetItem(
 		pubAt = *item.PublishedAt
 	}
 
+	// 記事所属フィードの表示メタデータ（タイトル / favicon）を取得して詳細応答に併記する。
+	// 認可は上記の SubscriptionChecker で済んでおり、本 lookup は表示用情報の付与のみ。
+	// items.feed_id は FK 制約により孤立しないため実運用では nil は発生しないが、内部
+	// 不整合の検出のため nil なら error として上位に伝播する（fail-fast。Issue #207 設計判断
+	// により ItemNotFoundError ではなく汎用 error として伝播し、上位 handleServiceError で 500
+	// に集約させる。購読外フィードの存在秘匿は SubscriptionChecker で既に担保済み）。
+	feed, err := s.feedRepo.FindByID(ctx, item.FeedID)
+	if err != nil {
+		return nil, err
+	}
+	if feed == nil {
+		return nil, fmt.Errorf("記事所属フィードの取得に失敗しました: feed_id=%s が見つかりません", item.FeedID)
+	}
+
 	return &ItemDetail{
 		ItemSummary: ItemSummary{
 			ID:              item.ID,
@@ -290,16 +318,23 @@ func (s *ItemService) GetItem(
 			IsStarred:       isStarred,
 			HatebuCount:     item.HatebuCount,
 		},
-		Content: item.Content,
-		Summary: item.Summary,
-		Author:  item.Author,
+		Content:        item.Content,
+		Summary:        item.Summary,
+		Author:         item.Author,
+		FeedTitle:      feed.Title,
+		FeedFaviconURL: model.FaviconDataURL(feed.FaviconData, feed.FaviconMime),
 	}, nil
 }
 
 // ItemDetail は記事詳細情報。
+// FeedTitle / FeedFaviconURL は当該記事が所属するフィードの表示用メタデータ
+// （Issue #207 / Req 3.1, 3.2）。FeedFaviconURL は favicon 未登録のとき nil
+// （Req 3.4。`*string` 採用により上位 handler 層で `omitempty` による省略を実現）。
 type ItemDetail struct {
 	ItemSummary
-	Content string
-	Summary string
-	Author  string
+	Content        string
+	Summary        string
+	Author         string
+	FeedTitle      string
+	FeedFaviconURL *string
 }

--- a/internal/item/service_test.go
+++ b/internal/item/service_test.go
@@ -2,6 +2,8 @@ package item
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -123,6 +125,27 @@ func unsubscribedChecker() *mockSubCheckerForService {
 	return &mockSubCheckerForService{subscribed: false}
 }
 
+// mockFeedMetaProviderForService は FeedMetaProvider のテスト用モック。
+// findByIDFn 未設定時はゼロ値の Feed（タイトル空 / favicon 空）を返し、既存テストが
+// GetItem の feed メタ取得追加（Issue #207 / Req 3.1, 3.2）の影響を受けないようにする。
+type mockFeedMetaProviderForService struct {
+	findByIDFn func(ctx context.Context, id string) (*model.Feed, error)
+}
+
+func (m *mockFeedMetaProviderForService) FindByID(ctx context.Context, id string) (*model.Feed, error) {
+	if m.findByIDFn != nil {
+		return m.findByIDFn(ctx, id)
+	}
+	// 既存テスト互換: feed 取得は成功するがメタは空（FeedTitle="" / FeedFaviconURL=nil）。
+	return &model.Feed{ID: id}, nil
+}
+
+// defaultFeedProvider は既存テスト互換用の最小 FeedMetaProvider モック。
+// 既存テストは FeedTitle / FeedFaviconURL を検査しないため、空 feed を返すデフォルトで十分。
+func defaultFeedProvider() *mockFeedMetaProviderForService {
+	return &mockFeedMetaProviderForService{}
+}
+
 // --- ItemService ListItems テスト ---
 
 // TestItemService_ListItems_ReturnsItems はフィードの記事一覧がpublished_at降順で返されることをテストする。
@@ -159,7 +182,7 @@ func TestItemService_ListItems_ReturnsItems(t *testing.T) {
 		}, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 	result, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterAll, "", 50)
 	if err != nil {
 		t.Fatalf("ListItems returned error: %v", err)
@@ -213,7 +236,7 @@ func TestItemService_ListItems_IncludesSummary(t *testing.T) {
 					},
 				}, nil
 			}
-			svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+			svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 
 			// Act
 			result, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterAll, "", 50)
@@ -256,7 +279,7 @@ func TestItemService_SummaryConsistentBetweenListAndDetail(t *testing.T) {
 		itemCopy := srcItem
 		return &itemCopy, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 
 	listResult, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterAll, "", 50)
 	if err != nil {
@@ -302,7 +325,7 @@ func TestItemService_ListItems_HasMore(t *testing.T) {
 		return items, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 	result, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterAll, "", 50)
 	if err != nil {
 		t.Fatalf("ListItems returned error: %v", err)
@@ -325,7 +348,7 @@ func TestItemService_ListItems_HasMore(t *testing.T) {
 // TestItemService_ListItems_InvalidFilter は無効なフィルタでエラーが返されることをテストする。
 func TestItemService_ListItems_InvalidFilter(t *testing.T) {
 	repo := newMockItemRepoForService()
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 
 	_, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilter("invalid"), "", 50)
 	if err == nil {
@@ -350,7 +373,7 @@ func TestItemService_ListItems_CursorParsing(t *testing.T) {
 		return nil, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 	cursorStr := "2026-02-27T10:00:00Z"
 	_, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterAll, cursorStr, 50)
 	if err != nil {
@@ -372,7 +395,7 @@ func TestItemService_ListItems_EmptyCursor(t *testing.T) {
 		return nil, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 	_, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterAll, "", 50)
 	if err != nil {
 		t.Fatalf("ListItems returned error: %v", err)
@@ -392,7 +415,7 @@ func TestItemService_ListItems_UnreadFilter(t *testing.T) {
 		return nil, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 	_, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterUnread, "", 50)
 	if err != nil {
 		t.Fatalf("ListItems returned error: %v", err)
@@ -412,7 +435,7 @@ func TestItemService_ListItems_StarredFilter(t *testing.T) {
 		return nil, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 	_, err := svc.ListItems(context.Background(), "user-123", "feed-1", model.ItemFilterStarred, "", 50)
 	if err != nil {
 		t.Fatalf("ListItems returned error: %v", err)
@@ -462,7 +485,7 @@ func TestItemService_ListStarredItems_EmptyCursor(t *testing.T) {
 			makeStarredRow("item-1", "feed-1", "Feed A", now),
 		}, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 
 	// Act
 	result, err := svc.ListStarredItems(context.Background(), "user-123", "", 50)
@@ -508,7 +531,7 @@ func TestItemService_ListStarredItems_InvalidCursor(t *testing.T) {
 		repoCalled = true
 		return nil, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 
 	// Act
 	_, err := svc.ListStarredItems(context.Background(), "user-123", "not-a-timestamp", 50)
@@ -551,7 +574,7 @@ func TestItemService_ListStarredItems_HasMoreTrue(t *testing.T) {
 		}
 		return rows, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 
 	// Act
 	result, err := svc.ListStarredItems(context.Background(), "user-123", "", 50)
@@ -593,7 +616,7 @@ func TestItemService_ListStarredItems_HasMoreFalse(t *testing.T) {
 			makeStarredRow("item-2", "feed-2", "Feed B", now.Add(-time.Hour)),
 		}, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 
 	// Act
 	result, err := svc.ListStarredItems(context.Background(), "user-123", "", 50)
@@ -644,7 +667,7 @@ func TestItemService_ListStarredItems_NextCursorRFC3339NanoFormat(t *testing.T) 
 		rows[outerLimit] = makeStarredRow("item-overflow", "feed-1", "Feed A", tailTime.Add(-time.Hour))
 		return rows, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 
 	// Act
 	result, err := svc.ListStarredItems(context.Background(), "user-123", "", outerLimit)
@@ -681,7 +704,7 @@ func TestItemService_ListStarredItems_CursorPassedToRepo(t *testing.T) {
 		receivedCursor = cursor
 		return nil, nil
 	}
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 	cursorStr := "2026-02-27T10:00:00Z"
 
 	// Act
@@ -729,7 +752,7 @@ func TestItemService_GetItem_ReturnsDetail(t *testing.T) {
 		IsStarred: true,
 	}
 
-	svc := NewItemService(repo, stateRepo, subscribedChecker())
+	svc := NewItemService(repo, stateRepo, subscribedChecker(), defaultFeedProvider())
 	detail, err := svc.GetItem(context.Background(), "user-123", "item-1")
 	if err != nil {
 		t.Fatalf("GetItem returned error: %v", err)
@@ -784,7 +807,7 @@ func TestItemService_GetItem_Unsubscribed_ReturnsNotFound(t *testing.T) {
 	}
 
 	// Act
-	svc := NewItemService(repo, newMockItemStateRepoForService(), checker)
+	svc := NewItemService(repo, newMockItemStateRepoForService(), checker, defaultFeedProvider())
 	detail, err := svc.GetItem(context.Background(), "user-123", "item-1")
 
 	// Assert: 存在を秘匿して ITEM_NOT_FOUND、本文は返さない
@@ -807,7 +830,7 @@ func TestItemService_GetItem_NotFound(t *testing.T) {
 		return nil, nil
 	}
 
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 	_, err := svc.GetItem(context.Background(), "user-123", "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for non-existent item")
@@ -836,7 +859,7 @@ func TestItemService_GetItem_NoState(t *testing.T) {
 	}
 
 	// item_statesにレコードなし
-	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker())
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), defaultFeedProvider())
 	detail, err := svc.GetItem(context.Background(), "user-123", "item-1")
 	if err != nil {
 		t.Fatalf("GetItem returned error: %v", err)
@@ -848,6 +871,148 @@ func TestItemService_GetItem_NoState(t *testing.T) {
 	}
 	if detail.IsStarred {
 		t.Error("expected detail.IsStarred to be false (no state)")
+	}
+}
+
+// TestItemService_GetItem_PopulatesFeedMetadata は、mock FeedMetaProvider が feed を返した際に
+// ItemDetail.FeedTitle / FeedFaviconURL が正しく populate されることを検証する。
+// 対応 AC: Req 3.1（feed_title）、Req 3.2（feed_favicon_url）。
+// FeedMetaProvider に渡される id が item.FeedID と一致することも併せて契約として確認する。
+func TestItemService_GetItem_PopulatesFeedMetadata(t *testing.T) {
+	// Arrange
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := newMockItemRepoForService()
+	repo.findByIDFn = func(_ context.Context, _ string) (*model.Item, error) {
+		return &model.Item{
+			ID:          "item-1",
+			FeedID:      "feed-1",
+			Title:       "記事タイトル",
+			Link:        "https://example.com/article",
+			Content:     "<p>本文</p>",
+			PublishedAt: &now,
+		}, nil
+	}
+	feedProv := &mockFeedMetaProviderForService{
+		findByIDFn: func(_ context.Context, id string) (*model.Feed, error) {
+			// 認可フローの後に呼ばれる前提で id が item.FeedID と一致することを検証
+			if id != "feed-1" {
+				t.Errorf("FeedMetaProvider.FindByID id = %q, want %q", id, "feed-1")
+			}
+			return &model.Feed{
+				ID:          "feed-1",
+				Title:       "テストフィード",
+				FaviconData: []byte("abc"),
+				FaviconMime: "image/png",
+			}, nil
+		},
+	}
+
+	// Act
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), feedProv)
+	detail, err := svc.GetItem(context.Background(), "user-123", "item-1")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("GetItem returned error: %v", err)
+	}
+	if detail == nil {
+		t.Fatal("expected non-nil detail")
+	}
+	if detail.FeedTitle != "テストフィード" {
+		t.Errorf("detail.FeedTitle = %q, want %q", detail.FeedTitle, "テストフィード")
+	}
+	if detail.FeedFaviconURL == nil {
+		t.Fatal("expected non-nil FeedFaviconURL when feed has favicon")
+	}
+	// model.FaviconDataURL の出力フォーマットと一致することを確認（data:<mime>;base64,<data>）。
+	wantFavicon := "data:image/png;base64,YWJj" // base64("abc")
+	if *detail.FeedFaviconURL != wantFavicon {
+		t.Errorf("FeedFaviconURL = %q, want %q", *detail.FeedFaviconURL, wantFavicon)
+	}
+}
+
+// TestItemService_GetItem_NullFaviconWhenFeedHasNone は、FaviconData / FaviconMime が空の feed が
+// 返ったときに FeedFaviconURL が nil となり、FeedTitle は populate されることを検証する。
+// 対応 AC: Req 3.4（favicon 未登録時に null / 省略）。
+func TestItemService_GetItem_NullFaviconWhenFeedHasNone(t *testing.T) {
+	// Arrange
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := newMockItemRepoForService()
+	repo.findByIDFn = func(_ context.Context, _ string) (*model.Item, error) {
+		return &model.Item{
+			ID:          "item-1",
+			FeedID:      "feed-1",
+			Title:       "記事",
+			PublishedAt: &now,
+		}, nil
+	}
+	feedProv := &mockFeedMetaProviderForService{
+		findByIDFn: func(_ context.Context, _ string) (*model.Feed, error) {
+			// favicon 情報が無い feed
+			return &model.Feed{
+				ID:          "feed-1",
+				Title:       "favicon なしフィード",
+				FaviconData: nil,
+				FaviconMime: "",
+			}, nil
+		},
+	}
+
+	// Act
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), feedProv)
+	detail, err := svc.GetItem(context.Background(), "user-123", "item-1")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("GetItem returned error: %v", err)
+	}
+	if detail == nil {
+		t.Fatal("expected non-nil detail")
+	}
+	if detail.FeedTitle != "favicon なしフィード" {
+		t.Errorf("detail.FeedTitle = %q, want %q", detail.FeedTitle, "favicon なしフィード")
+	}
+	if detail.FeedFaviconURL != nil {
+		t.Errorf("expected FeedFaviconURL to be nil when feed has no favicon, got %q", *detail.FeedFaviconURL)
+	}
+}
+
+// TestItemService_GetItem_FeedRepoError_PropagatesError は、mock FeedMetaProvider が error を返したとき
+// その error が上位に伝播し ItemDetail が nil で返されることを検証する。
+// 対応 AC: 設計判断 fail-fast（feed lookup 失敗時は部分応答を生成せず 500 系として上位に返す）。
+func TestItemService_GetItem_FeedRepoError_PropagatesError(t *testing.T) {
+	// Arrange
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := newMockItemRepoForService()
+	repo.findByIDFn = func(_ context.Context, _ string) (*model.Item, error) {
+		return &model.Item{
+			ID:          "item-1",
+			FeedID:      "feed-1",
+			Title:       "記事",
+			PublishedAt: &now,
+		}, nil
+	}
+	wantErr := fmt.Errorf("simulated feed DB error")
+	feedProv := &mockFeedMetaProviderForService{
+		findByIDFn: func(_ context.Context, _ string) (*model.Feed, error) {
+			return nil, wantErr
+		},
+	}
+
+	// Act
+	svc := NewItemService(repo, newMockItemStateRepoForService(), subscribedChecker(), feedProv)
+	detail, err := svc.GetItem(context.Background(), "user-123", "item-1")
+
+	// Assert
+	if detail != nil {
+		t.Errorf("expected nil detail when feed lookup fails, got %+v", detail)
+	}
+	if err == nil {
+		t.Fatal("expected error to propagate from FeedMetaProvider")
+	}
+	if !errors.Is(err, wantErr) && err.Error() != wantErr.Error() {
+		// 上位伝播時は wrap せず原 error をそのまま返す（既存 itemRepo / itemStateRepo の error と同型）
+		t.Errorf("expected propagated error = %v, got %v", wantErr, err)
 	}
 }
 

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -144,6 +144,33 @@ func NewServiceWithTx(
 	}
 }
 
+// GetByID は指定 userID の current user を取得する。
+//
+// 認可は呼び出し側（BearerOrSession middleware）が担保しており、本メソッドは
+// ビジネス認可を行わない（caller userID = lookup userID 前提）。userID が DB 上に
+// 存在しない場合は model.NewUserNotFoundError を返す（既存 Withdraw と同パターン）。
+//
+// txBeginner が設定されている場合は txUserDeleter.FindByID を、設定されていない
+// 場合は userRepo.FindByID を呼ぶ（既存 Withdraw の lookup と同一の選択ロジック）。
+func (s *Service) GetByID(ctx context.Context, userID string) (*model.User, error) {
+	var (
+		user *model.User
+		err  error
+	)
+	if s.txBeginner != nil {
+		user, err = s.txUserDeleter.FindByID(ctx, userID)
+	} else {
+		user, err = s.userRepo.FindByID(ctx, userID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("ユーザーの取得に失敗しました: %w", err)
+	}
+	if user == nil {
+		return nil, model.NewUserNotFoundError()
+	}
+	return user, nil
+}
+
 // Withdraw はユーザーの退会処理を実行する。
 // 削除順序（トランザクションパス）: item_states → subscriptions → sessions →
 // auth_codes → refresh_token_families → user

--- a/internal/user/service_test.go
+++ b/internal/user/service_test.go
@@ -624,6 +624,188 @@ func TestService_Withdraw_Tx_RollsBackOnRefreshTokenDeleteError(t *testing.T) {
 	}
 }
 
+// --- Issue #207: user.Service.GetByID のテスト ---
+
+// TestService_GetByID_Success は GetByID が repository から取得した user を
+// そのまま返すことを検証する（Req 2.1 / 2.2）。レガシーパスと txBeginner パスの
+// 両方で同一挙動になることを subtest で確認する。
+func TestService_GetByID_Success(t *testing.T) {
+	want := &model.User{ID: "user-1", Email: "test@example.com", Name: "Test User"}
+
+	t.Run("レガシーパスのとき repository が返した user をそのまま返す", func(t *testing.T) {
+		// Arrange
+		userRepo := &mockUserRepo{
+			findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+				if id != want.ID {
+					t.Errorf("FindByID id = %q, want %q", id, want.ID)
+				}
+				return want, nil
+			},
+		}
+		svc := NewService(userRepo, nil, nil, nil)
+
+		// Act
+		got, err := svc.GetByID(context.Background(), want.ID)
+
+		// Assert
+		if err != nil {
+			t.Fatalf("GetByID returned error: %v", err)
+		}
+		if got != want {
+			t.Errorf("GetByID returned %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("txBeginner パスのとき txUserDeleter が返した user をそのまま返す", func(t *testing.T) {
+		// Arrange
+		rec := &txRecorder{}
+		beginner := &fakeTxBeginner{}
+		user := &txUserDeleter{
+			rec: rec,
+			findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+				if id != want.ID {
+					t.Errorf("FindByID id = %q, want %q", id, want.ID)
+				}
+				return want, nil
+			},
+		}
+		svc := newTxService(beginner, user,
+			&txSessionDeleter{rec: rec},
+			&txSubDeleter{rec: rec},
+			&txItemStateDeleter{rec: rec},
+			nil, nil,
+		)
+
+		// Act
+		got, err := svc.GetByID(context.Background(), want.ID)
+
+		// Assert
+		if err != nil {
+			t.Fatalf("GetByID returned error: %v", err)
+		}
+		if got != want {
+			t.Errorf("GetByID returned %+v, want %+v", got, want)
+		}
+		if beginner.beginCalled {
+			t.Error("expected no transaction to be started for read-only lookup")
+		}
+	})
+}
+
+// TestService_GetByID_NotFound_ReturnsUserNotFoundError は repository が nil を
+// 返したとき model.NewUserNotFoundError が返ることを検証する（Req 2.3）。
+// レガシーパスと txBeginner パスの両方を確認する。
+func TestService_GetByID_NotFound_ReturnsUserNotFoundError(t *testing.T) {
+	t.Run("レガシーパスのとき repository が nil なら UserNotFound を返す", func(t *testing.T) {
+		// Arrange
+		userRepo := &mockUserRepo{
+			findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+				return nil, nil
+			},
+		}
+		svc := NewService(userRepo, nil, nil, nil)
+
+		// Act
+		got, err := svc.GetByID(context.Background(), "missing-user")
+
+		// Assert
+		if got != nil {
+			t.Errorf("expected nil user, got %+v", got)
+		}
+		var apiErr *model.APIError
+		if !errors.As(err, &apiErr) || apiErr.Code != model.ErrCodeUserNotFound {
+			t.Fatalf("expected UserNotFound error, got %v", err)
+		}
+	})
+
+	t.Run("txBeginner パスのとき txUserDeleter が nil なら UserNotFound を返す", func(t *testing.T) {
+		// Arrange
+		rec := &txRecorder{}
+		beginner := &fakeTxBeginner{}
+		user := &txUserDeleter{
+			rec: rec,
+			findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+				return nil, nil
+			},
+		}
+		svc := newTxService(beginner, user,
+			&txSessionDeleter{rec: rec},
+			&txSubDeleter{rec: rec},
+			&txItemStateDeleter{rec: rec},
+			nil, nil,
+		)
+
+		// Act
+		got, err := svc.GetByID(context.Background(), "missing-user")
+
+		// Assert
+		if got != nil {
+			t.Errorf("expected nil user, got %+v", got)
+		}
+		var apiErr *model.APIError
+		if !errors.As(err, &apiErr) || apiErr.Code != model.ErrCodeUserNotFound {
+			t.Fatalf("expected UserNotFound error, got %v", err)
+		}
+	})
+}
+
+// TestService_GetByID_RepoError_PropagatesError は repository がエラーを返したとき
+// wrap された error が返ることを検証する。レガシーパスと txBeginner パスの両方で
+// 同一挙動になることを subtest で確認する。
+func TestService_GetByID_RepoError_PropagatesError(t *testing.T) {
+	repoErr := errors.New("db connection lost")
+
+	t.Run("レガシーパスのとき repository のエラーを wrap して返す", func(t *testing.T) {
+		// Arrange
+		userRepo := &mockUserRepo{
+			findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+				return nil, repoErr
+			},
+		}
+		svc := NewService(userRepo, nil, nil, nil)
+
+		// Act
+		got, err := svc.GetByID(context.Background(), "user-1")
+
+		// Assert
+		if got != nil {
+			t.Errorf("expected nil user on error, got %+v", got)
+		}
+		if !errors.Is(err, repoErr) {
+			t.Errorf("expected error to wrap %v, got %v", repoErr, err)
+		}
+	})
+
+	t.Run("txBeginner パスのとき txUserDeleter のエラーを wrap して返す", func(t *testing.T) {
+		// Arrange
+		rec := &txRecorder{}
+		beginner := &fakeTxBeginner{}
+		user := &txUserDeleter{
+			rec: rec,
+			findByIDFn: func(ctx context.Context, id string) (*model.User, error) {
+				return nil, repoErr
+			},
+		}
+		svc := newTxService(beginner, user,
+			&txSessionDeleter{rec: rec},
+			&txSubDeleter{rec: rec},
+			&txItemStateDeleter{rec: rec},
+			nil, nil,
+		)
+
+		// Act
+		got, err := svc.GetByID(context.Background(), "user-1")
+
+		// Assert
+		if got != nil {
+			t.Errorf("expected nil user on error, got %+v", got)
+		}
+		if !errors.Is(err, repoErr) {
+			t.Errorf("expected error to wrap %v, got %v", repoErr, err)
+		}
+	})
+}
+
 // TestService_Withdraw_Tx_NilNativeAuthDeletersSkip は native auth deleter が
 // 両方 nil のとき、退会が従来どおり成功し（NFR 1.1 後方互換）、
 // auth_codes / refresh_token_families の段がスキップされることを検証する


### PR DESCRIPTION
## 概要

Feedman v1 モバイルクライアント（Android / iOS）が依存する API 契約を整備し、サーバー応答を補正した。

- v1 共通方針（認証ヘッダ・エラー応答形式・JSON 命名規約）および全エンドポイントの URL / 認証 / 要求・応答形状を `docs/specs/207--mobile-api-v1-api/mobile-api-contract.md` として明文化した（Req 1）
- モバイルと Web の両認証方式（Bearer / Cookie）に対応する統一ユーザー情報取得エンドポイント `GET /api/users/me` を新設し、既存 `GET /auth/me`（Web Cookie 専用）の後方互換を維持した（Req 2）
- 記事詳細応答に `feed_title` / `feed_favicon_url` フィールドを追加し、追加 API 呼び出しなしにフィードコンテキストを表示できるようにした（Req 3）
- 上記 3 点の主要契約を自動テストで検証する契約テストスイートを追加した（Req 4）

## 対応 Issue

Closes #207

## 関連 PR

- 設計 PR: #208（merged）

## 実装内容

- (Req 1.1〜1.5 / NFR 2.1, 2.2) `docs/specs/207--mobile-api-v1-api/mobile-api-contract.md` を新規作成（共通方針 §2 / Native Auth サマリ §3 / 統一ユーザー情報 §4 / v1 共通動線 §5 / v1 スコープ外 §6 / 後方互換ポリシー §7）
- (Req 1.6) `README.md` API エンドポイント一覧に `GET /api/users/me` / Native Auth 系 / starred/search/cross-feed/manual fetch を追記し、契約文書への参照リンクを追加
- (Req 2.1〜2.5) `internal/user/service.go` に `GetByID`、`internal/handler/user_handler.go` に `UserHandler.GetCurrent` / `currentUserResponse`、`internal/handler/service_adapter.go` に `UserServiceAdapter.GetCurrent`、`internal/handler/router.go` 認証必須グループに `GET /api/users/me` を配線
- (Req 2.6 / NFR 1.1) `GET /auth/me` Cookie 経路 non-regression テスト `TestAuthHandler_Me_CookiePathUnchanged` を追加（`auth_handler.go` / `SetupAuthRoutes` は無変更）
- (Req 3.1〜3.5 / NFR 1.2) `internal/item/service.go` に `FeedMetaProvider` interface と `GetItem` 拡張（認可フロー後に feed lookup → `model.FaviconDataURL` 整形）、`internal/handler/item_handler.go` の `itemDetailResponse` に `feed_title` / `feed_favicon_url` フィールドを追加（既存 11 フィールド不変）

## 受入基準チェック

- [x] Req 1.1: The Mobile API Contract Document shall 共通方針を記載する ← `mobile-api-contract.md` §2
- [x] Req 1.2: The Mobile API Contract Document shall native auth 系エンドポイントのサマリを記載する ← §3
- [x] Req 1.3: The Mobile API Contract Document shall 統一ユーザー情報取得エンドポイントの URL / 認証 / 応答を記載する ← §4
- [x] Req 1.4: The Mobile API Contract Document shall 記事一覧・詳細・検索・購読・クロスフィードを記載する ← §5
- [x] Req 1.5: The Mobile API Contract Document shall v1 スコープ外を明示する ← §6
- [x] Req 1.6: The README shall 各 API を一覧に追記し契約文書への参照を含める ← `README.md` 更新
- [x] Req 2.1: When Bearer token 提示 → 200 current user ← `TestUserHandler_GetCurrent_Success_ReturnsCurrentUser`
- [x] Req 2.2: When Cookie 提示 → 200 current user ← `TestNewRouter_UserRoutes_GetCurrentEndpoint`
- [x] Req 2.3: The エンドポイント shall id/email/name/avatar_url を含める ← `TestUserHandler_GetCurrent_Success_ReturnsCurrentUser`
- [x] Req 2.4: Where avatar_url 無し → JSON 省略 ← `TestUserHandler_GetCurrent_OmitsAvatarWhenNil`
- [x] Req 2.5: If 未認証 → 401 ← `TestUserHandler_GetCurrent_NoUserID_ReturnsUnauthorized` / `TestRouter_GetUsersMe_RequiresAuth`
- [x] Req 2.6: The /auth/me shall 本 spec 導入前と同一動作 ← `TestAuthHandler_Me_CookiePathUnchanged`
- [x] Req 3.1: feed_title フィールド追加 ← `TestItemService_GetItem_PopulatesFeedMetadata` / `TestItemHandler_GetItem_ReturnsFeedMetadata`
- [x] Req 3.2: feed_favicon_url フィールド追加 ← 同上
- [x] Req 3.3: 既存フィールド不変 ← `TestItemHandler_GetItem_PreservesExistingFields`
- [x] Req 3.4: favicon 無し → 省略 ← `TestItemService_GetItem_NullFaviconWhenFeedHasNone` / `TestItemHandler_GetItem_OmitsFaviconWhenNil`
- [x] Req 3.5: 未購読 → ITEM_NOT_FOUND 不変 ← `TestItemService_GetItem_Unsubscribed_ReturnsNotFound`（変更なし pass）
- [x] Req 4.1: Bearer token → current user 検証 ← `TestUserHandler_GetCurrent_Success_ReturnsCurrentUser`
- [x] Req 4.2: Cookie → current user 検証 ← `TestNewRouter_UserRoutes_GetCurrentEndpoint`
- [x] Req 4.3: /auth/me Cookie 動線 non-regression ← `TestAuthHandler_Me_CookiePathUnchanged`
- [x] Req 4.4: 記事詳細に feed_title / feed_favicon_url 両フィールド確認 ← `TestItemHandler_GetItem_ReturnsFeedMetadata`
- [x] Req 4.5: 記事詳細に既存フィールド一式 ← `TestItemHandler_GetItem_PreservesExistingFields`

## テスト結果

```
go test ./... && go vet ./...
→ 全 22 パッケージ pass（Reviewer 側で再実行済み。詳細は review-notes.md §Verify 実行結果を参照）
go vet ./internal/user/... ./internal/item/... ./internal/handler/... ./internal/app/... — clean
```

## 実装上の判断

- `BearerOrSession` middleware が 401 で `unauthorized` plain text を返す（JSON ではない）既存仕様を契約文書 §2.2 に明記し、クライアントが 401 を JSON パース失敗で検出しない実装にするよう注記した
- `avatar_url` は v1 時点で常に nil 固定（将来 OAuth `picture` claim 保存後に自動で実値になるよう `*string + omitempty` で実装）
- feed lookup 認可フロー後配置（`SubscriptionChecker` 通過後に `FeedMetaProvider.FindByID` を呼ぶ）により、Req 3.5 の未購読 ITEM_NOT_FOUND 条件を完全維持
- 既存 item 系テスト群は `defaultFeedProvider()` ヘルパーの追加引数のみで NFR 1.3 を達成（既存テストロジック無変更）

詳細は `docs/specs/207--mobile-api-v1-api/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- 最終 PR: tasks.md 全完了（全 7 タスク `[x]`）のため Closes を採用
- base: develop / baseRefName: develop / OK（PR 作成後に検証）
- Reviewer approve 済み（round=1 / RESULT: approve）。詳細は `docs/specs/207--mobile-api-v1-api/review-notes.md` を参照
- `GET /api/users/me` は `GET /auth/me` との棲み分け（モバイルは `/api/users/me` を利用し `/auth/me` は Web Cookie 専用として温存）が README および契約文書 §4 に明記されている点をご確認ください

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #207 のコメントを参照してください。
