### PR TITLE
fix(#218): safeurl を v0.2.4 に更新し GO-2026-5997 を解消

### DIFF
--- a/docs/specs/218-fix-deps-safeurl-v0-2-4-go-2026-5997/impl-notes.md
+++ b/docs/specs/218-fix-deps-safeurl-v0-2-4-go-2026-5997/impl-notes.md
@@ -1,0 +1,99 @@
+# Implementation Notes — Issue #218
+
+## 実施内容
+
+- `github.com/doyensec/safeurl` を v0.2.2 → v0.2.4 に更新し、GO-2026-5997（v0.2.2 の blocklist に
+  IPv6 CIDR レンジが欠けている問題）を解消した。
+- 変更対象は `go.mod` と `go.sum` のみ（`internal/security/ssrf_guard.go` を含むアプリケーション
+  コード・テストコードは無変更）。NFR 2.1 のスコープ限定制約を遵守。
+- リポジトリ構成: `go.mod` はルート 1 ファイルのみ（api / worker で分割されておらず、
+  `github.com/hitoshi/feedman` 単一モジュール構成）。他モジュール向けの対応は不要。
+
+## 実行コマンドと結果
+
+| ステップ | コマンド | 結果 |
+|---|---|---|
+| 依存更新 | `go get github.com/doyensec/safeurl@v0.2.4` | `upgraded github.com/doyensec/safeurl v0.2.2 => v0.2.4` |
+| tidy | `go mod tidy` | 差分は `go.mod` の safeurl 行と `go.sum` の safeurl 2 行のみ |
+| ビルド | `go build ./...` | エラーなし（exit 0） |
+| 静的解析 | `go vet ./...` | 違反 0 件（exit 0） |
+| テスト | `go test ./...` | 全 22 パッケージ pass（SSRF ガードを含む `internal/security` を含む） |
+| 脆弱性スキャン | `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` | `No vulnerabilities found.` / exit 0 / GO-2026-5997 の検出行 0 件 |
+
+### govulncheck 出力の要点
+
+- 呼び出し到達（`=== Symbol Results ===`）で **No vulnerabilities found.** を確認
+- verbose 出力で列挙されたモジュール脆弱性は `GO-2026-5970` と `GO-2026-5942` の 2 件のみで、
+  いずれも本 Issue の対象 `GO-2026-5997` ではない（かつ呼び出し到達なし）。よって本 Issue の
+  スコープ（GO-2026-5997 の解消）は達成されている。
+- CI 側は `go install golang.org/x/vuln/cmd/govulncheck@latest && govulncheck ./...` を使用しており、
+  本ローカル実行の `go run` と実行対象は等価（`.github/workflows/ci.yml` の当該ジョブは変更なし）。
+
+## 受入基準の達成状況
+
+### Requirement 1: safeurl の脆弱性解消
+
+- **1.1**（`go.mod` が safeurl v0.2.4 以上を要求）: `go.mod` の `require` ブロックで
+  `github.com/doyensec/safeurl v0.2.4` を指定。`git diff go.mod` で確認済み。
+- **1.2**（`go.sum` に v0.2.4 以上のエントリ）: `go.sum` に
+  `github.com/doyensec/safeurl v0.2.4 h1:...` と `.../go.mod h1:...` の 2 行を含む。
+- **1.3**（govulncheck が GO-2026-5997 を検出しない）: 上記 `govulncheck ./...` 出力に
+  GO-2026-5997 の検出行 0 件を確認済み。
+- **1.4**（govulncheck がゼロ終了）: `EXIT=0` を確認済み。
+
+### Requirement 2: 既存ビルド・テストの後方互換
+
+- **2.1**（`go test ./...` 全成功）: 22 パッケージすべて `ok`。SSRF ガード
+  （`internal/security`）を含む。
+- **2.2**（`go vet ./...` 違反 0 件）: exit 0、警告出力なし。
+- **2.3**（`gofmt` 差分ゼロ）: **確認事項参照**。本 Issue の変更前後で `gofmt -l .` 出力は同一
+  （差分は既存 main の状態に由来し、本 Issue の safeurl 更新起因ではない）。
+- **2.4**（既存テストを弱めない）: 既存 SSRF ガードテストはすべて pass しており、テスト側を
+  変更する必要は発生しなかった。
+
+### Requirement 3: SSRF ガード挙動の維持
+
+- **3.1–3.4**: `internal/security/ssrf_guard.go` および `internal/security/*_test.go` は
+  無変更で、`internal/security` パッケージのテストが全 pass。許可 scheme / port / タイムアウト /
+  プライベートアドレス遮断の挙動は退行していない。
+
+### Non-Functional Requirements
+
+- **NFR 1.1**（CI 所要時間）: 純粋な依存バージョン更新（v0.2.2 → v0.2.4 の patch bump）のため、
+  govulncheck・テスト所要時間に有意な変化は想定されない。
+- **NFR 2.1**（スコープ限定）: 変更ファイルは `go.mod` / `go.sum` のみ（`git diff --name-only`
+  で確認済み）。
+- **NFR 3.1**（追跡可能性）: govulncheck 出力に GO-2026-5997 の検出行を含まないことを確認済み。
+
+## 確認事項
+
+- **`gofmt -l .` に既存 main 由来の差分が残存**: 本 Issue の変更前（`git stash` した状態）でも
+  以下 11 ファイルが `gofmt -l` に列挙される。本 Issue の safeurl 更新起因ではないため、
+  スコープ限定制約（NFR 2.1）に従い**本 PR では修正しない**。別 Issue（chore: gofmt 差分の
+  一括解消）で対応することを推奨。
+  - `internal/crossfeed/service_test.go`
+  - `internal/handler/crossfeed_handler_test.go`
+  - `internal/handler/feed_handler_test.go`
+  - `internal/handler/item_search_handler.go`
+  - `internal/handler/router_full_test.go`
+  - `internal/hatebu/batch.go`
+  - `internal/itemsearch/service.go`
+  - `internal/itemsearch/service_test.go`
+  - `internal/middleware/ratelimit_test.go`
+  - `internal/model/item.go`
+  - `internal/security/content_sanitizer_test.go`
+
+  なお、これら既存 gofmt 差分が CI で fail しているとの報告は Issue #218 の記述に無く、CI 上の
+  gofmt 検査ステップは `.github/workflows/ci.yml` を確認する限り現状存在しない。本 Issue の
+  完了判定には影響しない。
+
+## その他
+
+- `govulncheck` バイナリはこの環境に事前インストールされていなかったため、`go run
+  golang.org/x/vuln/cmd/govulncheck@latest ./...` の代替経路で検証した。CI 側は
+  `go install ...` 経由で同 CLI をインストールして実行する構成であり、実行対象は等価。
+- 追加した依存は無し（safeurl のバージョン変更のみで indirect 依存の増減もなし）。
+- 参考: 過去 Issue #212 / PR #213 / commit `cb53d40`（Go toolchain 1.25.12 更新の `fix(deps):`
+  対応）。今回は toolchain ではなく単一パッケージのバージョン bump のため差分は最小。
+
+STATUS: complete

--- a/docs/specs/218-fix-deps-safeurl-v0-2-4-go-2026-5997/requirements.md
+++ b/docs/specs/218-fix-deps-safeurl-v0-2-4-go-2026-5997/requirements.md
@@ -1,0 +1,97 @@
+# Requirements Document
+
+## Introduction
+
+CI の `Go Vulnerability Scan (govulncheck)` ジョブが 2026-07-23 以降、新規公開されたアドバイザリ
+**GO-2026-5997**（`github.com/doyensec/safeurl` v0.2.2 の blocklist に IPv6 CIDR レンジが欠けており、
+v0.2.4 で修正済み）を検出して fail しており、develop 宛て全 PR の CI が赤くなって idd-claude
+ワークフローのマージ判断を阻害している。到達可能な symbol も `internal/security/ssrf_guard.go` 等で
+実測されているため単なる依存検出ではない。本 Issue は `safeurl` を v0.2.4 以上へ更新して当該
+advisory を解消し、CI ゲートを green に戻すことを目的とする。同時に SSRF ガードの既存挙動
+（許可 scheme / port / timeout、プライベートアドレス遮断）が upgrade によって退行しないことを
+保証する。
+
+## Requirements
+
+### Requirement 1: safeurl の脆弱性解消
+
+**Objective:** As a 開発者, I want `github.com/doyensec/safeurl` を GO-2026-5997 が修正された
+バージョン以上に更新すること, so that CI の依存脆弱性スキャンが当該 advisory を検出せずに済む
+
+#### Acceptance Criteria
+
+1. The Go モジュール定義 shall `github.com/doyensec/safeurl` の要求バージョンを v0.2.4 以上に指定する
+2. The Go モジュールのロックファイル shall 実際に解決された `github.com/doyensec/safeurl` の
+   バージョンとして v0.2.4 以上のエントリを含む
+3. When 依存脆弱性スキャンをリポジトリの全パッケージに対して実行したとき, the 依存脆弱性スキャン
+   shall GO-2026-5997 を検出しない
+4. When 依存脆弱性スキャンをリポジトリの全パッケージに対して実行したとき, the 依存脆弱性スキャン
+   shall ゼロ終了で完了する
+
+### Requirement 2: 既存ビルド・テストの後方互換
+
+**Objective:** As a 開発者, I want safeurl の更新後も既存のテスト・静的解析・整形チェックがすべて
+従来どおり通ること, so that 依存更新に伴う退行を検知できる
+
+#### Acceptance Criteria
+
+1. When リポジトリの全パッケージに対してユニットテストを実行したとき, the テストランナー shall
+   全テストを成功として完了する
+2. When リポジトリの全パッケージに対して Go 静的解析を実行したとき, the 静的解析 shall 違反を
+   0 件で完了する
+3. When リポジトリの Go ソースに対して整形チェックを実行したとき, the 整形チェック shall 差分を
+   検出しない
+4. If 既存の SSRF ガード関連テストが safeurl 更新後に失敗した場合, the 対応作業 shall テスト側を
+   弱めず、失敗内容を確認事項として PR 本文または Issue コメントで報告する
+
+### Requirement 3: SSRF ガード挙動の維持
+
+**Objective:** As a 運用者, I want safeurl 更新後も SSRF ガードの外部から観測可能な既存挙動が
+維持されること, so that 外向き HTTP 取得のセキュリティ境界が退行しない
+
+#### Acceptance Criteria
+
+1. The SSRF ガード shall 更新前と同じ許可 scheme（http / https）以外の URL に対する外向き取得を
+   拒否する
+2. The SSRF ガード shall 更新前と同じ許可ポート範囲以外への外向き取得を拒否する
+3. The SSRF ガード shall プライベート／ループバック／リンクローカル等の内部向けアドレスに対する
+   外向き取得を拒否する
+4. The SSRF ガード shall 更新前と同じタイムアウト境界で外向き取得を打ち切る
+
+## Non-Functional Requirements
+
+### NFR 1: CI 所要時間
+
+1. The CI パイプライン shall 依存更新後も `Go Vulnerability Scan (govulncheck)` ジョブおよび
+   バックエンドテストジョブの完了までの所要時間を、更新前の直近成功時と比較して有意に増やさない
+   （目安として 20% 以内の増加に収める）
+
+### NFR 2: スコープ限定性
+
+1. The 変更対象 shall Go モジュール定義（`go.mod`）と Go モジュールのロックファイル（`go.sum`）
+   に限定し、`internal/security/ssrf_guard.go` を含むアプリケーションコードおよびテストコードを
+   変更しない
+
+### NFR 3: 検出結果の追跡可能性
+
+1. When `Go Vulnerability Scan (govulncheck)` ジョブが更新後に成功したとき, the CI ログ shall
+   GO-2026-5997 に関する検出行を含まない状態で終了する
+
+## Out of Scope
+
+- npm audit 側の赤の解消（別 Issue で扱う）
+- `internal/security/ssrf_guard.go` のロジック変更・設定変更（許可 scheme / port / timeout /
+  プライベートアドレス遮断範囲の変更を含む）
+- `safeurl` 以外の Go 依存パッケージのバージョン更新
+- Go toolchain バージョンの変更
+- CI ワークフロー（`.github/workflows/ci.yml`）の構成変更・追加ステップ導入
+- 新規テストの追加（既存 SSRF ガードテストの実行のみで退行検知する）
+
+## Open Questions
+
+- なし
+
+## 関連
+
+- Related: #212
+- Related: #213

--- a/docs/specs/218-fix-deps-safeurl-v0-2-4-go-2026-5997/review-notes.md
+++ b/docs/specs/218-fix-deps-safeurl-v0-2-4-go-2026-5997/review-notes.md
@@ -1,0 +1,36 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-8 timestamp=2026-07-24T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-218-impl-fix-deps-safeurl-v0-2-4-go-2026-5997
+- HEAD commit: baf7fdfb46dd112ca2aacb8345462acb0c228772
+- Compared to: develop..HEAD
+- 変更ファイル: `go.mod` / `go.sum`（+ spec: `requirements.md` / `impl-notes.md`）。design-less impl のため `tasks.md` / `design.md` は不在（境界は NFR 2.1 が定義）。Feature Flag Protocol は opt-out のため flag 観点は非適用。
+
+## Verified Requirements
+
+- 1.1 — `go.mod` の `require` ブロックが `github.com/doyensec/safeurl v0.2.4` を指定（diff で確認）
+- 1.2 — `go.sum` に `safeurl v0.2.4` の `h1:` / `go.mod h1:` 2 行を含む（diff で確認）。`go mod verify` = all modules verified
+- 1.3 — reviewer 側で `govulncheck ./...` を再実行し `No vulnerabilities found.` / GO-2026-5997 の検出行なしを実測確認
+- 1.4 — 同 `govulncheck` 実行の終了コード 0 を実測確認（GOVULN_EXIT=0）
+- 2.1 — `go build ./...` exit 0、`go test ./internal/security/...` ok を実測。impl-notes は全 22 パッケージ pass を報告
+- 2.2 — `go vet ./internal/security/...` exit 0 を実測。impl-notes は `go vet ./...` 違反 0 件を報告
+- 2.3 — safeurl 更新（go.mod/go.sum のみ）は新規 gofmt 差分を導入しない。impl-notes が既存 develop 由来の 11 ファイルの gofmt 差分を「確認事項」として明示し、NFR 2.1 のスコープ限定に従い本 PR では未修正（別 Issue 推奨）。本変更に起因する退行ではないため観点充足
+- 2.4 — 既存 SSRF ガードテストは pass、テスト側の書き換えなし（application/test code 無変更を確認）
+- 3.1〜3.4 — `internal/security/ssrf_guard.go` および `internal/security/*_test.go` 無変更、`internal/security` テスト green（scheme/port/timeout/プライベートアドレス遮断の外部観測挙動を維持）
+- NFR 2.1 — 変更は `go.mod` / `go.sum` のみ（`git diff --name-only` で app/test code 無変更を確認）
+- NFR 3.1 — govulncheck 出力に GO-2026-5997 の検出行を含まないことを実測確認
+
+新規テスト追加は requirements.md の Out of Scope（「既存 SSRF ガードテストの実行のみで退行検知」）で明示的に除外されているため、missing test には該当しない。
+
+## Findings
+
+なし
+
+## Summary
+
+safeurl v0.2.2 → v0.2.4 の純粋な依存 bump。全 numeric AC（1.1〜1.4 / 2.1〜2.4 / 3.1〜3.4 / NFR 2.1 / 3.1）を diff・impl-notes・reviewer 実測（build/vet/security test/govulncheck）で確認。境界（NFR 2.1: go.mod/go.sum 限定）逸脱なし、新規テストは spec で明示除外。AC 2.3 の既存 gofmt 差分はスコープ外の確認事項として適切に文書化されており reject 事由に当たらない。
+
+RESULT: approve

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 )
 
 require (
-	github.com/doyensec/safeurl v0.2.2
+	github.com/doyensec/safeurl v0.2.4
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/mmcdole/gofeed v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/doyensec/safeurl v0.2.2 h1:+sFUqwOnqqmtUAC85/sGdOKfJh8zOacyghkaLzsOk40=
-github.com/doyensec/safeurl v0.2.2/go.mod h1:3H0cgRpPYPSpgxRRn5yGD35Ns/LgGX/BVWSBbzUqXtY=
+github.com/doyensec/safeurl v0.2.4 h1:ldwQEPsr1WQbB3rL0pramhG2NBLfCk5y+V4zSeyN/w0=
+github.com/doyensec/safeurl v0.2.4/go.mod h1:3H0cgRpPYPSpgxRRn5yGD35Ns/LgGX/BVWSBbzUqXtY=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=


### PR DESCRIPTION
## 概要

CI の `Go Vulnerability Scan (govulncheck)` ジョブが GO-2026-5997（`github.com/doyensec/safeurl` v0.2.2 の blocklist に IPv6 CIDR レンジが欠けており、v0.2.4 で修正済み）を検出して fail し、develop 宛て全 PR の CI が赤になっていた。本 PR は `safeurl` を v0.2.4 に bump することで当該 advisory を解消し、CI ゲートを green に戻す。変更対象は `go.mod` / `go.sum` のみ（アプリケーションコード・テストコード無変更）で、既存の SSRF ガード挙動（許可 scheme / port / timeout / プライベートアドレス遮断）の後方互換を確認済み。

## 対応 Issue

Closes #218

## 関連 PR

なし

## 実装内容

- (Req 1.1 / 1.2) `go.mod` / `go.sum` の safeurl を v0.2.2 → v0.2.4 に更新
- (Req 1.3 / 1.4) `govulncheck ./...` で GO-2026-5997 の非検出・ゼロ終了を確認
- (Req 2.1〜2.4) `go build` / `go test` / `go vet` すべて通過、既存テスト無変更
- (Req 3.1〜3.4 / NFR 2.1) アプリケーションコード・テストコードは無変更、SSRF ガード挙動の後方互換を維持

## 受入基準チェック

- [x] Req 1.1: `go.mod` が safeurl v0.2.4 以上を要求 ← `go.mod` の `require` 行変更
- [x] Req 1.2: `go.sum` に v0.2.4 のエントリ ← `go.sum` の 2 行追加
- [x] Req 1.3: govulncheck が GO-2026-5997 を検出しない ← `No vulnerabilities found.` / 検出行 0 件
- [x] Req 1.4: govulncheck がゼロ終了 ← exit 0 確認
- [x] Req 2.1: `go test ./...` 全成功 ← 全 22 パッケージ pass
- [x] Req 2.2: `go vet ./...` 違反 0 件 ← exit 0
- [x] Req 2.3: gofmt 差分検出なし（本 PR 起因分） ← safeurl 更新前後で gofmt 出力に変化なし
- [x] Req 2.4: 既存テストを弱めない ← テストコード無変更
- [x] Req 3.1〜3.4: SSRF ガード挙動の維持 ← `internal/security` テスト green / コード無変更
- [x] NFR 2.1: 変更スコープ限定 ← `go.mod` / `go.sum` のみ変更

## テスト結果

```
$ go test ./...
# 全 22 パッケージ pass（internal/security を含む）
ok  github.com/hitoshi/feedman/internal/security  (代表例)

$ go run golang.org/x/vuln/cmd/govulncheck@latest ./...
No vulnerabilities found.
# GO-2026-5997 の検出行 0 件 / exit 0
```

## 実装上の判断

- 変更対象を `go.mod` / `go.sum` のみに限定（NFR 2.1 遵守）。`go get github.com/doyensec/safeurl@v0.2.4 && go mod tidy` で実施
- govulncheck はインストール済みバイナリが不在のため `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` で代替。CI は `go install` 経由で同 CLI を使用しており実行対象は等価
- 既存 gofmt 差分（11 ファイル）は本 PR 変更前から存在する main 由来のもので、本 PR のスコープ外。別 Issue での対応を推奨（詳細は `impl-notes.md` の確認事項を参照）
- 詳細は `docs/specs/218-fix-deps-safeurl-v0-2-4-go-2026-5997/impl-notes.md` を参照

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- Reviewer 判定: approve（`docs/specs/218-fix-deps-safeurl-v0-2-4-go-2026-5997/review-notes.md` 参照）
- 既存 gofmt 差分（11 ファイル）は本 PR スコープ外。別途 `chore: gofmt 差分一括解消` Issue での対処を推奨
- base: develop / baseRefName: develop / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #218 のコメントを参照してください。
