### PR TITLE
fix(deps): Go toolchain を 1.25.12 に更新し GO-2026-5856 を解消

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hitoshi/feedman
 
 go 1.25.0
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5


### PR DESCRIPTION
## 概要

develop CI の Go Vulnerability Scan (govulncheck) が Go 標準ライブラリの脆弱性 [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)（crypto/tls の Encrypted Client Hello privacy leak、go1.25.11 で検出・go1.25.12 で修正済み）を検出し failure になっていた（[failed run](https://github.com/hitoshiichikawa/feedman/actions/runs/29058295102)）。コード変更起因ではなく、脆弱性 DB 更新による時限的な赤（#162 / #209 / #210 と同パターン）。

go.mod の `toolchain` directive を `go1.25.12` へ bump して解消する。

## 変更内容

- `go.mod`: `toolchain go1.25.11` → `toolchain go1.25.12`（1 行のみ）

## 影響範囲

- CI は `actions/setup-go@v5` + `go-version-file: go.mod` のため toolchain directive に自動追従
- `Dockerfile` は `golang:1.25-alpine` の floating tag のため変更不要

## ローカル検証

- `go build ./...` pass（go1.25.12）
- `go test ./...` 全パッケージ pass
- `govulncheck ./...` → **No vulnerabilities found**

## 確認事項

- toolchain の patch bump のみでコード変更なし。挙動変化はない想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
