### PR TITLE
fix(#219): web の npm audit high 検出（next / js-yaml ほか）を解消

### DIFF
--- a/docs/specs/219-fix-deps-web-npm-audit-high-next-js-yaml/impl-notes.md
+++ b/docs/specs/219-fix-deps-web-npm-audit-high-next-js-yaml/impl-notes.md
@@ -1,0 +1,172 @@
+# Implementation Notes
+
+## 概要
+
+Issue #219 の対応として、`web/` 配下の `npm audit --audit-level=high` の赤（Frontend Dependency
+Vulnerability Scan ジョブの fail 要因）を解消するため、依存パッケージを **semver 互換の範囲**
+で更新した。変更は `web/package.json`（`overrides` 追加）と `web/package-lock.json` のみに
+限定し、Next.js の major（15.x）や App Router 構成には手を入れていない（Req 3.1〜3.5 /
+Req 4.1〜4.4）。
+
+## 対応した脆弱性一覧
+
+| パッケージ | 旧バージョン | 新バージョン | 更新方式 | 対応アドバイザリ（Issue 本文より） | 現行 major 維持 |
+|---|---|---|---|---|---|
+| `next` | 15.5.19 | 15.5.21 | `package.json` の `^15.5.18` が既に許容する patch 追随（`npm install`） | Server Actions DoS / SSRF / レスポンスキャッシュ混同 | Yes（15.x 維持） |
+| `js-yaml` | 4.2.0 | 4.3.0 | transitive dep の semver 互換 minor 追随（`npm install`） | merge-key チェーンによる quadratic CPU 消費 | Yes（4.x 維持） |
+| `postcss`（`next` 経由） | 8.4.31 | 8.5.22 | `overrides.next.postcss` を `^8.5.22` に設定 | Next.js の間接依存として連鎖検出される postcss（high） | Yes（8.x 維持） |
+| `sharp` | 0.34.5 | 0.35.3 | `overrides.sharp` を `^0.35.3` に設定（Next.js の image optimization 用 optional dep として transitive で入る） | Next.js の間接依存として連鎖検出される sharp（high） | Yes（0.x 維持。数値 major 番号 0 → 0） |
+
+上記に付随して `@img/sharp-*`（各プラットフォーム variant）と `@img/sharp-libvips-*`、
+`@next/env` / `@next/swc-*`、`@emnapi/runtime`、`@hono/node-server`、`dompurify`、
+`nanoid`、`body-parser` などの transitive 依存が npm の resolver によって semver 互換範囲で
+追随更新されている（lockfile diff 上で 500 行超）。これらは主要な脆弱性解消対象パッケージを
+bump した際に npm が自動解決した副次的な更新であり、Req 3.5（脆弱性解消に不要な依存の追加・
+削除・更新を含まない）の禁止対象である「独立した機能追加のための dep 更新」ではない。
+
+### 補足: `overrides` を使った理由
+
+- `postcss` は `next` の内部 dependency として `node_modules/next/node_modules/postcss` に
+  ネストされて解決されるため、`web/package.json` の直接 dependencies に置いても効かない。
+  npm の `overrides` で `next` サブツリー内の `postcss` を強制上書きする形が必要
+- `sharp` も同様に Next.js の image optimization 用 optional dependency として transitive で
+  入るため、`overrides` で強制上書きする形を採った
+
+## 検証結果
+
+以下は本 impl-notes 作成時点（HEAD = `96548c1`）で `web/` 配下から実行した結果:
+
+### 1. `npm ci`（lockfile の再現性 / NFR 1.1）
+
+```
+added 798 packages, and audited 799 packages in 11s
+4 vulnerabilities (1 low, 3 moderate)
+```
+
+- 終了コード: 0
+- `web/package-lock.json` から fresh install が成功し、決定論的にツリー再現可能
+
+### 2. `npm audit --audit-level=high`（Req 1.1, 1.2）
+
+- 終了コード: **0**
+- サマリ: `4 vulnerabilities (1 low, 3 moderate, 0 high, 0 critical)`
+- **high 以上 0 件** を確認
+- 残存する low / moderate（合計 4 件）:
+  - `@hono/node-server` < 2.0.5（moderate、GHSA-frvp-7c67-39w9 / Windows での path traversal）
+    → transitive dep（`@modelcontextprotocol/sdk` → `shadcn` 経由）
+  - `@modelcontextprotocol/sdk` >= 1.25.0（moderate、上記の伝播）
+  - `shadcn` >= 3.8.4（moderate、上記の伝播）
+  - `esbuild` 0.27.3 - 0.28.0（low、GHSA-g7r4-m6w7-qqqr / Windows dev server での file read）
+  - いずれも `--audit-level=high` の基準未満のため CI ジョブの合否には影響しない
+    （Out of Scope: moderate / low / info レベルの脆弱性の解消は本 Issue のスコープ外）
+
+### 3. `npm test`（Req 2.1）
+
+- コマンド: `npm test` （= `vitest run`）
+- 結果: `Test Files 42 passed (42) / Tests 407 passed (407)`
+- 終了コード: **0**
+
+### 4. `npm run lint`（Req 2.2）
+
+- コマンド: `npm run lint` （= `eslint`）
+- 結果: `5 problems (0 errors, 5 warnings)` — すべて既存 warning（`@next/next/no-img-element`
+  および `@typescript-eslint/no-unused-vars`）で本対応前と同じ内容。error は 0 件
+- 終了コード: **0**（eslint は warning のみの場合 exit 0 を返す。「lint 違反 0 件」= error 0 件と解釈）
+
+### 5. `npm run build`（Req 2.3）
+
+- コマンド: `npm run build` （= `next build --turbopack`）
+- 結果: `Compiled successfully in 6.8s`、`✓ Generating static pages (5/5)`、
+  `Route (app) / 72.3 kB First Load JS 197 kB`
+- 終了コード: **0**
+
+## Req 3.4 該当ケース（semver 互換では解消不能な脆弱性）
+
+**該当なし**。Issue 本文で挙げられていた high 以上のアドバイザリはすべて semver 互換
+（現行 major 内 / `overrides` によるサブツリー固定）の範囲で解消できた。Next.js の major を
+15.x → 16.x に上げる必要は生じていない。
+
+なお、残存する low / moderate（`shadcn` サブツリーの `@hono/node-server` 系、`esbuild`）は
+`--audit-level=high` の閾値未満のため本 Issue のスコープ外であり、`npm audit fix --force` を
+実行すると `shadcn@3.8.3` への **breaking downgrade** が入る点にも留意する（本対応では
+実行しない）。
+
+## Requirement トレーサビリティ
+
+| Requirement ID | 確認手段 |
+|---|---|
+| 1.1 | `web/` 配下で `npm ci && npm audit --audit-level=high` が終了コード 0（上記 §2） |
+| 1.2 | `npm audit --audit-level=high` サマリで high 0 件 / critical 0 件（上記 §2） |
+| 1.3 | 対応後の branch を push すれば CI の `Frontend Dependency Vulnerability Scan (npm audit)` ジョブが green になる想定（ローカルで実行内容と同じ `npm audit --audit-level=high` が CI 側で実行される） |
+| 1.4 | Issue 本文で言及された Next.js（Server Actions DoS / SSRF / レスポンスキャッシュ混同）、js-yaml（merge-key quadratic CPU）、Next.js 間接依存の postcss / sharp を、それぞれ next 15.5.19 → 15.5.21、js-yaml 4.2.0 → 4.3.0、postcss 8.4.31 → 8.5.22、sharp 0.34.5 → 0.35.3 で解消（上記「対応した脆弱性一覧」） |
+| 2.1 | `npm test` が 407 pass / 終了コード 0（上記 §3） |
+| 2.2 | `npm run lint` が 0 error / 終了コード 0（上記 §4） |
+| 2.3 | `npm run build` がエラーなく成功（上記 §5） |
+| 2.4 | バックエンド（`api` / `worker` / `internal/**`）や `go.mod` / `go.sum`、`.github/workflows/**` を変更していないため、CI の Backend Tests / Go Static Analysis / Go Vulnerability Scan の成否判定は本対応で変化しない（変更ファイル `git diff --stat develop..HEAD` は `web/package.json` と `web/package-lock.json` のみ） |
+| 2.5 | Web アプリのユーザー可視挙動（フィード購読・記事一覧・記事詳細・認証等）は、`npm test`（407 pass）と `npm run build`（成功）で回帰不具合が入っていないことを裏付ける。依存更新は semver 互換範囲に限定しており、API シグネチャ変更を伴わない |
+| 3.1 | すべての更新パッケージが現行 major を維持（next 15.x / js-yaml 4.x / postcss 8.x / sharp 0.x） |
+| 3.2 | `next` は 15.5.19 → 15.5.21 で 15.x 維持 |
+| 3.3 | `web/src/app/` 配下の変更なし（`git diff develop..HEAD -- web/src/` は空） |
+| 3.4 | 該当なし（上記「Req 3.4 該当ケース」） |
+| 3.5 | 本対応の変更は `web/package.json` の `overrides` 追加と、それに伴う lockfile の依存解決結果のみ。無関係な依存追加・削除・機能拡張のための更新は含まない |
+| 4.1 | `git diff --name-only develop..HEAD` は `web/package.json` と `web/package-lock.json` の 2 ファイルのみ |
+| 4.2 | `web/src/**` の変更なし |
+| 4.3 | 型定義追随や API 互換性の都合でソースコード修正が必要になったケースは発生しなかった |
+| 4.4 | バックエンド（`api` / `worker` / `internal/**` / `go.mod` / `go.sum`）およびインフラ設定（`Dockerfile` / `docker-compose*.yml` / `.github/workflows/**`）は変更なし |
+| NFR 1.1 | `npm ci` で lockfile から fresh install が成功。同一 lockfile で同一ツリーが得られる |
+| NFR 1.2 | 本対応では `npm install`（reify 成功）で lockfile を更新できたため、`--package-lock-only` 方式は用いていない。NFR 1.2 の許容条項に頼らずとも成立している |
+| NFR 2.1 | CI 側の `Frontend Dependency Vulnerability Scan (npm audit)` ジョブは既存の `.github/workflows/ci.yml` の定義をそのまま用いる（本対応で workflow は変更していない）。当該ジョブは `npm audit --audit-level=high` を実行してサマリを出力する既存挙動 |
+
+## 是正の経緯（Reviewer round=1 の reject を受けて）
+
+前回サイクル（Reviewer round=1）では、`web/package.json`（`overrides` 追加）および
+`web/package-lock.json` の変更が **作業ツリー上の未コミット変更**として残ったまま Implementer
+が終了したため、`develop..HEAD` の diff が空となり、Reviewer は「Requirement 1（npm audit high
+解消）に紐づく観測可能な実装が存在しない」として reject した（`review-notes.md` の Finding 1
+参照）。
+
+本サイクルでは以下の順で是正を実施した:
+
+1. 未コミット状態の `web/package.json` / `web/package-lock.json` の diff を確認し、`overrides`
+   の意図（`next.postcss` → ^8.5.22、`sharp` → ^0.35.3）を Requirement 1・3・4 と突き合わせて
+   妥当性を検証
+2. `web/` で `npm ci` を実行して lockfile の再現性を確認（NFR 1.1）
+3. `npm audit --audit-level=high` で終了コード 0・high 0 件・critical 0 件を確認（Req 1.1, 1.2）
+4. `npm test` / `npm run lint` / `npm run build` を実行して既存挙動の維持を確認（Req 2.1〜2.3）
+5. すべての検証をパスした状態で `fix(deps): web の npm audit high 検出（next / js-yaml /
+   postcss / sharp）を解消` として commit（HEAD = `96548c1`）し、`develop..HEAD` の diff として
+   Reviewer 判定可能な状態に修正した
+6. 本 `impl-notes.md` を新規作成し、対応した脆弱性、検証結果、Requirement トレーサビリティ、
+   Req 3.4 該当ケースの有無を記載
+
+## 補足ノート
+
+- **`overrides.sharp` の必要性について**: `sharp` は Next.js の image optimization 用に
+  transitive で入る optional dependency で、`web/package.json` の直接 dependencies には無い。
+  npm の `overrides` を通じてサブツリー内の sharp を `^0.35.3` に固定することで、対応前の
+  `sharp` 0.34.5 系に紐づいていた `@img/sharp-libvips-*` の脆弱性連鎖を断ち切っている
+- **`overrides.next.postcss` の必要性について**: Next.js は内部で `postcss` を
+  `node_modules/next/node_modules/postcss` にネストして解決するため、`web/package.json` の
+  直接依存として `postcss` を上位に上げるだけでは Next.js 内部の脆弱な postcss を置き換え
+  られない。`overrides.next.postcss` でサブツリーを狙って上書きするのが最小介入
+- **sharp の 0.34 → 0.35 について**: sharp は 0.x（zero-major）系であり厳格な semver 解釈
+  では minor 差分が breaking と扱われうるが、本対応の Requirement 3.1（現行 major バージョンを
+  維持）は「数値としての major 番号（0 or 15）を変えない」という運用意図と解釈しており、
+  0.34 → 0.35 は同一 major（0）内の更新として扱った。App Router 側で sharp を直接呼び出す
+  コードは存在せず、`npm run build` も `npm test` も pass しているため互換性への実害は
+  観測されていない
+- **CI 側での再確認**: 本 commit を origin に push すれば、`.github/workflows/ci.yml` の
+  `Frontend Dependency Vulnerability Scan (npm audit)` ジョブが green に転じることが期待される
+  （AC 1.3）。ローカル再現の内容と CI 側の実行内容は同一の `npm audit --audit-level=high` 契約
+  に依拠している
+
+## Confirmation Items（PR レビュワー向け確認事項）
+
+- `overrides.next.postcss` および `overrides.sharp` は本 Issue で提示された脆弱性解消のための
+  最小構成として採用した。将来 Next.js 本体が上記依存を default で bump した際は、`overrides`
+  の unpin（削除）を後続 Issue で検討する余地がある
+- 残存 low / moderate（`shadcn` サブツリーの `@hono/node-server` 系、`esbuild`）は
+  `--audit-level=high` の閾値未満で本 Issue のスコープ外だが、必要であれば別 Issue で解消を
+  検討する
+
+STATUS: complete

--- a/docs/specs/219-fix-deps-web-npm-audit-high-next-js-yaml/requirements.md
+++ b/docs/specs/219-fix-deps-web-npm-audit-high-next-js-yaml/requirements.md
@@ -1,0 +1,91 @@
+# Requirements Document
+
+## Introduction
+
+Feedman の CI（`.github/workflows/ci.yml`）の `Frontend Dependency Vulnerability Scan
+(npm audit)` ジョブが、`web/` 配下の依存に対する新規公開アドバイザリ群（high 6 件を含む
+計 12 件）の検出により fail している状態である。主な検出は Next.js（Server Actions DoS /
+SSRF / レスポンスキャッシュ混同ほか）、js-yaml（merge-key チェーンによる quadratic CPU）、
+および Next.js の間接依存として連鎖検出される postcss / sharp。この赤は develop 宛ての
+全 PR に継承され、脆弱性対応と無関係な PR の CI までブロックしている。本要件は、`web/` の
+依存を semver 互換の範囲で更新することにより `frontend-audit` ジョブを green に戻し、
+Web アプリの既存挙動（テスト・lint・ビルド）を維持することを目的とする。バックエンド側
+（govulncheck）の脆弱性対応は本 Issue のスコープ外（別 Issue #218 で対応）。
+
+## Requirements
+
+### Requirement 1: npm audit high 以上検出の解消
+
+**Objective:** As a リポジトリのメンテナ, I want `web/` 配下の high 以上の npm 脆弱性検出を解消すること, so that PR の CI が脆弱性対応と無関係な要因でブロックされない状態に戻る
+
+#### Acceptance Criteria
+
+1. When 対応後の `web/package-lock.json` を用いて `web/` 配下で `npm ci` に続けて `npm audit --audit-level=high` を実行したとき, the Frontend Dependency Vulnerability Scan shall 終了コード 0 で完了する
+2. When 対応後の `web/package-lock.json` を用いて `web/` 配下で `npm audit --audit-level=high` を実行したとき, the Frontend Dependency Vulnerability Scan shall high 以上（high または critical）の脆弱性を 0 件として報告する
+3. When 対応後のブランチに対して CI がトリガーされたとき, the `Frontend Dependency Vulnerability Scan (npm audit)` ジョブ shall 成功（green）ステータスとなる
+4. The 本対応 shall Issue 本文で特定された既知の high 以上アドバイザリ（Next.js の Server Actions DoS / SSRF / レスポンスキャッシュ混同、js-yaml の merge-key quadratic CPU、および Next.js 間接依存として連鎖検出される postcss / sharp のうち high 以上のもの）を解消する
+
+### Requirement 2: 既存挙動・既存テストの維持
+
+**Objective:** As a リポジトリのメンテナ, I want 依存更新後も Web アプリの既存挙動と CI の他ジョブが従来どおり通ること, so that 脆弱性対応が回帰不具合を持ち込まない
+
+#### Acceptance Criteria
+
+1. When 対応後のブランチで `web/` 配下の `npm test`（vitest）が実行されたとき, the Frontend Tests ジョブ shall 全テストを pass して終了コード 0 で完了する
+2. When 対応後のブランチで `web/` 配下の `npm run lint`（eslint）が実行されたとき, the Frontend Lint ジョブ shall lint 違反 0 件で終了コード 0 で完了する
+3. When 対応後のブランチで `web/` 配下の `npm run build` が実行されたとき, the Web ビルド shall エラーなく成功する
+4. The バックエンド側 CI ジョブ（`Backend Tests` / `Go Static Analysis (go vet)` / `Go Vulnerability Scan (govulncheck)`） shall 本対応前と同一の成否判定を維持する
+5. The Web アプリのユーザー可視挙動（フィード購読・記事一覧・記事詳細・認証等の既存ユースケース） shall 本対応前と同一の挙動を維持する
+
+### Requirement 3: 更新方針の制約（semver 互換の範囲に限定）
+
+**Objective:** As a リポジトリのメンテナ, I want 脆弱性解消のための依存更新が semver 互換の範囲に限定されること, so that major 更新に伴う予期せぬ破壊的変更を回避しつつ最小変更で赤を解消できる
+
+#### Acceptance Criteria
+
+1. The 本対応での依存バージョン更新 shall 各パッケージの現行 major バージョンを維持する（現行 major と異なる major への更新を含まない）
+2. The 本対応 shall Next.js の major バージョンを現行の `15.x` から他 major（例: `16.x` など）へ更新しない
+3. The 本対応 shall Next.js の App Router 構成（`web/src/app/` 配下のルーティング構造）を変更しない
+4. If ある脆弱性の解消が現行 major 内のパッチ／マイナー更新のみでは達成できず major 更新を要すると判明した場合, the 本対応 shall 当該脆弱性を本 Issue のスコープから除外し、`Open Questions` または後続 Issue への切り出しとして明示する
+5. The 本対応 shall 脆弱性解消に不要な依存パッケージの追加、削除、またはバージョン更新を含まない
+
+### Requirement 4: 変更ファイル範囲の限定
+
+**Objective:** As a リポジトリのメンテナ, I want 本対応の変更範囲がフロントエンド依存メタデータに限定されること, so that レビュー対象が最小化され副作用の混入リスクが下がる
+
+#### Acceptance Criteria
+
+1. The 本対応の diff shall `web/package.json` および `web/package-lock.json` を主たる変更対象とする
+2. The 本対応 shall アプリケーションソースコード（`web/src/**`）を機能変更目的で変更しない
+3. If 依存更新に伴い型定義変更や API 互換性の都合でソースコードの軽微な追随修正が必要となった場合, the 本対応 shall 当該修正の範囲と理由を PR 本文で明示する
+4. The 本対応 shall バックエンド（`api` / `worker` / `internal/**` / `go.mod` / `go.sum`）およびインフラ設定（`Dockerfile` / `docker-compose*.yml` / `.github/workflows/**`）を変更しない
+
+## Non-Functional Requirements
+
+### NFR 1: 対応の再現性
+
+1. The 本対応 shall CI 環境（`npm ci` による fresh install）で決定論的に再現可能な `web/package-lock.json` を成果物として含める（同一 lockfile に対して `npm ci` すれば同一ツリーが得られる状態）
+2. Where ローカル環境の `web/node_modules/` に Docker 由来の root 所有ファイルなどが混在し `npm audit fix` の reify が失敗する制約に遭遇した場合, the 本対応 shall `--package-lock-only` 方式など lockfile のみを更新する手段を許容する（CI 側は `npm ci` で fresh install するため十分と扱う）
+
+### NFR 2: 検出の可視性
+
+1. When 本対応後に CI の `Frontend Dependency Vulnerability Scan (npm audit)` ジョブが実行されたとき, the 当該ジョブ shall `npm audit` の実行結果（検出件数のサマリー）を CI ステップログに出力する
+
+## Out of Scope
+
+- バックエンド側の脆弱性対応（`govulncheck` の赤の解消。Issue #218 で対応）
+- Next.js の major バージョンアップ（例: `15.x` → `16.x`）および App Router 構成の変更
+- 脆弱性解消に不要な依存の追加・削除・更新（機能拡張や UI ライブラリの入れ替え等）
+- moderate / low / info レベルの脆弱性の解消（本対応の合否判定は `--audit-level=high` に一致させる）
+- npm audit の allowlist（`.audit-ignore` 等）機構の導入
+- CI ワークフロー（`.github/workflows/ci.yml`）のジョブ構成・閾値・トリガーの変更
+- Docker イメージスキャン（Trivy）や eslint ルールセット自体の変更
+- 「semver 互換範囲では解消不能」と判明した個別脆弱性の major 更新による解消（Req 3.4 に従い後続 Issue へ切り出す）
+
+## Open Questions
+
+- なし（Issue 本文にて「semver 互換 bump のみ」「Next.js major 更新禁止」「変更範囲は `web/package.json` / `web/package-lock.json` のみ」「`--package-lock-only` 方式の許容」が明示済み。追加コメントは存在しない）
+
+## 関連
+
+- Sibling: #218

--- a/docs/specs/219-fix-deps-web-npm-audit-high-next-js-yaml/review-notes.md
+++ b/docs/specs/219-fix-deps-web-npm-audit-high-next-js-yaml/review-notes.md
@@ -1,0 +1,73 @@
+# Review Notes
+
+<!-- idd-claude:review round=2 model=claude-opus-4-7 timestamp=2026-07-24T02:41:25Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-219-impl-fix-deps-web-npm-audit-high-next-js-yaml
+- HEAD commit: 910b7af09762b437a89ee890182bf01db67f00ed
+- Compared to: develop..HEAD
+
+commit 構成:
+
+- `96548c1` fix(deps): web の npm audit high 検出（next / js-yaml / postcss / sharp）を解消
+- `910b7af` docs(specs): #219 の impl-notes.md を追加
+
+変更ファイル（`git diff --name-only develop..HEAD`）: `web/package.json` /
+`web/package-lock.json` / `docs/specs/219-.../impl-notes.md` の 3 ファイルのみ。
+本 Issue は design を経由しない design-less impl（`design.md` / `tasks.md` 不在）のため
+`_Boundary:_` アノテーションは存在せず、変更範囲の境界は requirements.md の Req 4 で規定される。
+
+## Verified Requirements
+
+- 1.1 — reviewer が `web/` で `npm ci`（exit 0, 798 packages）→ `npm audit --audit-level=high`
+  を独立再実行し **終了コード 0** を確認。
+- 1.2 — 上記 `npm audit --audit-level=high` サマリが `4 vulnerabilities (1 low, 3 moderate)` で
+  **high 0 件 / critical 0 件** を確認。残存は moderate（`@hono/node-server` 系 3 件）/ low
+  （`esbuild` 1 件）のみで、いずれも `--audit-level=high` 閾値未満（Out of Scope）。
+- 1.3 — CI の `Frontend Dependency Vulnerability Scan (npm audit)` ジョブと同一契約
+  （`npm audit --audit-level=high`）がローカルで exit 0 を返すため、push 後 green に転じる見込み。
+- 1.4 — lockfile 上で next 15.5.19→**15.5.21** / js-yaml 4.2.0→**4.3.0** /
+  next 内 postcss→**8.5.22** / sharp 0.34.5→**0.35.3** への bump を確認（Issue 本文の
+  Next.js / js-yaml / postcss / sharp のアドバイザリに対応）。
+- 2.1 — reviewer が `npm test`（vitest run）を独立再実行し **Test Files 42 passed / Tests 407
+  passed / exit 0** を確認。
+- 2.2 — `npm run lint` は 0 error（impl-notes §4。既存 warning 5 件のみ、exit 0）。
+- 2.3 — `npm run build` はエラーなく成功（impl-notes §5、`Compiled successfully`）。
+- 2.4 — バックエンド（`api` / `worker` / `internal/**` / `go.mod` / `go.sum`）および
+  `.github/workflows/**` に変更が無い（`git diff --name-only` は web 依存メタと impl-notes のみ）
+  ため CI 他ジョブの成否判定は不変。
+- 2.5 — 依存更新は semver 互換範囲に限定され、`npm test`（407 pass）で回帰不具合が観測されない。
+- 3.1 — 全更新パッケージが現行 major 維持（next 15.x / js-yaml 4.x / postcss 8.x / sharp 0.x）。
+- 3.2 — next は 15.5.21 で 15.x 維持（16.x への更新なし）。
+- 3.3 — `web/src/app/` 配下の変更なし（diff にソース変更なし）。
+- 3.4 — 該当なし（semver 互換範囲で全 high 解消。impl-notes に明示）。
+- 3.5 — 変更は `overrides`（next.postcss ^8.5.22 / sharp ^0.35.3）追加と、それに伴う
+  resolver 由来の transitive 追随のみ。無関係な依存追加・削除・機能更新は含まない。
+- 4.1 — 主たる変更対象が `web/package.json` / `web/package-lock.json`。
+- 4.2 — `web/src/**` の機能変更なし。
+- 4.3 — 該当なし（ソース追随修正は発生せず）。
+- 4.4 — バックエンド / インフラ設定（`Dockerfile` / `docker-compose*.yml` / `.github/workflows/**`）
+  の変更なし。
+- NFR 1.1 — `npm ci` で lockfile から fresh install が成功（exit 0）。決定論的に再現可能。
+- NFR 1.2 — 該当なし（`npm install` の reify が成功、`--package-lock-only` 未使用）。
+- NFR 2.1 — 既存 workflow を変更せず、`npm audit` サマリ出力の既存挙動を維持。
+
+## Findings
+
+なし（approve）。
+
+補足: round=1 の reject 理由（依存更新が未コミットの作業ツリー変更に留まり `develop..HEAD` の
+diff が空で Requirement 1 の観測可能な実装を確認できなかった）は、本 round では commit
+`96548c1`（依存更新）+ `910b7af`（impl-notes 追加）として HEAD に積まれ、`develop..HEAD` の
+diff として観測可能になったことで **解消済み**。reviewer が `npm ci` / `npm audit
+--audit-level=high` / `npm test` を独立再実行し、いずれも exit 0（high 0 件）を確認した。
+
+## Summary
+
+round=1 の reject 理由（未コミットで diff 空）は commit 済みとなり解消。web 依存を semver 互換
+範囲で更新（next 15.5.21 / js-yaml 4.3.0 / postcss 8.5.22 / sharp 0.35.3）し、reviewer 独立再実行で
+`npm audit --audit-level=high` exit 0（high/critical 0 件）・`npm test` 407 pass を確認。全 numeric
+ID をカバーし、変更範囲は web 依存メタに限定、missing test / boundary 逸脱なし。
+
+RESULT: approve

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1034,9 +1034,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1697,9 +1697,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.15",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
+      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1762,9 +1762,9 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1772,9 +1772,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -1784,19 +1784,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -1806,19 +1806,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -1832,9 +1851,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -1848,9 +1867,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -1864,9 +1883,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -1880,9 +1899,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -1896,9 +1915,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -1912,9 +1931,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -1928,9 +1947,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -1944,9 +1963,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -1960,9 +1979,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -1976,9 +1995,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -1988,19 +2007,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -2010,19 +2029,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -2032,19 +2051,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2054,19 +2073,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -2076,19 +2095,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -2098,19 +2117,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -2120,19 +2139,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -2142,38 +2161,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -2183,16 +2218,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -2202,16 +2237,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -2221,7 +2256,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -2366,9 +2401,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2462,9 +2497,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.19.tgz",
-      "integrity": "sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.21.tgz",
+      "integrity": "sha512-hjJI/GfrjWHgNguRIBzItjRRu0m3Nrz17GhxsjuHfjIvg9hyg3239REd2dpI+bpMTFuVrVprHzEQ19m++cDtbw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2478,9 +2513,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.19.tgz",
-      "integrity": "sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.21.tgz",
+      "integrity": "sha512-ZfjqPEdi6TRC/fWx7UDbwb1fbVgyh2uD5tVTRKIDZDlYM+UNuE/LafDG2fwuAoZilADpABh46OY/F5qf9JjqLQ==",
       "cpu": [
         "arm64"
       ],
@@ -2494,9 +2529,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.19.tgz",
-      "integrity": "sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.21.tgz",
+      "integrity": "sha512-TlCf1NpxgQLzTrexuev75xwmNCJMd1/qkJpTVP1GRRcih93hlIBn1P72hkh8T0gnRFr6BmWksQtbyG3jT6jnww==",
       "cpu": [
         "x64"
       ],
@@ -2510,9 +2545,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.19.tgz",
-      "integrity": "sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.21.tgz",
+      "integrity": "sha512-LXRsq1p+HvHSi7ygwNcSEEcK0zuo5jS75ZlqFHtOH+LF7qntXAJVJxah+1Pi/GyBm7EpkwU7m4EgbvIKrMqm9A==",
       "cpu": [
         "arm64"
       ],
@@ -2526,9 +2561,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.19.tgz",
-      "integrity": "sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.21.tgz",
+      "integrity": "sha512-hyGixhFxpDKjqoev6l4KlcRBlt9AXWrGhDZwmwg49sMJM5tnKQPSi+SEj9+e5n+l/bthRGZUdh59GKIs6lQPRw==",
       "cpu": [
         "arm64"
       ],
@@ -2542,9 +2577,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.19.tgz",
-      "integrity": "sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.21.tgz",
+      "integrity": "sha512-qfE+YfOba6S2+13e8qn1/UozDVNZ2clBlrs8UtDoax4s8ediu6sq93z66OEHUYlb69Tffh5JTNkgtsAKiSuugg==",
       "cpu": [
         "x64"
       ],
@@ -2558,9 +2593,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.19.tgz",
-      "integrity": "sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.21.tgz",
+      "integrity": "sha512-BXLGG+EvIwp/Rrgl6HY8sqvD6BOUOIRz8/naDbeLNX7mlA5H2XRcL6MW/0IGnJISfj5BA9gNhFyJj5yOoiIDJQ==",
       "cpu": [
         "x64"
       ],
@@ -2574,9 +2609,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.19.tgz",
-      "integrity": "sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.21.tgz",
+      "integrity": "sha512-tNGNOlT0Wn7E4IMsSnufjXN/l2L2/AGdLLpa2vzS89SYCBuihgLn3ngLsIrvndAnWo9nAkus+4gZHTI/Ijx9HA==",
       "cpu": [
         "arm64"
       ],
@@ -2590,9 +2625,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.19.tgz",
-      "integrity": "sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.21.tgz",
+      "integrity": "sha512-DmIdWmC9p4rdNIiQqo8ap0+Cnj6kKtTZnuSCxoYydSc8sgpDgAg9wFhxplunak9imLV0pTvc5WVCOHwm5eHLtQ==",
       "cpu": [
         "x64"
       ],
@@ -5110,16 +5145,16 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@ts-morph/common/node_modules/fast-glob": {
@@ -5521,16 +5556,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -6445,21 +6480,21 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -6469,10 +6504,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7306,9 +7355,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -8334,9 +8383,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -9776,9 +9825,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -10601,9 +10650,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -10652,12 +10701,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.19",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.19.tgz",
-      "integrity": "sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==",
+      "version": "15.5.21",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.21.tgz",
+      "integrity": "sha512-/TsdBtkWLhkl+NVL3Uqws2UphNd6IPzOtzSk1fHaf+0P7GQKLZDUytyhns/Ykbzdy9+YRjwG7ONvrHaaTDdFqQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.19",
+        "@next/env": "15.5.21",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -10670,14 +10719,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.19",
-        "@next/swc-darwin-x64": "15.5.19",
-        "@next/swc-linux-arm64-gnu": "15.5.19",
-        "@next/swc-linux-arm64-musl": "15.5.19",
-        "@next/swc-linux-x64-gnu": "15.5.19",
-        "@next/swc-linux-x64-musl": "15.5.19",
-        "@next/swc-win32-arm64-msvc": "15.5.19",
-        "@next/swc-win32-x64-msvc": "15.5.19",
+        "@next/swc-darwin-arm64": "15.5.21",
+        "@next/swc-darwin-x64": "15.5.21",
+        "@next/swc-linux-arm64-gnu": "15.5.21",
+        "@next/swc-linux-arm64-musl": "15.5.21",
+        "@next/swc-linux-x64-gnu": "15.5.21",
+        "@next/swc-linux-x64-musl": "15.5.21",
+        "@next/swc-win32-arm64-msvc": "15.5.21",
+        "@next/swc-win32-x64-msvc": "15.5.21",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -10704,9 +10753,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -10723,9 +10772,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -12105,9 +12154,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {
@@ -12326,48 +12375,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {
@@ -13148,18 +13202,36 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/web/package.json
+++ b/web/package.json
@@ -40,5 +40,11 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^5",
     "vitest": "^4.1.8"
+  },
+  "overrides": {
+    "next": {
+      "postcss": "^8.5.22"
+    },
+    "sharp": "^0.35.3"
   }
 }


### PR DESCRIPTION
## 概要

Feedman の CI で `Frontend Dependency Vulnerability Scan (npm audit)` ジョブが `web/` 配下の依存に対する high 以上のアドバイザリ（Next.js の Server Actions DoS / SSRF / レスポンスキャッシュ混同、js-yaml の merge-key quadratic CPU、Next.js 間接依存の postcss / sharp の高深刻度連鎖検出）の検出により fail していた。本 PR は `web/package.json`（`overrides` 追加）と `web/package-lock.json` を semver 互換の範囲で更新することで `npm audit --audit-level=high` を exit 0（high/critical 0 件）に戻す。Next.js の major（15.x）や App Router 構成には変更を加えない。

## 対応 Issue

Closes #219

## 関連 PR

なし

## 実装内容

- (Req 1.1 / 1.2 / 1.4) next 15.5.19 → 15.5.21、js-yaml 4.2.0 → 4.3.0 の semver 互換 bump（`npm install` による追随）
- (Req 1.4) `web/package.json` に `overrides.next.postcss ^8.5.22` および `overrides.sharp ^0.35.3` を追加し、Next.js サブツリー内の postcss / sharp を強制上書き
- (Req 4.1) 変更範囲を `web/package.json` / `web/package-lock.json` のみに限定（ソースコード・バックエンド・インフラ設定の変更なし）

## 受入基準チェック

- [x] Req 1.1: `npm ci && npm audit --audit-level=high` が exit 0 ← `npm ci`（exit 0）→ `npm audit --audit-level=high`（exit 0）
- [x] Req 1.2: high/critical 0 件 ← `4 vulnerabilities (1 low, 3 moderate)` のみ
- [x] Req 1.4: Next.js / js-yaml / postcss / sharp のアドバイザリを解消 ← bump および overrides で対応
- [x] Req 2.1: `npm test` 全 pass ← `Test Files 42 passed / Tests 407 passed`（exit 0）
- [x] Req 2.2: `npm run lint` 0 error ← `5 warnings, 0 errors`（exit 0）
- [x] Req 2.3: `npm run build` 成功 ← `Compiled successfully in 6.8s`
- [x] Req 3.1 / 3.2: 現行 major 維持（next 15.x / js-yaml 4.x / postcss 8.x / sharp 0.x）
- [x] Req 4.1: 変更ファイルは `web/package.json` / `web/package-lock.json` のみ

## テスト結果

```
npm test     : Test Files 42 passed (42) / Tests 407 passed (407) — exit 0
npm audit    : 4 vulnerabilities (1 low, 3 moderate, 0 high, 0 critical) — exit 0
npm run build: Compiled successfully in 6.8s — exit 0
```

## 実装上の判断

- **`overrides.next.postcss` 採用**: postcss は `node_modules/next/node_modules/postcss` にネストされるため、直接依存への追加では Next.js 内部の脆弱な postcss を置き換えられない。`overrides` でサブツリーを狙って上書きするのが最小介入
- **`overrides.sharp` 採用**: sharp は Next.js image optimization 用の transitive optional dep として入るため、同様に `overrides` で強制上書き
- **`sharp 0.34 → 0.35`（zero-major 内 minor 差）**: 数値 major（0）を変えない更新として Req 3.1 の範囲と解釈。`npm test`（407 pass）/ `npm run build`（成功）で互換性への実害は観測されていない

詳細は `docs/specs/219-fix-deps-web-npm-audit-high-next-js-yaml/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- `overrides.next.postcss` および `overrides.sharp` は最小構成として採用。将来 Next.js 本体が上記依存を bump した際は `overrides` の unpin（削除）を後続 Issue で検討する余地がある
- 残存 low / moderate（`shadcn` サブツリーの `@hono/node-server` 系 3 件・`esbuild` 1 件）は `--audit-level=high` 閾値未満で本 Issue のスコープ外。必要であれば別 Issue で解消を検討
- Reviewer 独立判定: approve（`docs/specs/219-fix-deps-web-npm-audit-high-next-js-yaml/review-notes.md` 参照）
- base: develop / baseRefName: develop / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #219 のコメントを参照してください。
