### PR TITLE
fix(#225): web の npm audit high 検出（brace-expansion / postcss）を解消

### DIFF
--- a/docs/specs/225-fix-deps-web-npm-audit-high-brace-expans/impl-notes.md
+++ b/docs/specs/225-fix-deps-web-npm-audit-high-brace-expans/impl-notes.md
@@ -1,0 +1,156 @@
+# 実装ノート #225: `web/` npm audit high（brace-expansion / postcss）解消
+
+## 変更概要
+
+`web/` 配下の high 以上の npm 脆弱性検出を semver 互換の範囲および既存 `overrides` 節への
+追記により解消した。
+
+### 変更ファイル
+
+- `web/package.json` — `overrides` 節に `"brace-expansion": "^5.0.8"` を 1 行追記
+- `web/package-lock.json` — 上記 override と `npm audit fix`（非 force） による semver 互換の
+  依存更新を反映
+
+アプリケーションソースコード（`web/src/**`）およびバックエンド／インフラ設定は変更なし
+（Req 4.1〜4.4）。
+
+## 対応方針の詳細
+
+### brace-expansion GHSA-mh99-v99m-4gvg の解消
+
+- 対応前の lockfile では `node_modules/brace-expansion` が **1.1.16** で解決されており、
+  npm advisory の vulnerable range `<=5.0.7` に該当していた（GHSA-mh99-v99m-4gvg は
+  brace-expansion の semver range を `<=5.0.7` として npm 側で記述しており、1.x
+  maintenance-v1 の 1.1.16 も範囲に含まれる）
+- semver 互換の lockfile 更新（`npm audit fix`）では 1.x 系のまま解消できず、high の
+  reject 対象だった
+- そこで `web/package.json` の既存 `overrides` 節に **`"brace-expansion": "^5.0.8"`** を
+  追記し、全チェーンで brace-expansion 5.0.8 を強制することで解消した（Req 3.4 に基づく
+  `overrides` 追記方式）
+- brace-expansion 5.x は `type: "module"` だが `"main": "./dist/commonjs/index.js"` と
+  CommonJS デュアルエクスポートを備えているため、`^1.1.7` を要求する minimatch 3.x など
+  1.x consumer（CommonJS `require()` 呼び出し）からも読み込める。API はシンプルな
+  `expand(string) → string[]` で、1.x〜5.x で互換
+- 検証: `npm ci` 後の `npm run lint` が 0 error（既存 warning 5 件は据え置き）、
+  `npm run build` 成功、`npm test`（vitest）407 テスト全 pass。eslint / minimatch を
+  介するツールチェーンが実行時エラーなしで動作することを確認
+
+### postcss GHSA-r28c-9q8g-f849 の解消
+
+- `npm audit fix`（非 force） による semver 互換の lockfile 更新で解消
+- `node_modules/postcss` が 8.5.23（top-level）、`node_modules/next/node_modules/postcss` が
+  8.5.22（既存 override `next.postcss ^8.5.22`）に更新され、いずれも patched バージョン
+  （>8.5.17）
+- 併せて `@eslint/config-array`、`@eslint/eslintrc`、`@eslint/js`、`eslint`、
+  `eslint-plugin-*` など eslint チェーンが patch レベルで自動更新されている（いずれも
+  major 変更なし。Req 3.2）
+
+## Audit 結果 before / after
+
+### before（対応前 / develop HEAD）
+
+```
+14 vulnerabilities (1 low, 3 moderate, 10 high)
+- brace-expansion <=5.0.7 (high) — minimatch → eslint chain で計 9 件
+- postcss <=8.5.17 (high) — 1 件
+- @hono/node-server <2.0.5 (moderate) — shadcn CLI chain 3 件（Out of Scope）
+- esbuild 0.27.3-0.28.0 (moderate) — 1 件（Out of Scope）
+- （low 1 件）
+```
+
+### after（対応後）
+
+```
+4 vulnerabilities (1 low, 3 moderate)
+- @hono/node-server <2.0.5 (moderate) — 3 件（Out of Scope）
+- esbuild 0.27.3-0.28.0 (moderate) — 1 件（Out of Scope）
+
+npm audit --audit-level=high の終了コード: 0
+高severity（high / critical）件数: 0
+```
+
+## 実行コマンドと結果
+
+すべて `web/` ディレクトリで実行:
+
+- `npm audit --audit-level=high` — exit 0, high: 0 / critical: 0 / moderate: 3 / low: 1
+- `npm ci` — 793 packages 追加、4 vulnerabilities（high 0 件）
+- `npm run lint` — 0 error, 5 warnings（対応前と同一の既存 warning）
+- `npm test` — 42 test files, 407 tests 全 pass, duration 58.20s
+- `npm run build` — 成功（Route: 2 static pages, First Load JS 197KB / 125KB）
+
+## 受入基準の達成確認
+
+- **Req 1.1**: `npm ci` → `npm audit --audit-level=high` で終了コード 0 を確認 ✓
+- **Req 1.2**: high / critical 0 件を確認 ✓
+- **Req 1.3**: CI での実行は PR 作成後に確認予定（本 impl でローカル同等コマンドの成功を確認済み）
+- **Req 1.4**: brace-expansion GHSA-mh99-v99m-4gvg / postcss GHSA-r28c-9q8g-f849 の両方を解消 ✓
+- **Req 2.1**: `npm test`（vitest）407 テスト全 pass ✓
+- **Req 2.2**: `npm run lint`（eslint）0 error ✓
+- **Req 2.3**: `npm run build` 成功 ✓
+- **Req 2.4**: eslint / eslint-config-next / @eslint/eslintrc / eslint-plugin-* の major 変更なし。
+  lint 実行時エラーなし、ルールセット消失なし ✓
+- **Req 2.5**: バックエンド側 CI ジョブは変更対象外（`api` / `worker` / `internal/**` /
+  `go.mod` / `go.sum` に変更なし） ✓
+- **Req 2.6**: `web/src/**` 変更なしのため既存ユーザー可視挙動に影響なし ✓
+- **Req 3.1**: `npm audit fix --force` 未使用（非 force の `npm audit fix` および `overrides`
+  追記のみ） ✓
+- **Req 3.2**: eslint 9.x、eslint-config-next 15.5.12、@eslint/eslintrc 3.x（対応前と同一
+  major） ✓
+- **Req 3.3**: 本番 dependencies（`web/package.json` の `dependencies` セクション）に
+  変更なし ✓
+- **Req 3.4**: brace-expansion は `overrides` への `"brace-expansion": "^5.0.8"` 追記で対応 ✓
+- **Req 3.5**: 依存パッケージの追加・削除・脆弱性解消と無関係なバージョン更新は含まれない
+  （semver 互換の patch 更新および override 追記のみ） ✓
+- **Req 3.6**: Req 3.1〜3.5 の制約範囲内で全 high 脆弱性を解消できたため、後続 Issue への
+  切り出しなし ✓
+- **Req 4.1**: 変更は `web/package.json` / `web/package-lock.json` のみ ✓
+- **Req 4.2**: `web/src/**` 変更なし ✓
+- **Req 4.3**: ソースコードの追随修正なし（該当せず） ✓
+- **Req 4.4**: バックエンド／インフラ設定変更なし ✓
+- **NFR 1.1**: `npm ci` で決定論的に再現可能な lockfile を成果物として含む ✓
+- **NFR 1.2**: 今回は `--package-lock-only` は不要だった（`npm ci` 相当が通常実行できたため）。
+  `npm install --package-lock-only` で override 反映後 `npm ci` で clean install も動作確認済み ✓
+- **NFR 2.1**: CI ステップログへの出力は既存 workflow の挙動に依存（本 impl での変更対象外）
+
+## 判断事項
+
+### なぜ brace-expansion を 5.0.8 に全チェーン強制したか
+
+Issue 本文にある通り、brace-expansion 1.x（1.1.16 含む）は npm advisory の vulnerable
+range `<=5.0.7` に含まれ、`npm audit fix`（非 force） では 1.x のまま解消できない。
+options:
+
+- (A) 全チェーンで 5.0.8 に override → 1 行追記で完結、5.x は CommonJS 互換なので既存 1.x
+  consumer（minimatch 3.x など）から `require()` 可能
+- (B) 特定パスのみ override（`"minimatch": {"brace-expansion": "^5.0.8"}` 等） → 記述が
+  冗長になり、将来別の consumer が増えたときの追随忘れリスク
+- (C) `npm audit fix --force` → `@eslint/eslintrc@0.1.0` への降格が発生し Req 3.1 / 3.2 に
+  違反
+
+(A) を採用。lint / test / build がすべて通過し、eslint ツールチェーンの実行時挙動に影響が
+ないことを確認済み。
+
+### なぜ postcss は `npm audit fix` のみで解消したか
+
+既存 `overrides.next.postcss ^8.5.22` が PR #221 で設定済み。`npm audit fix`（非 force）を
+実行すると `@eslint/eslintrc` の間接依存として拾われる postcss および依存する eslint 系
+package が semver 互換で patch 更新され、結果的に postcss が 8.5.22 / 8.5.23 に更新された。
+既存 override 側で明示的なバージョン変更は不要だった。
+
+## 確認事項（レビュワー向け）
+
+- brace-expansion を全チェーンで 5.x に強制する override は将来的な eslint / minimatch の
+  更新で回帰する可能性があります。次回 npm audit で新規 GHSA が公開されたら、
+  overrides を見直して 5.x が引き続き最新の non-vulnerable range に含まれることを確認して
+  ください
+- Out of Scope の残存 moderate（`@hono/node-server` / `esbuild`）は本 Issue のスコープ外
+  ですが、shadcn CLI 側の major 更新（`shadcn 3.8.3` への降格を含む breaking change）が
+  必要になるため、別 Issue として起票済みか要確認です
+
+## Feature Flag Protocol
+
+対象 repo `CLAUDE.md` の `## Feature Flag Protocol` は `**採否**: opt-out` 宣言。通常フローで
+実装した（flag 導入なし）。
+
+STATUS: complete

--- a/docs/specs/225-fix-deps-web-npm-audit-high-brace-expans/requirements.md
+++ b/docs/specs/225-fix-deps-web-npm-audit-high-brace-expans/requirements.md
@@ -1,0 +1,99 @@
+# Requirements Document
+
+## Introduction
+
+Feedman の CI（`.github/workflows/ci.yml`）の `Frontend Dependency Vulnerability Scan
+(npm audit)` ジョブが、`web/` 配下の依存に対する新規公開アドバイザリ群により fail している
+状態である（high 10 件を含む計 14 件）。high の実体は 2 系統で、(a) `brace-expansion` の
+DoS 系（GHSA-mh99-v99m-4gvg。`minimatch` → `@eslint/config-array` / `@eslint/eslintrc` /
+`eslint-plugin-import` / `eslint-plugin-jsx-a11y` / `eslint-plugin-react` → `eslint` →
+`eslint-config-next` の devDependencies 連鎖で計上され high の大半を占める）、(b) `postcss`
+の sourceMappingURL パストラバーサル系（GHSA-r28c-9q8g-f849）である。この赤は develop 宛て
+の全 PR に継承され、脆弱性対応と無関係な PR（例: 設計 spec のみの PR #224）の CI までブロック
+している。本 Issue は同型対応の 3 回目（#210 → #219 に続く再発）であり、`web/` の依存を
+semver 互換の範囲もしくは既存 `overrides` 節への追記により更新することで `frontend-audit`
+ジョブを green に戻し、Web アプリの既存挙動（テスト・lint・ビルド）と eslint ツールチェーンの
+動作を維持することを目的とする。
+
+## Requirements
+
+### Requirement 1: npm audit high 以上検出の解消
+
+**Objective:** As a リポジトリのメンテナ, I want `web/` 配下の high 以上の npm 脆弱性検出を解消すること, so that PR の CI が脆弱性対応と無関係な要因でブロックされない状態に戻る
+
+#### Acceptance Criteria
+
+1. When 対応後の `web/package-lock.json` を用いて `web/` 配下で `npm ci` に続けて `npm audit --audit-level=high` を実行したとき, the Frontend Dependency Vulnerability Scan shall 終了コード 0 で完了する
+2. When 対応後の `web/package-lock.json` を用いて `web/` 配下で `npm audit --audit-level=high` を実行したとき, the Frontend Dependency Vulnerability Scan shall high 以上（high または critical）の脆弱性を 0 件として報告する
+3. When 対応後のブランチに対して CI がトリガーされたとき, the `Frontend Dependency Vulnerability Scan (npm audit)` ジョブ shall 成功（green）ステータスとなる
+4. The 本対応 shall Issue 本文で特定された既知の high 以上アドバイザリ（`brace-expansion` <=5.0.7 の DoS 系 GHSA-mh99-v99m-4gvg、および `postcss` <=8.5.17 の sourceMappingURL パストラバーサル系 GHSA-r28c-9q8g-f849）の両方を解消する
+
+### Requirement 2: 既存挙動・既存テストの維持
+
+**Objective:** As a リポジトリのメンテナ, I want 依存更新後も Web アプリの既存挙動と CI の他ジョブが従来どおり通ること, so that 脆弱性対応が回帰不具合を持ち込まない
+
+#### Acceptance Criteria
+
+1. When 対応後のブランチで `web/` 配下の `npm test`（vitest）が実行されたとき, the Frontend Tests ジョブ shall 全テストを pass して終了コード 0 で完了する
+2. When 対応後のブランチで `web/` 配下の `npm run lint`（eslint）が実行されたとき, the Frontend Lint ジョブ shall lint 違反 0 件で終了コード 0 で完了する
+3. When 対応後のブランチで `web/` 配下の `npm run build` が実行されたとき, the Web ビルド shall エラーなく成功する
+4. The eslint ツールチェーン（`eslint` / `eslint-config-next` / `@eslint/eslintrc` および連鎖する eslint-plugin 群） shall 対応後も従来どおり実行可能な状態を維持する（実行時エラー・ルールセット消失を起こさない）
+5. The バックエンド側 CI ジョブ（`Backend Tests` / `Go Static Analysis (go vet)` / `Go Vulnerability Scan (govulncheck)`） shall 本対応前と同一の成否判定を維持する
+6. The Web アプリのユーザー可視挙動（フィード購読・記事一覧・記事詳細・認証等の既存ユースケース） shall 本対応前と同一の挙動を維持する
+
+### Requirement 3: 更新方針の制約（破壊的変更の禁止）
+
+**Objective:** As a リポジトリのメンテナ, I want 脆弱性解消のための依存更新が破壊的変更を含まないこと, so that lint ツールチェーンや本番挙動を壊さずに最小変更で赤を解消できる
+
+#### Acceptance Criteria
+
+1. The 本対応 shall `npm audit fix --force` による破壊的ダウングレード（例: `@eslint/eslintrc@0.1.0` への降格）を行わない
+2. The 本対応 shall `eslint` / `eslint-config-next` / `@eslint/eslintrc` の major バージョンをアップグレードもダウングレードもしない
+3. The 本対応 shall 本番 dependencies（`web/package.json` の `dependencies` セクション） の各パッケージに破壊的変更（既存 API 挙動の変化を伴う更新）を持ち込まない
+4. Where `brace-expansion` の semver 互換 fix が lockfile のみの更新で取れない場合, the 本対応 shall `web/package.json` の既存 `overrides` 節に `brace-expansion` の修正版を追記する方式を許容する（`overrides` 追記後は `npm run lint` が実行可能であることを確認する）
+5. The 本対応 shall 脆弱性解消に不要な依存パッケージの追加、削除、またはバージョン更新を含まない
+6. If ある脆弱性の解消が上記制約（Req 3.1〜3.5）の範囲内で達成できないと判明した場合, the 本対応 shall 当該脆弱性を本 Issue のスコープから除外し、`Open Questions` または後続 Issue への切り出しとして明示する
+
+### Requirement 4: 変更ファイル範囲の限定
+
+**Objective:** As a リポジトリのメンテナ, I want 本対応の変更範囲がフロントエンド依存メタデータに限定されること, so that レビュー対象が最小化され副作用の混入リスクが下がる
+
+#### Acceptance Criteria
+
+1. The 本対応の diff shall `web/package.json` および `web/package-lock.json` を主たる変更対象とする
+2. The 本対応 shall アプリケーションソースコード（`web/src/**`） を機能変更目的で変更しない
+3. If 依存更新に伴い型定義変更や API 互換性の都合でソースコードの軽微な追随修正が必要となった場合, the 本対応 shall 当該修正の範囲と理由を PR 本文で明示する
+4. The 本対応 shall バックエンド（`api` / `worker` / `internal/**` / `go.mod` / `go.sum`）およびインフラ設定（`Dockerfile` / `docker-compose*.yml` / `.github/workflows/**`） を変更しない
+
+## Non-Functional Requirements
+
+### NFR 1: 対応の再現性
+
+1. The 本対応 shall CI 環境（`npm ci` による fresh install）で決定論的に再現可能な `web/package-lock.json` を成果物として含める（同一 lockfile に対して `npm ci` すれば同一ツリーが得られる状態）
+2. Where ローカル環境の `web/node_modules/` に Docker 由来の root 所有ファイルなどが混在し `npm audit fix` の reify が失敗する制約に遭遇した場合, the 本対応 shall `--package-lock-only` 方式など lockfile のみを更新する手段を許容する（CI 側は `npm ci` で fresh install するため十分と扱う）
+
+### NFR 2: 検出の可視性
+
+1. When 本対応後に CI の `Frontend Dependency Vulnerability Scan (npm audit)` ジョブが実行されたとき, the 当該ジョブ shall `npm audit` の実行結果（検出件数のサマリー）を CI ステップログに出力する
+
+## Out of Scope
+
+- moderate / low / info レベルの脆弱性のみの解消（`@hono/node-server`（shadcn CLI 経由）や `esbuild` GHSA-g7r4-m6w7-qqqr など。本対応の合否判定は `--audit-level=high` に一致させる）
+- eslint 体系の major 更新・設定刷新（`eslint` / `eslint-config-next` / `@eslint/eslintrc`）
+- shadcn CLI の major 更新
+- Next.js の major 更新および App Router 構成の変更
+- バックエンド側の脆弱性対応（`govulncheck` の対応）
+- 脆弱性解消に不要な依存の追加・削除・更新（機能拡張や UI ライブラリの入れ替え等）
+- npm audit の allowlist（`.audit-ignore` 等）機構の導入
+- CI ワークフロー（`.github/workflows/ci.yml`）のジョブ構成・閾値・トリガーの変更
+- Docker イメージスキャン（Trivy）や eslint ルールセット自体の変更
+- 「Req 3 の制約範囲では解消不能」と判明した個別脆弱性の破壊的手段による解消（Req 3.6 に従い後続 Issue へ切り出す）
+
+## Open Questions
+
+- なし（Issue 本文にて「high 実体の 2 系統特定」「`npm audit fix --force` 禁止」「eslint 系 major 変更禁止」「本番 deps に breaking change 禁止」「変更範囲は `web/package.json` / `web/package-lock.json` のみ」「`overrides` 追記方式の許容」「`--package-lock-only` 方式の許容」がすべて明示済み。人間による追加の決定事項コメントもなし）
+
+## 関連
+
+- Related: #219
+- Related: #210

--- a/docs/specs/225-fix-deps-web-npm-audit-high-brace-expans/review-notes.md
+++ b/docs/specs/225-fix-deps-web-npm-audit-high-brace-expans/review-notes.md
@@ -1,0 +1,53 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-07-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-225-impl-fix-deps-web-npm-audit-high-brace-expans
+- HEAD commit: 72a51a305dea42c969e7a09bceb620250c31a847
+- Compared to: develop..HEAD
+
+（design-less impl のため design.md / tasks.md は不在。`_Boundary:_` は無く、
+変更範囲制約は requirements.md の Req 4 で判定した。Feature Flag Protocol は
+CLAUDE.md で opt-out 宣言のため、通常の 3 カテゴリ判定のみを適用。）
+
+## Verified Requirements
+
+- 1.1 — lockfile 検証で `brace-expansion` が単一 5.0.8、`postcss` が 8.5.22/8.5.23（patched）に解決。impl-notes に `npm ci` → `npm audit --audit-level=high` exit 0 の記録あり
+- 1.2 — impl-notes の after 結果で high/critical 0 件（残存は Out of Scope の moderate 3 / low 1）。lockfile 上に vulnerable な brace-expansion 1.x / postcss <=8.5.17 は残存せず
+- 1.3 — CI green は PR 作成後に確定する性質。impl-notes にローカル同等コマンド（audit/lint/test/build）成功の記録あり
+- 1.4 — brace-expansion GHSA-mh99-v99m-4gvg（→5.0.8）と postcss GHSA-r28c-9q8g-f849（→8.5.22/8.5.23）の両系統を解消。lockfile で確認
+- 2.1 — impl-notes: `npm test`（vitest）42 files / 407 tests 全 pass
+- 2.2 — impl-notes: `npm run lint` 0 error（既存 warning 5 件据え置き）
+- 2.3 — impl-notes: `npm run build` 成功
+- 2.4 — lockfile: eslint 9.39.3→9.39.5 / @eslint/eslintrc 3.3.4→3.3.6 / @eslint/config-array 0.21.1→0.21.2 いずれも patch レベル。eslint 連鎖は major 変更なしで維持
+- 2.5 — backend（`api` / `worker` / `internal/**` / `go.mod` / `go.sum`）に変更なし。CI 判定に影響なし
+- 2.6 — `web/src/**` に変更なし。ユーザー可視挙動に影響なし
+- 3.1 — `@eslint/eslintrc` は 3.3.6 に維持され 0.1.0 への降格なし。`--force` 相当の破壊的ダウングレードなし
+- 3.2 — eslint / eslint-config-next / @eslint/eslintrc の major 変更なし（lockfile で確認）
+- 3.3 — 本番 dependencies に変更なし。package-lock.json の更新エントリはすべて `dev: true`
+- 3.4 — `web/package.json` の既存 overrides 節に `"brace-expansion": "^5.0.8"` を追記（diff で確認）
+- 3.5 — 追加/削除された concat-map・nested balanced-match/brace-expansion は brace-expansion 5.x 化に伴う必然的な推移的更新であり、脆弱性解消に無関係な依存変更ではない
+- 3.6 — Req 3.1〜3.5 の制約内で全 high を解消済み。後続 Issue への切り出しは不要
+- 4.1 — diff の主対象は `web/package.json` / `web/package-lock.json`（他は spec docs のみ）
+- 4.2 — `web/src/**` を機能変更目的で変更していない
+- 4.3 — ソースコードの追随修正は発生せず（該当なし）
+- 4.4 — backend / インフラ設定（`Dockerfile` / `docker-compose*` / `.github/workflows/**`）に変更なし
+- NFR 1.1 — `npm ci` で決定論的に再現可能な lockfile を成果物として含む
+- NFR 1.2 — `--package-lock-only` 方式は今回不要（許容規定であり未使用でも AC に反しない）
+- NFR 2.1 — CI ステップログ出力は既存 workflow の挙動に依存（本対応の変更対象外）
+
+## Findings
+
+なし
+
+## Summary
+
+依存メタデータ（`web/package.json` overrides + `web/package-lock.json`）のみの変更で
+brace-expansion / postcss の high 系を解消しており、lockfile 検証でも解決版が patched で
+あることを確認した。eslint 連鎖は patch レベルの更新のみで major 変更なし、本番 deps・
+`web/src/**`・backend・infra への変更なしで Req 4 の範囲制約も満たす。全 numeric AC を
+カバーしており、missing test / boundary 逸脱にも該当しない。
+
+RESULT: approve

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1539,15 +1539,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1580,9 +1580,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
-      "integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1592,8 +1592,8 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.3",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -1604,9 +1604,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
-      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5134,29 +5134,6 @@
         "path-browserify": "^1.0.1"
       }
     },
-    "node_modules/@ts-morph/common/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@ts-morph/common/node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -5543,29 +5520,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -6450,11 +6404,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
@@ -6519,14 +6476,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6879,13 +6838,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -7744,25 +7696,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
-      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.3",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -7781,7 +7733,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -11365,9 +11317,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -11385,7 +11337,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/web/package.json
+++ b/web/package.json
@@ -45,6 +45,7 @@
     "next": {
       "postcss": "^8.5.22"
     },
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "brace-expansion": "^5.0.8"
   }
 }


### PR DESCRIPTION
## 概要

Feedman の CI（`.github/workflows/ci.yml`）の `Frontend Dependency Vulnerability Scan (npm audit)` ジョブが、`web/` 配下の依存に対する新規公開アドバイザリ（brace-expansion GHSA-mh99-v99m-4gvg / postcss GHSA-r28c-9q8g-f849、high 計 10 件）により fail していた状態を解消した。
`web/package.json` の `overrides` 節に `"brace-expansion": "^5.0.8"` を 1 行追記し、`npm audit fix`（非 force）による semver 互換の lockfile 更新で postcss も併せて解消。アプリケーションソースコード・バックエンド・インフラ設定は一切変更なし。

## 対応 Issue

Closes #225

## 関連 PR

なし（design-less impl のため設計 PR は作成されていない。関連する過去対応: #219, #210）

## 実装内容

- (Req 1.4 / 3.4) `web/package.json` の `overrides` 節に `"brace-expansion": "^5.0.8"` を追記し、全チェーンで brace-expansion を patched 版に強制 → GHSA-mh99-v99m-4gvg 解消
- (Req 1.4) `npm audit fix`（非 force）による semver 互換の lockfile 更新で postcss 8.5.22/8.5.23 に引き上げ → GHSA-r28c-9q8g-f849 解消
- (Req 2.4) eslint / eslint-config-next / @eslint/eslintrc は patch レベルの追随更新のみ（major 変更なし）
- (Req 3.3) 本番 dependencies（`web/package.json` の `dependencies` セクション）に変更なし
- (Req 4.1〜4.4) 変更対象は `web/package.json` / `web/package-lock.json` のみ

## 受入基準チェック

- [x] Req 1.1: `npm ci` → `npm audit --audit-level=high` exit 0 ← impl-notes にローカル実行結果記録あり
- [x] Req 1.2: high / critical 0 件 ← impl-notes after audit: 0 件確認
- [x] Req 1.3: CI での確認は PR 作成後（ローカル同等コマンド成功済み）
- [x] Req 1.4: brace-expansion GHSA-mh99-v99m-4gvg / postcss GHSA-r28c-9q8g-f849 の両方を解消
- [x] Req 2.1: `npm test`（vitest）42 files / 407 tests 全 pass ← impl-notes
- [x] Req 2.2: `npm run lint` 0 error（既存 warning 5 件据え置き）← impl-notes
- [x] Req 2.3: `npm run build` 成功 ← impl-notes
- [x] Req 2.4: eslint ツールチェーン実行可能、major 変更なし ← impl-notes / lockfile 確認
- [x] Req 2.5: バックエンド側 CI ジョブ変更なし（対象外）
- [x] Req 2.6: `web/src/**` 変更なし、ユーザー可視挙動に影響なし
- [x] Req 3.1〜3.6: 破壊的変更なし（overrides 追記 + 非 force audit fix のみ）
- [x] Req 4.1〜4.4: 変更範囲は `web/package.json` / `web/package-lock.json` のみ

## テスト結果

```
npm test（vitest）: 42 test files, 407 tests 全 pass（duration 58.20s）
npm run lint: 0 error, 5 warnings（対応前と同一の既存 warning）
npm run build: 成功（Route: 2 static pages, First Load JS 197KB / 125KB）
npm audit --audit-level=high: exit 0, high: 0 / critical: 0 / moderate: 3 / low: 1
```

## 実装上の判断

- brace-expansion の解消に `overrides` 追記（全チェーン 5.0.8 強制）を採用した理由: brace-expansion 1.x は npm advisory の vulnerable range `<=5.0.7` に含まれ、非 force の `npm audit fix` では 1.x のまま解消不能。brace-expansion 5.x は CommonJS デュアルエクスポートを備えており、1.x consumer（minimatch 3.x など）からも `require()` 可能なため互換性を維持できる（impl-notes.md 参照）
- postcss は既存 `overrides.next.postcss ^8.5.22`（PR #221 で設定済み）と `npm audit fix` の組み合わせで semver 互換の patch 更新として解消できたため、overrides の追加変更は不要

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- brace-expansion を全チェーンで 5.x に強制する override は、将来の eslint / minimatch 更新で回帰する可能性があります。次回 `npm audit` で新規 GHSA が公開されたら、overrides の `^5.0.8` が引き続き non-vulnerable range に含まれるか確認してください
- Out of Scope の残存 moderate（`@hono/node-server` / `esbuild`）は本 Issue スコープ外です（shadcn CLI 系の major 更新が必要なため別 Issue の検討を推奨）
- Reviewer 判定: RESULT: approve（`docs/specs/225-fix-deps-web-npm-audit-high-brace-expans/review-notes.md` 参照）
- base ブランチ確認: `--base develop` 指定 / baseRefName 検証は PR 作成後に実施

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #225 のコメントを参照してください。
