### PR TITLE
spec(#231): パスキー登録後のセッション合流・実装境界・脅威モデルの差分設計

### DIFF
--- a/docs/specs/231-design-web-auth/design.md
+++ b/docs/specs/231-design-web-auth/design.md
@@ -17,6 +17,16 @@ registration/finish` の検証成功から同一 DB トランザクションで 
 用（auth_code 交換）としてそのまま残す。本設計は初版 design（auth_code additive 案 = 仮案 B）を
 全面的に置き換える。
 
+**前提となる先行実装（#230 / PR #232）**: 新規登録 finish の user + credential を単一
+トランザクションで INSERT する基盤は Issue #230（PR #232）が既に実装済みである
+（`passkey.RegistrationTx` / `RegistrationTxBeginner` / `RegistrationService.txBeginner` の
+`BeginTx → defer Rollback → Commit` パターン、`UserWriter.CreateUserOnlyExec` /
+`PasskeyCredentialWriter.CreateExec`、`app` 側の `passkeyRegistrationTxBeginnerAdapter`）。
+本 spec は **その既存トランザクションを session 行まで拡張する**（新しい tx 実行機構を作らない）。
+`internal/repository/tx.go` は #231 では変更しない。`CreateUserOnlyExec` / credential `CreateExec` /
+`txBeginner` は **#230 由来の既存前提**であり #231 の新規作業には数えない。運用順序は
+**#230（PR #232）を develop に merge → PR #229 がその実装を取り込む** とし、tasks の依存で明示する。
+
 **Users**: 未認証 Web 訪問者（パスキーで新規作成する層／ iOS #216 で作成したパスキーで Web
 にログインする層）と、既存 Google OAuth ユーザー、Feedman 運用者。iOS #216 ユーザーへの
 影響はゼロ（`/api/passkey/registration/*` / `/api/passkey/authentication/*` の request/response
@@ -24,43 +34,55 @@ JSON を変更しない。Web の差分は `Set-Cookie` ヘッダのみ / NFR 3.
 
 **Impact**: 本 spec は独立した実装 PR を作らない。design PR merge 後、PR #229 の
 `needs-iteration` 1 回で製品コード（`internal/passkey/` / `internal/handler/` /
-`internal/repository/` / `web/src/`）・テスト・spec の `impl-notes.md` / `context-map.md`
-（**#223 / #216 spec の requirements.md / design.md / tasks.md は書き換えない**）へ差分を反映する。
+`internal/repository/` / `internal/auth/` / `internal/config/` / `web/src/`）・テスト・spec の
+`impl-notes.md` / `context-map.md`（**#223 / #216 / #230 spec の requirements.md / design.md /
+tasks.md は書き換えない**）へ差分を反映する。
 
 ### 補正する 6 つの Delta サマリ
 
 - **Delta 1（Requirement 1）— 直接 Cookie session**: 登録 finish で二度目の WebAuthn ceremony を
-  廃止する。`internal/passkey/RegistrationService.FinishRegistrationNew` を、既存
-  `internal/repository/tx.go` のトランザクション基盤を用いて **user → credential → session の
-  3 行を単一トランザクションで作成** する構成に拡張し、handler が commit 後に既存 Cookie 属性で
-  `Set-Cookie` する。`registration/finish` の request/response JSON は Web / iOS とも `{user_id}`
-  のまま変更しない（Web だけ `Set-Cookie` が付く / NFR 3.2）。登録 begin の `code_challenge` は
-  #216 契約維持のためフィールドを残すが **形式検証のみ** で永続化・束縛しない。
+  廃止する。#230（PR #232）の既存 `RegistrationService.FinishRegistrationNew`（`txBeginner` の
+  `BeginTx → defer Rollback → Commit` で user → credential を作成）を、**credential INSERT の後・
+  commit の前に session 行 INSERT を 1 つ加える** 形に拡張する（3 行 atomic）。session の
+  ID / `CreatedAt` / `ExpiresAt` は既存 login session 発行と共有する **session factory** で一貫生成する。
+  handler は commit 後に既存 Cookie 属性で `Set-Cookie` する。`registration/finish` の request/response
+  JSON は Web / iOS とも `{user_id}` のまま変更しない（Web だけ `Set-Cookie` が付く / NFR 3.2）。
+  登録 begin の `code_challenge` は #216 契約維持のためフィールドを残すが **形式検証のみ** で
+  永続化・束縛しない。
 - **Delta 2（Requirement 2）— File Structure Plan 補正**: PR #229 の実変更ファイルを
-  File Structure Plan 差分に完全列挙する（`web/src/lib/api.ts` / `api.test.ts` /
-  `.env.sample` / `docker-compose.yml` を含む）。本設計で新規追加する session tx 対応
-  （`CreateExec` 群・共有 Cookie builder・実 DB tx test）も列挙する。
-- **Delta 3（Requirement 3）— fail-closed 表 5 列化**: fail-closed 表を
+  File Structure Plan 差分に **exact-path で完全列挙**し、「#231 でさらに編集するもの」と
+  「PR #229 / #232 に既に含まれるが #231 では不変のもの」を分離する（`web/src/lib/api.ts` /
+  `api.test.ts` / `.env.sample` / `docker-compose.yml` / `review-notes.md` /
+  `router_unauth_ratelimit_test.go` / `session_exchange_test.go` /
+  `use-passkey-authentication.contract.test.tsx` を含む）。本設計で新規追加する
+  session tx 対応（session repo `CreateExec`・共有 session factory・共有 Cookie builder・
+  `WebPasskeyAllowedOrigin` config）も列挙する。
+- **Delta 3（Requirement 3）— fail-closed 表 5 列化 + readiness 強化**: fail-closed 表を
   Web capability / Web login exchange / Web registration direct session / iOS registration/* /
   iOS authentication/* の **5 列独立** で組み直す。router の capability / `/api/auth/session` gate は
-  PR #229 の `NativeAuthHandler.SessionReady()` を **維持**（`NativeAuthHandler != nil` に弱めない）し、
-  Origin 検証が不能な構成（`CORS_ALLOWED_ORIGIN` 未設定）でも fail-closed に倒す。
+  PR #229 の `NativeAuthHandler.SessionReady()` を **維持**（弱めない）し、capability には
+  **direct-registration readiness（`webRegistrationReady()`）と明示された exact Origin** を
+  **追加要件**として課す（capability 200 なのに signup 500 の不整合を防ぐ）。
 - **Delta 4（Requirement 4）— CSRF / PKCE 正確化**: 「攻撃者は (auth_code, code_verifier) ペアを
-  取得できない」の誤記述を撤回する。直接登録 session の主防御（exact Origin / JSON Content-Type /
-  CORS preflight / SameSite / **必須ユーザー生体ジェスチャ**）と、ログイン auth_code 交換の主防御
+  取得できない」の誤記述を撤回する。直接登録 session の主防御（authenticator の
+  **authorization gesture**（user presence、場合により user verification）+ exact Origin +
+  JSON Content-Type + CORS preflight / SameSite）と、ログイン auth_code 交換の主防御
   （上記 + PKCE 単回 60s TTL）を **分離** して明記し、PKCE が直接登録を防御しないことを述べる。
-  既存 `/api/auth/session`（login）の Origin 検証も **Origin 不在・不一致・allowedOrigin 未設定を
+  既存 `/api/auth/session`（login）の Origin 検証も **Origin 不在・不一致・許可 Origin 未設定を
   拒否** する fail-closed へ補正する。
 - **Delta 5（Requirement 5）— 完了不明状態**: 「finish dispatch 後に確定的な pre-commit 4xx を
   得られない」ケース（network reject / timeout / 送出後 Abort / 5xx / commit 済みを示唆する 2xx だが
   body 欠損・途中切断・parse 不能）を **第 3 の完了不明状態** `registration_uncertain` として定義する。
-  復旧は「**discoverable なパスキーログイン**（ユーザー名入力なし）で確認 → 成功なら完了 →
-  一律の `AUTHENTICATION_FAILED` の後にのみ再作成導線」に統一する（login と再作成を初期画面に
-  同列並置しない）。
+  この判別を成立させるため **API 層（`api.ts`）で「fetch 成功後の 2xx body parse 失敗」を status
+  付きの型に正規化**し、dispatch 前のローカル失敗と区別できるようにする。復旧は
+  「**discoverable なパスキーログイン**（ユーザー名入力なし）で確認 → 成功なら完了 →
+  一律の `AUTHENTICATION_FAILED` の後にのみ再作成導線」に統一する。
 - **Delta 6（Requirement 6）— 運用 config 統合**: `.env.sample` / `docker-compose.yml` の記述差分を
   PR #229 のスコープに統合する（別 prerequisite PR に分離しない）。`CORS_ALLOWED_ORIGIN` の
-  未設定・不一致と fail-closed 挙動の接続を明示し、Verify に代表 env 値付き `docker compose config` を
-  追加する。
+  **既定を空へ変更**し、config が「明示設定された exact Origin のみを Web パスキーで信頼する」
+  ように補正することで、fail-closed（未設定 → capability 404 / Origin 検証 403）を **到達可能・
+  検証可能**にする。Verify には代表 env 値（`SESSION_SECRET` / `POSTGRES_PASSWORD` を含む）付き
+  `docker compose config` を追加する。
 
 ### Goals
 
@@ -74,196 +96,177 @@ JSON を変更しない。Web の差分は `Set-Cookie` ヘッダのみ / NFR 3.
   - PR #229 に本差分を反映した後の `go test ./...` / `go vet ./...` / `web` の test / lint / build が green
   - `POST /api/passkey/registration/finish` が Web（Origin 一致）で 200 `{user_id}` + `Set-Cookie` を返し、
     二度目 ceremony なしで 2 ペイン UI に到達する
-  - 実 PostgreSQL で「session 書込失敗時に user / credential も作成されない（3 行 atomic）」ことを検証
+  - 実 PostgreSQL で「session 書込失敗時に user / credential も作成されず Set-Cookie も出ない
+    （3 行 atomic）」ことを検証
+  - `CORS_ALLOWED_ORIGIN` 未設定時に capability=404、明示設定時に capability=200 となることを config テストと router テストで検証
   - `NATIVE_AUTH_JWT_SECRET` 未設定 + `WEBAUTHN_*` 設定済み env で iOS 用
     `/api/passkey/registration/*` / `/api/passkey/authentication/*` が引き続き 200 応答する
 
 ### Non-Goals
 
-- **#223 / #216 spec の物理ファイル書換え**（各 requirements.md / design.md / tasks.md）— 本 spec は
-  差分宣言のみを行い、物理ファイルは触らない（NFR 1.1 / 1.3）
+- **#223 / #216 / #230 spec の物理ファイル書換え**（各 requirements.md / design.md / tasks.md）— 本 spec は
+  差分宣言のみを行い、それら物理ファイルは触らない（NFR 1.1 / 1.3）
 - **独立した実装 PR の作成** — 差分は PR #229 の needs-iteration 1 回で反映（NFR 1.2）
 - **#216 iOS パスキー API の request/response JSON 契約の破壊的変更**（NFR 1.3 / NFR 3.2）
+- **新しいトランザクション実行機構（`WithinTx` / `txRunner` 等）の追加** — #230 の
+  `RegistrationTxBeginner` を再利用する（`internal/repository/tx.go` は不変）
 - **登録用 auth_code / 二度目 ceremony / 登録専用 session 交換 endpoint / exchange artifact の導入**
   （決定 1.A により不採用）
 - **browser-bound state（transaction cookie / 追加 CSRF token / Origin-bound challenge 拡張）の導入**
   （Requirement 4 の決定事項）
 - **`.env.sample` / `docker-compose.yml` を別 prerequisite PR に分離すること**（Requirement 6 の決定事項）
+- **WebAuthn の user verification（生体認証）を必須化する設計**（現 adapter は
+  `userVerification=required` を指定せず、authorization gesture は user presence の場合もある。Delta 4 参照）
 
 ## Architecture
 
-### Existing Architecture Analysis（PR #229 head 実装に基づく）
+### Existing Architecture Analysis（PR #229 / #232 head 実装に基づく）
 
-本差分は #216 / PR #229 が確立した以下の既存アーキテクチャを **維持する前提** で補正する。
+本差分は #216 / PR #229 / #230(PR #232) が確立した以下の既存アーキテクチャを **維持する前提** で補正する。
 責務境界・依存方向は変更しない（`handler → service → repository → model` の一方向 / CLAUDE.md §1）:
 
 - **維持する既存要素**:
-  - `internal/passkey/` の ceremony 責務（`RegistrationService` / `AuthenticationService`）と
-    `internal/handler/passkey_handler.go` の HTTP I/O 責務の分離（#216 で確立）
-  - `challengeStore.Issue/Consume` を通じた TTL 付き単回消費（#216 で確立）
-  - `internal/repository/tx.go` のトランザクション基盤（`SQLTx` / `BeginTx` / `Querier() DBTX` /
-    `Commit` / `Rollback`）と、repo の `*Exec(ctx, q DBTX, ...)` 変種パターン
-    （既存例: `PostgresUserRepo.DeleteByIDExec` / `PostgresSessionRepo.DeleteByUserIDExec`）
-  - `NativeAuthHandler.Session`（`POST /api/auth/session`）+ `auth.SessionExchangeService`
-    （auth_code → Web Cookie session 交換 / PR #229）と `SessionReady()` readiness
-  - `NativeAuthHandler.Session` の CSRF 防御（Content-Type application/json 必須 / Origin allowlist）
-  - Google OAuth Callback（`auth_handler.go::Callback`）の Cookie 属性
-    （`session_id` / HttpOnly / SameSite=Lax / Secure / Path=/ / Domain / Max-Age）
-  - fail-closed による route 未登録判定（`if <条件> { register }` パターン）
-- **本差分が変更する点**:
-  - `RegistrationService.FinishRegistrationNew` を **user → credential → session の単一トランザクション**
-    に拡張（session 発行は Web mode のみ）。シグネチャに `issueWebSession bool` を追加し、返り値に
-    `*model.Session`（Web session、iOS では nil）を追加
-  - `PasskeyHandler.RegistrationFinish` に Origin ベースの Web / iOS mode 判定と Web mode の
-    `Set-Cookie` を追加
-  - repo に session 作成の tx 変種 `PostgresSessionRepo.CreateExec(ctx, DBTX, *model.Session)` と、
-    user / credential の tx 変種 `CreateUserOnlyExec` / `CreateExec` を追加
-  - Cookie 生成を **canonical builder に集約**（`auth_handler.Callback` /
-    `native_auth_handler.Session` / `passkey_handler.RegistrationFinish` で共有 / 重複排除）
-  - `router.go` の capability route 登録条件に `CORS_ALLOWED_ORIGIN` 設定要件を追加（Origin 検証不能時の
-    fail-closed）
-  - `native_auth_handler.Session` の Origin 検証を fail-closed（不在・不一致・allowedOrigin 未設定を拒否）へ補正
-  - Web hook `use-passkey-registration.ts` の chain（二度目 ceremony 除去 + `registration_uncertain` 追加）
-  - Web UI `passkey-signup-dialog.tsx` の完了不明状態 UI と discoverable ログイン復旧導線
-  - `.env.sample` / `docker-compose.yml` の既存 WebAuthn env documentation / passthrough 整備
+  - `internal/passkey/` の ceremony 責務と `internal/handler/passkey_handler.go` の HTTP I/O 責務の分離、
+    `challengeStore.Issue/Consume` の TTL 付き単回消費（#216 で確立）
+  - **#230（PR #232）の新規登録 tx 基盤**: `passkey.RegistrationTx`（`Querier() repository.DBTX` /
+    `Commit` / `Rollback`）/ `passkey.RegistrationTxBeginner`（`BeginTx(ctx) (RegistrationTx, error)`）/
+    `RegistrationService.txBeginner` / `FinishRegistrationNew` の
+    `BeginTx → defer Rollback → CreateUserOnlyExec → CreateExec → Commit` パターン /
+    `app` 側 `passkeyRegistrationTxBeginnerAdapter`、および
+    `UserWriter.CreateUserOnlyExec` / `PasskeyCredentialWriter.CreateExec`（**すべて #230 既存**。UNIQUE 衝突を
+    `ErrUsernameTaken` / `ErrCredentialAlreadyRegistered` に正規化）。`internal/repository/tx.go` は **#231 では変更しない**
+  - login session 発行: `auth.Service.createSession` と `auth.SessionExchangeService`（PR #229）は
+    いずれも `generateSessionID`（**`internal/auth/service.go` に定義**）+ `now` + `CreatedAt=now` +
+    `ExpiresAt=now+TTL` で `model.Session{ID, UserID, ExpiresAt, CreatedAt}` を構築する
+  - `NativeAuthHandler.Session` + `SessionReady()` / `PasskeyHandler.Capability`（到達 = `{available:true}`）/
+    Google OAuth Callback の Cookie 属性（`session_id` / HttpOnly / SameSite=Lax / Secure / Path=/ / Domain / Max-Age）
+  - `config.go` の `CORSAllowedOrigin`（既定 `http://localhost:3000`）/ `CookieDomain`（既定空）/
+    `CookieSecure`（`BaseURL` が https で true）/ `SessionMaxAge`（既定 86400）、fail-closed route 判定パターン
+- **本差分が変更する点**（詳細ファイルは §File Structure Plan [E]/[N] を参照）: 既存 #230 tx クロージャ内へ
+  session 行 INSERT を追加（`FinishRegistrationNew` に `issueWebSession bool` + `*model.Session` 返却）/
+  session repo `CreateExec`（#231 新規）と **共有 session factory**（`internal/auth/session_factory.go`）で
+  session 構築を一元化 / `PasskeyHandler.RegistrationFinish` の Origin mode 判定 + `Set-Cookie` /
+  Cookie 生成を canonical builder に集約 / `config.go` の `WebPasskeyAllowedOrigin`（明示設定 exact Origin。
+  `CORSAllowedOrigin` 既定は不変）/ capability gate に origin + `webRegistrationReady()` 追加（`SessionReady()` 維持）/
+  `native_auth_handler.Session` の Origin fail-closed 補正 / Web の二度目 ceremony 除去 + `registration_uncertain` +
+  `api.ts` の 2xx parse 型付き正規化 + 完了不明状態 UI / `.env.sample`・`docker-compose.yml` の CORS 既定変更
 - **尊重すべき制約**:
   - iOS #216 の request/response 契約：`registration/begin` request `{username, email?, code_challenge}`、
     `registration/finish` request `{challenge_id, credential}` / response `{user_id}`、
     `authentication/*` の各フィールド構造をそのまま維持する（Web も response は `{user_id}` 不変。
     差分は `Set-Cookie` ヘッダのみで JSON body には現れない）
-  - NFR 1.1（#223 spec 物理ファイル不変）/ NFR 1.3（#216 spec 物理ファイル・API 契約不変）
+  - NFR 1.1（#223 spec 物理ファイル不変）/ NFR 1.3（#216 / #230 spec 物理ファイル・API 契約不変）
 
 ### 差分適用の運用境界
 
 ```mermaid
 flowchart LR
     subgraph This231 [#231 spec（本 design）]
-        R231[requirements.md]
         D231[design.md<br/>Delta 1〜6]
         T231[tasks.md<br/>PR #229 への差分作業]
     end
+    subgraph Prior230 [#230 / PR #232（先行 merge）]
+        TX230[RegistrationTx 基盤<br/>user+credential 1 tx]
+    end
     subgraph Existing223 [#223 spec（物理不変）]
         D223[design.md<br/>該当節を supersede]
-    end
-    subgraph Existing216 [#216 spec（物理不変 / API 契約不変）]
-        D216[design.md]
     end
     subgraph PR229 [PR #229 実装]
         S229[製品コード<br/>internal/**, web/src/**]
         SPEC229[spec 補助<br/>context-map.md / impl-notes.md]
         CONF229[運用 config<br/>.env.sample / docker-compose.yml]
     end
+    TX230 -->|develop merge 先行| S229
     D231 -.supersedes.-> D223
+    D231 -.extends.-> TX230
     T231 -->|needs-iteration 1| S229
     T231 -->|needs-iteration 1| SPEC229
     T231 -->|needs-iteration 1| CONF229
-    T231 -.non-invasive.-> D216
 ```
 
 ### Technology Stack
 
 本差分は **技術スタック追加なし**。既存の技術選定（Go 1.25 / chi/v5 / PostgreSQL 16 /
 go-webauthn / `database/sql` トランザクション / Next.js 15 / TanStack Query / shadcn/ui /
-Vitest）をそのまま使用する。session ID 生成は既存 `auth.SessionExchangeService` /
-Google OAuth Callback と同一の生成器を再利用する（重複しない）。
+Vitest）をそのまま使用する。session ID 生成は既存 `internal/auth/service.go` の
+`generateSessionID`（32 バイト crypto random / hex）を **共有 session factory 経由で再利用**する
+（新たな生成器を作らない）。
 
 ## File Structure Plan（PR #229 に適用する差分の変更対象 / 新規追加）
 
-本セクションは PR #229 の `needs-iteration` 1 回で反映する対象ファイルを **変更対象** と
-**新規追加** に分けて明示する。**#223 design.md「File Structure Plan」節を supersede する**
-（Requirement 2）。Reviewer は本節を canonical として PR #229 の全変更ファイル被覆を確認できる
-（Requirement 2.5）。
+本セクションは PR #229 の `needs-iteration` 1 回で反映する対象ファイルを、Reviewer が
+`git diff --name-only develop..<PR#229 head>` と 1:1 で突合できるよう **exact-path** で列挙する
+（Requirement 2 / 2.5）。**#223 design.md「File Structure Plan」節を supersede する**。
+各ファイルを 3 区分に分類する:
 
-### Modified Files（サーバ側）
+- **[E]** = #231 でさらに編集する（PR #229 の needs-iteration 1 回で本差分を反映）
+- **[U]** = PR #229 / #232 に既に含まれるが **#231 ではさらに編集しない**（記録のみ / 過剰変更でない証跡）
+- **[N]** = 本差分で新規追加する
 
-- `internal/repository/tx.go` — **変更**（3 行 tx orchestration の helper 追加）
-  - closure 型のトランザクション実行ヘルパー `WithinTx(ctx, fn func(q DBTX) error) error` を
-    `SQLTxBeginner` に追加（`BeginTx` → `fn(tx.Querier())` → 正常時 `Commit` / エラー・panic 時
-    `Rollback`）。既存 `SQLTx` / `BeginTx` / `Querier` / `Commit` / `Rollback` は変更しない
-- `internal/repository/postgres_session_repo.go` — **変更**
-  - `CreateExec(ctx, q DBTX, s *model.Session) error` を追加（既存 `DeleteByUserIDExec` の
-    DBTX 変種パターンに準拠）。既存 `Create(ctx, s)` は `CreateExec(ctx, r.db, s)` へ委譲に変更
-    （差分等価 / 挙動不変）
-- `internal/repository/postgres_user_repo.go` — **変更**
-  - `CreateUserOnlyExec(ctx, q DBTX, u *model.User) error` を追加。既存 `CreateUserOnly` は
-    `CreateUserOnlyExec(ctx, r.db, u)` へ委譲（`ErrUsernameTaken` 正規化は変えない）
-- `internal/repository/postgres_passkey_credential_repo.go` — **変更**
-  - `CreateExec(ctx, q DBTX, c *model.PasskeyCredential) error` を追加。既存 `Create` は
-    `CreateExec(ctx, r.db, c)` へ委譲（`ErrCredentialAlreadyRegistered` 正規化は変えない）
-- `internal/passkey/registration_service.go` — **変更**（Delta 1 サーバ中核）
-  - 最小 IF を追加/拡張: `SessionWriter{CreateExec}`、`UserWriter` に `CreateUserOnlyExec`、
-    `PasskeyCredentialWriter` に `CreateExec`、tx 実行 IF `txRunner{WithinTx}`
-  - 構造体に `sessions SessionWriter` / `tx txRunner` / `newSessionID func() (string, error)` /
-    `sessionTTL time.Duration` を追加（**auth_code 関連依存は追加しない**）
-  - `FinishRegistrationNew` を単一 tx + `issueWebSession bool` 対応に変更（後述 §Delta 1）
-  - `WebSessionReady() bool`（session writer / tx / 生成器が非 nil）を追加
-- `internal/passkey/registration_service_test.go` — **変更**（新シグネチャ追従 + branch/正規化テスト）
-- `internal/handler/session_cookie.go` — **新規**（後述 §New Files）
-- `internal/handler/passkey_handler.go` — **変更**（Delta 1 handler + Delta 3）
-  - `PasskeyHandler` に `allowedOrigin string` と Cookie 設定（domain / secure / maxAge）を
-    Option で注入（既存 `NativeAuthHandler` の `WithSession*` Option idiom を踏襲）
-  - `RegistrationFinish` に Origin ベース mode 判定・Web mode の JSON Content-Type 検証・
-    readiness fail-closed・commit 後 `Set-Cookie` を追加（response は 200 `{user_id}` 不変）
-- `internal/handler/passkey_handler_test.go` — **変更**（mode 判定 / Set-Cookie / iOS `{user_id}` 回帰）
-- `internal/handler/native_auth_handler.go` — **変更**（Delta 4 login Origin fail-closed 補正）
-  - `Session` の Origin 検証を「Origin 不在・不一致・allowedOrigin 未設定を拒否（403）」に補正
-- `internal/handler/native_auth_handler_test.go` — **変更**（Origin fail-closed の異常系追加）
-- `internal/handler/router.go` — **変更**（Delta 3）
-  - capability route 条件に `deps.CORSAllowedOrigin != ""` を追加（`SessionReady()` は維持）
-  - `/api/auth/session` 条件は既存 `NativeAuthHandler != nil && SessionReady()` を維持
-  - iOS `/api/passkey/registration/*` / `/api/passkey/authentication/*`（および Web と共有する
-    `registration/finish`）は `PasskeyHandler != nil` を維持（#216 契約 / NFR 3.2）
-- `internal/handler/router_test.go` — **変更**（fail-closed 5 列に対応する route 登録テスト）
-- `internal/handler/passkey_e2e_db_test.go` — **変更**（実 PostgreSQL で 3 行 commit / rollback 原子性）
-- `internal/auth/session_exchange.go` — **変更**（session ID 生成器を `auth.GenerateSessionID` として
-  export し RegistrationService と共有 / 重複排除。`SessionExchangeService` の契約は不変）
-- `internal/app/app.go` — **変更**（wiring）
-  - `passkey.NewRegistrationService(...)` に `sessionRepo`（SessionWriter）/ tx runner /
-    `auth.GenerateSessionID` / `sessionTTL` を注入
-  - `handler.NewPasskeyHandler(...)` に `allowedOrigin`（`cfg.CORSAllowedOrigin`）と Cookie 設定
-    （`cfg.CookieDomain` / `cfg.CookieSecure` / `cfg.SessionMaxAge`）を注入
-  - 注記: session 発行依存（sessionRepo / cookie / origin）は `NATIVE_AUTH_JWT_SECRET` に依存せず、
-    `WEBAUTHN_*` 設定時（passkey handler 生成時）に常時配線する
+> #216 / #230 spec 本体（`docs/specs/216--app-store-4-8/**` / `docs/specs/230-fix-passkey-credential/**`）は
+> いずれの区分にも入れない（NFR 1.3。tasks に編集タスクを置かない）。
 
-### Modified Files（Web 側）
+### サーバ（Go）
 
-- `web/src/hooks/use-passkey-registration.ts` — **変更**（Delta 1 Web + Delta 5 hook）
-  - chain を「begin → create → finish（2xx + Set-Cookie）→ invalidateQueries」に短縮
-    （`authentication/begin` / `get` / `authentication/finish` / 登録用 `/api/auth/session` を除去）
-  - `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加。registration 経路は
-    `session_exchange_failed` を発生させない（直接 session 化により該当段が消滅）
-- `web/src/hooks/use-passkey-registration.test.ts` — **変更**（uncertain 4 サブケース + 二度目 ceremony 不在回帰）
-- `web/src/components/passkey-signup-dialog.tsx` — **変更**（Delta 5 UI: 完了不明 + discoverable 復旧導線）
-- `web/src/components/passkey-signup-dialog.test.tsx` — **変更**
-- `web/src/hooks/use-passkey-authentication.ts` — 既存維持（discoverable ログイン復旧で **再利用**、変更なし）
-- `web/src/components/login-page.tsx` / `login-page.test.tsx` / `login-page-recovery.test.tsx` —
-  **変更**（PR #229 で追加済み。完了不明 → discoverable ログイン → 成功で 2 ペイン到達の recovery テスト整合）
-- `web/src/lib/api.ts` — **変更対象として列挙**（Requirement 2.1 / #223 design の「無変更」記述を訂正。
-  PR #229 で `credentials: "include"` 経路等が変更済み。本差分自身は api.ts をさらに触る必要はない）
-- `web/src/lib/api.test.ts` — **変更対象として列挙**（PR #229 で追加済みだが #223 design 未列挙 / Req 2.1）
-- `web/src/types/passkey.ts` — **変更**（`PasskeyRegistrationErrorKind` に uncertain 追加。
-  `RegistrationFinishResponse` は `{user_id}` のまま **auth_code を追加しない**）
-- `web/src/lib/webauthn.ts` / `pkce.ts` / `passkey-capability.ts` / `use-passkey-capability.ts` /
-  `passkey-buttons.tsx`（各 `.test`）— 既存維持（変更なし）
+| 区分 | パス | #231 での扱い |
+|---|---|---|
+| [U] | `internal/repository/tx.go` | #230/#232 の tx 基盤を **そのまま再利用**。#231 変更なし |
+| [U] | `internal/repository/postgres_user_repo.go` | `CreateUserOnlyExec` は **#230 既存**。#231 変更なし |
+| [U] | `internal/repository/postgres_passkey_credential_repo.go` | `CreateExec` は **#230 既存**。#231 変更なし |
+| [N] | `internal/repository/postgres_session_repo.go` | session 作成の tx 変種 `CreateExec(ctx, q DBTX, s)` を追加、既存 `Create` は委譲（差分等価） |
+| [N] | `internal/auth/session_factory.go` | 共有 session factory（ID + 単一 now + CreatedAt + ExpiresAt）。`SessionExchangeService` と RegistrationService が共有 |
+| [N] | `internal/auth/session_factory_test.go` | factory の ID / CreatedAt / ExpiresAt / 単一 now / generator 失敗を検証 |
+| [E] | `internal/auth/service.go` | `generateSessionID` は本ファイルに定義済み（File Plan の旧「session_exchange.go から export」は誤り）。factory から参照できるよう **同 package の export helper `NewSessionID`** を追加（`Service.createSession` の挙動は差分等価） |
+| [E] | `internal/auth/session_exchange.go` | session 構築を新 factory 呼び出しに差し替え（`SessionExchangeService` の外部契約・挙動は不変 / 差分等価） |
+| [E] | `internal/auth/session_exchange_test.go` | factory 差し替え後も既存アサーションが pass することを確認（CreatedAt / ExpiresAt 検証を追加） |
+| [E] | `internal/passkey/registration_service.go` | `FinishRegistrationNew` を既存 tx クロージャ内 session INSERT + `issueWebSession bool` + `*model.Session` 返却に拡張。session factory / session writer を注入、`WebSessionReady()` 追加 |
+| [E] | `internal/passkey/registration_service_test.go` | 新シグネチャ追従 + Web/iOS branch + 全 rollback + session の ID/CreatedAt/ExpiresAt 検証 |
+| [E] | `internal/handler/passkey_handler.go` | `allowedOrigin` + Cookie 設定 Option 注入、`RegistrationFinish` の mode 判定 / JSON Content-Type / readiness fail-closed / commit 後 `Set-Cookie`、`webRegistrationReady()` |
+| [E] | `internal/handler/passkey_handler_test.go` | mode 判定 / Set-Cookie / iOS `{user_id}` + Cookie なし回帰 / partial readiness fail-closed |
+| [N] | `internal/handler/session_cookie.go` | canonical Cookie builder `buildSessionCookie(...)` を 3 handler で共有 |
+| [N] | `internal/handler/session_cookie_test.go` | builder の属性が Google OAuth Callback と一致することを検証 |
+| [E] | `internal/handler/native_auth_handler.go` | `Session` の Origin 検証を fail-closed（不在・不一致・許可 Origin 未設定を 403）へ補正 |
+| [E] | `internal/handler/native_auth_handler_test.go` | Origin fail-closed の異常系追加 |
+| [E] | `internal/handler/router.go` | capability 条件に `WebPasskeyAllowedOrigin != ""` + `PasskeyHandler.webRegistrationReady()` を追加（`SessionReady()` 維持）。iOS route 条件 `PasskeyHandler != nil` は不変 |
+| [E] | `internal/handler/router_test.go` | fail-closed 表 5 列 + partial wiring（capability/session/registration の登録一致）を table-driven で検証 |
+| [U] | `internal/handler/router_unauth_ratelimit_test.go` | PR #229 で追加済み。#231 変更なし（記録） |
+| [E] | `internal/handler/passkey_e2e_db_test.go` | 実 PostgreSQL で 3 行 commit / session 失敗時の全 rollback + Set-Cookie なし |
+| [E] | `internal/config/config.go` | `WebPasskeyAllowedOrigin`（明示設定された exact Origin、未設定/空 → `""`）を追加。`CORSAllowedOrigin` 既定は不変（新規 env は追加しない） |
+| [E] | `internal/config/config_test.go` | `CORS_ALLOWED_ORIGIN` set/unset/empty での `WebPasskeyAllowedOrigin` を検証 |
+| [E] | `internal/app/app.go` | RegistrationService へ session writer / session factory / TTL を注入、PasskeyHandler へ `WebPasskeyAllowedOrigin` + Cookie 設定を注入（`NATIVE_AUTH_JWT_SECRET` 非依存で `WEBAUTHN_*` 設定時に配線） |
 
-### Modified Files（運用 config / Requirement 6）
+### Web（TypeScript）
 
-- `.env.sample` — **変更**（既存 WebAuthn env 群と `CORS_ALLOWED_ORIGIN` の documentation 整備 / 新規 env なし）
-- `docker-compose.yml` — **変更**（`api` サービスへ WebAuthn env passthrough 追加 / 新規 env なし）
+| 区分 | パス | #231 での扱い |
+|---|---|---|
+| [E] | `web/src/lib/api.ts` | 2xx の `response.json()` 失敗を status 付きの型（`ResponseParseError`）へ正規化し、dispatch 前失敗と区別可能にする |
+| [E] | `web/src/lib/api.test.ts` | 2xx body 欠損/途中切断/parse 不能で `ResponseParseError`（status 2xx）を投げ、pre-dispatch 失敗と区別されることを検証 |
+| [E] | `web/src/types/passkey.ts` | `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加。`RegistrationFinishResponse` は `{user_id}` のまま（auth_code を追加しない） |
+| [E] | `web/src/hooks/use-passkey-registration.ts` | chain を「begin → create → finish → invalidateQueries」に短縮（二度目 ceremony / 登録用 `/api/auth/session` を除去）。finish の error を uncertain / rejected / 非-uncertain に分類 |
+| [E] | `web/src/hooks/use-passkey-registration.test.tsx` | 二度目 ceremony 不在回帰 + uncertain 4 サブケース + 全 4xx=rejected 回帰（ファイル拡張子は `.test.tsx` / PR #229 実体に一致） |
+| [E] | `web/src/components/passkey-signup-dialog.tsx` | 完了不明状態 UI + discoverable ログイン復旧導線（段階提示） |
+| [E] | `web/src/components/passkey-signup-dialog.test.tsx` | uncertain 見出し / 段階提示 / 内部詳細非漏出の回帰 |
+| [E] | `web/src/components/login-page-recovery.test.tsx` | uncertain → discoverable ログイン成功 → 2 ペイン到達の recovery 整合 |
+| [U] | `web/src/hooks/use-passkey-authentication.ts` | discoverable ログイン復旧で **再利用**。#231 変更なし |
+| [U] | `web/src/hooks/use-passkey-authentication.test.tsx` / `use-passkey-authentication.contract.test.tsx` | PR #229 追加済み。#231 変更なし（記録） |
+| [U] | `web/src/components/login-page.tsx` / `login-page.test.tsx` / `passkey-buttons.tsx` / `passkey-buttons.test.tsx` | PR #229 追加済み。#231 変更なし |
+| [U] | `web/src/hooks/use-passkey-capability.ts` / `use-passkey-capability.test.tsx` | 同上（#231 変更なし） |
+| [U] | `web/src/lib/webauthn.ts` / `webauthn.test.ts` / `pkce.ts` / `pkce.test.ts` / `passkey-capability.ts` / `passkey-capability.test.ts` | 同上（#231 変更なし） |
 
-### Modified Files（spec 補助 / #223 spec の本体 3 文書は不変）
+### 運用 config（Requirement 6）
 
-- `docs/specs/223-feat-web-web/impl-notes.md` — **変更**（#231 delta 適用結果の追記）
-- `docs/specs/223-feat-web-web/context-map.md` — **変更**（`finish → Cookie session` へ経路更新 /
-  fail-closed 表 supersede / 完了不明状態の遷移追加）
+| 区分 | パス | #231 での扱い |
+|---|---|---|
+| [E] | `.env.sample` | `CORS_ALLOWED_ORIGIN` の fail-closed 接続（未設定 → capability 404 / Origin 検証 403）をコメントで明記。WebAuthn env ブロックは PR #229 で追加済み（記述整備のみ） |
+| [E] | `docker-compose.yml` | `api` の `CORS_ALLOWED_ORIGIN=${CORS_ALLOWED_ORIGIN:-http://localhost:3000}` を `${CORS_ALLOWED_ORIGIN:-}` へ変更（未設定 → 空 → fail-closed 到達可能に）。WebAuthn passthrough は PR #229 で追加済み |
 
-### New Files（本差分で新規追加）
+### spec 補助（#223 spec 本体 3 文書は不変 / NFR 1.1）
 
-- `internal/handler/session_cookie.go` — **新規**: canonical な `session_id` Cookie builder
-  `buildSessionCookie(name, value, domain string, secure bool, maxAge int) *http.Cookie` を定義し、
-  `auth_handler.Callback` / `native_auth_handler.Session` / `passkey_handler.RegistrationFinish` の
-  3 箇所で共有する（Cookie 属性の重複定義を排除 / Delta 4 §Cookie 属性の維持）。
-  同ファイルに `session_cookie_test.go` を近接配置し、属性が Google OAuth Callback と一致することを検証する
+| 区分 | パス | #231 での扱い |
+|---|---|---|
+| [E] | `docs/specs/223-feat-web-web/impl-notes.md` | #231 delta 適用結果を追記 |
+| [E] | `docs/specs/223-feat-web-web/context-map.md` | `finish → 3 行 tx → commit → Set-Cookie` へ経路更新 / fail-closed 表 5 列 supersede / 完了不明状態遷移追加 |
+| [U] | `docs/specs/223-feat-web-web/requirements.md` / `design.md` / `tasks.md` / `review-notes.md` | PR #229 に既存。#231 では **書き換えない**（NFR 1.1。記録） |
 
 ## Requirements Traceability
 
@@ -271,26 +274,28 @@ Google OAuth Callback と同一の生成器を再利用する（重複しない�
 |-------------|---------|-----------|
 | 1.1 | 登録 finish 後の追加 WebAuthn ceremony 禁止 | Delta 1 §Sequence / §Web Hook |
 | 1.2 | 二度目 ceremony を実装として採用しない | Delta 1 §Before → After |
-| 1.3 | 登録トランザクションに紐付いた合流経路 | Delta 1 §3 行トランザクション / §Set-Cookie |
+| 1.3 | 3 行単一 tx → commit → Set-Cookie（iOS は 2 行・Cookie なし） | Delta 1 §3 行トランザクション / §Set-Cookie / §iOS 契約維持 |
 | 1.4 | 2 ペイン UI 初期表示 | Delta 1 §Sequence（invalidateQueries → AuthGuard） |
 | 1.5 | ログイン導線への影響なし | Delta 1 §影響範囲（`use-passkey-authentication` 未変更） |
-| 2.1 | api.ts / api.test.ts を変更対象に明示 | File Structure Plan §Web 側 |
+| 2.1 | api.ts / api.test.ts を変更対象に明示 | File Structure Plan §Web |
 | 2.2 | .env.sample / docker-compose.yml を変更対象に明示 | File Structure Plan §運用 config |
 | 2.3 | needs-iteration 1 回で完結する粒度のタスク | tasks.md 全体 |
-| 2.4 | #223 / #216 spec 書換タスクを含まない | tasks.md（spec 本体編集タスク不在） |
-| 2.5 | Reviewer が変更ファイルを突合できる状態 | File Structure Plan §Modified/New Files |
+| 2.4 | #223 / #216 / #230 spec 書換タスクを含まない | File Structure Plan（[U] 記録 / 本体編集タスク不在） |
+| 2.5 | Reviewer が変更ファイルを exact-path で突合できる | File Structure Plan（[E]/[U]/[N] 区分） |
 | 3.1 | Web login session 交換 endpoint を独立列に | Delta 3 §fail-closed 表（列 B） |
 | 3.2 | Web capability probe を独立列に | Delta 3 §fail-closed 表（列 A） |
 | 3.3 | NATIVE unset + WEBAUTHN set で iOS 継続 | Delta 3 §fail-closed 表 行 2 / §iOS 契約維持 |
 | 3.4 | WEBAUTHN unset で Web 縮退 + iOS 停止 | Delta 3 §fail-closed 表 行 4 / 5 |
 | 3.5 | iOS request/response 契約破壊禁止 | Delta 1 §iOS 契約維持 / Delta 3 §登録条件不変 |
-| 4.1 | CSRF 主防御要素を要素ごと・endpoint ごとに明記 | Delta 4 §主防御要素表（登録直接 / login 交換） |
+| 3.6 | direct-registration readiness 不足時に capability 404 | Delta 3 §capability readiness / §webRegistrationReady |
+| 4.1 | CSRF 主防御要素を要素ごと・endpoint ごとに明記 | Delta 4 §主防御要素表 |
 | 4.2 | 旧誤記述の撤回と正しい前提の明記 | Delta 4 §旧記述の撤回 |
 | 4.3 | 残余リスクの列挙 | Delta 4 §残余リスク |
 | 4.4 | browser-bound state 不要の決定明記 | Delta 4 §決定記録 |
 | 4.5 | Cookie 属性の既存 Google OAuth 一致維持 | Delta 4 §Cookie 属性の維持 / New Files（共有 builder） |
 | 4.6 | 将来検討導線を残す | Delta 4 §将来検討導線 |
-| 5.1 | 第 3 の完了不明状態としてユーザーに提示 | Delta 5 §状態定義 / §Hook 判定 |
+| 4.7 | PKCE を直接登録に適用せず login 交換に限定 | Delta 1 §mode 判定（code_challenge 形式検証のみ）/ Delta 4 §主防御要素表 |
+| 5.1 | 第 3 の完了不明状態としてユーザーに提示 | Delta 5 §状態定義 / §API 層の型付き正規化 / §Hook 判定 |
 | 5.2 | discoverable ログイン確認を提示（再作成は同列不可） | Delta 5 §UI 文言と復旧導線 |
 | 5.3 | 復旧ログイン成功で 2 ペイン UI | Delta 5 §状態遷移図（成功） |
 | 5.4 | 一律失敗の後にのみ再作成導線 | Delta 5 §状態遷移図（失敗） |
@@ -298,15 +303,15 @@ Google OAuth Callback と同一の生成器を再利用する（重複しない�
 | 5.6 | 他状態と混同されない文言 | Delta 5 §既存 error kind との弁別 |
 | 6.1 | .env.sample を変更対象に明示 | Delta 6 §反映内容 / File Structure Plan |
 | 6.2 | docker-compose.yml を変更対象に明示 | Delta 6 §反映内容 / File Structure Plan |
-| 6.3 | needs-iteration 1 回で完結する config タスク | tasks.md Task 6 |
+| 6.3 | needs-iteration 1 回で完結する config タスク | tasks.md Task 7 |
 | 6.4 | 別 prerequisite PR に分離しない決定明記 | Delta 6 §決定記録 |
 | 6.5 | 既存 env 流用に留め新規 env 追加なしを担保 | Delta 6 §既存 env 流用 |
-| NFR 1.1 | #223 spec 物理ファイル不変 | Non-Goals / File Structure Plan（#223 本体編集タスク不在） |
+| NFR 1.1 | #223 spec 物理ファイル不変 | Non-Goals / File Structure Plan（[U] 記録） |
 | NFR 1.2 | 独立実装 PR を作らず PR #229 needs-iteration 1 回で反映 | Non-Goals / tasks.md 全体 |
-| NFR 1.3 | #216 契約を破壊するタスクを含まない | Delta 1 §iOS 契約維持 / File Structure Plan（#216 本体編集タスク不在） |
+| NFR 1.3 | #216 / #230 契約を破壊するタスクを含まない | Delta 1 §iOS 契約維持 / File Structure Plan（[U] 記録） |
 | NFR 2.1 | 完了不明状態・session 発行の秘密情報非漏出 | Delta 1 §NFR / Delta 5 §秘密情報の非漏出 |
 | NFR 2.2 | CSRF / fail-closed 記述に秘密値を例示しない | Delta 3 / Delta 4（例示値なし） |
-| NFR 3.1 | Google OAuth 既存挙動を破壊しない | 全 Delta（Google 経路無変更）/ File Structure Plan（auth 経路本体未変更） |
+| NFR 3.1 | Google OAuth 既存挙動を破壊しない | 全 Delta（Google 経路無変更）/ Delta 6（CORS 層既定不変） |
 | NFR 3.2 | iOS #216 request/response 契約不変 | Delta 1 §iOS 契約維持 / Delta 3 §登録条件不変 |
 
 ## Delta 1: 登録 finish の直接 Cookie session（Requirement 1）
@@ -320,34 +325,12 @@ Google OAuth Callback と同一の生成器を再利用する（重複しない�
 
 ### Before → After Sequence
 
-#### Before（PR #229 head の現行実装 = 仮案 B の系譜）
+**Before（PR #229 head の現行実装 = 仮案 B の系譜 / 除去対象）**: finish 200 の後に
+`authentication/begin → navigator.credentials.get()`（**二度目 ceremony**）`→ authentication/finish`
+`→ POST /api/auth/session {auth_code, code_verifier}`（204 + Set-Cookie）という追加 chain で session に
+合流していた。この 4 呼び出しと二度目の authorization gesture を廃止する。
 
-```mermaid
-sequenceDiagram
-    autonumber
-    participant U as User
-    participant HR as usePasskeyRegistration
-    participant NC as navigator.credentials
-    participant SVR as Feedman API
-    U->>HR: mutate({username})
-    HR->>SVR: POST /api/passkey/registration/begin {username, email:"", code_challenge}
-    SVR-->>HR: 200 {challenge_id, options}
-    HR->>NC: create({publicKey})  %% 1 回目 ceremony
-    NC-->>HR: attestation
-    HR->>SVR: POST /api/passkey/registration/finish {challenge_id, credential}
-    SVR-->>HR: 200 {user_id}
-    Note over HR,SVR: 二度目 ceremony（除去対象）
-    HR->>SVR: POST /api/passkey/authentication/begin {code_challenge}
-    SVR-->>HR: 200 {challenge_id, options}
-    HR->>NC: get({publicKey})  %% 2 回目 ceremony（Face ID/Touch ID 再発火）
-    NC-->>HR: assertion
-    HR->>SVR: POST /api/passkey/authentication/finish
-    SVR-->>HR: 200 {auth_code}
-    HR->>SVR: POST /api/auth/session {auth_code, code_verifier}
-    SVR-->>HR: 204 + Set-Cookie
-```
-
-#### After（本 Delta 1 で確定する挙動 = 決定 1.A）
+**After（本 Delta 1 で確定する挙動 = 決定 1.A）**:
 
 ```mermaid
 sequenceDiagram
@@ -357,152 +340,161 @@ sequenceDiagram
     participant NC as navigator.credentials
     participant PH as PasskeyHandler.RegistrationFinish
     participant RS as RegistrationService
-    participant DB as PostgreSQL (single tx)
+    participant DB as PostgreSQL (RegistrationTx)
     U->>HR: mutate({username})
     HR->>PH: POST /api/passkey/registration/begin {username, email:"", code_challenge}
     Note over RS: code_challenge は形式検証のみ（永続化・束縛しない）
     PH-->>HR: 200 {challenge_id, options}
-    HR->>NC: create({publicKey})  %% 唯一の生体認証プロンプト
+    HR->>NC: create({publicKey})  %% 唯一の authorization gesture
     NC-->>HR: attestation
     HR->>PH: POST /api/passkey/registration/finish {challenge_id, credential}<br/>(Origin: 許可オリジン)
     Note over PH: JSON Content-Type / exact Origin を mutation 前に検証<br/>→ Web mode 判定
     PH->>RS: FinishRegistrationNew(..., issueWebSession=true)
-    RS->>DB: BEGIN
-    RS->>DB: INSERT user
-    RS->>DB: INSERT credential
-    RS->>DB: INSERT session (generateSessionID)
-    RS->>DB: COMMIT  %% いずれか失敗で全 ROLLBACK
+    RS->>DB: BeginTx (既存 #230 txBeginner)
+    RS->>DB: CreateUserOnlyExec (user)
+    RS->>DB: CreateExec (credential)
+    RS->>DB: CreateExec (session = factory.NewSession(userID))
+    RS->>DB: Commit  %% いずれか失敗で defer Rollback（全取消）
     RS-->>PH: (user_id, *Session)
     PH-->>HR: 200 {user_id} + Set-Cookie session_id  %% commit 後のみ
     HR->>HR: invalidateQueries(["auth","me"]) → AuthGuard → 2 ペイン UI
 ```
 
-追加のブラウザ生体認証プロンプト（`navigator.credentials.get`）が消滅し、体験する ceremony は
+追加のブラウザ authorization gesture（`navigator.credentials.get`）が消滅し、体験する ceremony は
 登録時の `create` 1 回のみになる（Requirement 1.1 / 1.2）。
 
 ### Web / iOS mode 判定（`PasskeyHandler.RegistrationFinish`）
 
 handler は challenge consume / DB mutation より **前** に、`Origin` ヘッダで mode を判定する
-（推奨境界。別実装でも「JSON body 追加・exchange artifact なしで直接 session」を満たせば可）:
+（推奨境界。別実装でも「JSON body 追加・exchange artifact なしで直接 session」を満たせば可）。
+判定に使う許可 Origin は `config.WebPasskeyAllowedOrigin`（**明示設定された** exact Origin。
+未設定/空なら `""`）を注入した `h.allowedOrigin` である:
 
-| `Origin` ヘッダ | `allowedOrigin`（`CORS_ALLOWED_ORIGIN`） | 判定 | 挙動 |
+| `Origin` ヘッダ | `h.allowedOrigin`（`WebPasskeyAllowedOrigin`） | 判定 | 挙動 |
 |---|---|---|---|
-| 一致（`origin == allowedOrigin`） | 設定済 | **Web mode** | JSON Content-Type 検証 → readiness 確認 → `issueWebSession=true` |
+| 一致（`origin == allowedOrigin` かつ `allowedOrigin != ""`） | 設定済 | **Web mode** | JSON Content-Type 検証 → readiness 確認 → `issueWebSession=true` |
 | 不在（`""`） | 任意 | **native/iOS mode** | 既存挙動（session 発行なし / `issueWebSession=false`） |
-| 非空・不一致、または `allowedOrigin` 未設定 | — | **拒否** | 403 FORBIDDEN_ORIGIN（mutation・consume なし / fail-closed） |
+| 非空・不一致、または `allowedOrigin` 未設定（`""`） | — | **拒否** | 403 FORBIDDEN_ORIGIN（mutation・consume なし / fail-closed） |
 
 - Web mode の追加検証（いずれも mutation 前）:
   - **JSON Content-Type 必須**（不一致は 415 UNSUPPORTED_MEDIA_TYPE）。native/iOS mode には
     本検証を **課さない**（#216 既存クライアント互換 / NFR 3.2）
-  - **readiness**（`PasskeyHandler.webRegistrationReady()` = `allowedOrigin != "" && Cookie 設定済み &&
-    RegistrationService.WebSessionReady()`）が false なら fail-closed（500 相当、mutation なし）。
-    通常 wiring では `WEBAUTHN_*` 設定時に session 発行依存が常時配線されるため、実質は
-    `allowedOrigin` 設定有無が支配的
+  - **readiness**（`PasskeyHandler.webRegistrationReady()`。定義は Delta 3）が false なら
+    fail-closed（500 相当、mutation なし）。通常 wiring では `WEBAUTHN_*` 設定時に session 発行依存が
+    常時配線されるため、実質は `WebPasskeyAllowedOrigin` の明示設定有無が支配的
 - iOS はネイティブ HTTP クライアントで `Origin` を送らないため native mode に落ち、session / Cookie を
   作らず `{user_id}` のみを返す（#216 と差分等価 / NFR 3.2）
 
 ### Server 側の実装差分
 
-#### `internal/passkey/registration_service.go`（Modified）
+#### 共有 session factory（`internal/auth/session_factory.go` / New / Blocker #2 対応）
+
+login session 発行（`Service.createSession` / `SessionExchangeService`）と registration direct session が
+**同一の session 構築ロジック**（ID 生成 + 単一 `now` + `CreatedAt=now` + `ExpiresAt=now+TTL`）を
+共有するための最小 factory を新設する。RegistrationService には具体型ではなく最小 interface を
+注入する（interface segregation / テスト可能性）:
 
 ```go
-// 追加/拡張する最小 IF（interface segregation / CLAUDE.md §5）
-type SessionWriter interface {
-    CreateExec(ctx context.Context, q repository.DBTX, s *model.Session) error
-}
-// UserWriter に追加: CreateUserOnlyExec(ctx, q repository.DBTX, u *model.User) error
-// PasskeyCredentialWriter に追加: CreateExec(ctx, q repository.DBTX, c *model.PasskeyCredential) error
-type txRunner interface {
-    WithinTx(ctx context.Context, fn func(q repository.DBTX) error) error
+// internal/auth/session_factory.go（New）
+// SessionFactory は model.Session を ID + 単一 now + CreatedAt + ExpiresAt で一貫生成する。
+// generateSessionID（internal/auth/service.go）と now / TTL を集約し、複製を排除する。
+type SessionFactory struct {
+    ttl time.Duration
+    now func() time.Time // テスト差し替え可（既定 time.Now）
 }
 
-// 構造体に追加（auth_code 関連は追加しない）
-type RegistrationService struct {
-    // ... 既存 adapter / challenges / users / credentials / now ...
-    sessions     SessionWriter
-    tx           txRunner
-    newSessionID func() (string, error) // = auth.GenerateSessionID（SessionExchangeService と共有）
-    sessionTTL   time.Duration          // = time.Duration(cfg.SessionMaxAge) * time.Second
+func NewSessionFactory(ttl time.Duration) *SessionFactory { /* now=time.Now 既定 */ }
+
+// NewSession は 1 度の now を用いて ID / CreatedAt / ExpiresAt を整合させた Session を返す。
+// ID 生成失敗（rand.Read 失敗）はそのまま error として返す（部分構築しない）。
+func (f *SessionFactory) NewSession(userID string) (*model.Session, error) {
+    id, err := NewSessionID() // = service.go の generateSessionID を export した薄い wrapper
+    if err != nil { return nil, err }
+    now := f.now()
+    return &model.Session{ID: id, UserID: userID, CreatedAt: now, ExpiresAt: now.Add(f.ttl)}, nil
 }
+
+// RegistrationService が受ける最小 IF（interface segregation）
+type SessionFactoryFunc interface {
+    NewSession(userID string) (*model.Session, error)
+}
+```
+
+- `SessionExchangeService` は現在の inline 構築（`generateSessionID` + `now` + `CreatedAt` + `ExpiresAt`）を
+  `SessionFactory.NewSession` 呼び出しに差し替える（外部契約・挙動は不変 / 差分等価）
+- `Service.createSession`（Google OAuth login）も同 factory 採用が望ましいが、最小差分として
+  少なくとも `SessionExchangeService` と registration direct session の 2 経路で factory を共有する
+  （review Blocker #2 の要求「at least existing SessionExchangeService and registration direct session」）
+- `generateSessionID` は **`internal/auth/service.go`** に定義されている（旧 File Plan の
+  「`session_exchange.go` から export」は誤り）。export helper `NewSessionID` を同ファイルに追加する
+
+#### `internal/passkey/registration_service.go`（Modified / #230 tx を拡張）
+
+```go
+// 追加する最小 IF（interface segregation / CLAUDE.md §5）。
+// user/credential の Exec 変種と RegistrationTxBeginner は #230 既存のため再宣言しない。
+type SessionWriter interface {
+    CreateExec(ctx context.Context, q repository.DBTX, s *model.Session) error // #231 新規（session repo）
+}
+
+// 構造体に追加（auth_code 関連依存は追加しない）:
+//   sessions       SessionWriter          // session 行 INSERT（tx 変種）
+//   sessionFactory auth.SessionFactoryFunc // ID + now + CreatedAt + ExpiresAt を一貫生成（共有）
+// 既存 txBeginner RegistrationTxBeginner（#230）はそのまま使用する。
 
 // WebSessionReady は Web mode の直接 session 発行が配線済みかを返す（defense-in-depth）。
 func (s *RegistrationService) WebSessionReady() bool {
-    return s.sessions != nil && s.tx != nil && s.newSessionID != nil
+    return s.sessions != nil && s.sessionFactory != nil && s.txBeginner != nil
 }
 
-// FinishRegistrationNew: 単一 tx で user → credential →（Web mode のみ）session を作成。
-//   - 既存 challenge consume / adapter.FinishRegistration（attestation 検証）は変更しない
-//   - user UNIQUE 衝突 → ErrRegistrationFailed / credential 重複 → ErrRegistrationFailed（既存正規化を維持）
-//   - session ID 生成失敗・session INSERT 失敗も含め、いずれかの失敗で全 ROLLBACK（3 行 atomic）
-//   - iOS（issueWebSession=false）は user + credential のみ作成し、webSession=nil を返す
+// FinishRegistrationNew: #230 の既存 BeginTx → defer Rollback → Commit を維持し、
+// credential CreateExec の後・Commit の前に session INSERT を 1 つ追加する（Web mode のみ）。
 func (s *RegistrationService) FinishRegistrationNew(
     ctx context.Context, challengeID string, requestBody []byte, issueWebSession bool,
 ) (userID string, webSession *model.Session, err error) {
-    // ... consume challenge / rebuild WebAuthnUser / adapter.FinishRegistration（既存どおり）...
-    newUser := &model.User{ ID: pendingUserID, Email: "", Username: normalized, UsernameNormalized: normalized }
-    cred := &model.PasskeyCredential{ /* parsed から既存どおり */ }
+    // ... challenge consume / adapter.FinishRegistration（#230 と同一。変更しない）...
+    tx, err := s.txBeginner.BeginTx(ctx)                       // #230 既存
+    if err != nil { return "", nil, fmt.Errorf("...: %w", err) }
+    committed := false
+    defer func() { if !committed { _ = tx.Rollback() } }()      // #230 既存の defer rollback
 
-    txErr := s.tx.WithinTx(ctx, func(q repository.DBTX) error {
-        if e := s.users.CreateUserOnlyExec(ctx, q, newUser); e != nil {
-            if errors.Is(e, repository.ErrUsernameTaken) { return ErrRegistrationFailed }
-            return fmt.Errorf("failed to create user: %w", e)
+    if err := s.users.CreateUserOnlyExec(ctx, tx.Querier(), newUser); err != nil { /* #230 既存の正規化 */ }
+    if err := s.credentials.CreateExec(ctx, tx.Querier(), cred); err != nil { /* #230 既存の正規化 */ }
+
+    if issueWebSession {                                        // ← #231 で追加する唯一の tx 内ステップ
+        sess, e := s.sessionFactory.NewSession(newUser.ID)     // ID + CreatedAt + ExpiresAt を factory で
+        if e != nil { return "", nil, fmt.Errorf("failed to build session: %w", e) }
+        if e := s.sessions.CreateExec(ctx, tx.Querier(), sess); e != nil {
+            return "", nil, fmt.Errorf("failed to create session: %w", e)
         }
-        if e := s.credentials.CreateExec(ctx, q, cred); e != nil {
-            if errors.Is(e, repository.ErrCredentialAlreadyRegistered) { return ErrRegistrationFailed }
-            return fmt.Errorf("failed to save passkey credential: %w", e)
-        }
-        if issueWebSession {
-            sid, e := s.newSessionID()
-            if e != nil { return fmt.Errorf("failed to generate session id: %w", e) }
-            webSession = &model.Session{ ID: sid, UserID: newUser.ID, ExpiresAt: s.now().Add(s.sessionTTL) }
-            if e := s.sessions.CreateExec(ctx, q, webSession); e != nil {
-                return fmt.Errorf("failed to create session: %w", e)
-            }
-        }
-        return nil
-    })
-    if txErr != nil {
-        webSession = nil // 部分状態を返さない（全 ROLLBACK 済み）
-        if errors.Is(txErr, ErrRegistrationFailed) { return "", nil, ErrRegistrationFailed }
-        return "", nil, txErr
+        webSession = sess
     }
+    if err := tx.Commit(); err != nil {                        // #230 既存
+        return "", nil, fmt.Errorf("...: %w", err)
+    }
+    committed = true
     return newUser.ID, webSession, nil
 }
 ```
 
-- Preconditions: `sessions` / `tx` / `newSessionID` は passkey handler 生成時（`WEBAUTHN_*` 設定時）に
-  非 nil で注入されている
+- Preconditions: `sessions` / `sessionFactory` は passkey handler 生成時（`WEBAUTHN_*` 設定時）に
+  非 nil で注入されている。`txBeginner` は #230 が既に注入している
 - Postconditions:
-  - 成功（Web mode）: user / credential / session の **3 行が同一 tx で永続化**される
+  - 成功（Web mode）: user / credential / session の **3 行が同一 tx で永続化**され、`webSession` は
+    factory が生成した ID / `CreatedAt=now` / `ExpiresAt=now+TTL` を持つ
   - 成功（iOS mode）: user / credential の 2 行のみ永続化（session なし / `{user_id}` 応答）
-  - 失敗: 部分保存は残さない（tx の atomic rollback。#216 の「非 tx で部分保存し得る」旧挙動を改善）
+  - 失敗: 部分保存は残さない（既存 defer Rollback により session INSERT 失敗 / commit 失敗でも
+    user / credential 行が残らない。3 行 atomic）
 - Invariants: `auth_code` 平文 / session ID 生値をログ・エラー・レスポンスに残さない（NFR 2.1。
   session ID は Set-Cookie でのみクライアントへ渡し、ログには出さない）
 
 #### `internal/handler/passkey_handler.go`（Modified）
 
-```go
-// RegistrationFinish（イメージ）:
-//   origin := r.Header.Get("Origin")
-//   webMode := false
-//   switch {
-//   case origin == "":
-//       // native/iOS: 既存挙動（JSON Content-Type 追加検証なし）
-//   case h.allowedOrigin != "" && origin == h.allowedOrigin:
-//       if !hasJSONContentType(r) { 415; return }          // mutation 前
-//       if !h.webRegistrationReady() { 500; return }        // fail-closed / mutation 前
-//       webMode = true
-//   default:
-//       middleware.WriteErrorResponse(w, 403, forbiddenOriginError()); return  // mutation 前
-//   }
-//   // decode {challenge_id, credential}（既存）
-//   userID, sess, err := h.regService.FinishRegistrationNew(ctx, req.ChallengeID, req.Credential, webMode)
-//   // 既存 error mapping（ErrRegistrationFailed → 400 REGISTRATION_FAILED / infra → 500）
-//   if sess != nil {
-//       http.SetCookie(w, buildSessionCookie(sessionCookieName, sess.ID, h.cookieDomain, h.cookieSecure, h.cookieMaxAge))
-//   }
-//   respond 200 {user_id: userID}   // JSON は Web / iOS とも不変
-```
+`RegistrationFinish` は上表の mode 判定（Origin と `h.allowedOrigin` で Web/iOS/拒否を分岐。Web mode は
+mutation 前に JSON Content-Type 検証 + `webRegistrationReady()` fail-closed）を行い、既存の
+`{challenge_id, credential}` decode → `FinishRegistrationNew(ctx, challengeID, credential, webMode)` を呼ぶ。
+既存 error mapping（`ErrRegistrationFailed` → 400 / infra → 500）を維持し、`webSession != nil` のとき
+`buildSessionCookie(...)` で `Set-Cookie` を付け、レスポンスは Web / iOS とも 200 `{user_id}`（不変）とする。
 
 #### iOS #216 契約が破壊されない論証（NFR 3.2 / Req 3.5）
 
@@ -510,7 +502,7 @@ func (s *RegistrationService) FinishRegistrationNew(
   ままで、差分は HTTP **ヘッダ** の `Set-Cookie` のみ（iOS は Origin を送らず native mode に落ちるため
   Cookie を受け取らない）
 - request JSON（`{challenge_id, credential}`）・`registration/begin` の JSON も不変。登録 begin の
-  `code_challenge` はフィールドを維持（形式検証のみ）
+  `code_challenge` はフィールドを維持（形式検証のみ / Req 4.7）
 - JSON Content-Type / Origin の追加検証は **Web mode のみ** に課すため、iOS の既存リクエスト経路は不変
 
 ### Web 側の実装差分（`use-passkey-registration.ts`）
@@ -533,17 +525,20 @@ async function mutationFn({ username }: { username: string }) {
 - `authentication/begin` / `navigator.credentials.get` / `authentication/finish` / 登録用
   `POST /api/auth/session` の 4 呼び出しを **完全削除**（Req 1.1 / 1.2）
 - `apiClient` は `credentials: "include"` で Cookie を受理・送出する（既存 PR #229 の api.ts 経路）
-- error 分類は §Delta 5 で `registration_uncertain` を追加
+- error 分類は §Delta 5 で `registration_uncertain` を追加（`api.ts` の型付き正規化に依拠）
 
 ### 影響範囲
 
-- 変更: `RegistrationService` / `PasskeyHandler.RegistrationFinish` / repo Exec 変種 / tx helper /
-  共有 Cookie builder / `use-passkey-registration.ts` / `passkey-signup-dialog.tsx` / `app.go`
+- 変更: `RegistrationService.FinishRegistrationNew` / `PasskeyHandler.RegistrationFinish` /
+  session repo `CreateExec` / 共有 session factory / 共有 Cookie builder /
+  `use-passkey-registration.ts` / `api.ts` / `passkey-signup-dialog.tsx` / `config.go` / `app.go`
 - **無変更で維持**:
+  - #230 の `RegistrationTx` / `RegistrationTxBeginner` / `txBeginner` / user・credential Exec 変種 /
+    `internal/repository/tx.go`（session ステップの追加以外は既存フローそのまま）
   - `AuthenticationService` / `use-passkey-authentication.ts` / `PasskeyButtons`
     （ログイン導線は影響を受けない。discoverable ログイン復旧で再利用のみ / Req 1.5）
-  - `SessionExchangeService` / `NativeAuthHandler.Session`（login の auth_code 交換として不変。
-    Delta 4 で Origin 検証の fail-closed 補正のみ）
+  - `SessionExchangeService` の外部契約（login の auth_code 交換として不変。session 構築のみ factory 化 /
+    Delta 4 で Origin 検証の fail-closed 補正）
   - iOS 用 `registration/*` / `authentication/*`（#216 契約不変 / NFR 3.2）
   - Google OAuth 経路一式（NFR 3.1）
 
@@ -557,15 +552,17 @@ async function mutationFn({ username }: { username: string }) {
 
 ### canonical 定義
 
-本 spec §File Structure Plan（Modified/New Files）が canonical。Reviewer は同節と PR #229 の
-`git diff --name-only` を突き合わせ、以下を確認できる（Requirement 2.5）:
+本 spec §File Structure Plan（[E]/[U]/[N] 区分表）が canonical。Reviewer は同節と PR #229 の
+`git diff --name-only develop..<head>` を突き合わせ、以下を確認できる（Requirement 2.5）:
 
-1. PR #229 の全変更ファイルが Modified/New Files に列挙されている
-2. Modified/New Files に列挙されているが PR #229 に含まれないファイルがない（過剰な予告なし）
-3. `web/src/lib/api.ts` / `api.test.ts` / `.env.sample` / `docker-compose.yml` が列挙されている
-   （旧 #223 design の見落としを訂正済み）
-4. 本差分で追加する session tx 対応（`tx.go` の `WithinTx` / 各 repo の `CreateExec` /
-   `session_cookie.go` / `passkey_e2e_db_test.go` の 3 行原子性テスト）が列挙されている
+1. PR #229 の全変更ファイルが [E] または [U] に exact-path で列挙されている（漏れなし）
+2. [E]/[N] に列挙されているが PR #229 に含まれないファイルがない（過剰な予告なし。[N] は本差分で新規追加）
+3. `web/src/lib/api.ts` / `api.test.ts` / `.env.sample` / `docker-compose.yml` /
+   `docs/specs/223-feat-web-web/review-notes.md` / `internal/handler/router_unauth_ratelimit_test.go` /
+   `internal/auth/session_exchange_test.go` / `web/src/hooks/use-passkey-authentication.contract.test.tsx` が
+   いずれかの区分に現れる（旧 #223 design の見落としを訂正済み）
+4. 本差分で追加する [N]（session repo `CreateExec` / session factory / `session_cookie.go` /
+   config `WebPasskeyAllowedOrigin`）が列挙されている
 
 ## Delta 3: fail-closed 表の 5 列補正と gate 維持（Requirement 3）
 
@@ -579,19 +576,25 @@ async function mutationFn({ username }: { username: string }) {
 ### 補正後の fail-closed 表（5 列独立）
 
 env 3 軸 — **W**=`WEBAUTHN_RP_ID`+`WEBAUTHN_ORIGINS`、**N**=`NATIVE_AUTH_JWT_SECRET`、
-**C**=`CORS_ALLOWED_ORIGIN`（exact Origin） — の代表組合せごとに、各 endpoint を独立列で示す。
+**C**=`CORS_ALLOWED_ORIGIN`（明示設定 = `WebPasskeyAllowedOrigin != ""`） — の代表組合せごとに、
+各 endpoint を独立列で示す。列 C は **endpoint の実挙動**を示し、公式 UI からの到達可否は注記で分離する。
 
 | # | W | N | C | A. capability (Web probe) | B. login exchange `/api/auth/session` | C. reg. direct session (finish Web mode) | D. iOS `registration/*` | E. iOS `authentication/*` |
 |---|---|---|---|---|---|---|---|---|
-| 1 | ✓ | ✓ | ✓ | 登録 (200) | 登録 (204) | 発行（Origin 一致で 200 + Set-Cookie） | 登録 (200) | 登録 (200) |
-| 2 | ✓ | ✗ | ✓ | **未登録 (404)** | 未登録 (404) | (capability 404 で Web UI 非表示のため未到達) | **登録 (200)** | **登録 (200)** |
+| 1 | ✓ | ✓ | ✓ | 登録 (200) | 登録 (204) | **200 + Set-Cookie**（Origin 一致） | 登録 (200) | 登録 (200) |
+| 2 | ✓ | ✗ | ✓ | **未登録 (404)** | 未登録 (404) | **200 + Set-Cookie**（endpoint 実挙動。※capability 404 で公式 UI からは未到達） | **登録 (200)** | **登録 (200)** |
 | 3 | ✓ | ✓ | ✗ | **未登録 (404)** | 全リクエスト拒否 (403 / Delta 4 補正) | Origin 検証不能 → **fail-closed (403)** | 登録 (200) | 登録 (200) |
 | 4 | ✗ | ✓ | ✓ | 未登録 (404) | 登録 (204) | (finish route 自体が未登録 404) | **未登録 (404)** | **未登録 (404)** |
 | 5 | ✗ | ✗ | * | 未登録 (404) | 未登録 (404) | 未登録 (404) | 未登録 (404) | 未登録 (404) |
 
 - **行 2（W✓ N✗ C✓）が最重要回帰**: `NATIVE_AUTH_JWT_SECRET` 未設定でも iOS 用
-  `registration/*` / `authentication/*` は **200 を維持**（列 D/E）。Web は capability=404 で
-  パスキー UI を非表示にし Google 単体へ縮退する（列 A）。iOS を「停止」と誤読させない
+  `registration/*` / `authentication/*` は **200 を維持**（列 D/E）。列 C の registration Web mode は
+  N に依存しないため endpoint としては **200 + Set-Cookie を返す**（直接 POST 時）。ただし capability=404
+  （SessionReady() が N を要求）で **公式 UI にはパスキー導線が出ない**ため、正規ユーザーはこの
+  endpoint に到達しない。「endpoint の実挙動」と「UI 到達可否」を分けて誤読を防ぐ（review Blocker #3）
+- **行 3（W✓ N✓ C✗）**: `WebPasskeyAllowedOrigin == ""` のため capability=404、`/api/auth/session` と
+  registration Web mode は Origin 検証不能で fail-closed（403）。C=✗ は config 補正（Delta 6）により
+  **実 wiring で到達可能**になった（旧 design では localhost:3000 default で到達不能だった）
 - **行 4（W✗）**: iOS 用 endpoint は `PasskeyHandler` に紐付くため、`WEBAUTHN_*` 未設定なら 404
   （#216 で確定済みの挙動）。Web も縮退
 - **列 B と 列 C の独立性**: login exchange（列 B）は N に依存、registration direct session（列 C）は
@@ -601,27 +604,47 @@ env 3 軸 — **W**=`WEBAUTHN_RP_ID`+`WEBAUTHN_ORIGINS`、**N**=`NATIVE_AUTH_JWT
 
 | 列 | 条件 | 依拠 env |
 |---|---|---|
-| A. `GET /api/passkey/capability` | `PasskeyHandler != nil && NativeAuthHandler != nil && NativeAuthHandler.SessionReady() && deps.CORSAllowedOrigin != ""` | W + N + C |
-| B. `POST /api/auth/session` | `NativeAuthHandler != nil && NativeAuthHandler.SessionReady()` **（`SessionReady()` 維持）** + handler 内 Origin fail-closed（Delta 4） | N（+ C で成立） |
-| C. `registration/finish` Web mode 発行 | route は `PasskeyHandler != nil`（iOS と共有）。Web mode 成立は `webRegistrationReady()`（session repo / Cookie / exact Origin） | W + C |
+| A. `GET /api/passkey/capability` | `PasskeyHandler != nil && NativeAuthHandler != nil && NativeAuthHandler.SessionReady() && deps.WebPasskeyAllowedOrigin != "" && deps.PasskeyHandler.webRegistrationReady()` | W + N + C |
+| B. `POST /api/auth/session` | `NativeAuthHandler != nil && NativeAuthHandler.SessionReady()` **（`SessionReady()` 維持）** + handler 内 Origin fail-closed（Delta 4） | N（+ C で実行成立） |
+| C. `registration/finish` Web mode 発行 | route は `PasskeyHandler != nil`（iOS と共有）。Web mode 成立は `webRegistrationReady()` + exact Origin 一致 | W + C |
 | D. `POST /api/passkey/registration/*` | `PasskeyHandler != nil` **（変更なし）** | W |
 | E. `POST /api/passkey/authentication/*` | `PasskeyHandler != nil` **（変更なし）** | W |
 
-### gate を弱めない（Req 3.1 / 3.2 / review #3・#5 との整合）
+### capability の readiness 強化（Req 3.6 / Blocker #3）
 
-- capability（列 A）と `/api/auth/session`（列 B）の gate は PR #229 の
-  `NativeAuthHandler.SessionReady()` を **維持**する（`NativeAuthHandler != nil` に弱めない）。
-  本差分は capability に `deps.CORSAllowedOrigin != ""` を **追加** するのみ（Origin 検証不能な
-  構成で Web パスキー UI を出さないための fail-closed 強化。行 3 参照）
-- 直接登録 session（列 C）は独自の readiness（session repo / Cookie 設定 / exact Origin）を持ち、
+`GET /api/passkey/capability` は「サーバがパスキー Web フロー全体を提供している」判定に使うため、
+**session 合流（login exchange）だけでなく direct-registration の発行 readiness も揃っている**ことを
+登録条件に加える。これにより「capability だけ 200 で signup が 500 になる部分配線」を排除する:
+
+```go
+// PasskeyHandler.webRegistrationReady（イメージ）:
+//   allowedOrigin != ""             // 明示された exact Origin（WebPasskeyAllowedOrigin）
+//   && cookieMaxAge > 0             // 正の Cookie MaxAge（= SessionMaxAge）
+//   && regService.WebSessionReady() // session writer / session factory / txBeginner がすべて非 nil
+// 注: cookieDomain 空・cookieSecure=false は有効な構成（本番は https で Secure=true、
+//     単一ドメインなら Domain 空が正）。したがって Domain / Secure は readiness 条件に含めない。
+//     session factory は正の TTL を内包する（= SessionMaxAge 由来）。
+```
+
+- capability route 条件（列 A）= `SessionReady()`（既存維持）**AND** `WebPasskeyAllowedOrigin != ""`
+  **AND** `PasskeyHandler.webRegistrationReady()`。3 者いずれか欠落で 404（Req 3.6）
+- readiness を曖昧な「Cookie 設定済み」ではなく、**exact Origin / 正の TTL・MaxAge / session writer /
+  session factory / #230 の txBeginner** の有効条件として定義する（Domain 空・Secure=false は有効）
+
+### gate を弱めない（Req 3.1 / 3.2 / review #2・#3 との整合）
+
+- `/api/auth/session`（列 B）の gate は PR #229 の `NativeAuthHandler.SessionReady()` を **維持**する
+  （`NativeAuthHandler != nil` に弱めない）。本差分は capability（列 A）に `WebPasskeyAllowedOrigin != ""` と
+  `webRegistrationReady()` を **追加**するのみ
+- 直接登録 session（列 C）は独自の readiness（webRegistrationReady + exact Origin）を持ち、
   未充足なら mutation 前に fail-closed する（§Delta 1 §mode 判定）
 
 ### iOS #216 契約が破壊されない論証（Req 3.5）
 
 - iOS が依存する `registration/*` / `authentication/*` はすべて `PasskeyHandler` に紐付き、
   router 登録条件は `PasskeyHandler != nil` のみで **変更しない**
-- 本差分で登録条件を強化するのは Web 用 capability（列 A への `C != ""` 追加）のみ。iOS は
-  capability を使用しない（#216 spec に依存記述なし）
+- 本差分で登録条件を強化するのは Web 用 capability（列 A）のみ。iOS は capability を使用しない
+  （#216 spec に依存記述なし）
 - したがって iOS 用 endpoint の稼働条件は #216 と完全同一（NFR 3.2 / Req 3.5）
 
 ## Delta 4: CSRF / PKCE 説明の正確化と残余リスクの明示（Requirement 4）
@@ -630,6 +653,8 @@ env 3 軸 — **W**=`WEBAUTHN_RP_ID`+`WEBAUTHN_ORIGINS`、**N**=`NATIVE_AUTH_JWT
 
 - `#223 design.md` §Security Considerations §CSRF の「攻撃者が事前に (auth_code, code_verifier) ペアを
   入手する経路が存在しない」記述、および `NativeAuthHandler.Session` §CSRF 対策の同旨の判断根拠
+- 初版 #231 design の「必須ユーザー生体ジェスチャ / 生体承認」を主防御とした記述
+  （WebAuthn の authorization gesture は user presence の場合もあり biometric を保証しない）
 
 ### 旧記述の撤回（Req 4.2）
 
@@ -644,22 +669,32 @@ authorization_code の中間者盗用を防ぐ」プロパティであり、攻�
 ペア** を防ぐものではない。したがって PKCE 単独では「攻撃者アカウントへのログイン誘引（login CSRF）」を
 阻止できない。
 
-### 主防御要素表（endpoint / 経路ごとに分離 / Req 4.1）
+### WebAuthn の防御性質の正確化（Req 4.1 / Blocker #6）
+
+- 登録 `navigator.credentials.create()` は **authenticator の authorization gesture**（user presence、
+  authenticator の構成次第で user verification = PIN / 生体）を要求する。現 adapter は
+  `userVerification=required` を **指定していない**（`ResidentKeyRequirementRequired` のみ指定）ため、
+  gesture は必ずしも生体認証ではない。したがって主防御を「必須生体認証」と記述せず、
+  **「ユーザー在席を要する authorization gesture（被害者の明示操作なしに cross-site から silently に
+  発火できない）」** と記述する（参考: <https://www.w3.org/TR/webauthn-3/#sctn-terminology>）
+
+### 主防御要素表（endpoint / 経路ごとに分離 / Req 4.1 / 4.7）
 
 セッションを発行する 2 経路を分けて防御要素を明記する（**PKCE の役割はログイン交換にのみ限定**）:
 
 | 経路 | 主防御要素 | 各要素の役割 |
 |---|---|---|
-| **登録 直接 session**（`registration/finish` Web mode） | 必須ユーザー生体ジェスチャ + exact Origin + JSON Content-Type + CORS preflight + SameSite=Lax | 登録は `navigator.credentials.create()` の生体承認（user gesture）を **必須**とするため、被害者の明示操作なしに cross-site から silently 発火できない。加えて exact Origin / JSON Content-Type / CORS preflight が cross-origin 発火を封じ、SameSite=Lax が Cookie 送信を制限。**PKCE は本経路の防御に用いない**（code_challenge は #216 契約維持のため形式検証のみ） |
+| **登録 直接 session**（`registration/finish` Web mode） | authenticator authorization gesture（user presence / 場合により UV）+ exact Origin + JSON Content-Type + CORS preflight + SameSite=Lax | 登録は `create()` の authorization gesture（ユーザー在席の明示操作）を要するため、被害者の操作なしに cross-site から silently 発火できない。加えて exact Origin / JSON Content-Type / CORS preflight が cross-origin 発火を封じ、SameSite=Lax が Cookie 送信を制限。**PKCE は本経路の防御に用いない**（code_challenge は #216 契約維持のため形式検証のみ / Req 4.7） |
 | **ログイン auth_code 交換**（`POST /api/auth/session`） | exact Origin + JSON Content-Type + CORS preflight + SameSite=Lax + PKCE 束縛（auth_code 単回 60s TTL） | exact Origin / JSON Content-Type / CORS preflight / SameSite が cross-origin 発火を封じる主防御。PKCE + 単回 60s TTL は「同一クライアント外」による盗聴 auth_code の交換を防ぐ（RFC 7636 の本来目的。login CSRF そのものの防御ではない） |
 | **共通** | HttpOnly Cookie | 発行後の `session_id` を JavaScript から不可視化し、XSS 時の生値読出しを阻止 |
 
 ### login `/api/auth/session` の Origin 検証を fail-closed へ補正（Req 4.1 / review #2）
 
 PR #229 head の `NativeAuthHandler.Session` は「Origin 不在 or allowedOrigin 未設定なら検証を
-スキップ」する（false-reject 回避のため存在時のみ厳格化）。本差分ではこれを **fail-closed** に補正する:
+スキップ」する（`origin != "" && h.allowedOrigin != "" && origin != h.allowedOrigin` のときのみ 403）。
+本差分ではこれを **fail-closed** に補正し、注入する許可 Origin は `WebPasskeyAllowedOrigin` とする:
 
-- `allowedOrigin == ""`（`CORS_ALLOWED_ORIGIN` 未設定）→ 全リクエスト 403（検証不能なら発行しない）
+- `allowedOrigin == ""`（`WebPasskeyAllowedOrigin` 未設定）→ 全リクエスト 403（検証不能なら発行しない）
 - `Origin` 不在 → 403（browser fetch は cross-origin で Origin を必ず送る前提。fail-closed）
 - `Origin != allowedOrigin` → 403（既存）
 - `Origin == allowedOrigin` のみ通過
@@ -677,8 +712,9 @@ PR #229 head の `NativeAuthHandler.Session` は「Origin 不在 or allowedOrigi
    取得し、被害者ブラウザで `POST /api/auth/session` を実行させ攻撃者アカウントとしてログインさせる。
    `/api/auth/session` は同一オリジン fetch のみ（exact Origin + JSON Content-Type + CORS）で、
    純粋な cross-site 経路では成立せず、同一オリジン XSS 経路に収束する
-- **登録直接 session（列 C）の login CSRF 非該当**: 登録は被害者の authenticator による生体承認
-  （user gesture）を必須とするため、cross-site から silently に「被害者を新規登録させる」ことはできない
+- **登録直接 session（列 C）の login CSRF 非該当**: 登録は被害者の authenticator による authorization
+  gesture（ユーザー在席の明示操作）を必須とするため、cross-site から silently に「被害者を新規登録
+  させる」ことはできない
 
 ### 決定記録: 追加の browser-bound state を導入しない（Req 4.4）
 
@@ -704,6 +740,28 @@ fetch ベースの Web app では十分。残余リスクは同一オリジン X
 
 ## Delta 5: 登録完了不明状態と復旧導線（Requirement 5）
 
+### API 層の型付き正規化（`api.ts` / Blocker #4）
+
+現行 `api.ts` の `request<T>` は 2xx（204/205 以外）で末尾 `return response.json();` を呼び、body が
+欠損・途中切断・parse 不能だと **plain `SyntaxError`** を投げる。この plain error は呼出側から
+「fetch 成功後の 2xx body parse 失敗」か「dispatch 前の JSON serialize 失敗」かを区別できない。
+そこで `api.ts` に status 付きの専用型を導入し、**fetch 成功後の 2xx parse 失敗のみ**を分離する:
+
+```typescript
+// web/src/lib/api.ts（Modified）
+export class ResponseParseError extends Error {
+  status: number;         // fetch 成功時の response.status（2xx）
+  constructor(status: number) { super(`Response parse failed: ${status}`); this.name = "ResponseParseError"; this.status = status; }
+}
+// request<T> 末尾:
+//   try { return await response.json(); }
+//   catch { throw new ResponseParseError(response.status); }  // 2xx だが body 不能
+```
+
+- これにより呼出側は「`ResponseParseError`（status 2xx）」= post-dispatch の commit 済み示唆 2xx parse 失敗 と、
+  dispatch 前の `TypeError`（serialize / URL 構築失敗）を **確実に区別**できる
+- `credentials: "include"` / 204/205 分岐など既存挙動は不変（末尾 json parse のみ try/catch で包む差分等価）
+
 ### 状態定義（Req 5.1）
 
 `PasskeyRegistrationErrorKind` に **新規 kind** `registration_uncertain` を追加する。本 kind は
@@ -713,14 +771,14 @@ fetch ベースの Web app では十分。残余リスクは同一オリジン X
 - fetch reject（`TypeError` = ネットワーク断 / 接続断 / DNS 失敗）
 - 送出後の Abort（`DOMException.name === "AbortError"`）/ timeout
 - 5xx 応答（サーバが受理・commit した可能性があるが応答段で失敗）
-- **commit 済みを示唆する 2xx だが応答 body が欠損 / 途中切断 / parse 不能**（Set-Cookie は付いた
-  可能性があり、成否をクライアント側で確定できない）
+- **commit 済みを示唆する 2xx だが body 不能**（`ResponseParseError`。Set-Cookie は付いた可能性があり、
+  成否をクライアント側で確定できない）
 
 以下は **uncertain にしない**:
 
-- **dispatch 前のローカル失敗**（request 構築 / JSON serialize 等）→ `server_error` 等（commit していないことが確定）
-- **確定的な 4xx**（finish の 400 REGISTRATION_FAILED / begin の 400/409 等）→ `server_rejected` /
-  `invalid_username` / `username_taken`（拒否が確定）
+- **dispatch 前のローカル失敗**（request 構築 / JSON serialize 等の `TypeError`）→ `server_error`（commit 不成立が確定）
+- **確定的な 4xx（すべての 4xx）**（finish の 400 REGISTRATION_FAILED / begin の 400/409 / その他 401/403/404/409/422 等）
+  → `server_rejected` / `invalid_username` / `username_taken`（拒否が確定。400 だけに限定しない / Blocker #4）
 - begin / create 段の失敗（`cancelled` / `network_error` 等、finish 送出前）
 
 > 直接 session 化により、registration 経路の `session_exchange_failed`（旧 auth_code→session 段の失敗）は
@@ -736,8 +794,8 @@ stateDiagram-v2
     Pending --> InvalidUsername: begin 400 INVALID_USERNAME
     Pending --> UsernameTaken: begin 409 USERNAME_TAKEN
     Pending --> Cancelled: create DOMException (NotAllowed/Abort)
-    Pending --> ServerRejected: finish 4xx REGISTRATION_FAILED
-    Pending --> Uncertain: finish reject / timeout / AbortError / 5xx / 2xx(body 不能)
+    Pending --> ServerRejected: finish 任意の 4xx（REGISTRATION_FAILED 等）
+    Pending --> Uncertain: finish reject / timeout / AbortError / 5xx / ResponseParseError(2xx)
     Pending --> Success: finish 2xx (Set-Cookie 受理)
     Uncertain --> ConfirmLogin: user が「ログインで確認する」を選ぶ
     ConfirmLogin --> [*]: discoverable ログイン成功 → 2 ペイン UI
@@ -752,24 +810,28 @@ stateDiagram-v2
 // finish request 段の catch（イメージ）:
 try {
   await apiClient.post("/api/passkey/registration/finish", {...});
-  // 2xx だが body parse に失敗した場合も uncertain（apiClient が parse エラーを投げる場合）
 } catch (err) {
+  if (err instanceof ResponseParseError) throw new PasskeyRegistrationError("registration_uncertain", err); // 2xx body 不能
   if (err instanceof DOMException && err.name === "AbortError")
-    throw new PasskeyRegistrationError("registration_uncertain", err);
+    throw new PasskeyRegistrationError("registration_uncertain", err);                                       // 送出後 Abort
   if (err instanceof ApiError) {
-    if (err.status >= 500) throw new PasskeyRegistrationError("registration_uncertain", err);       // 5xx
-    if (err.status === 400 && err.body?.code === "REGISTRATION_FAILED")
-      throw new PasskeyRegistrationError("server_rejected", err);                                    // 確定拒否
-    if (err.kind === "unparseable_2xx") throw new PasskeyRegistrationError("registration_uncertain", err); // 2xx body 不能
+    if (err.status >= 500) throw new PasskeyRegistrationError("registration_uncertain", err);                // 5xx
+    if (err.status >= 400) {                                                                                 // 全 4xx = 拒否確定
+      if (err.status === 400 && err.body?.code === "REGISTRATION_FAILED")
+        throw new PasskeyRegistrationError("server_rejected", err);
+      throw new PasskeyRegistrationError("server_rejected", err);
+    }
     throw new PasskeyRegistrationError("server_error", err);
   }
-  if (err instanceof TypeError) throw new PasskeyRegistrationError("registration_uncertain", err);    // fetch reject
-  throw new PasskeyRegistrationError("server_error", err);
+  if (err instanceof TypeError) throw new PasskeyRegistrationError("registration_uncertain", err);           // fetch reject（送出後）
+  throw new PasskeyRegistrationError("server_error", err);                                                   // dispatch 前ローカル失敗
 }
 ```
 
 **安全側 fail 原則**: finish 送出後に「拒否が確定（4xx）」でない限り、commit 済みの可能性を排除できないため
-uncertain に倒す。送出前の失敗は commit 不成立が確定するため uncertain にしない。
+uncertain に倒す。dispatch 前の失敗（`TypeError` のうち fetch 到達前のもの）は commit 不成立が確定するため
+uncertain にしない。`api.ts` の `ResponseParseError` により「fetch 成功後の 2xx parse 失敗」を確実に
+uncertain 側へ振り分けられる。
 
 ### UI 文言と復旧導線（`passkey-signup-dialog.tsx` / Req 5.2〜5.6）
 
@@ -795,6 +857,8 @@ uncertain に倒す。送出前の失敗は commit 不成立が確定するた�
   3. 一律 `AUTHENTICATION_FAILED`（内部理由を区別しない）で失敗: **その後にはじめて**「再度作成する」導線を
      提示する（Req 5.4）。再作成は `mutation.reset()` で Idle に戻す。登録済みなら再試行時に
      `username_taken` になる旨も併記可
+  - 再作成導線は **discoverable ログインの一律失敗の後のみ**提示する。cancel / network / 5xx / uncertain の
+    初期画面には再作成を出さない（Blocker #4 / Blocker #8 の負ケース）
 
 ### 秘密情報の非漏出（Req 5.5 / NFR 2.1）
 
@@ -822,116 +886,155 @@ uncertain に倒す。送出前の失敗は commit 不成立が確定するた�
 ### 決定記録: 別 prerequisite PR に分離しない（Req 6.4）
 
 人間運用者決定として、`.env.sample` / `docker-compose.yml` の変更を別 prerequisite PR に切り出さない。
-理由: 既存 env の documentation / passthrough 整備のみで独立 Issue にする複雑度がなく、1 PR = 1 Issue を
-維持し、Web 動作と config を同一 PR で reviewer が確認できるのが妥当。
+理由: 既存 env の documentation / passthrough 整備と CORS default 補正のみで独立 Issue にする複雑度がなく、
+1 PR = 1 Issue を維持し、Web 動作と config を同一 PR で reviewer が確認できるのが妥当。
+
+### `CORS_ALLOWED_ORIGIN` の既定変更で fail-closed を到達可能にする（Blocker #3）
+
+現行の到達不能問題:
+
+- `config.go`: `cfg.CORSAllowedOrigin = getEnvString("CORS_ALLOWED_ORIGIN", "http://localhost:3000")`
+  （空/未設定 → localhost:3000 に default）
+- `docker-compose.yml`: `CORS_ALLOWED_ORIGIN=${CORS_ALLOWED_ORIGIN:-http://localhost:3000}`
+
+このため `allowedOrigin == ""` は通常 wiring で到達せず、「未設定なら capability 404」が実装できない。
+
+採用する方式（**明示設定の判別 + CORS 層既定の温存**。理由も併記）:
+
+- `config.go`: **CORS 層用の `CORSAllowedOrigin` は既定 `http://localhost:3000` のまま**（既存 CORS
+  ミドルウェア・Google OAuth の後方互換 / NFR 3.1）。加えて Web パスキー専用の
+  `WebPasskeyAllowedOrigin string` を **新設**し、`os.Getenv("CORS_ALLOWED_ORIGIN")` の生値を用いる
+  （空文字/未設定 → `""`。localhost へ default しない）。パスキー系の Origin fail-closed 判定は
+  すべて `WebPasskeyAllowedOrigin` を参照する
+- `docker-compose.yml`: `api` の `CORS_ALLOWED_ORIGIN=${CORS_ALLOWED_ORIGIN:-http://localhost:3000}` を
+  `${CORS_ALLOWED_ORIGIN:-}` に変更。理由: 未設定の運用者にはコンテナへ **空文字** が渡り、
+  `WebPasskeyAllowedOrigin=""` → capability 404 / registration・login Origin fail-closed（403）に
+  到達可能になる。CORS ミドルウェアは `config.go` の getEnvString 既定で引き続き localhost:3000 に
+  fall back するため、既存 CORS / Google OAuth の default 挙動は不変（NFR 3.1）
+- **新規 env は追加しない**（`WebPasskeyAllowedOrigin` は既存 `CORS_ALLOWED_ORIGIN` env から派生する
+  config field であり env ではない / Req 6.5）
+
+方式選択の根拠: review が挙げた 3 案（empty default / 明示設定フラグ / BASE_URL 検証）のうち、
+「CORS 層既定を壊さず、パスキーだけ明示設定を要求する」= 明示設定フラグ相当を採る。empty default 単独では
+CORS ミドルウェアの既定挙動（localhost:3000）まで空に倒れ Google OAuth の default dev 体験を壊すため
+不採用。BASE_URL 検証は BASE_URL と CORS を暗黙結合させ運用の自由度を下げるため不採用。
 
 ### 既存 env 流用に留める（Req 6.5）
 
 - `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_DISPLAY_NAME` / `WEBAUTHN_ORIGINS` / `WEBAUTHN_IOS_APP_ID` /
   `PASSKEY_CHALLENGE_TTL_SECONDS`（#216 で追加済み）、`NATIVE_AUTH_JWT_SECRET`（#166 系）、
   `CORS_ALLOWED_ORIGIN`（既存 CORS 層）はいずれも `internal/config` が既読み込み済みの **既存 env**
-- **新規 env は追加しない**。本差分は operator 向け documentation（`.env.sample`）と container passthrough
-  （`docker-compose.yml`）の整備のみ（#223 Scope 維持 / Req 6.5）
-
-### `CORS_ALLOWED_ORIGIN` と fail-closed の接続の明示
-
-- `CORS_ALLOWED_ORIGIN` は Delta 3 の列 A（capability）成立条件・Delta 1 の Web mode 判定・Delta 4 の
-  Origin 検証の **共通入力**である。未設定なら Web パスキー UI は非表示（capability 404）、
-  `/api/auth/session` と registration Web mode は fail-closed（403）に倒れる（行 3）。
-  `.env.sample` / `docker-compose.yml` にこの接続をコメントで明記する
+- **新規 env は追加しない**。本差分は既存 `CORS_ALLOWED_ORIGIN` の default 補正と、operator 向け
+  documentation（`.env.sample`）の整備のみ（#223 Scope 維持 / Req 6.5）。WebAuthn env の passthrough /
+  `.env.sample` ブロックは **PR #229 で既に追加済み**であり、本差分は記述整備に留める
 
 ### 反映内容（イメージ）
 
-**`.env.sample`**（Native Auth / CORS 節の後にブロック追加。文言は tasks / 実装 PR で確定）:
+**`.env.sample`**（既存 CORS 節に fail-closed 接続を追記。文言は tasks / 実装 PR で確定）:
 
 ```dotenv
-# Passkey / WebAuthn（Issue #216 iOS API / Issue #229 Web パスキー導線）
-# 空文字（未設定）だと passkey handler が生成されず /api/passkey/* が 404（fail-closed）。
-# WEBAUTHN_RP_ID=              # 例: example.com（scheme/port を含まないドメイン）
-# WEBAUTHN_RP_DISPLAY_NAME=Feedman
-# WEBAUTHN_ORIGINS=            # 例: https://example.com,feedman://（カンマ区切り）
-# WEBAUTHN_IOS_APP_ID=         # 例: TEAMID.com.example.feedman（AASA 用）
-# PASSKEY_CHALLENGE_TTL_SECONDS=300
-# CORS_ALLOWED_ORIGIN は Web パスキーの exact Origin 検証にも使用される。未設定だと
-# GET /api/passkey/capability は 404、POST /api/auth/session と Web registration は 403（fail-closed）。
+# CORS_ALLOWED_ORIGIN は Web パスキーの exact Origin 検証にも使用される。
+# 未設定（空）だと GET /api/passkey/capability は 404、POST /api/auth/session と
+# Web 新規登録（registration/finish の Web mode）は 403（fail-closed）になり、Web は
+# パスキー導線を出さず Google 単体構成に縮退する。Web パスキーを使うには明示設定すること。
+CORS_ALLOWED_ORIGIN=http://localhost:3000
 ```
 
-**`docker-compose.yml`**（`api` サービスの `environment` に追加。`worker` は passkey 非依存のため対象外）:
+**`docker-compose.yml`**（`api` サービスの既定を空へ変更）:
 
 ```yaml
 services:
   api:
     environment:
-      - WEBAUTHN_RP_ID=${WEBAUTHN_RP_ID:-}
-      - WEBAUTHN_RP_DISPLAY_NAME=${WEBAUTHN_RP_DISPLAY_NAME:-Feedman}
-      - WEBAUTHN_ORIGINS=${WEBAUTHN_ORIGINS:-}
-      - WEBAUTHN_IOS_APP_ID=${WEBAUTHN_IOS_APP_ID:-}
-      - PASSKEY_CHALLENGE_TTL_SECONDS=${PASSKEY_CHALLENGE_TTL_SECONDS:-300}
+      # 未設定なら空 → Web パスキーは fail-closed（capability 404 / Origin 検証 403）。
+      # CORS ミドルウェアは config.go の既定（localhost:3000）に fall back する。
+      - CORS_ALLOWED_ORIGIN=${CORS_ALLOWED_ORIGIN:-}
 ```
 
-すべて `${VAR:-<既定 or 空>}` 形式で **未設定なら空文字 fail-closed**（NFR 3.1）。`CORS_ALLOWED_ORIGIN` は
-既存 passthrough 済みのため追加しない（コメントで用途を明記するのみ）。
+WebAuthn passthrough（`WEBAUTHN_*` / `PASSKEY_CHALLENGE_TTL_SECONDS`）は PR #229 で既に
+`${VAR:-<既定 or 空>}` 形式で追加済みのため、本差分では追加しない（記述の整合確認のみ）。
 
 ## Error Handling
 
 既存方針を踏襲し、新規は以下:
 
 - **サーバ**: `FinishRegistrationNew` の tx 内失敗（user race / credential 重複 → `ErrRegistrationFailed`、
-  session ID 生成 / session INSERT / commit の infra 失敗 → `fmt.Errorf(...: %w, err)` wrap）は全 ROLLBACK 後に
-  handler へ返し、`ErrRegistrationFailed` は 400 REGISTRATION_FAILED、それ以外は 500 INTERNAL_ERROR にマップ。
-  応答・ログに内部詳細 / session ID 生値を反射しない（NFR 2.1）
-- **Web**: `PasskeyRegistrationErrorKind` に `registration_uncertain` を追加し、Dialog の段階提示に対応
+  session factory の ID 生成 / session INSERT / commit の infra 失敗 → `fmt.Errorf(...: %w, err)` wrap）は
+  既存 defer Rollback 後に handler へ返し、`ErrRegistrationFailed` は 400 REGISTRATION_FAILED、それ以外は
+  500 INTERNAL_ERROR にマップ。応答・ログに内部詳細 / session ID 生値を反射しない（NFR 2.1）
+- **Web（API 層）**: `api.ts` は 2xx の body parse 失敗を `ResponseParseError`（status 付き）に正規化し、
+  dispatch 前失敗（plain `TypeError`）と区別可能にする（Delta 5）
+- **Web（hook）**: `PasskeyRegistrationErrorKind` に `registration_uncertain` を追加し、Dialog の段階提示に対応
 
 ## Security Considerations
 
-Delta 4 §主防御要素表・§残余リスク・§決定記録 を参照。追加事項として、直接 session 発行は既存 Google OAuth
-Callback / `SessionExchangeService` と **同一の session ID 生成器・同一 Cookie 属性**（canonical builder 共有）を
-用いるため、session の秘匿性・属性は既存経路と一貫する。
+Delta 4 §主防御要素表・§WebAuthn の防御性質の正確化・§残余リスク・§決定記録 を参照。追加事項として、
+直接 session 発行は既存 Google OAuth Callback / `SessionExchangeService` と **同一の session factory
+（ID 生成器・now・TTL）・同一 Cookie 属性**（canonical builder 共有）を用いるため、session の秘匿性・
+属性は既存経路と一貫する。
 
 ## Testing Strategy
 
 ### Server（Go / `go test`）
 
+- **Unit（`session_factory_test.go`）**:
+  1. `NewSession` が ID（非空 / 32 バイト hex）・`CreatedAt`・`ExpiresAt=CreatedAt+TTL` を返し、
+     `CreatedAt` と `ExpiresAt` が **同一 now** に基づく（factory の now を固定して検証）
+  2. ID 生成失敗（rand 失敗を注入）で error を返し部分構築しない
 - **Unit（`registration_service_test.go`）**:
-  1. 正常系（Web mode）: user / credential / session が同一 tx で作成され、`webSession` に生成 ID・
-     `now+sessionTTL` の期限が入る（tx runner を fake し `WithinTx` 内の呼び出し順を検証）
+  1. 正常系（Web mode）: 既存 txBeginner の `BeginTx` 内で user → credential → session の順に呼ばれ、
+     `webSession` に factory 生成の ID / `CreatedAt` / `ExpiresAt` が入る（fake tx で呼び出し順を検証）
   2. 正常系（iOS mode）: `issueWebSession=false` で session を作らず `webSession=nil`・`{user_id}` 相当
   3. 異常系: user UNIQUE 衝突 → `ErrRegistrationFailed`（session 未作成）
   4. 異常系: credential 重複 → `ErrRegistrationFailed`（session 未作成）
-  5. 異常系: session ID 生成失敗 / session INSERT 失敗 → 全 ROLLBACK・`webSession=nil`・エラー伝播
+  5. 異常系: session INSERT 失敗 / session factory の ID 生成失敗 → defer Rollback・`webSession=nil`・エラー伝播
 - **Integration（実 PostgreSQL / `passkey_e2e_db_test.go`）**:
   1. Web mode finish 成功で users / passkey_credentials / sessions に **3 行がすべて存在**
-  2. session INSERT を失敗させた場合（例: 重複 session ID を注入）に users / passkey_credentials にも
-     **行が残らない（3 行 atomic rollback / orphan なし）**
+  2. session INSERT を失敗させた場合（重複 session ID 注入等）に users / passkey_credentials にも
+     **行が残らない（3 行 atomic rollback / orphan なし）かつ handler が Set-Cookie を出さない**
   3. iOS mode finish 成功で users / passkey_credentials の 2 行のみ存在（sessions なし）
+  4. Web session の `CreatedAt` / `ExpiresAt` が Cookie の Max-Age（= SessionMaxAge）と整合する（Blocker #8）
 - **Unit（`passkey_handler_test.go`）**:
   1. Origin 一致 → 200 `{user_id}` + `Set-Cookie session_id`（属性は Google OAuth Callback と一致）
   2. Origin 不在（iOS）→ 200 `{user_id}`・`Set-Cookie` **なし**（#216 回帰）
   3. Origin 非空不一致 / allowedOrigin 未設定 → 403、mutation 呼ばれず（regService stub 未呼出）
   4. Web mode で Content-Type 非 JSON → 415、mutation 呼ばれず
-- **Unit（`native_auth_handler_test.go`）**: `/api/auth/session` の Origin 不在・不一致・allowedOrigin
+  5. `webRegistrationReady()` false（session writer / factory 未配線）→ 500、mutation 呼ばれず（Blocker #8）
+- **Unit（`native_auth_handler_test.go`）**: `/api/auth/session` の Origin 不在・不一致・許可 Origin
   未設定で 403（Delta 4 fail-closed 補正の回帰）
+- **Unit（`config_test.go`）**: `CORS_ALLOWED_ORIGIN` set → `WebPasskeyAllowedOrigin=値` /
+  unset・empty → `WebPasskeyAllowedOrigin=""`、`CORSAllowedOrigin` は既定 localhost:3000 を維持（Blocker #8）
 - **Integration（`router_test.go`）**: fail-closed 表 行 1〜5 の各 endpoint（列 A〜E）登録有無。特に
-  行 2（W✓ N✗ C✓）で iOS registration/*・authentication/* が 200、capability が 404
+  行 2（W✓ N✗ C✓）で iOS registration/*・authentication/* が 200・capability が 404、
+  行 3（W✓ N✓ C✗）で capability 404、partial wiring（webRegistrationReady 未充足）で capability が
+  未登録になること（Blocker #8）
 - **Unit（`session_cookie_test.go`）**: `buildSessionCookie` の属性が Google OAuth Callback と一致
 
 ### Web（Vitest + Testing Library）
 
-- **Unit（`use-passkey-registration.test.ts`）**:
+- **Unit（`api.test.ts`）**:
+  1. 2xx で body 欠損 / 途中切断 / parse 不能 → `ResponseParseError`（status 2xx）を投げる
+  2. dispatch 前の JSON serialize 失敗（循環参照等）→ plain `TypeError`（`ResponseParseError` ではない）
+     で、両者が区別できる（Blocker #4 / #8）
+- **Unit（`use-passkey-registration.test.tsx`）**:
   1. 正常系: begin → create → finish の 3 呼び出しのみ。`authentication/*` / 登録用 `/api/auth/session` が
      呼ばれない（二度目 ceremony 除去の回帰）
-  2. `registration_uncertain` × fetch reject（`TypeError`）
+  2. `registration_uncertain` × fetch reject（送出後 `TypeError`）
   3. `registration_uncertain` × 5xx
   4. `registration_uncertain` × AbortError
-  5. `registration_uncertain` × 2xx body parse 不能
-  6. `server_rejected` × 400 REGISTRATION_FAILED（uncertain に誤分類されない回帰）
-  7. begin 段の `invalid_username` / `username_taken` / `cancelled` は既存挙動維持
+  5. `registration_uncertain` × `ResponseParseError`（2xx body 不能）
+  6. **全 4xx（400 REGISTRATION_FAILED / 401 / 403 / 404 / 409 / 422）が `server_rejected`（拒否確定）に
+     分類され uncertain に誤分類されない**（400 だけに限定しない / Blocker #4 / #8）
+  7. dispatch 前ローカル失敗（`TypeError`）が `server_error`（非-uncertain）に分類される
+  8. begin 段の `invalid_username` / `username_taken` / `cancelled` は既存挙動維持
 - **Component（`passkey-signup-dialog.test.tsx`）**:
   1. `registration_uncertain` で見出し「登録が完了したかどうかを確認できませんでした」が表示され、
      初期に「再度作成する」が **表示されない**（同列並置しない / Req 5.2）
   2. 「ログインで確認する」押下で discoverable ログイン（`usePasskeyAuthentication`）が起動
   3. discoverable ログインが一律失敗した後に「再度作成する」が表示され、押下で `mutation.reset()`
-  4. 文言中にサーバ内部詳細 / 他 kind の代表文言が含まれない（Req 5.5 / 5.6 回帰）
+  4. login の cancel / network / 5xx では初期画面に「再度作成する」が出ない（一律 AUTHENTICATION_FAILED
+     の後のみ / Blocker #8）
+  5. 文言中にサーバ内部詳細 / 他 kind の代表文言が含まれない（Req 5.5 / 5.6 回帰）
 - **Recovery（`login-page-recovery.test.tsx`）**: `registration_uncertain` → 「ログインで確認する」→
   discoverable ログイン成功 → 2 ペイン UI 到達（Req 5.3。unit で組めない場合は E2E 側へ委譲する旨を明記）
 
@@ -942,19 +1045,24 @@ Callback / `SessionExchangeService` と **同一の session ID 生成器・同�
 
 ## Configuration
 
-Delta 6 を参照。**追加 env は無い**。既存 env の documentation（`.env.sample`）と container passthrough
-（`docker-compose.yml`）のみ整備する。
+Delta 6 を参照。**追加 env は無い**。既存 `CORS_ALLOWED_ORIGIN` の default を補正して Web パスキーの
+fail-closed を到達可能にし（`config.go` の `WebPasskeyAllowedOrigin` 派生 + compose 既定を空へ）、
+`.env.sample` に fail-closed 接続を documentation する。
 
 ## Supporting References
 
+- WebAuthn Level 3 §Terminology（authorization gesture / user presence / user verification の定義）:
+  <https://www.w3.org/TR/webauthn-3/#sctn-terminology>
 - WebAuthn Level 2 §7.1 Registration Ceremony: <https://www.w3.org/TR/webauthn-2/#sctn-registering-a-new-credential>
 - RFC 7636 (PKCE for OAuth Public Clients): <https://datatracker.ietf.org/doc/html/rfc7636>
 - RFC 9700 (OAuth 2.0 Security Best Current Practice) §4.7 CSRF: <https://datatracker.ietf.org/doc/html/rfc9700>
 - MDN Fetch: Origin header は cross-origin および unsafe method の same-origin で付与される:
   <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin>
-- 既存 tx 基盤: `internal/repository/tx.go`（`SQLTx` / `BeginTx` / `Querier` / `Commit` / `Rollback`）
-- 既存 DBTX 変種の前例: `PostgresUserRepo.DeleteByIDExec` / `PostgresSessionRepo.DeleteByUserIDExec`
-- 既存 Web session 交換（login）: `internal/handler/native_auth_handler.go`（`Session` / `SessionReady`）,
-  `internal/auth/session_exchange.go`（`SessionExchangeService` / session ID 生成器）
+- 先行実装 #230 の tx 基盤: `internal/passkey/registration_service.go`（`RegistrationTx` /
+  `RegistrationTxBeginner` / `FinishRegistrationNew` の BeginTx→defer Rollback→Commit）,
+  `internal/app/withdraw_wiring.go`（`passkeyRegistrationTxBeginnerAdapter`）
+- 既存 session 発行: `internal/auth/service.go`（`createSession` / `generateSessionID`）,
+  `internal/auth/session_exchange.go`（`SessionExchangeService`）
+- 既存 DBTX 変種の前例: `PostgresSessionRepo.DeleteByUserIDExec` / `PostgresUserRepo.CreateUserOnlyExec`(#230)
 - 既存 #216 サーバ設計 / 既存 #223 Web 設計（本 spec が supersede する対象）:
   `docs/specs/216--app-store-4-8/design.md` / `docs/specs/223-feat-web-web/design.md`

--- a/docs/specs/231-design-web-auth/design.md
+++ b/docs/specs/231-design-web-auth/design.md
@@ -73,16 +73,20 @@ tasks.md は書き換えない**）へ差分を反映する。
 - **Delta 5（Requirement 5）— 完了不明状態**: 「finish dispatch 後に確定的な pre-commit 4xx を
   得られない」ケース（network reject / timeout / 送出後 Abort / 5xx / commit 済みを示唆する 2xx だが
   body 欠損・途中切断・parse 不能）を **第 3 の完了不明状態** `registration_uncertain` として定義する。
-  この判別を成立させるため **API 層（`api.ts`）で「fetch 成功後の 2xx body parse 失敗」を status
-  付きの型に正規化**し、dispatch 前のローカル失敗と区別できるようにする。復旧は
-  「**discoverable なパスキーログイン**（ユーザー名入力なし）で確認 → 成功なら完了 →
+  この判別を成立させるため **API 層（`api.ts`）で dispatch 前の request preparation 失敗を
+  `RequestPreparationError`、fetch 成功後の 2xx body parse 失敗を `ResponseParseError`（status 付き）に
+  正規化**し、`fetch()` reject の plain `TypeError` を含む 3 起点を機械的に区別できるようにする（Blocker #1）。
+  さらに **discoverable ログインの一律 `AUTHENTICATION_FAILED` を auth hook の machine-readable kind に正規化**
+  し（Blocker #3）、復旧は「**discoverable なパスキーログイン**（ユーザー名入力なし）で確認 → 成功なら完了 →
   一律の `AUTHENTICATION_FAILED` の後にのみ再作成導線」に統一する。
 - **Delta 6（Requirement 6）— 運用 config 統合**: `.env.sample` / `docker-compose.yml` の記述差分を
   PR #229 のスコープに統合する（別 prerequisite PR に分離しない）。`CORS_ALLOWED_ORIGIN` の
   **既定を空へ変更**し、config が「明示設定された exact Origin のみを Web パスキーで信頼する」
   ように補正することで、fail-closed（未設定 → capability 404 / Origin 検証 403）を **到達可能・
-  検証可能**にする。Verify には代表 env 値（`SESSION_SECRET` / `POSTGRES_PASSWORD` を含む）付き
-  `docker compose config` を追加する。
+  検証可能**にする。`WebPasskeyAllowedOrigin` は生値の非空判定ではなく **trim + strict exact-Origin
+  validation** を課し、malformed 値も `""`（fail-closed）に倒す（Blocker #6）。Verify には代表 env 値
+  （`SESSION_SECRET` / `POSTGRES_PASSWORD` を含む）付き `docker compose config` を **set / unset 両方**で
+  実行し、api の `CORS_ALLOWED_ORIGIN` 展開値（set=明示 origin / unset=空）を assertion する（Blocker #7）。
 
 ### Goals
 
@@ -195,9 +199,11 @@ Vitest）をそのまま使用する。session ID 生成は既存 `internal/auth
 ## File Structure Plan（PR #229 に適用する差分の変更対象 / 新規追加）
 
 本セクションは PR #229 の `needs-iteration` 1 回で反映する対象ファイルを、Reviewer が
-`git diff --name-only develop..<PR#229 head>` と 1:1 で突合できるよう **exact-path** で列挙する
-（Requirement 2 / 2.5）。**#223 design.md「File Structure Plan」節を supersede する**。
-各ファイルを 3 区分に分類する:
+`git diff --name-only develop..<PR#229 head>` と 1:1 で突合できるよう **1 ファイル 1 行の full exact-path** で
+列挙する（Requirement 2 / 2.5）。**#223 design.md「File Structure Plan」節を supersede する**。
+**canonical な比較対象（機械照合の基準時点）**は、**#230（PR #232）を develop に merge し、PR #229 が
+その develop を取り込んだ後の最終 diff**（`git diff --name-only develop..<PR#229 head>`）とする。その時点で
+本表と 1:1 の機械照合が成立する（Blocker #5）。各ファイルを 3 区分に分類する:
 
 - **[E]** = #231 でさらに編集する（PR #229 の needs-iteration 1 回で本差分を反映）
 - **[U]** = PR #229 / #232 に既に含まれるが **#231 ではさらに編集しない**（記録のみ / 過剰変更でない証跡）
@@ -213,10 +219,10 @@ Vitest）をそのまま使用する。session ID 生成は既存 `internal/auth
 | [U] | `internal/repository/tx.go` | #230/#232 の tx 基盤を **そのまま再利用**。#231 変更なし |
 | [U] | `internal/repository/postgres_user_repo.go` | `CreateUserOnlyExec` は **#230 既存**。#231 変更なし |
 | [U] | `internal/repository/postgres_passkey_credential_repo.go` | `CreateExec` は **#230 既存**。#231 変更なし |
-| [N] | `internal/repository/postgres_session_repo.go` | session 作成の tx 変種 `CreateExec(ctx, q DBTX, s)` を追加、既存 `Create` は委譲（差分等価） |
+| [E] | `internal/repository/postgres_session_repo.go` | **既存ファイル**（既存 `Create` / `DeleteByUserIDExec` を持つ）へ session 作成の tx 変種 `CreateExec(ctx, q DBTX, s)` を追加、既存 `Create` は委譲（差分等価）。新規ファイルではないため [E]（Blocker #5） |
 | [N] | `internal/auth/session_factory.go` | 共有 session factory（ID + 単一 now + CreatedAt + ExpiresAt）。`SessionExchangeService` と RegistrationService が共有 |
 | [N] | `internal/auth/session_factory_test.go` | factory の ID / CreatedAt / ExpiresAt / 単一 now / generator 失敗を検証 |
-| [E] | `internal/auth/service.go` | `generateSessionID` は本ファイルに定義済み（File Plan の旧「session_exchange.go から export」は誤り）。factory から参照できるよう **同 package の export helper `NewSessionID`** を追加（`Service.createSession` の挙動は差分等価） |
+| [U] | `internal/auth/service.go` | `generateSessionID`（**unexported**）を本ファイルに定義済みのまま再利用。`session_factory.go` が同一 package（`internal/auth`）からそのまま参照するため #231 変更なし。旧 File Plan の「session_exchange.go から export」は誤りで、**薄い public `NewSessionID` は追加しない**（Blocker #2） |
 | [E] | `internal/auth/session_exchange.go` | session 構築を新 factory 呼び出しに差し替え（`SessionExchangeService` の外部契約・挙動は不変 / 差分等価） |
 | [E] | `internal/auth/session_exchange_test.go` | factory 差し替え後も既存アサーションが pass することを確認（CreatedAt / ExpiresAt 検証を追加） |
 | [E] | `internal/passkey/registration_service.go` | `FinishRegistrationNew` を既存 tx クロージャ内 session INSERT + `issueWebSession bool` + `*model.Session` 返却に拡張。session factory / session writer を注入、`WebSessionReady()` 追加 |
@@ -225,33 +231,44 @@ Vitest）をそのまま使用する。session ID 生成は既存 `internal/auth
 | [E] | `internal/handler/passkey_handler_test.go` | mode 判定 / Set-Cookie / iOS `{user_id}` + Cookie なし回帰 / partial readiness fail-closed |
 | [N] | `internal/handler/session_cookie.go` | canonical Cookie builder `buildSessionCookie(...)` を 3 handler で共有 |
 | [N] | `internal/handler/session_cookie_test.go` | builder の属性が Google OAuth Callback と一致することを検証 |
-| [E] | `internal/handler/native_auth_handler.go` | `Session` の Origin 検証を fail-closed（不在・不一致・許可 Origin 未設定を 403）へ補正 |
+| [E] | `internal/handler/auth_handler.go` | Google OAuth `Callback` のインライン `session_id` Cookie 生成を canonical `buildSessionCookie(...)` へ差し替え（属性は現行と完全一致・差分等価 / Blocker #5） |
+| [E] | `internal/handler/native_auth_handler.go` | `Session` の Origin 検証を fail-closed（不在・不一致・許可 Origin 未設定を 403）へ補正。加えてインライン Cookie 生成を `buildSessionCookie(...)` へ差し替え（差分等価） |
 | [E] | `internal/handler/native_auth_handler_test.go` | Origin fail-closed の異常系追加 |
 | [E] | `internal/handler/router.go` | capability 条件に `WebPasskeyAllowedOrigin != ""` + `PasskeyHandler.webRegistrationReady()` を追加（`SessionReady()` 維持）。iOS route 条件 `PasskeyHandler != nil` は不変 |
 | [E] | `internal/handler/router_test.go` | fail-closed 表 5 列 + partial wiring（capability/session/registration の登録一致）を table-driven で検証 |
 | [U] | `internal/handler/router_unauth_ratelimit_test.go` | PR #229 で追加済み。#231 変更なし（記録） |
 | [E] | `internal/handler/passkey_e2e_db_test.go` | 実 PostgreSQL で 3 行 commit / session 失敗時の全 rollback + Set-Cookie なし |
-| [E] | `internal/config/config.go` | `WebPasskeyAllowedOrigin`（明示設定された exact Origin、未設定/空 → `""`）を追加。`CORSAllowedOrigin` 既定は不変（新規 env は追加しない） |
-| [E] | `internal/config/config_test.go` | `CORS_ALLOWED_ORIGIN` set/unset/empty での `WebPasskeyAllowedOrigin` を検証 |
+| [E] | `internal/config/config.go` | `WebPasskeyAllowedOrigin`（`CORS_ALLOWED_ORIGIN` を **trim + strict exact-Origin validation** した値。未設定/空/malformed → `""` の fail-closed）を追加。`CORSAllowedOrigin` 既定は不変（新規 env は追加しない / Blocker #6） |
+| [E] | `internal/config/config_test.go` | `CORS_ALLOWED_ORIGIN` の set / unset / empty / **malformed（前後空白・末尾スラッシュ・path/query/fragment 付き・複数 origin）** での `WebPasskeyAllowedOrigin`（valid のみ採用 / それ以外 `""`）を検証。`CORSAllowedOrigin` は既定 localhost:3000 を維持（Blocker #6） |
 | [E] | `internal/app/app.go` | RegistrationService へ session writer / session factory / TTL を注入、PasskeyHandler へ `WebPasskeyAllowedOrigin` + Cookie 設定を注入（`NATIVE_AUTH_JWT_SECRET` 非依存で `WEBAUTHN_*` 設定時に配線） |
 
 ### Web（TypeScript）
 
 | 区分 | パス | #231 での扱い |
 |---|---|---|
-| [E] | `web/src/lib/api.ts` | 2xx の `response.json()` 失敗を status 付きの型（`ResponseParseError`）へ正規化し、dispatch 前失敗と区別可能にする |
-| [E] | `web/src/lib/api.test.ts` | 2xx body 欠損/途中切断/parse 不能で `ResponseParseError`（status 2xx）を投げ、pre-dispatch 失敗と区別されることを検証 |
-| [E] | `web/src/types/passkey.ts` | `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加。`RegistrationFinishResponse` は `{user_id}` のまま（auth_code を追加しない） |
-| [E] | `web/src/hooks/use-passkey-registration.ts` | chain を「begin → create → finish → invalidateQueries」に短縮（二度目 ceremony / 登録用 `/api/auth/session` を除去）。finish の error を uncertain / rejected / 非-uncertain に分類 |
-| [E] | `web/src/hooks/use-passkey-registration.test.tsx` | 二度目 ceremony 不在回帰 + uncertain 4 サブケース + 全 4xx=rejected 回帰（ファイル拡張子は `.test.tsx` / PR #229 実体に一致） |
+| [E] | `web/src/lib/api.ts` | 2xx の `response.json()` 失敗を status 付き `ResponseParseError` へ、dispatch 前の request preparation 失敗（`JSON.stringify` / URL 構築）を `RequestPreparationError` へ **それぞれ正規化**し、`fetch()` reject の plain `TypeError` と機械的に区別可能にする（Blocker #1） |
+| [E] | `web/src/lib/api.test.ts` | 2xx body 欠損/途中切断/parse 不能 → `ResponseParseError`（status 2xx）、request preparation 失敗 → `RequestPreparationError`、fetch reject → plain `TypeError` の 3 者が区別されることを検証（Blocker #1） |
+| [E] | `web/src/types/passkey.ts` | `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加。authentication error 種別に「finish の一律 `AUTHENTICATION_FAILED` のみを表す machine-readable kind」を追加（Blocker #3。raw body / 内部理由は保持しない）。`RegistrationFinishResponse` は `{user_id}` のまま（auth_code を追加しない） |
+| [E] | `web/src/hooks/use-passkey-registration.ts` | chain を「begin → create → finish → invalidateQueries」に短縮（二度目 ceremony / 登録用 `/api/auth/session` を除去）。finish の error を uncertain / rejected（全 4xx）/ server_error（`RequestPreparationError`）に分類（Blocker #1） |
+| [E] | `web/src/hooks/use-passkey-registration.test.tsx` | 二度目 ceremony 不在回帰 + uncertain 4 サブケース + 全 4xx=rejected 回帰 + `RequestPreparationError`=server_error（ファイル拡張子は `.test.tsx` / PR #229 実体に一致） |
+| [E] | `web/src/hooks/use-passkey-authentication.ts` | discoverable ログイン復旧で再利用。**finish の一律 `AUTHENTICATION_FAILED` を表す machine-readable kind** を追加し、begin 拒否 / cancel / network / 5xx / session 交換失敗を別 kind に保つ（Blocker #3。内部理由・raw body は UI に渡さない） |
+| [E] | `web/src/hooks/use-passkey-authentication.test.tsx` | 一律 `AUTHENTICATION_FAILED` kind の付与と、begin 拒否 / cancel / network / 5xx / session 交換失敗が別 kind になる negative test（Blocker #3） |
 | [E] | `web/src/components/passkey-signup-dialog.tsx` | 完了不明状態 UI + discoverable ログイン復旧導線（段階提示） |
-| [E] | `web/src/components/passkey-signup-dialog.test.tsx` | uncertain 見出し / 段階提示 / 内部詳細非漏出の回帰 |
+| [E] | `web/src/components/passkey-signup-dialog.test.tsx` | uncertain 見出し / 段階提示 / 一律 `AUTHENTICATION_FAILED` 後のみ再作成 / 内部詳細非漏出の回帰 |
 | [E] | `web/src/components/login-page-recovery.test.tsx` | uncertain → discoverable ログイン成功 → 2 ペイン到達の recovery 整合 |
-| [U] | `web/src/hooks/use-passkey-authentication.ts` | discoverable ログイン復旧で **再利用**。#231 変更なし |
-| [U] | `web/src/hooks/use-passkey-authentication.test.tsx` / `use-passkey-authentication.contract.test.tsx` | PR #229 追加済み。#231 変更なし（記録） |
-| [U] | `web/src/components/login-page.tsx` / `login-page.test.tsx` / `passkey-buttons.tsx` / `passkey-buttons.test.tsx` | PR #229 追加済み。#231 変更なし |
-| [U] | `web/src/hooks/use-passkey-capability.ts` / `use-passkey-capability.test.tsx` | 同上（#231 変更なし） |
-| [U] | `web/src/lib/webauthn.ts` / `webauthn.test.ts` / `pkce.ts` / `pkce.test.ts` / `passkey-capability.ts` / `passkey-capability.test.ts` | 同上（#231 変更なし） |
+| [U] | `web/src/hooks/use-passkey-authentication.contract.test.tsx` | PR #229 追加済み。#231 変更なし（記録） |
+| [U] | `web/src/components/login-page.tsx` | PR #229 追加済み。#231 変更なし |
+| [U] | `web/src/components/login-page.test.tsx` | PR #229 追加済み。#231 変更なし |
+| [U] | `web/src/components/passkey-buttons.tsx` | PR #229 追加済み。#231 変更なし |
+| [U] | `web/src/components/passkey-buttons.test.tsx` | PR #229 追加済み。#231 変更なし |
+| [U] | `web/src/hooks/use-passkey-capability.ts` | PR #229 追加済み。#231 変更なし |
+| [U] | `web/src/hooks/use-passkey-capability.test.tsx` | PR #229 追加済み。#231 変更なし |
+| [U] | `web/src/lib/webauthn.ts` | PR #229 追加済み。#231 変更なし |
+| [U] | `web/src/lib/webauthn.test.ts` | PR #229 追加済み。#231 変更なし |
+| [U] | `web/src/lib/pkce.ts` | PR #229 追加済み。#231 変更なし |
+| [U] | `web/src/lib/pkce.test.ts` | PR #229 追加済み。#231 変更なし |
+| [U] | `web/src/lib/passkey-capability.ts` | PR #229 追加済み。#231 変更なし |
+| [U] | `web/src/lib/passkey-capability.test.ts` | PR #229 追加済み。#231 変更なし |
 
 ### 運用 config（Requirement 6）
 
@@ -266,7 +283,10 @@ Vitest）をそのまま使用する。session ID 生成は既存 `internal/auth
 |---|---|---|
 | [E] | `docs/specs/223-feat-web-web/impl-notes.md` | #231 delta 適用結果を追記 |
 | [E] | `docs/specs/223-feat-web-web/context-map.md` | `finish → 3 行 tx → commit → Set-Cookie` へ経路更新 / fail-closed 表 5 列 supersede / 完了不明状態遷移追加 |
-| [U] | `docs/specs/223-feat-web-web/requirements.md` / `design.md` / `tasks.md` / `review-notes.md` | PR #229 に既存。#231 では **書き換えない**（NFR 1.1。記録） |
+| [U] | `docs/specs/223-feat-web-web/requirements.md` | PR #229 に既存。#231 では **書き換えない**（NFR 1.1。記録） |
+| [U] | `docs/specs/223-feat-web-web/design.md` | PR #229 に既存。#231 では **書き換えない**（NFR 1.1。記録） |
+| [U] | `docs/specs/223-feat-web-web/tasks.md` | PR #229 に既存。#231 では **書き換えない**（NFR 1.1。記録） |
+| [U] | `docs/specs/223-feat-web-web/review-notes.md` | PR #229 に既存。#231 では **書き換えない**（NFR 1.1。記録） |
 
 ## Requirements Traceability
 
@@ -287,7 +307,7 @@ Vitest）をそのまま使用する。session ID 生成は既存 `internal/auth
 | 3.3 | NATIVE unset + WEBAUTHN set で iOS 継続 | Delta 3 §fail-closed 表 行 2 / §iOS 契約維持 |
 | 3.4 | WEBAUTHN unset で Web 縮退 + iOS 停止 | Delta 3 §fail-closed 表 行 4 / 5 |
 | 3.5 | iOS request/response 契約破壊禁止 | Delta 1 §iOS 契約維持 / Delta 3 §登録条件不変 |
-| 3.6 | direct-registration readiness 不足時に capability 404 | Delta 3 §capability readiness / §webRegistrationReady |
+| 3.6 | direct-registration readiness 不足時に capability 404 | Delta 3 §capability readiness / §webRegistrationReady / Delta 6 §exact Origin validation |
 | 4.1 | CSRF 主防御要素を要素ごと・endpoint ごとに明記 | Delta 4 §主防御要素表 |
 | 4.2 | 旧誤記述の撤回と正しい前提の明記 | Delta 4 §旧記述の撤回 |
 | 4.3 | 残余リスクの列挙 | Delta 4 §残余リスク |
@@ -298,7 +318,7 @@ Vitest）をそのまま使用する。session ID 生成は既存 `internal/auth
 | 5.1 | 第 3 の完了不明状態としてユーザーに提示 | Delta 5 §状態定義 / §API 層の型付き正規化 / §Hook 判定 |
 | 5.2 | discoverable ログイン確認を提示（再作成は同列不可） | Delta 5 §UI 文言と復旧導線 |
 | 5.3 | 復旧ログイン成功で 2 ペイン UI | Delta 5 §状態遷移図（成功） |
-| 5.4 | 一律失敗の後にのみ再作成導線 | Delta 5 §状態遷移図（失敗） |
+| 5.4 | 一律失敗の後にのみ再作成導線 | Delta 5 §状態遷移図（失敗）/ §discoverable ログイン結果の machine-readable 判定（auth hook） |
 | 5.5 | サーバ内部詳細を反射しない | Delta 5 §UI 文言（generic 固定） |
 | 5.6 | 他状態と混同されない文言 | Delta 5 §既存 error kind との弁別 |
 | 6.1 | .env.sample を変更対象に明示 | Delta 6 §反映内容 / File Structure Plan |
@@ -397,18 +417,25 @@ login session 発行（`Service.createSession` / `SessionExchangeService`）と 
 ```go
 // internal/auth/session_factory.go（New）
 // SessionFactory は model.Session を ID + 単一 now + CreatedAt + ExpiresAt で一貫生成する。
-// generateSessionID（internal/auth/service.go）と now / TTL を集約し、複製を排除する。
+// generateSessionID（internal/auth/service.go / 同一 package）と now / TTL を集約し、複製を排除する。
 type SessionFactory struct {
-    ttl time.Duration
-    now func() time.Time // テスト差し替え可（既定 time.Now）
+    ttl   time.Duration
+    now   func() time.Time       // テスト差し替え可（既定 time.Now）
+    newID func() (string, error) // ID 生成の test seam（既定 = generateSessionID）。
+                                 // crypto/rand.Reader の global 差替えを避け、rand 失敗を局所注入できる（Blocker #2）
 }
 
-func NewSessionFactory(ttl time.Duration) *SessionFactory { /* now=time.Now 既定 */ }
+// NewSessionFactory は production 既定（now=time.Now / newID=generateSessionID）で factory を構築する。
+// generateSessionID は同一 package（internal/auth）の unexported 関数のため、export helper を新設せず
+// そのまま既定 newID に束ねる（薄い public NewSessionID は追加しない / Blocker #2）。
+func NewSessionFactory(ttl time.Duration) *SessionFactory {
+    return &SessionFactory{ttl: ttl, now: time.Now, newID: generateSessionID}
+}
 
 // NewSession は 1 度の now を用いて ID / CreatedAt / ExpiresAt を整合させた Session を返す。
-// ID 生成失敗（rand.Read 失敗）はそのまま error として返す（部分構築しない）。
+// ID 生成失敗（newID 失敗 = rand.Read 失敗）はそのまま error として返す（部分構築しない）。
 func (f *SessionFactory) NewSession(userID string) (*model.Session, error) {
-    id, err := NewSessionID() // = service.go の generateSessionID を export した薄い wrapper
+    id, err := f.newID() // 既定は generateSessionID。テストは失敗する newID を注入して検証（Blocker #2）
     if err != nil { return nil, err }
     now := f.now()
     return &model.Session{ID: id, UserID: userID, CreatedAt: now, ExpiresAt: now.Add(f.ttl)}, nil
@@ -425,8 +452,11 @@ type SessionFactoryFunc interface {
 - `Service.createSession`（Google OAuth login）も同 factory 採用が望ましいが、最小差分として
   少なくとも `SessionExchangeService` と registration direct session の 2 経路で factory を共有する
   （review Blocker #2 の要求「at least existing SessionExchangeService and registration direct session」）
-- `generateSessionID` は **`internal/auth/service.go`** に定義されている（旧 File Plan の
-  「`session_exchange.go` から export」は誤り）。export helper `NewSessionID` を同ファイルに追加する
+- `generateSessionID` は **`internal/auth/service.go`** に **unexported** で定義されている（旧 File Plan の
+  「`session_exchange.go` から export」は誤り）。`session_factory.go` は同一 package（`internal/auth`）のため
+  この unexported 関数を既定 `newID` としてそのまま参照でき、**`service.go` の変更も薄い public `NewSessionID` の
+  追加も不要**（Blocker #2 の指摘に沿う）。ID 生成失敗テストは factory に失敗する `newID` を注入して行い、
+  `crypto/rand.Reader` の global 差替え（並列テスト汚染）を避ける
 
 #### `internal/passkey/registration_service.go`（Modified / #230 tx を拡張）
 
@@ -535,8 +565,10 @@ async function mutationFn({ username }: { username: string }) {
 - **無変更で維持**:
   - #230 の `RegistrationTx` / `RegistrationTxBeginner` / `txBeginner` / user・credential Exec 変種 /
     `internal/repository/tx.go`（session ステップの追加以外は既存フローそのまま）
-  - `AuthenticationService` / `use-passkey-authentication.ts` / `PasskeyButtons`
-    （ログイン導線は影響を受けない。discoverable ログイン復旧で再利用のみ / Req 1.5）
+  - `AuthenticationService` / `PasskeyButtons`（ログイン導線の**挙動**は影響を受けない / Req 1.5）。
+    `use-passkey-authentication.ts` は discoverable ログイン復旧で再利用しつつ、**復旧判定用に finish 一律
+    `AUTHENTICATION_FAILED` を表す machine-readable kind を追加する**のみで、既存ログイン flow の挙動・契約は不変
+    （Blocker #3 / Delta 5 §auth hook 判定）
   - `SessionExchangeService` の外部契約（login の auth_code 交換として不変。session 構築のみ factory 化 /
     Delta 4 で Origin 検証の fail-closed 補正）
   - iOS 用 `registration/*` / `authentication/*`（#216 契約不変 / NFR 3.2）
@@ -552,8 +584,9 @@ async function mutationFn({ username }: { username: string }) {
 
 ### canonical 定義
 
-本 spec §File Structure Plan（[E]/[U]/[N] 区分表）が canonical。Reviewer は同節と PR #229 の
-`git diff --name-only develop..<head>` を突き合わせ、以下を確認できる（Requirement 2.5）:
+本 spec §File Structure Plan（[E]/[U]/[N] 区分表。**1 ファイル 1 行の full exact path**）が canonical。
+機械照合の基準時点は **#230（PR #232）を develop に merge し PR #229 が取り込んだ後**とし、Reviewer は
+同節と PR #229 の `git diff --name-only develop..<head>` を突き合わせ、以下を確認できる（Requirement 2.5 / Blocker #5）:
 
 1. PR #229 の全変更ファイルが [E] または [U] に exact-path で列挙されている（漏れなし）
 2. [E]/[N] に列挙されているが PR #229 に含まれないファイルがない（過剰な予告なし。[N] は本差分で新規追加）
@@ -740,27 +773,45 @@ fetch ベースの Web app では十分。残余リスクは同一オリジン X
 
 ## Delta 5: 登録完了不明状態と復旧導線（Requirement 5）
 
-### API 層の型付き正規化（`api.ts` / Blocker #4）
+### API 層の型付き正規化（`api.ts` / Blocker #1・旧 Blocker #4）
 
-現行 `api.ts` の `request<T>` は 2xx（204/205 以外）で末尾 `return response.json();` を呼び、body が
-欠損・途中切断・parse 不能だと **plain `SyntaxError`** を投げる。この plain error は呼出側から
-「fetch 成功後の 2xx body parse 失敗」か「dispatch 前の JSON serialize 失敗」かを区別できない。
-そこで `api.ts` に status 付きの専用型を導入し、**fetch 成功後の 2xx parse 失敗のみ**を分離する:
+現行 `api.ts` の `request<T>` は、(a) request 送出前の `JSON.stringify(body)` / URL 構築で **plain `TypeError`** を、
+(b) `fetch()` の reject でも **plain `TypeError`** を、(c) 2xx（204/205 以外）末尾の `response.json()` 失敗で
+**plain `SyntaxError`** を投げ得る。(a) と (b) はどちらも plain `TypeError` のため、呼出側は「dispatch 前の
+request preparation 失敗（commit 不成立が確定）」と「dispatch 後の fetch reject（commit 済みの可能性が残る）」を
+発生位置の推測なしに区別できない。これは round3 item 1 が指摘した contract 不成立である。
+
+そこで `api.ts` で **2 種類の専用型** を導入し、3 つの失敗起点を機械的に分離する（「plain `TypeError` の発生
+位置を呼出側が推測する」設計にしない）:
 
 ```typescript
 // web/src/lib/api.ts（Modified）
+// (a) dispatch 前の request preparation 失敗（JSON.stringify / URL 構築）を正規化する専用型。
+export class RequestPreparationError extends Error {
+  constructor(cause?: unknown) { super("Request preparation failed"); this.name = "RequestPreparationError"; this.cause = cause; }
+}
+// (c) fetch 成功後の 2xx body parse 失敗を status 付きで正規化する専用型。
 export class ResponseParseError extends Error {
   status: number;         // fetch 成功時の response.status（2xx）
   constructor(status: number) { super(`Response parse failed: ${status}`); this.name = "ResponseParseError"; this.status = status; }
 }
-// request<T> 末尾:
+
+// request<T> の構造（イメージ）:
+//   let init: RequestInit;
+//   try { init = buildInit(body); /* JSON.stringify / URL 構築を含む */ }
+//   catch (e) { throw new RequestPreparationError(e); }        // (a) dispatch 前 = commit 不成立が確定
+//   const response = await fetch(url, init);                   // (b) reject は plain TypeError（dispatch 後 = 不確定）
+//   ... status handling / 204,205 分岐 ...
 //   try { return await response.json(); }
-//   catch { throw new ResponseParseError(response.status); }  // 2xx だが body 不能
+//   catch { throw new ResponseParseError(response.status); }   // (c) 2xx だが body 不能 = 不確定
 ```
 
-- これにより呼出側は「`ResponseParseError`（status 2xx）」= post-dispatch の commit 済み示唆 2xx parse 失敗 と、
-  dispatch 前の `TypeError`（serialize / URL 構築失敗）を **確実に区別**できる
-- `credentials: "include"` / 204/205 分岐など既存挙動は不変（末尾 json parse のみ try/catch で包む差分等価）
+- これにより呼出側は 3 起点を確実に弁別できる:
+  - `RequestPreparationError` = **dispatch 前**の serialize / URL 構築失敗 → **commit 不成立が確定** → `server_error`
+  - plain `TypeError`（`fetch()` の reject）= **dispatch 後**のネットワーク断 → **commit 済みの可能性が残る** → `registration_uncertain`
+  - `ResponseParseError`（status 2xx）= **dispatch 後**の 2xx body 不能 → **commit 済み示唆だが確定不能** → `registration_uncertain`
+- `credentials: "include"` / 204/205 分岐など既存挙動は不変（request preparation を try/catch で囲み、末尾 json parse を
+  try/catch で囲む差分等価。`fetch()` reject の plain `TypeError` はそのまま透過させる）
 
 ### 状態定義（Req 5.1）
 
@@ -768,7 +819,8 @@ export class ResponseParseError extends Error {
 「`registration/finish` の request dispatch **後**に確定的な pre-commit 4xx を得られなかった」場合に
 のみ設定される。具体条件:
 
-- fetch reject（`TypeError` = ネットワーク断 / 接続断 / DNS 失敗）
+- fetch reject（`fetch()` が投げる plain `TypeError` = dispatch 後のネットワーク断 / 接続断 / DNS 失敗。
+  dispatch 前の `RequestPreparationError` とは別起点）
 - 送出後の Abort（`DOMException.name === "AbortError"`）/ timeout
 - 5xx 応答（サーバが受理・commit した可能性があるが応答段で失敗）
 - **commit 済みを示唆する 2xx だが body 不能**（`ResponseParseError`。Set-Cookie は付いた可能性があり、
@@ -776,9 +828,10 @@ export class ResponseParseError extends Error {
 
 以下は **uncertain にしない**:
 
-- **dispatch 前のローカル失敗**（request 構築 / JSON serialize 等の `TypeError`）→ `server_error`（commit 不成立が確定）
+- **dispatch 前のローカル失敗**（request preparation = `JSON.stringify` / URL 構築失敗。`api.ts` が
+  `RequestPreparationError` に正規化）→ `server_error`（request がブラウザを離れておらず commit 不成立が確定 / Blocker #1）
 - **確定的な 4xx（すべての 4xx）**（finish の 400 REGISTRATION_FAILED / begin の 400/409 / その他 401/403/404/409/422 等）
-  → `server_rejected` / `invalid_username` / `username_taken`（拒否が確定。400 だけに限定しない / Blocker #4）
+  → `server_rejected` / `invalid_username` / `username_taken`（拒否が確定。400 だけに限定しない）
 - begin / create 段の失敗（`cancelled` / `network_error` 等、finish 送出前）
 
 > 直接 session 化により、registration 経路の `session_exchange_failed`（旧 auth_code→session 段の失敗）は
@@ -811,27 +864,58 @@ stateDiagram-v2
 try {
   await apiClient.post("/api/passkey/registration/finish", {...});
 } catch (err) {
+  // dispatch 前（request preparation = JSON.stringify / URL 構築）= commit 不成立が確定
+  // → server_error（uncertain にしない）。fetch reject の TypeError より前に判定する（Blocker #1）
+  if (err instanceof RequestPreparationError) throw new PasskeyRegistrationError("server_error", err);
   if (err instanceof ResponseParseError) throw new PasskeyRegistrationError("registration_uncertain", err); // 2xx body 不能
   if (err instanceof DOMException && err.name === "AbortError")
     throw new PasskeyRegistrationError("registration_uncertain", err);                                       // 送出後 Abort
   if (err instanceof ApiError) {
     if (err.status >= 500) throw new PasskeyRegistrationError("registration_uncertain", err);                // 5xx
-    if (err.status >= 400) {                                                                                 // 全 4xx = 拒否確定
-      if (err.status === 400 && err.body?.code === "REGISTRATION_FAILED")
-        throw new PasskeyRegistrationError("server_rejected", err);
-      throw new PasskeyRegistrationError("server_rejected", err);
-    }
+    if (err.status >= 400) throw new PasskeyRegistrationError("server_rejected", err);                       // 全 4xx = 拒否確定
     throw new PasskeyRegistrationError("server_error", err);
   }
+  // 残る plain TypeError は fetch() の reject（dispatch 後）のみ（preparation は上で分岐済み）→ uncertain
   if (err instanceof TypeError) throw new PasskeyRegistrationError("registration_uncertain", err);           // fetch reject（送出後）
-  throw new PasskeyRegistrationError("server_error", err);                                                   // dispatch 前ローカル失敗
+  throw new PasskeyRegistrationError("server_error", err);                                                   // その他の想定外
 }
 ```
 
 **安全側 fail 原則**: finish 送出後に「拒否が確定（4xx）」でない限り、commit 済みの可能性を排除できないため
-uncertain に倒す。dispatch 前の失敗（`TypeError` のうち fetch 到達前のもの）は commit 不成立が確定するため
-uncertain にしない。`api.ts` の `ResponseParseError` により「fetch 成功後の 2xx parse 失敗」を確実に
-uncertain 側へ振り分けられる。
+uncertain に倒す。dispatch 前の失敗は commit 不成立が確定するため uncertain にしない。`api.ts` が
+**dispatch 前の request preparation 失敗を `RequestPreparationError`、fetch 成功後の 2xx parse 失敗を
+`ResponseParseError`（status 2xx）** に正規化するため、hook は「plain `TypeError` の発生位置」を推測せずに
+「dispatch 前（`RequestPreparationError` → server_error）/ fetch reject（plain `TypeError` → uncertain）/
+2xx parse 失敗（`ResponseParseError` → uncertain）」を機械的に振り分けられる（Blocker #1）。
+
+### discoverable ログイン結果の machine-readable 判定（`use-passkey-authentication.ts` / Blocker #3）
+
+完了不明状態の復旧は「discoverable ログイン → **一律 `AUTHENTICATION_FAILED` の後にのみ再作成導線**」に
+固定する（Req 5.4）。ところが PR #229 head の `usePasskeyAuthentication` は begin / finish の 400 / 409 を
+すべて `server_rejected` に畳み、status / code / phase を捨てるため、Dialog は「finish の一律
+`AUTHENTICATION_FAILED`」を他の失敗（begin 拒否 / cancel / network / 5xx / session 交換失敗）から区別できない。
+File Plan で当該 hook を [U]（不変）としていたことと合わせ、そのままでは Req 5.4 を満たせない（Blocker #3）。
+
+そこで `usePasskeyAuthentication` に **authentication finish の一律 `AUTHENTICATION_FAILED` のみを表す
+machine-readable な error kind**（例: `authentication_failed`）を追加する。判定は既存の response から得られる
+status / code のみで行い、**raw body / 内部理由（credential 未解決 等）は UI に渡さない**（NFR 2.1）。他の失敗は
+既存 kind を保つ:
+
+| discoverable ログインの失敗 | error kind（例） | 再作成導線 |
+|---|---|---|
+| finish の一律 `AUTHENTICATION_FAILED` | `authentication_failed`（**NEW**） | **提示する**（Req 5.4） |
+| begin の拒否（400 / 409 等） | 既存の begin 系 kind（`server_rejected` 等） | 提示しない |
+| ユーザー cancel（`NotAllowedError` / `AbortError`） | `cancelled` | 提示しない |
+| ネットワーク断（fetch reject） | `network_error` | 提示しない |
+| 5xx | `server_error` | 提示しない |
+| session 交換段（`/api/auth/session`）失敗 | 既存の交換系 kind（`session_exchange_failed` 等） | 提示しない |
+
+- Dialog は復旧ログインの結果 error の kind が `authentication_failed`（finish 一律失敗）**のときにのみ**
+  「再度作成する」を提示する（Req 5.4）。上表の他 kind では再作成を出さない（Blocker #3 の negative 条件）
+- 本 kind は「finish の一律失敗」という **観察可能な単一事実** のみを表し、内部理由の細分は行わない
+  （Req 5.4 の「内部理由を区別して提示しない」と NFR 2.1 を同時に満たす）
+- 本補正により File Plan の `use-passkey-authentication.ts` / `use-passkey-authentication.test.tsx` は
+  [U]→[E] に更新する（§File Structure Plan §Web）
 
 ### UI 文言と復旧導線（`passkey-signup-dialog.tsx` / Req 5.2〜5.6）
 
@@ -854,11 +938,11 @@ uncertain 側へ振り分けられる。
   1. 初期: 「ログインで確認する」ボタンのみ。押下で `usePasskeyAuthentication` の **discoverable ログイン**
      （`navigator.credentials.get()` を allowCredentials 空で実行 / ユーザー名入力なし）を起動する（Req 5.2）
   2. 成功: 通常の Cookie セッション認証に到達し 2 ペイン UI（Req 5.3）
-  3. 一律 `AUTHENTICATION_FAILED`（内部理由を区別しない）で失敗: **その後にはじめて**「再度作成する」導線を
-     提示する（Req 5.4）。再作成は `mutation.reset()` で Idle に戻す。登録済みなら再試行時に
-     `username_taken` になる旨も併記可
-  - 再作成導線は **discoverable ログインの一律失敗の後のみ**提示する。cancel / network / 5xx / uncertain の
-    初期画面には再作成を出さない（Blocker #4 / Blocker #8 の負ケース）
+  3. 復旧ログインの結果 error kind が `authentication_failed`（finish 一律 `AUTHENTICATION_FAILED` /
+     §auth hook 判定。内部理由を区別しない）の失敗: **その後にはじめて**「再度作成する」導線を提示する
+     （Req 5.4）。再作成は `mutation.reset()` で Idle に戻す。登録済みなら再試行時に `username_taken` になる旨も併記可
+  - 再作成導線は **復旧ログインの kind が `authentication_failed` のときのみ**提示する。begin 拒否 / cancel /
+    network / 5xx / session 交換失敗 / uncertain の初期画面には再作成を出さない（Blocker #3 / Blocker #8 の負ケース）
 
 ### 秘密情報の非漏出（Req 5.5 / NFR 2.1）
 
@@ -903,9 +987,12 @@ uncertain 側へ振り分けられる。
 
 - `config.go`: **CORS 層用の `CORSAllowedOrigin` は既定 `http://localhost:3000` のまま**（既存 CORS
   ミドルウェア・Google OAuth の後方互換 / NFR 3.1）。加えて Web パスキー専用の
-  `WebPasskeyAllowedOrigin string` を **新設**し、`os.Getenv("CORS_ALLOWED_ORIGIN")` の生値を用いる
-  （空文字/未設定 → `""`。localhost へ default しない）。パスキー系の Origin fail-closed 判定は
-  すべて `WebPasskeyAllowedOrigin` を参照する
+  `WebPasskeyAllowedOrigin string` を **新設**し、`os.Getenv("CORS_ALLOWED_ORIGIN")` の値を
+  **trim + strict exact-Origin validation** に通した結果を用いる（下記 §exact Origin validation）。
+  **生値の `!= ""` だけで readiness を成立させない**（Blocker #6）: trim 後に空、または exact Origin として
+  invalid（scheme/host を欠く / path・query・fragment・userinfo を持つ / 末尾スラッシュ / 空白や複数 origin を
+  含む 等）な値は **`WebPasskeyAllowedOrigin = ""` に倒す**（= capability 404 / Origin 検証 403 の fail-closed）。
+  localhost へは default しない。パスキー系の Origin fail-closed 判定はすべて `WebPasskeyAllowedOrigin` を参照する
 - `docker-compose.yml`: `api` の `CORS_ALLOWED_ORIGIN=${CORS_ALLOWED_ORIGIN:-http://localhost:3000}` を
   `${CORS_ALLOWED_ORIGIN:-}` に変更。理由: 未設定の運用者にはコンテナへ **空文字** が渡り、
   `WebPasskeyAllowedOrigin=""` → capability 404 / registration・login Origin fail-closed（403）に
@@ -918,6 +1005,29 @@ uncertain 側へ振り分けられる。
 「CORS 層既定を壊さず、パスキーだけ明示設定を要求する」= 明示設定フラグ相当を採る。empty default 単独では
 CORS ミドルウェアの既定挙動（localhost:3000）まで空に倒れ Google OAuth の default dev 体験を壊すため
 不採用。BASE_URL 検証は BASE_URL と CORS を暗黙結合させ運用の自由度を下げるため不採用。
+
+### exact Origin validation（`WebPasskeyAllowedOrigin` の readiness 判定 / Blocker #6）
+
+`WebPasskeyAllowedOrigin` は「Web パスキーが信頼する **唯一の exact Origin**」であり、単なる非空判定では
+malformed 値（末尾空白・path 付き・複数 origin 等）を 200 で通してしまい、capability=200 なのに実 finish が
+Origin mismatch で ceremony 後に 500 / 403 破綻する（Req 3.6 違反）。これを避けるため、config load 時に
+`os.Getenv("CORS_ALLOWED_ORIGIN")` を以下で検証し、**valid な単一 exact Origin のみ**を採用する:
+
+1. **trim**: 前後空白（`" \t\r\n"`）を除去する
+2. **非空**: trim 後が空なら invalid（→ `""`）
+3. **単一 origin**: 内部に空白・カンマを含む（複数 origin 列挙）なら invalid
+4. **scheme + host を持つ exact Origin**: `url.Parse` で scheme（`http` / `https`）と host（非空）を持ち、
+   **path が空**（`""` のみ許容。`"/"` や任意 path は不可）、**query / fragment / userinfo を持たない** こと。
+   末尾スラッシュ（`https://example.com/`）は path を持つため invalid
+5. 上記いずれか不成立なら **`WebPasskeyAllowedOrigin = ""`（fail-closed。capability 404 / Origin 検証 403）** とする
+
+- **fail-closed へ倒す（既定）**: invalid 値は起動を止めず `""` に正規化し、Web はパスキー導線を出さず Google
+  単体へ縮退する。この結果 capability=404 となり「capability だけ 200 で signup 500」の不整合（Req 3.6）を
+  構造的に発生させない。運用者向けには invalid を検知した旨を **秘密値を含めず** ログ warn する（生 Origin 値は
+  設定ミスの調査に必要な範囲でのみ出し、session_id / secret は出さない / NFR 2.2）
+- **代替（起動エラー）**: より厳格な運用では invalid 時に起動を fail させる選択も可能。本設計は既存の
+  「未設定 → 空 → fail-closed」方針と一貫させるため **`""` 正規化を既定** とし、起動エラーは採らない
+  （挙動を tasks / config test で固定する）
 
 ### 既存 env 流用に留める（Req 6.5）
 
@@ -979,8 +1089,9 @@ Delta 4 §主防御要素表・§WebAuthn の防御性質の正確化・§残余
 
 - **Unit（`session_factory_test.go`）**:
   1. `NewSession` が ID（非空 / 32 バイト hex）・`CreatedAt`・`ExpiresAt=CreatedAt+TTL` を返し、
-     `CreatedAt` と `ExpiresAt` が **同一 now** に基づく（factory の now を固定して検証）
-  2. ID 生成失敗（rand 失敗を注入）で error を返し部分構築しない
+     `CreatedAt` と `ExpiresAt` が **同一 now** に基づく（factory の `now` を固定して検証）
+  2. ID 生成失敗を **factory の `newID` seam に失敗関数を注入**して再現し、error を返し部分構築しないことを検証する
+     （`crypto/rand.Reader` の global 差替えを行わず、並列テストを汚染しない / Blocker #2）
 - **Unit（`registration_service_test.go`）**:
   1. 正常系（Web mode）: 既存 txBeginner の `BeginTx` 内で user → credential → session の順に呼ばれ、
      `webSession` に factory 生成の ID / `CreatedAt` / `ExpiresAt` が入る（fake tx で呼び出し順を検証）
@@ -1002,8 +1113,10 @@ Delta 4 §主防御要素表・§WebAuthn の防御性質の正確化・§残余
   5. `webRegistrationReady()` false（session writer / factory 未配線）→ 500、mutation 呼ばれず（Blocker #8）
 - **Unit（`native_auth_handler_test.go`）**: `/api/auth/session` の Origin 不在・不一致・許可 Origin
   未設定で 403（Delta 4 fail-closed 補正の回帰）
-- **Unit（`config_test.go`）**: `CORS_ALLOWED_ORIGIN` set → `WebPasskeyAllowedOrigin=値` /
-  unset・empty → `WebPasskeyAllowedOrigin=""`、`CORSAllowedOrigin` は既定 localhost:3000 を維持（Blocker #8）
+- **Unit（`config_test.go`）**: `CORS_ALLOWED_ORIGIN` valid set → `WebPasskeyAllowedOrigin=正規化値` /
+  unset・empty・**malformed（前後空白 `" https://x "` / 末尾スラッシュ `https://x/` / path・query・fragment 付き /
+  複数 origin `a,b`）→ `WebPasskeyAllowedOrigin=""`（fail-closed）**、`CORSAllowedOrigin` は既定 localhost:3000 を
+  維持（Blocker #6 / Blocker #8）
 - **Integration（`router_test.go`）**: fail-closed 表 行 1〜5 の各 endpoint（列 A〜E）登録有無。特に
   行 2（W✓ N✗ C✓）で iOS registration/*・authentication/* が 200・capability が 404、
   行 3（W✓ N✓ C✗）で capability 404、partial wiring（webRegistrationReady 未充足）で capability が
@@ -1014,8 +1127,9 @@ Delta 4 §主防御要素表・§WebAuthn の防御性質の正確化・§残余
 
 - **Unit（`api.test.ts`）**:
   1. 2xx で body 欠損 / 途中切断 / parse 不能 → `ResponseParseError`（status 2xx）を投げる
-  2. dispatch 前の JSON serialize 失敗（循環参照等）→ plain `TypeError`（`ResponseParseError` ではない）
-     で、両者が区別できる（Blocker #4 / #8）
+  2. dispatch 前の request preparation 失敗（`JSON.stringify` の循環参照 / URL 構築失敗）→ `RequestPreparationError`
+  3. `fetch()` の reject（ネットワーク断）→ plain `TypeError`（`RequestPreparationError` でも `ResponseParseError` でもない）
+     で、3 起点が機械的に区別できる（Blocker #1）
 - **Unit（`use-passkey-registration.test.tsx`）**:
   1. 正常系: begin → create → finish の 3 呼び出しのみ。`authentication/*` / 登録用 `/api/auth/session` が
      呼ばれない（二度目 ceremony 除去の回帰）
@@ -1024,16 +1138,24 @@ Delta 4 §主防御要素表・§WebAuthn の防御性質の正確化・§残余
   4. `registration_uncertain` × AbortError
   5. `registration_uncertain` × `ResponseParseError`（2xx body 不能）
   6. **全 4xx（400 REGISTRATION_FAILED / 401 / 403 / 404 / 409 / 422）が `server_rejected`（拒否確定）に
-     分類され uncertain に誤分類されない**（400 だけに限定しない / Blocker #4 / #8）
-  7. dispatch 前ローカル失敗（`TypeError`）が `server_error`（非-uncertain）に分類される
+     分類され uncertain に誤分類されない**（400 だけに限定しない / Blocker #1 / #8）
+  7. dispatch 前ローカル失敗（`api.ts` の `RequestPreparationError`）が `server_error`（非-uncertain）に分類され、
+     fetch reject の plain `TypeError`（uncertain）と取り違えられない（Blocker #1）
   8. begin 段の `invalid_username` / `username_taken` / `cancelled` は既存挙動維持
+- **Unit（`use-passkey-authentication.test.tsx` / Blocker #3）**:
+  1. discoverable ログインの finish 一律 `AUTHENTICATION_FAILED` が machine-readable kind
+     （例: `authentication_failed`）に分類される
+  2. begin 拒否 / cancel（`NotAllowedError`）/ network（fetch reject）/ 5xx / session 交換段
+     （`/api/auth/session`）失敗が **`authentication_failed` 以外の別 kind** になる（negative: 再作成条件に該当しない）
+  3. 内部理由 / raw body を error に含めない（NFR 2.1）
 - **Component（`passkey-signup-dialog.test.tsx`）**:
   1. `registration_uncertain` で見出し「登録が完了したかどうかを確認できませんでした」が表示され、
      初期に「再度作成する」が **表示されない**（同列並置しない / Req 5.2）
   2. 「ログインで確認する」押下で discoverable ログイン（`usePasskeyAuthentication`）が起動
   3. discoverable ログインが一律失敗した後に「再度作成する」が表示され、押下で `mutation.reset()`
-  4. login の cancel / network / 5xx では初期画面に「再度作成する」が出ない（一律 AUTHENTICATION_FAILED
-     の後のみ / Blocker #8）
+  4. 復旧ログインの kind が `authentication_failed` のときのみ「再度作成する」が出る。begin 拒否 / cancel /
+     network / 5xx / session 交換失敗では初期画面にも失敗後にも「再度作成する」が出ない（一律
+     `AUTHENTICATION_FAILED` の後のみ / Blocker #3 / Blocker #8）
   5. 文言中にサーバ内部詳細 / 他 kind の代表文言が含まれない（Req 5.5 / 5.6 回帰）
 - **Recovery（`login-page-recovery.test.tsx`）**: `registration_uncertain` → 「ログインで確認する」→
   discoverable ログイン成功 → 2 ペイン UI 到達（Req 5.3。unit で組めない場合は E2E 側へ委譲する旨を明記）

--- a/docs/specs/231-design-web-auth/design.md
+++ b/docs/specs/231-design-web-auth/design.md
@@ -1,0 +1,1128 @@
+# Design Document
+
+## Overview
+
+**Purpose**: 本設計は Issue #223（Web ログイン画面のパスキー導線追加）に対する
+**差分設計（normative delta）** である。#223 の実装 PR #229 レビューで発見された 5 件の
+不整合（登録直後の二度目 WebAuthn ceremony / File Structure Plan の欠落 /
+fail-closed 表の不正確さ / CSRF 記述の誤り / 完了不明状態の未定義）を、#223 spec の
+物理ファイルを一切変更せず、本 spec 内で normative に上書き（supersede）する。
+
+**Users**: 未認証 Web 訪問者（パスキーで新規作成する層／ iOS #216 で作成したパスキーで Web
+にログインする層）と、既存 Google OAuth ユーザー、Feedman 運用者。iOS #216 ユーザーへの
+影響はゼロ（本差分は iOS の request/response 契約を破壊しない / 追加は additive のみ /
+NFR 3.2）。
+
+**Impact**: 本 spec は独立した実装 PR を作らない。design PR merge 後、PR #229 の
+`needs-iteration` 1 回で製品コード（`internal/passkey/` / `internal/handler/` /
+`web/src/hooks/` / `web/src/components/`）・テスト・spec の
+`impl-notes.md` / `context-map.md`（**#223 spec の requirements.md / design.md /
+tasks.md は書き換えない**）へ差分を反映する。#231 spec の tasks.md は「PR #229 に
+適用する差分作業」を独立コミット可能な粒度で列挙する（NFR 1.2）。
+
+### 補正する 5 つの Delta サマリ
+
+- **Delta 1（Requirement 1）**: 登録 finish で二度目の WebAuthn ceremony を廃止し、
+  `POST /api/passkey/registration/finish` の応答に **additive で `auth_code` を含める**方式に
+  改める。`internal/passkey/registration_service.go` の `RegistrationService` に、既存
+  `AuthenticationService.authnSession` と同型の `registrationSession` 封筒を導入して
+  begin 時の `code_challenge` を finish まで運び、既存 `auth.AuthCodeCreator` で auth_code を
+  発行する。iOS #216 の `registration/finish` レスポンスは既存 `{user_id}` に `auth_code` が
+  追加されるのみで、iOS の JSON 復号は未知フィールドを無視する慣行のため契約破壊にはならない。
+- **Delta 2（Requirement 2）**: PR #229 の実変更ファイル一覧を File Structure Plan 差分の
+  「変更対象」に完全列挙する（`web/src/lib/api.ts` / `api.test.ts` / `.env.sample` /
+  `docker-compose.yml` を含む）。#223 design の「api.ts 無変更」記述を訂正する。
+- **Delta 3（Requirement 3）**: fail-closed 表を env × 4 endpoint（session / capability /
+  iOS registration/* / iOS authentication/*）の独立列に組み直し、`NATIVE_AUTH_JWT_SECRET`
+  未設定時に iOS endpoint が **維持される** ことを表現する。合わせて Web 用 capability probe の
+  route 登録条件を `PasskeyHandler != nil` から **`PasskeyHandler != nil && NativeAuthHandler
+  != nil`** に強化し、Web で end-to-end 実行不能な env 構成では capability = 404 として
+  Google 単体表示に確実に縮退させる（router 側の小修正）。iOS endpoint 群の登録条件は
+  従来どおり `PasskeyHandler != nil` のみで変えないため #216 契約は破壊しない（NFR 3.2）。
+- **Delta 4（Requirement 4）**: 「攻撃者は (auth_code, code_verifier) ペアを取得できない」の
+  誤記述を撤回し、CSRF 主防御（exact Origin / JSON Content-Type / CORS preflight /
+  SameSite / PKCE + auth_code 単回 60s TTL）と 2 種の残余リスク（同一オリジン XSS 経由 /
+  攻撃者自身の credential による自アカウント誘引）を明記する。人間運用者決定として追加の
+  browser-bound state（transaction cookie / 追加 CSRF token / Origin-bound challenge 拡張）は
+  導入しない旨も決定記録として残す。**design 側の記述変更のみ**で製品コードへの挙動変更を
+  伴わない。
+- **Delta 5（Requirement 5）**: 「サーバは registration/finish を commit したがクライアントが
+  応答を受け取れなかった」ケースを **第 3 の完了不明状態** として定義し、`PasskeyRegistration
+  ErrorKind` に `registration_uncertain` を追加。UI では既存の
+  `invalid_username` / `username_taken` / `cancelled` / `server_rejected` /
+  `session_exchange_failed` と識別可能な文言で提示し、ログイン導線での確認 / 再作成の
+  復旧導線を提供する。
+
+### Goals
+
+- 主要目標 1: 新規作成完了までに追加の WebAuthn ceremony を要求しない（Requirement 1）
+- 主要目標 2: iOS #216 の `/api/passkey/*` request/response 契約を破壊しない（NFR 3.2）
+- 主要目標 3: 完了不明状態を含む復旧導線を Web UX として明確化する（Requirement 5）
+- 主要目標 4: fail-closed 表と CSRF 記述を運用者・レビュワーが誤読しない粒度で明確化する
+  （Requirement 3 / 4）
+- 成功基準:
+  - PR #229 に本差分を反映した後の `go test ./...` と `web/npm test` が既存テストを含めて green
+  - `POST /api/passkey/registration/finish` のレスポンスが `{user_id, auth_code}` を含み、
+    web が二度目 WebAuthn ceremony なしで `POST /api/auth/session` 呼び出しに到達する
+  - `NATIVE_AUTH_JWT_SECRET` 未設定 + `WEBAUTHN_RP_ID/ORIGINS` 設定済み env で iOS 用
+    `/api/passkey/registration/*` / `/api/passkey/authentication/*` が引き続き 200 応答する
+
+### Non-Goals
+
+- **#223 spec の物理ファイル書換え**（`docs/specs/223-feat-web-web/requirements.md` /
+  `design.md` / `tasks.md`）— 本 spec は差分宣言のみを行い、物理ファイルは触らない（NFR 1.1）
+- **独立した実装 PR の作成** — 差分は PR #229 の needs-iteration 1 回で反映（NFR 1.2）
+- **#216 iOS パスキー API 契約の破壊的変更**（NFR 1.3 / NFR 3.2）
+- **Issue #230 相当の DB トランザクション統合実装**（本 spec は Delta 1 の合流方式要件までを
+  扱い、user / credential の単一トランザクション化は #230 に委ねる）
+- **browser-bound state（transaction cookie / 追加 CSRF token / Origin-bound challenge 拡張）
+  の導入**（Requirement 4 の決定事項として本 spec では要求しない）
+- **`.env.sample` / `docker-compose.yml` を別 prerequisite PR に分離すること**
+  （Requirement 6 の決定事項）
+
+## Architecture
+
+### Existing Architecture Analysis
+
+本差分は #223 design が確立した以下の既存アーキテクチャを **維持する前提** で、上記 5 点の
+不整合のみを補正する。責務境界・依存方向・fail-closed 判定ロジック本体は変更しない
+（Delta 3 の router 条件のみ 1 行相当を強化）:
+
+- **既存パターンの維持**:
+  - `handler → service → repository → model` の一方向依存（CLAUDE.md §1）
+  - `internal/passkey/` の ceremony 責務（`RegistrationService` / `AuthenticationService`）と
+    `internal/handler/passkey_handler.go` の HTTP I/O 責務の分離（#216 で確立）
+  - `challengeStore.Issue/Consume` を通じた TTL 付き単回消費（#216 で確立）
+  - `AuthenticationService` が既に採用している `authnSession` 封筒パターン（sessionData
+    バイト列を `{WebAuthnSession, CodeChallenge}` で opaque に運ぶ）→ **Delta 1 で
+    `RegistrationService` にも横展開**
+  - Web 側の `lib/` 純粋関数 → `hooks/` mutation → `components/` UI の 3 層構成（#223 で確立）
+  - fail-closed による route 未登録判定（`if deps.<Handler> != nil { register }` パターン）
+- **本差分が変更する点**:
+  - `RegistrationService.BeginRegistrationNew` / `FinishRegistrationNew` の内部処理と
+    `FinishRegistrationNew` のシグネチャ（`(userID, error)` → `(userID, authCodePlain, error)`）
+  - `PasskeyHandler.RegistrationFinish` のレスポンス body に `auth_code` を additive 追加
+  - `router.go` の capability route 登録条件を「両 handler 非 nil」に強化
+  - Web hook `use-passkey-registration.ts` の内部 chain（二度目 ceremony 除去 +
+    `registration_uncertain` state 追加）
+  - Web UI `passkey-signup-dialog.tsx` の error state 分岐に uncertain 状態と復旧導線 UI を追加
+  - `.env.sample` / `docker-compose.yml` に既存 WebAuthn env の記述を整備（**新規 env 追加は
+    なし**、既存 env の documentation / passthrough のみ）
+- **尊重すべき制約**:
+  - iOS #216 の request/response 契約：`registration/begin` request `{username, email?, code_challenge}`,
+    `registration/finish` request `{challenge_id, credential}`, `authentication/begin` request
+    `{code_challenge}`, `authentication/finish` response `{auth_code}` の各フィールド構造は
+    そのまま維持する。**additive な optional response field 追加のみ許容**（`registration/finish`
+    レスポンスへの `auth_code` 追加）
+  - `#223` design.md の全 Components セクション（`SessionExchangeService` / `NativeAuthHandler.
+    Session` / `PasskeyHandler.Capability` / Web 側 hook/component 群）の責務・契約はそのまま
+    維持
+  - NFR 1.1（`#223` requirements.md / design.md / tasks.md の物理ファイル不変）
+  - NFR 1.3（#216 requirements.md / design.md / tasks.md および `/api/passkey/registration/*` /
+    `/api/passkey/authentication/*` の request/response 契約変更禁止 — 本差分の
+    `registration/finish` 応答への `auth_code` 追加は additive のため許容）
+
+### 差分適用の運用境界
+
+```mermaid
+flowchart LR
+    subgraph This231 [#231 spec（本 design）]
+        R231[requirements.md]
+        D231[design.md<br/>本ファイル<br/>Delta 1〜5]
+        T231[tasks.md<br/>PR #229 への差分作業]
+    end
+
+    subgraph Existing223 [#223 spec（物理不変）]
+        R223[requirements.md]
+        D223[design.md<br/>該当節を supersede]
+        T223[tasks.md<br/>tasks 追加なし]
+    end
+
+    subgraph Existing216 [#216 spec（物理不変）]
+        R216[requirements.md]
+        D216[design.md]
+        T216[tasks.md]
+    end
+
+    subgraph PR229 [PR #229 実装]
+        S229[製品コード<br/>internal/**, web/src/**]
+        SPEC229[spec 補助<br/>context-map.md<br/>impl-notes.md]
+        CONF229[運用 config<br/>.env.sample<br/>docker-compose.yml]
+    end
+
+    D231 -.supersedes.-> D223
+    T231 -->|needs-iteration 1| S229
+    T231 -->|needs-iteration 1| SPEC229
+    T231 -->|needs-iteration 1| CONF229
+    R231 -.non-invasive.-> R223
+    T231 -.non-invasive.-> T223
+    T231 -.non-invasive.-> R216
+    T231 -.non-invasive.-> D216
+    T231 -.non-invasive.-> T216
+```
+
+- `#231 design.md` は `#223 design.md` の該当節を supersede する（本ファイル内の Delta 1〜5 で
+  before → after を明示）
+- `#231 tasks.md` は PR #229 に適用する製品コード / テスト / 運用 config / spec 補助
+  （`impl-notes.md` / `context-map.md`）への差分作業のみを列挙し、**`#223` / `#216` の
+  requirements.md / design.md / tasks.md を書き換えるタスクを含まない**
+- `#216` spec 全体は本差分の対象外（NFR 1.3）
+
+### Technology Stack
+
+本差分は **技術スタック追加なし**。既存の技術選定（Go 1.25 / chi/v5 / PostgreSQL 16 /
+go-webauthn / Next.js 15 / TanStack Query / shadcn/ui / Vitest）をそのまま使用する。
+
+## File Structure Plan（PR #229 に適用する差分の変更対象 / 新規追加）
+
+本セクションは PR #229 の `needs-iteration` 1 回で反映する対象ファイルを **変更対象**
+（既存 or PR #229 で既に追加済み → 本差分でさらに編集）と **新規追加**（本差分で初めて
+生成）に分けて明示する。**#223 design.md「File Structure Plan」節を supersede する**
+（Requirement 2）。
+
+### Modified Files（PR #229 に対する編集対象）
+
+#### サーバ側
+
+- `internal/passkey/registration_service.go` — **変更**（Delta 1 / #216 で main 済み）
+  - `registrationSession` 封筒構造体を追加（`{WebAuthnSession json.RawMessage,
+    CodeChallenge string}`、既存 `authentication_service.go::authnSession` と同型）
+  - `BeginRegistrationNew` を修正: 検証済み `code_challenge` を封筒に格納し
+    `challengeStore.Issue(sessionData=封筒 marshal)` として運ぶ
+  - `FinishRegistrationNew` のシグネチャを **`(userID string, error) → (userID string,
+    authCodePlain string, error)`** に変更（additive: 呼び出し側は handler のみ）
+  - `FinishRegistrationNew` に auth_code 発行ロジック追加（`auth.GenerateAuthCode` +
+    `auth.HashNativeSecret` + `AuthCodeCreator.Create` — `authentication_service.go` と
+    完全同経路）
+  - `RegistrationService` 構造体に `authCodes auth.AuthCodeCreator` フィールドを追加、
+    `NewRegistrationService` シグネチャに `authCodes` を追加（wiring 側で
+    `PostgresAuthCodeRepo` を注入）
+- `internal/passkey/registration_service_test.go` — **変更**
+  - 既存ケースの assertion を新シグネチャに追従（`userID` に加え `authCodePlain` を返す）
+  - 新規ケース: 正常系で `AuthCodeCreator.Create` が `envelope.CodeChallenge` を PKCE として
+    紐付ける AuthCode を受け取ることを stub で検証
+  - 新規ケース: `code_challenge` を封筒 → sessionData → 復元まで往復させて begin/finish 間で
+    保持されることを検証
+- `internal/handler/passkey_handler.go` — **変更**（Delta 1 handler 側 + Delta 3 不変）
+  - `RegistrationFinish` ハンドラ内で `RegistrationService.FinishRegistrationNew` の 2 番目
+    返り値（`authCodePlain`）をレスポンス body へ additive に組み込む
+    （`{user_id, auth_code}` の形式）
+  - `Capability` ハンドラ（PR #229 で新規追加済み）は本差分では変更しない（route 側の登録
+    条件のみ router.go で変更）
+- `internal/handler/passkey_handler_test.go` — **変更**
+  - `TestPasskeyHandler_RegistrationFinish` の assertion に `body.auth_code` の存在確認・
+    形式検証（base64url 43 文字以上、既存 `HashNativeSecret` 入力形式）・**iOS ignore-unknown
+    互換の観点で追加フィールドのみ増えたことを確認する**回帰ケースを追加
+- `internal/handler/router.go` — **変更**（Delta 3 router 登録条件強化）
+  - 現状想定される `if deps.PasskeyHandler != nil { r.With(...).Get("/api/passkey/capability",
+    deps.PasskeyHandler.Capability) }` を **`if deps.PasskeyHandler != nil &&
+    deps.NativeAuthHandler != nil`** に強化する（NATIVE 系 env が未設定なら Web 側 probe を
+    404 に倒し Google 単体に確実に縮退させる）
+  - iOS 用 `/api/passkey/registration/*` および `/api/passkey/authentication/*` の登録条件は
+    従来どおり `PasskeyHandler != nil` のみで **変更しない**（#216 契約維持 / NFR 3.2）
+- `internal/handler/router_test.go` — **変更**
+  - fail-closed 表の 4 環境行に対応する route 登録有無テストを追加:
+    - 全 env 設定済み → `/api/auth/session` 204 / capability 200 / iOS registration/* /
+      authentication/* いずれも登録
+    - NATIVE unset + WEBAUTHN set → session 404 / capability 404 / iOS 系登録
+    - NATIVE set + WEBAUTHN unset → session 登録 / capability 404 / iOS 系 404
+    - 両 unset → 全 404
+- `internal/handler/router_unauth_ratelimit_test.go` — 既存テスト維持（本差分で追加変更なし）
+- `internal/handler/native_auth_handler.go` — 既存 PR #229 実装を維持（本差分で追加変更なし）
+- `internal/handler/native_auth_handler_test.go` — 既存 PR #229 実装を維持
+- `internal/auth/session_exchange.go` — 既存 PR #229 実装を維持
+- `internal/auth/session_exchange_test.go` — 既存 PR #229 実装を維持
+- `internal/app/app.go` — **変更**
+  - `passkey.NewRegistrationService` の呼び出しに `authCodes`（`repository.PostgresAuthCodeRepo`）
+    を注入する（既存 `AuthenticationService` の wiring と同じ具体依存を再利用）
+
+#### Web 側
+
+- `web/src/hooks/use-passkey-registration.ts` — **変更**（Delta 1 web + Delta 5 hook）
+  - 現行 PR #229 の chain は「begin → create → finish → `<認証 chain>: begin → get → finish
+    → session`」であり、finish 200 後に **二度目の WebAuthn ceremony**（`navigator.credentials
+    .get`）を実行している。本差分ではこの二度目 ceremony を **完全除去** し、finish の応答
+    body の `auth_code` を直接 `POST /api/auth/session {auth_code, code_verifier}` に渡す
+  - `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加（Delta 5）
+  - error 分類ロジックを step index ベースで再構成し、`step === registration_finish` かつ
+    `fetch reject`（`TypeError`） / 5xx / タイムアウト時に `registration_uncertain` を返す
+    （詳細は §Delta 5「状態遷移と判定」）
+- `web/src/hooks/use-passkey-registration.test.ts` — **変更**
+  - 既存の「登録 → 認証 → session」正常系 test を「登録 → session」正常系に書き換え
+    （二度目 ceremony が呼ばれないことを assert）
+  - 新規: `registration_uncertain` を 3 サブケース（fetch reject / 5xx / abort）で誘発する test
+  - 既存 error kind 分岐（`invalid_username` / `username_taken` / `cancelled` /
+    `server_rejected` / `session_exchange_failed`）の test はシグネチャに追従して維持
+- `web/src/components/passkey-signup-dialog.tsx` — **変更**（Delta 5 UI）
+  - `error.kind === "registration_uncertain"` 分岐を追加し、Delta 5 §UI 文言と復旧導線
+    （「ログイン画面で確認する」「再度作成する」の 2 ボタン）を表示
+  - 既存 error kind 分岐は文言・挙動を維持（Requirement 5.6 の弁別性を担保）
+- `web/src/components/passkey-signup-dialog.test.tsx` — **変更**
+  - `registration_uncertain` 分岐の文言表示と復旧ボタンの callback 呼び出しを検証する test を追加
+- `web/src/components/login-page.tsx` — 既存 PR #229 実装を維持（本差分で追加変更なし）
+- `web/src/components/login-page.test.tsx` — 既存 PR #229 実装を維持
+- `web/src/components/login-page-recovery.test.tsx` — **変更**（PR #229 で追加済み）
+  - `registration_uncertain` → ログイン試行 → 成功時に 2 ペイン UI に到達する recovery E2E-ish
+    テストの追加を検討（Requirement 5.3）。ユニットレベルで実現困難な場合は既存
+    login-page.test.tsx 側のカバレッジで代替してよい（本テスト新規は必須ではない / 詳細は
+    tasks.md 側で判断）
+- `web/src/lib/api.ts` — **変更**（Requirement 2.1 / 現行 #223 design が誤って「無変更」と
+  記述している）
+  - PR #229 で `credentials: "include"` 経路の追加拡張・エラー body 保持形式の変更・
+    `ApiError.code` 判定強化などが行われた形跡。本差分では PR #229 で既に加えた変更を
+    File Structure Plan に **正確に列挙する**（本差分自身が api.ts をさらに触る必要はない）
+- `web/src/lib/api.test.ts` — **変更**（PR #229 で追加済みだが #223 design 未列挙）
+  - 上記 api.ts 変更に対応するテストが PR #229 に含まれる。File Structure Plan に列挙する
+- `web/src/lib/webauthn.ts` / `web/src/lib/webauthn.test.ts` — 既存 PR #229 実装を維持
+- `web/src/lib/pkce.ts` / `web/src/lib/pkce.test.ts` — 既存 PR #229 実装を維持
+- `web/src/lib/passkey-capability.ts` / `web/src/lib/passkey-capability.test.ts` — 既存維持
+- `web/src/hooks/use-passkey-capability.ts` / `.test.ts` — 既存維持
+- `web/src/hooks/use-passkey-authentication.ts` / `.test.ts` / `.contract.test.ts` — 既存維持
+- `web/src/components/passkey-buttons.tsx` / `.test.tsx` — 既存維持
+- `web/src/types/passkey.ts` — **変更**
+  - `RegistrationFinishResponse` 型に `auth_code: string` フィールドを additive 追加
+    （`user_id` は既存維持）
+
+#### 運用 config（PR #229 のスコープに含める / Requirement 6）
+
+- `.env.sample` — **変更**（Requirement 6.1 / 現行 #223 design が「追加 env 無し」と記述
+  しつつ既存 WebAuthn 系 env の documentation が未整備）
+  - `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_DISPLAY_NAME` / `WEBAUTHN_ORIGINS` /
+    `WEBAUTHN_IOS_APP_ID` / `PASSKEY_CHALLENGE_TTL_SECONDS` の 5 変数を **既存 env として
+    documentation**（コメントアウト行 + fail-closed 挙動の解説）を追加する
+  - **新規 env の追加は行わない**（Requirement 6.5 と #223 Scope の維持）
+- `docker-compose.yml` — **変更**（Requirement 6.2）
+  - `api` サービスの `environment` に `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_DISPLAY_NAME` /
+    `WEBAUTHN_ORIGINS` / `WEBAUTHN_IOS_APP_ID` / `PASSKEY_CHALLENGE_TTL_SECONDS` の
+    passthrough を追加（すべて `${VAR:-}` 形式で **既定値なし**、未設定なら空文字で fail-closed）
+  - **新規 env の追加は行わない**
+
+#### spec 補助（`docs/specs/223-feat-web-web/` 配下 — requirements/design/tasks 本体は不変）
+
+- `docs/specs/223-feat-web-web/impl-notes.md` — **変更**
+  - 「#231 の normative delta を適用済み」旨の追記と、Delta 1〜5 に対応する PR #229 側の
+    実装差分の要約を追記する（confirm 事項ではなく事後の記録）
+- `docs/specs/223-feat-web-web/context-map.md` — **変更**
+  - 二度目 WebAuthn ceremony 除去に伴う経路図の更新、fail-closed 表の supersede 記録、
+    完了不明状態の遷移追加
+
+### New Files（本差分で新規追加）
+
+なし。すべての差分は既存ファイル（PR #229 が既に追加した / 既に main 済みのもの含む）への
+編集で完結する。
+
+## Requirements Traceability
+
+| Requirement | Summary | Traced to |
+|-------------|---------|-----------|
+| 1.1 | 登録 finish 後の追加 WebAuthn ceremony 禁止 | Delta 1 §Registration Service / §Web Hook |
+| 1.2 | 二度目 ceremony を実装として採用しない | Delta 1 §before → after 図 |
+| 1.3 | 登録トランザクションに紐付いた合流経路 | Delta 1 §envelope パターン |
+| 1.4 | 2 ペイン UI 初期表示 | Delta 1 §Sequence 図 |
+| 1.5 | ログイン導線への影響なし | Delta 1 §影響範囲、`use-passkey-authentication` 未変更 |
+| 2.1 | api.ts / api.test.ts を変更対象に明示 | File Structure Plan §Modified Files |
+| 2.2 | .env.sample / docker-compose.yml を変更対象に明示 | File Structure Plan §Modified Files |
+| 2.3 | needs-iteration 1 回で完結する粒度のタスク | tasks.md 全体（6 タスク） |
+| 2.4 | #223 spec 書換タスクを含まない | tasks.md 全体（#223 requirements/design/tasks の編集タスク不在） |
+| 2.5 | Reviewer が変更ファイルを突合できる状態 | File Structure Plan §Modified Files（PR #229 変更 25 ファイル全列挙） |
+| 3.1 | session endpoint の登録・未登録を独立列に | Delta 3 §fail-closed 表（列: `/api/auth/session`） |
+| 3.2 | capability endpoint の登録・未登録を独立列に | Delta 3 §fail-closed 表（列: `/api/passkey/capability`） |
+| 3.3 | NATIVE unset + WEBAUTHN set で iOS 継続 | Delta 3 §env 行 2 と router 変更 |
+| 3.4 | WEBAUTHN unset で capability 404 + iOS 停止 | Delta 3 §env 行 3 / 4 |
+| 3.5 | iOS request/response 契約破壊禁止 | Delta 3 §iOS 契約維持論証 / Delta 1 §additive 論証 |
+| 4.1 | CSRF 主防御要素を要素ごとに明記 | Delta 4 §主防御要素表 |
+| 4.2 | 旧誤記述の撤回と正しい前提の明記 | Delta 4 §旧記述の撤回 |
+| 4.3 | 残余リスクの列挙 | Delta 4 §残余リスク |
+| 4.4 | browser-bound state 不要の決定明記 | Delta 4 §決定記録 |
+| 4.5 | Cookie 属性の既存 Google OAuth 一致維持 | Delta 4 §Cookie 属性維持 |
+| 4.6 | 将来検討導線を残す | Delta 4 §将来検討導線 |
+| 5.1 | 第 3 の完了不明状態としてユーザーに提示 | Delta 5 §状態定義 / §Hook error kind 追加 |
+| 5.2 | ログインで確認する旨の復旧案内を同一画面に | Delta 5 §UI 文言と復旧導線 |
+| 5.3 | 復旧ログインで成功時に 2 ペイン UI | Delta 5 §状態遷移図（成功遷移） |
+| 5.4 | 復旧ログイン失敗時に再作成導線 | Delta 5 §状態遷移図（失敗遷移） |
+| 5.5 | サーバ内部詳細を反射しない | Delta 5 §UI 文言（generic 固定） |
+| 5.6 | 他状態と混同されない文言 | Delta 5 §既存 error kind との弁別表 |
+| 6.1 | .env.sample を変更対象に明示 | File Structure Plan §運用 config |
+| 6.2 | docker-compose.yml を変更対象に明示 | File Structure Plan §運用 config |
+| 6.3 | needs-iteration 1 回で完結する config タスク | tasks.md Task 5 |
+| 6.4 | 別 prerequisite PR に分離しない決定明記 | Delta 6 §決定記録 |
+| 6.5 | 既存 env 流用に留め新規 env 追加なしを担保 | File Structure Plan §運用 config 本文 |
+| NFR 1.1 | #223 spec 物理ファイル不変 | File Structure Plan（#223 spec 編集タスク不在）+ Non-Goals |
+| NFR 1.2 | 独立実装 PR を作らず PR #229 needs-iteration 1 回で反映 | Non-Goals + tasks.md 全体 |
+| NFR 1.3 | #216 契約を破壊するタスクを含まない | Delta 1 §additive 論証 + File Structure Plan（#216 spec 編集タスク不在） |
+| NFR 2.1 | 完了不明状態の秘密情報非漏出 | Delta 5 §秘密情報の非漏出 |
+| NFR 2.2 | CSRF / fail-closed 記述に秘密値を例示しない | Delta 3 / Delta 4（例示値なし） |
+| NFR 3.1 | Google OAuth 既存挙動を破壊しない | 全 Delta（既存 Google 経路無変更）+ File Structure Plan（auth_handler.go / use-auth.ts 未変更） |
+| NFR 3.2 | iOS #216 request/response 契約不変 | Delta 1 §additive 論証 + Delta 3 §iOS 契約維持論証 |
+
+## Delta 1: 登録 finish 直後のセッション合流（Requirement 1）
+
+### Supersedes（#223 design.md の該当節）
+
+- `#223 design.md` §Flows「新規作成フロー（Sequence / 抜粋）」（line ~957-999）— 特に
+  L993 の `HR->>HR: <認証 chain>: begin → get → finish → session` の記述と、それに続く
+  L994-996 のシーケンス
+- `#223 design.md` §`use-passkey-registration.ts` の「5. **直後に認証 chain**」以降（L655-661）
+- `#223 tasks.md` L177-179 の task 8 (5) 「**直後に認証 chain**」記述
+
+### Before → After Sequence
+
+#### Before（現行 #223 design / PR #229 の実装）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant HR as usePasskeyRegistration
+    participant PK as lib/pkce
+    participant NC as navigator.credentials
+    participant SVR as Feedman API
+
+    U->>HR: mutate({username})
+    HR->>PK: generatePkcePair()
+    PK-->>HR: {code_verifier, code_challenge}
+    HR->>SVR: POST /api/passkey/registration/begin
+    SVR-->>HR: 200 {challenge_id, options}
+    HR->>NC: create({publicKey})  %% 1 回目 ceremony
+    NC-->>HR: PublicKeyCredential (attestation)
+    HR->>SVR: POST /api/passkey/registration/finish
+    SVR-->>HR: 200 {user_id}
+    Note over HR,SVR: 二度目 ceremony（除去対象）
+    HR->>SVR: POST /api/passkey/authentication/begin
+    SVR-->>HR: 200 {challenge_id, options}
+    HR->>NC: get({publicKey})  %% 2 回目 ceremony（Face ID / Touch ID プロンプト再発火）
+    NC-->>HR: PublicKeyCredential (assertion)
+    HR->>SVR: POST /api/passkey/authentication/finish
+    SVR-->>HR: 200 {auth_code}
+    HR->>SVR: POST /api/auth/session {auth_code, code_verifier}
+    SVR-->>HR: 204 + Set-Cookie
+    HR->>HR: invalidateQueries(["auth","me"])
+```
+
+#### After（本 Delta 1 で確定する挙動）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant HR as usePasskeyRegistration
+    participant PK as lib/pkce
+    participant NC as navigator.credentials
+    participant SVR as Feedman API
+
+    U->>HR: mutate({username})
+    HR->>PK: generatePkcePair()
+    PK-->>HR: {code_verifier, code_challenge}
+    HR->>SVR: POST /api/passkey/registration/begin {username, email:"", code_challenge}
+    Note over SVR: BeginRegistrationNew:<br/>PKCE 検証 + registrationSession 封筒に code_challenge を格納
+    SVR-->>HR: 200 {challenge_id, options}
+    HR->>NC: create({publicKey})  %% 1 回目 ceremony（唯一の生体認証プロンプト）
+    NC-->>HR: PublicKeyCredential (attestation)
+    HR->>SVR: POST /api/passkey/registration/finish {challenge_id, credential}
+    Note over SVR: FinishRegistrationNew:<br/>envelope 復元 → user 作成 → credential 保存<br/>→ auth_code 発行（code_challenge を PKCE として紐付け）
+    SVR-->>HR: 200 {user_id, auth_code}  %% additive に auth_code 追加
+    HR->>SVR: POST /api/auth/session {auth_code, code_verifier}
+    SVR-->>HR: 204 + Set-Cookie
+    HR->>HR: invalidateQueries(["auth","me"])
+```
+
+追加のブラウザ生体認証プロンプト（`navigator.credentials.get`）が消滅し、ユーザーが体験する
+ceremony は登録時の `create` の 1 回のみになる。
+
+### Server 側の実装差分
+
+#### `internal/passkey/registration_service.go`（Modified）
+
+`AuthenticationService` に既に存在する `authnSession` 封筒パターンを踏襲する
+（`internal/passkey/authentication_service.go` L57-66 と同型）。`model.PasskeyChallenge` /
+`WebAuthnAdapter` / `challengeStore` の interface は変更せず、sessionData バイト列に
+`{WebAuthnSession, CodeChallenge}` を JSON marshal して opaque に運ぶ。
+
+```go
+// internal/passkey/registration_service.go に追加（authentication_service.go::authnSession と同型）
+
+// registrationSession は registration_new kind の challenge に紐付ける封筒。
+// begin 時の code_challenge を finish まで運び、auth_code の PKCEChallenge として紐付ける
+// （Req 1.3 の「登録トランザクションと結び付いた合流経路」）。
+type registrationSession struct {
+    // WebAuthnSession は adapter.BeginRegistration が返す webauthn.SessionData の JSON bytes。
+    // FinishRegistration にそのまま渡すため RawMessage で無改変に保持する。
+    WebAuthnSession json.RawMessage `json:"webauthn_session"`
+    // CodeChallenge は begin 時に検証した PKCE S256 challenge（base64url 43 文字）。
+    // finish 時に auth_code の PKCEChallenge として設定される。
+    CodeChallenge string `json:"code_challenge"`
+}
+
+// RegistrationService に authCodes フィールドを追加
+type RegistrationService struct {
+    adapter     WebAuthnAdapter
+    challenges  challengeStore
+    users       UserWriter
+    credentials PasskeyCredentialWriter
+    authCodes   auth.AuthCodeCreator  // 新規: auth_code 発行（authentication_service.go と同じ具体依存）
+    now         func() time.Time
+}
+
+// NewRegistrationService のシグネチャに authCodes を追加（wiring 側で調整）
+func NewRegistrationService(
+    adapter WebAuthnAdapter, challenges challengeStore,
+    users UserWriter, credentials PasskeyCredentialWriter,
+    authCodes auth.AuthCodeCreator, now func() time.Time,
+) *RegistrationService
+
+// BeginRegistrationNew: PKCE 検証済み code_challenge を封筒に格納
+//   - PKCE 形式検証（既存挙動、変更なし / Req 1.5 の early validation 継続）
+//   - envelope := registrationSession{WebAuthnSession: sessionData, CodeChallenge: codeChallenge}
+//   - envelopeBytes := json.Marshal(envelope)
+//   - challenges.Issue(sessionData=envelopeBytes, ...) として保存
+//   - 戻り値は既存と同じ (challengeID string, options []byte, error)
+func (s *RegistrationService) BeginRegistrationNew(
+    ctx context.Context, rawUsername string, optionalEmail string, codeChallenge string,
+) (string, []byte, error)
+
+// FinishRegistrationNew:
+//   - シグネチャ変更: (string, error) → (string, string, error)
+//     - 1 番目: userID
+//     - 2 番目: authCodePlain（NEW）
+//     - 3 番目: error
+//   - challenges.Consume で PasskeyChallenge を取得
+//   - envelope を json.Unmarshal し、WebAuthnSession と CodeChallenge を復元
+//     （破損 / 不完全は ErrRegistrationFailed / uniform 拒否）
+//   - 既存の adapter.FinishRegistration → CreateUserOnly → credentials.Create フローを維持
+//   - **auth_code 発行を末尾に追加**:
+//       plain, _ := auth.GenerateAuthCode()  // authentication_service.go L320 と同じ
+//       codeHash := auth.HashNativeSecret(plain)
+//       authCode := &model.AuthCode{
+//         ID:            uuid.New().String(),
+//         CodeHash:      codeHash,
+//         UserID:        newUser.ID,
+//         PKCEChallenge: envelope.CodeChallenge,  // Req 1.3 の合流点
+//         ExpiresAt:     s.now().Add(auth.NativeAuthCodeTTL),
+//       }
+//       s.authCodes.Create(ctx, authCode)
+//   - 平文 plain を戻り値としてのみ返す（NFR 2.1 準拠、authentication_service.go と同方針）
+//   - ログには hash 先頭 8 文字のみ（authentication_service.go L338-341 と同方針）
+func (s *RegistrationService) FinishRegistrationNew(
+    ctx context.Context, challengeID string, requestBody []byte,
+) (userID string, authCodePlain string, err error)
+```
+
+- Preconditions: `authCodes` は `NewRegistrationService` 時に non-nil で注入されている
+  （`app.go` の wiring で `PostgresAuthCodeRepo` を渡す。既存 `AuthenticationService` と同経路）
+- Postconditions:
+  - 成功時: user / credential / auth_code の 3 レコードが永続化される
+    （single-transaction 統合は #230 のスコープで本 spec の対象外 / Out of Scope）
+  - 失敗時: 部分保存は `#216` の既存挙動と同じ（追加の rollback ロジックは持たない）
+- Invariants:
+  - `envelope.CodeChallenge` が空 or 復元不能なら `ErrRegistrationFailed`（uniform 拒否）
+  - `auth_code` 平文をログ・エラーメッセージに残さない（NFR 2.1 / `authentication_service.go`
+    L336-341 の既存方針を踏襲）
+
+#### `internal/handler/passkey_handler.go`（Modified）
+
+```go
+// PasskeyHandler.RegistrationFinish（新シグネチャに追従）
+
+// レスポンス body 型を additive に拡張
+type registrationFinishResponse struct {
+    UserID   string `json:"user_id"`
+    AuthCode string `json:"auth_code"`  // NEW: additive フィールド
+}
+
+// 内部ロジック（イメージ）:
+//   userID, authCode, err := h.regService.FinishRegistrationNew(ctx, req.ChallengeID, req.Credential)
+//   if err != nil { ... 既存の error mapping（400 REGISTRATION_FAILED / 500）... }
+//   respond 200 registrationFinishResponse{UserID: userID, AuthCode: authCode}
+```
+
+#### iOS #216 契約が破壊されない論証
+
+- iOS の `POST /api/passkey/registration/finish` レスポンス期待値は `#216 design.md` L708 で
+  `{user_id}` と規定されている。本差分では **既存 `user_id` フィールドを削除せず維持し、
+  `auth_code` を additive に追加する** のみである。
+- Swift の JSON decoding（`Codable` / `JSONDecoder`）は既定で未知フィールドを **無視する**
+  （`JSONDecoder` は `allowsJSON5` / `dateDecodingStrategy` などのオプションはあるが、
+  「未知キー拒否」は既定オプションに存在しない）。iOS 実装が意図的に strict-mode の decoder を
+  組んでいない限り、追加フィールドは黙って無視される。#216 iOS design（`docs/specs/216--app-store-4-8/`）
+  でも strict decode の記述はない。
+- iOS の登録フローは `#216 design.md` L681-685 の記述どおり、`registration/finish` の後に
+  authentication ceremony を走らせて `authentication/finish` で `auth_code` を取得する経路を
+  採る（Web 実装より 1 ceremony 多い）。iOS はこの経路を維持できる（`authentication/*` endpoint
+  も無変更）。
+- したがって本差分は **iOS の request/response 契約を破壊しない**（NFR 1.3 / NFR 3.2）。
+
+### Web 側の実装差分
+
+`web/src/hooks/use-passkey-registration.ts` の内部 mutation chain を以下に整理する。
+`#223 design.md` §`use-passkey-registration.ts` の「5. **直後に認証 chain**」以降 4 ステップを
+除去する。
+
+```typescript
+// use-passkey-registration.ts の mutationFn（イメージ、実装コードではない）
+
+// Before（現行 PR #229）: 6 段の chain（登録 → 認証 → session）
+// After（本差分）: 4 段の chain（登録 → session）
+
+async function mutationFn({ username }: { username: string }) {
+  const { codeVerifier, codeChallenge } = await generatePkcePair();
+
+  // 1. registration/begin
+  const beginRes = await apiClient.post<PasskeyBeginResponse>(
+    "/api/passkey/registration/begin",
+    { username, email: "", code_challenge: codeChallenge }
+  );
+
+  // 2. navigator.credentials.create（唯一の WebAuthn ceremony）
+  const creationOptions = decodeCreationOptions(beginRes.options);
+  const cred = await navigator.credentials.create(creationOptions);
+
+  // 3. registration/finish → **additive な auth_code を受け取る**
+  const finishRes = await apiClient.post<RegistrationFinishResponse>(
+    "/api/passkey/registration/finish",
+    { challenge_id: beginRes.challenge_id, credential: encodeAttestationResponse(cred) }
+  );
+  // finishRes.auth_code を直接次段へ渡す（二度目 ceremony 廃止）
+
+  // 4. session 交換
+  await apiClient.post(
+    "/api/auth/session",
+    { auth_code: finishRes.auth_code, code_verifier: codeVerifier }
+  );
+
+  await queryClient.invalidateQueries({ queryKey: ["auth", "me"] });
+}
+```
+
+- `code_verifier` は closure 変数のみに保持（NFR 2.1 準拠、`#223 design.md` §NFR 1.1 準拠）
+- `auth_code` は `finishRes` から `apiClient.post("/api/auth/session", ...)` に渡す 1 request 間
+  のみメモリ保持し、それ以降は参照されない
+- error 分類は §Delta 5 で `registration_uncertain` を追加する形で拡張する
+
+### 影響範囲
+
+- 変更対象コンポーネント: `RegistrationService` / `PasskeyHandler.RegistrationFinish` /
+  `router.go`（Delta 3 と合わせて）/ `use-passkey-registration.ts` /
+  `passkey-signup-dialog.tsx`（Delta 5 と合わせて）/ `types/passkey.ts` / `app.go`（wiring）
+- **無変更で維持する既存要素**:
+  - `AuthenticationService` / `use-passkey-authentication.ts` / `PasskeyButtons`（ログイン
+    導線は影響を受けない / Requirement 1.5）
+  - `SessionExchangeService` / `NativeAuthHandler.Session`（受け取る `auth_code` の由来が
+    「authentication 由来」→「registration 由来」に増えるだけで、契約自体は不変）
+  - iOS 用 `authentication/*` endpoint（iOS は従来経路を維持）
+  - Google OAuth 経路一式（NFR 3.1）
+
+## Delta 2: File Structure Plan の補正（Requirement 2）
+
+### Supersedes
+
+- `#223 design.md` §File Structure Plan の以下記述:
+  - L255: `api.ts # 既存（無変更）` → **変更**（`web/src/lib/api.ts` は PR #229 で変更されている）
+  - `.env.sample` / `docker-compose.yml` が File Structure Plan に **列挙されていない** →
+    **列挙する**
+  - `web/src/lib/api.test.ts` が File Structure Plan に **列挙されていない** → **列挙する**
+
+### 補正後の変更対象表（本 spec §File Structure Plan §Modified Files が canonical）
+
+上記「File Structure Plan」節が本 Delta の実質的な canonical 定義であり、Reviewer は同節を
+参照して PR #229 の全変更ファイルの被覆を確認できる（Requirement 2.5）。#223 design.md の
+「api.ts # 既存（無変更）」記述は本 delta で supersede される。
+
+### Reviewer 突合の観点（Requirement 2.5）
+
+Reviewer は PR #229 の変更ファイル一覧（`git diff --name-only`）を本 File Structure Plan §
+Modified Files と突き合わせ、以下を確認できる:
+
+1. PR #229 の全変更ファイルが `Modified Files` セクションに列挙されている
+2. `Modified Files` に列挙されているが PR #229 に含まれないファイルがない（過剰な予告なし）
+3. `web/src/lib/api.ts` / `api.test.ts` / `.env.sample` / `docker-compose.yml` が
+   Modified Files に含まれている（旧 #223 design の見落としを訂正済み）
+
+## Delta 3: fail-closed 表の補正と capability 登録条件の強化（Requirement 3）
+
+### Supersedes
+
+- `#223 design.md` §Configuration §fail-closed 挙動の表（L1158-1162）—
+  `NATIVE_AUTH_JWT_SECRET` 未設定行で `POST /api/passkey/*` を「未登録 (404)」と
+  誤って記述している箇所
+
+### 補正後の fail-closed 表
+
+env 組合せごとに **各 endpoint を独立列** として表現し、iOS 用 endpoint と Web 用 endpoint の
+提供状態を混同しない形に組み直す。
+
+| Env 状態 | `POST /api/auth/session`（Web） | `GET /api/passkey/capability`（Web probe） | iOS `/api/passkey/registration/*` | iOS `/api/passkey/authentication/*` | Web 挙動 | iOS 挙動 |
+|---|---|---|---|---|---|---|
+| **NATIVE_AUTH_JWT_SECRET 設定 + WEBAUTHN_RP_ID/ORIGINS 設定** | 登録済 (204) | 登録済 (200) | 登録済 (200) | 登録済 (200) | パスキー導線 2 種 + Google 導線 | 通常稼働 |
+| **NATIVE_AUTH_JWT_SECRET 未設定 + WEBAUTHN_RP_ID/ORIGINS 設定** | 未登録 (404) | 未登録 (404) | 登録済 (200) | 登録済 (200) | Google 単体表示（capability = 404 で PasskeyButtons 非表示） | **通常稼働（Req 3.3）** |
+| **NATIVE_AUTH_JWT_SECRET 設定 + WEBAUTHN_RP_ID/ORIGINS 未設定** | 登録済 (204) | 未登録 (404) | 未登録 (404) | 未登録 (404) | Google 単体表示（capability = 404） | 停止（#216 で確定済み） |
+| **NATIVE_AUTH_JWT_SECRET 未設定 + WEBAUTHN_RP_ID/ORIGINS 未設定** | 未登録 (404) | 未登録 (404) | 未登録 (404) | 未登録 (404) | Google 単体表示 | 停止 |
+
+各列の登録条件（router.go の判定式）:
+
+| Endpoint | 登録条件（`router.go` の判定） | 依拠 env |
+|---|---|---|
+| `POST /api/auth/session` | `deps.NativeAuthHandler != nil` | `NATIVE_AUTH_JWT_SECRET` |
+| `GET /api/passkey/capability` | `deps.PasskeyHandler != nil && deps.NativeAuthHandler != nil` **（強化）** | `WEBAUTHN_RP_ID` + `WEBAUTHN_ORIGINS` + `NATIVE_AUTH_JWT_SECRET` |
+| `POST /api/passkey/registration/*` | `deps.PasskeyHandler != nil` **（従来どおり / 変更なし）** | `WEBAUTHN_RP_ID` + `WEBAUTHN_ORIGINS` |
+| `POST /api/passkey/authentication/*` | `deps.PasskeyHandler != nil` **（従来どおり / 変更なし）** | `WEBAUTHN_RP_ID` + `WEBAUTHN_ORIGINS` |
+
+### capability 登録条件を強化する理由（設計判断）
+
+- **意図**: Web の capability probe は「Web で end-to-end に完了できるか」を答える endpoint と
+  して意味を持つべき。NATIVE 未設定環境で `capability = 200` を返すと、Web は PasskeyButtons を
+  表示するがユーザーが実行すると最後の `/api/auth/session` で 404 に遭遇し UX が悪化する
+  （Req 3.3 が言う「Google 単体表示に縮退する」の主旨に反する）。
+- **判断**: capability の登録条件を「両 handler 非 nil」に強化することで、Web は capability =
+  404 を受け取り PasskeyButtons を非表示にする（Requirement 5.2 の既存挙動を踏襲）。
+- **iOS への影響**: iOS 用 `registration/*` / `authentication/*` の登録条件は `PasskeyHandler
+  != nil` のみで **変更しないため、iOS 契約は不変**（NFR 3.2 / Req 3.5）。
+
+### iOS #216 契約が破壊されない論証（Req 3.5）
+
+- iOS が依存する 6 endpoint（`registration/{begin,finish,add/begin,add/finish}` /
+  `authentication/{begin,finish}`）はすべて `PasskeyHandler` に紐付いており、router.go での
+  登録条件は `PasskeyHandler != nil` のみで変更しない。
+- 本差分で新規に登録条件を強化するのは `/api/passkey/capability` のみで、これは PR #229 で
+  Web 用に追加した endpoint であり iOS は使用しない（#216 spec には capability endpoint への
+  依存記述がない）。
+- したがって iOS 用 endpoint 群の稼働条件は #216 と完全同一で、iOS の request/response
+  契約・提供状態の env 依存性ともに破壊されない。
+
+## Delta 4: CSRF / PKCE 説明の正確化と残余リスクの明示（Requirement 4）
+
+### Supersedes
+
+- `#223 design.md` §Security Considerations §CSRF 箇条書き（L1115-1121）— 特に L1119-1120 の
+  「攻撃者が事前に (auth_code, code_verifier) ペアを入手する経路が存在しない」記述
+- `#223 design.md` §`NativeAuthHandler.Session` §CSRF 対策（L862-867）— 同上の誤記述と、
+  「明示的 CSRF token は不要」の判断根拠
+
+### 旧記述の撤回
+
+以下の記述を **撤回する**:
+
+> auth_code は 60 秒 TTL + 単回消費 + PKCE 束縛 → クロスサイト攻撃者が事前に (auth_code,
+> code_verifier) ペアを入手する経路が存在しない
+
+**正しい前提**（Delta 4 §主防御要素表 §PKCE + auth_code 単回 60s TTL の役割で置き換え）:
+
+- 攻撃者は **自身のブラウザで自身のパスキー credential を用いて完全な認証フローを走行させ、
+  自分の (auth_code, code_verifier) ペアを取得できる**。RFC 7636 の PKCE は「同一クライアント
+  内での authorization_code の中間者盗用を防ぐ」プロパティであり、攻撃者が **自身のセッション
+  で正規に取得したペア** を防ぐものではない。
+- したがって PKCE 単独では「攻撃者による自アカウントへのログイン誘引（login CSRF）」を阻止
+  できない。これに対する主防御は SameSite Cookie / Origin 検証 / CORS preflight /
+  JSON Content-Type の複合による cross-origin 発火不能化である。
+
+### 主防御要素表（Web セッション交換 endpoint の CSRF 対策）
+
+| 防御要素 | 役割 | 何を防ぐか |
+|---|---|---|
+| **exact Origin 検証** | ブラウザ fetch の Origin ヘッダを CORS で厳密検証 | クロスオリジンからの直接 `POST /api/auth/session` を preflight で拒否 |
+| **JSON Content-Type 要求** | `application/json` 以外の Content-Type を 400 で拒否 | classic な HTML form submit（`application/x-www-form-urlencoded`）による cross-site POST を無効化（form は Content-Type を任意に設定できない） |
+| **CORS preflight** | non-simple request の preflight OPTIONS 要求 | クロスオリジンの `application/json` POST は preflight を必ず経由するため、Origin 未許可なら本 request が発火しない |
+| **SameSite=Lax Cookie** | `session_id` Cookie の SameSite 属性 | 攻撃者サイトからの top-level ナビゲーションでも Cookie 送信を制限（既存 Google OAuth と同じ属性） |
+| **PKCE 束縛 + auth_code 単回 60 秒 TTL** | 特定の attacker-in-the-middle シナリオ | 「同一クライアント内で認証 flow を開始したセッション以外」が正しい code_verifier を持たないため、盗聴された auth_code を交換できない。ネットワーク中間経路での code 盗用に対する定番対策（RFC 7636 の本来目的） |
+| **HttpOnly Cookie** | `session_id` を JavaScript から不可視化 | XSS 発生時に Cookie 生値を script が読み出して外部送信するのを阻止 |
+| **auth_code の 60 秒 TTL + 単回消費** | 発行済み auth_code の有効期間・再利用防止 | replay / 盗聴された auth_code の遅延利用ウィンドウを最小化 |
+
+### 残余リスク（受容する脅威）
+
+上記主防御を受容した上で残る 2 種の残余リスクを明記する:
+
+1. **同一オリジン XSS 経由の全フロー実行**
+   - 前提: 攻撃者が Feedman Web の同一オリジンに XSS を注入できた状態
+   - 攻撃: 注入 script が完全な passkey 認証フローを走行させ、被害者が Face ID を承認した
+     結果で被害者のセッションを乗っ取る、または攻撃者が用意した credential でログイン誘引
+   - 補足: 前提を満たす時点で Feedman Web の完全な同一オリジン権限を攻撃者が持つため、
+     どんな追加 CSRF token を導入しても同一 script から読める → 防御不能。この脅威の主対策は
+     既存 CSP / DOMPurify sanitize（#223 NFR 1.3 で維持）による XSS 発生確率の最小化。
+2. **攻撃者自身の credential によるアカウント誘引**
+   - 前提: 攻撃者が自身のブラウザで先に (auth_code, code_verifier) ペアを取得し、被害者を
+     誘導して被害者ブラウザで `POST /api/auth/session {攻撃者の auth_code, 攻撃者の code_verifier}`
+     を実行させる
+   - 攻撃: 被害者が **攻撃者アカウントとしてログインしてしまう**（login CSRF）
+   - 現状の主防御:
+     - `/api/auth/session` は同一オリジン fetch のみ（CORS + exact Origin）→ 被害者ブラウザ内の
+       攻撃者スクリプト経由でしか発火できない → **同一オリジン XSS がなければ発火不能**
+     - 直接的な cross-site form submit は JSON Content-Type 要求で拒否
+   - 補足: 純粋な cross-site 経路では本攻撃は成立しない。同一オリジン XSS を経由する経路は
+     上記 1 と同じ脅威モデルに収束する。
+
+### 決定記録: 追加の browser-bound state を導入しない（Req 4.4）
+
+人間運用者の Issue コメント決定（2.A）として、以下を採用 **しない**:
+
+- transaction cookie（begin 時に発行 → finish 時に検証する Cookie）
+- 追加の CSRF token（同期トークンパターン）
+- Origin-bound challenge 拡張（WebAuthn Level 3 の `additionalUnknownAssertionInputs` 等）
+
+**理由**:
+- 現状の主防御（exact Origin + JSON Content-Type + CORS preflight + SameSite + PKCE）は
+  RFC 9700 (OAuth 2.0 Security BCP §4.7.1 CSRF) の推奨に整合しており、単一オリジン fetch
+  ベースの Web app では十分な CSRF 主防御となる
+- 残余リスクは同一オリジン XSS に収束するため、追加 state を導入しても XSS 発生時には同じく
+  読める → 追加防御コストに見合わない
+- WebAuthn Level 3 の browser-side origin binding（`ClientDataJSON.origin`）は WebAuthn
+  ceremony の中で既に検証済みで、passkey 発行段階の attester 認証には効いている
+
+### Cookie 属性の維持（Req 4.5）
+
+- `POST /api/auth/session` が Set-Cookie で発行する `session_id` の各属性は、既存 Google OAuth
+  Callback（`auth_handler.go::Callback`）と **完全同一**:
+  - `Name = "session_id"`
+  - `HttpOnly = true`
+  - `SameSite = http.SameSiteLaxMode`
+  - `Secure = cookieSecure`（`COOKIE_SECURE` env と `BASE_URL` の https 判定に従う）
+  - `Path = "/"`
+  - `Domain = cookieDomain`（`COOKIE_DOMAIN` env）
+  - `Max-Age = sessionMaxAge`（`SESSION_MAX_AGE` env、既定 86400 秒）
+- PR #229 の `NativeAuthHandler.Session` 既存実装がこれを既に満たしている（本差分では変更しない）
+
+### 将来検討導線（Req 4.6）
+
+将来、以下のいずれかを新規 Issue として切り出す前提を残す:
+
+- 同一オリジン XSS 由来の CSRF 突破が問題化した場合 → 追加 Origin-bound state（transaction
+  cookie + double-submit token）の導入検討
+- 攻撃者自身の credential による login CSRF が問題化した場合 → OAuth 2.0 の `state`
+  パラメータ相当を introspection 可能な形で追加する検討
+- WebAuthn Level 3 の `additionalUnknownAssertionInputs` によるチャレンジ拡張の実装検討
+
+これらは本差分では扱わず、必要性が生じた時点で別 Issue として起票する。
+
+## Delta 5: 登録完了不明状態と復旧導線（Requirement 5）
+
+### 状態定義
+
+現行 `PasskeyRegistrationErrorKind` に **新規 kind** `registration_uncertain` を追加する。
+本 kind は以下いずれかの条件を満たす場合にのみ設定される:
+
+- `POST /api/passkey/registration/finish` の request 送出後、**レスポンスを受け取れなかった**
+  （fetch reject `TypeError` = ネットワーク断・DNS 失敗・接続断など）
+- `POST /api/passkey/registration/finish` の request 送出後、**5xx 応答**を受け取った
+  （サーバが request を受理して commit した可能性はあるが、応答段で失敗した状態）
+- `POST /api/passkey/registration/finish` の request が **タイムアウト**した
+  （fetch AbortController / signal timeout。Feedman Web は明示 timeout を持たないため実質
+  ネットワーク断と同じ扱いになるが、判定コードでは AbortError も含める）
+
+上記以外の失敗（begin での 4xx / create の DOMException / finish の 400 REGISTRATION_FAILED /
+session 段の 400/500）は既存 kind（`invalid_username` / `username_taken` / `cancelled` /
+`server_rejected` / `session_exchange_failed`）で表現し、`registration_uncertain` にはしない。
+
+### 状態遷移図
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle: Dialog open
+    Idle --> Pending: user clicks 作成
+    Pending --> InvalidUsername: begin 400 INVALID_USERNAME
+    Pending --> UsernameTaken: begin 409 USERNAME_TAKEN
+    Pending --> Cancelled: create DOMException (NotAllowed/Abort/InvalidState)
+    Pending --> ServerError: begin 500 / create pre-network 500
+    Pending --> NetworkError: begin fetch reject (pre-finish)
+    Pending --> ServerRejected: finish 400 REGISTRATION_FAILED
+    Pending --> RegistrationUncertain: finish fetch reject / 5xx / AbortError
+    Pending --> SessionExchangeFailed: session 400/500 (finish は 200 完了)
+    Pending --> Success: session 204
+    InvalidUsername --> Idle: user 修正
+    UsernameTaken --> Idle: user 別名で再試行
+    Cancelled --> Idle: mutation.reset()
+    ServerError --> Idle: user 再試行
+    NetworkError --> Idle: user 再試行
+    ServerRejected --> Idle: user 再試行
+    SessionExchangeFailed --> [*]: Dialog を閉じてログイン画面へ
+    RegistrationUncertain --> LoginAttempt: user が「ログインで確認」を選ぶ
+    RegistrationUncertain --> Idle: user が「再度作成する」を選ぶ
+    LoginAttempt --> [*]: ログイン成功 → 2 ペイン UI
+    LoginAttempt --> Idle: ログイン credential 未解決 → 再作成へ
+    Success --> [*]: Dialog close → AuthGuard 再判定
+```
+
+### Hook 側の判定ロジック（`use-passkey-registration.ts` 内部）
+
+```typescript
+// mutationFn 内の error catch（イメージ）:
+
+try {
+  // ... 1. generatePkcePair / 2. begin ...
+  // ... 3. create ...
+  let finishRes: RegistrationFinishResponse;
+  try {
+    finishRes = await apiClient.post("/api/passkey/registration/finish", {...});
+  } catch (err) {
+    // finish request 段の失敗は uncertain / server_rejected / network_error を弁別
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw new PasskeyRegistrationError("registration_uncertain", err);
+    }
+    if (err instanceof ApiError) {
+      if (err.status >= 500 && err.status <= 599) {
+        // 5xx: commit したかも / しなかったかも → uncertain
+        throw new PasskeyRegistrationError("registration_uncertain", err);
+      }
+      if (err.status === 400 && err.body?.code === "REGISTRATION_FAILED") {
+        throw new PasskeyRegistrationError("server_rejected", err);
+      }
+      throw new PasskeyRegistrationError("server_error", err);
+    }
+    if (err instanceof TypeError) {
+      // fetch reject（network drop / connection reset）
+      // finish request は送出済みの可能性が高いため uncertain 側に倒す
+      throw new PasskeyRegistrationError("registration_uncertain", err);
+    }
+    throw new PasskeyRegistrationError("server_error", err);
+  }
+  // ... 4. session 交換 ...
+} catch (err) {
+  // begin / create / session 段の失敗は既存分類（invalid_username / username_taken /
+  // cancelled / server_rejected / session_exchange_failed / server_error / network_error）
+  // registration_uncertain は上の finish catch 内でのみ発生する
+}
+```
+
+**判定原則（安全側 fail 原則 / Req 5.1）**:
+
+- finish の request が **送出済みでレスポンスが確定的に失敗（4xx）** した場合のみ、
+  「サーバが登録を拒否した = commit していない」と断定可能 → `server_rejected`
+- finish の request が **送出済みで response が確定できない**（fetch reject / 5xx / abort）
+  場合、サーバが commit したかもしれないし、していないかもしれない → `registration_uncertain`
+- finish 送出 **前** の失敗（begin での network error）は uncertain ではなく `network_error` /
+  `server_error` として扱う（commit していないことが確定するため）
+
+### UI 文言と復旧導線（`passkey-signup-dialog.tsx`）
+
+`error.kind === "registration_uncertain"` の場合、Dialog は以下を提示する:
+
+- **メッセージ本文**（Req 5.1 / 5.5 / 5.6 の弁別性を担保）:
+
+  ```
+  登録が完了したかどうかを確認できませんでした。
+
+  この状態は、通信の一時的な問題により、サーバ側での登録の成否をブラウザ側で
+  判別できない場合に発生します。次のいずれかをお試しください:
+
+  ・「ログインで確認する」— 入力したユーザー名でログインをお試しください。ログインが
+    成功すれば登録は完了しています。
+  ・「再度作成する」— ログインで解決しない場合、もう一度新規作成をお試しください。
+    登録済みのユーザー名は再利用できないため、この時はユーザー名重複エラーが表示
+    される可能性があります。
+  ```
+
+- **ボタン 2 種**:
+  - 「ログインで確認する」: Dialog を閉じ、`LoginPage` にフォーカスを戻す。ユーザーが
+    `PasskeyButtons` の「パスキーでログイン」を押下し、input なしの認証フローで credential
+    確認を行う（Req 5.3）。登録が実は完了していれば認証成功 → 2 ペイン UI に遷移する
+  - 「再度作成する」: `mutation.reset()` を呼び Dialog を Idle 状態に戻す（同じ username
+    で再試行すると多くの場合 `username_taken` になり登録済みが確認できる / Req 5.4）
+
+### 秘密情報の非漏出（Req 5.5 / NFR 2.1）
+
+- 上記メッセージ本文にはサーバ側の内部詳細（スタックトレース・SQL 内部エラー・DB 名・
+  内部 URL・attestation バイト列・code_verifier・auth_code）を一切含まない
+- Hook 側で `PasskeyRegistrationError` の `body` は Dialog に渡さない（`kind` のみを判定
+  材料とする / #223 design §秘密情報の非漏出 と同方針）
+- `console.log` / `console.error` を追加しない
+
+### 既存 error kind との弁別（Req 5.6）
+
+| error.kind | 主要文言（要旨） | ユーザーに求める行動 |
+|---|---|---|
+| `invalid_username` | 「ユーザー名の形式が不正です（3〜32 文字、英数字・ハイフン・アンダースコアのみ）」 | ユーザー名を修正 |
+| `username_taken` | 「このユーザー名は既に使用されています」 | 別のユーザー名で再試行 |
+| `cancelled` | （エラー表示なし、Idle に戻る） | 再試行 |
+| `server_rejected` | 「認証に失敗しました。時間をおいて再度お試しください」 | 時間をおいて再試行 |
+| `session_exchange_failed` | 「ログインに問題が発生しました。ログイン画面から再度お試しください」 | ログイン画面へ遷移してログイン試行 |
+| **`registration_uncertain`（NEW）** | 「登録が完了したかどうかを確認できませんでした」+ 詳細案内 | 「ログインで確認する」または「再度作成する」を選ぶ |
+| `server_error` / `network_error` | 「エラーが発生しました。時間をおいて再度お試しください」 | 時間をおいて再試行 |
+
+7 種すべての文言が相互に区別可能（Req 5.6）。特に `registration_uncertain` は
+`session_exchange_failed` と紛らわしくならないよう、専用の説明文（「登録が完了したかどうかを
+確認できませんでした」）を採用する。
+
+### #223 Requirement 3.4 との関係整理
+
+- **#223 Req 3.4**（合流失敗時のログイン画面復帰）→ 本 spec の `session_exchange_failed` kind
+  が担当する。この場合 registration/finish は 200 完了しており、user と credential は
+  永続化済み。session 交換のみが失敗しているため、ユーザーはログイン画面から通常ログインで
+  復帰可能。
+- **#231 Req 5**（登録 commit の完了不明）→ 本 spec の `registration_uncertain` kind が担当
+  する。registration/finish 自体が確定応答を返さなかった状態で、commit の有無が不明。
+  Req 5.2 の「ログイン試行で確認」経路は、実は commit 済みなら `session_exchange_failed` 相当
+  の後続フロー（もう既に user は作成済み → ログイン成功）を経由する。
+
+両者は **finish 応答が確定したかどうか** で明確に分岐する（前者は 200 確定・後者は不確定）。
+状態遷移図と UI 文言で区別を担保する。
+
+## Delta 6: 運用 config を PR #229 に統合する境界（Requirement 6）
+
+### 決定記録: 別 prerequisite PR に分離しない（Req 6.4）
+
+人間運用者の Issue コメント決定（3.A）として、以下を採用 **しない**:
+
+- `.env.sample` および `docker-compose.yml` の変更を **別 prerequisite PR** として PR #229 の
+  前に merge させる
+
+**理由**:
+- config 変更は既存 env の documentation / passthrough 整備のみで、独立した Issue にする
+  ほどの複雑度・レビュー観点を持たない
+- PR 分岐を単純化して 1 PR = 1 Issue の原則を維持する（CLAUDE.md）
+- iOS 側の稼働環境で `WEBAUTHN_*` env が既に設定されているデプロイでは、passthrough を
+  追加するだけで Web 側の capability 判定が正しく動作するため、config 反映と Web 動作は
+  同一 PR で reviewer が確認できたほうが妥当
+
+### 既存 env 流用に留める（Req 6.5）
+
+- `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_DISPLAY_NAME` / `WEBAUTHN_ORIGINS` /
+  `WEBAUTHN_IOS_APP_ID` / `PASSKEY_CHALLENGE_TTL_SECONDS` は **すべて #216 で追加済み**の
+  既存 env であり、`internal/config/config.go` L87-109 に既に読込ロジックが存在する
+- `NATIVE_AUTH_JWT_SECRET` / `NATIVE_AUTH_JWT_KID` は **#166 系で追加済み**の既存 env であり
+  現行 `.env.sample` L120-130 と `docker-compose.yml` L74-76 に既に記述されている
+- **新規追加する env は無い**。本差分の config 変更は「既に config.go / runtime が読み込む
+  env を、operator 向けの documentation（`.env.sample`）と container passthrough
+  （`docker-compose.yml`）に整備するのみ」の範囲
+- したがって `#223 requirements.md` の Scope（既存 env 流用に留め、新規 env は追加しない）を
+  破らない
+
+### 反映内容（イメージ）
+
+**`.env.sample`**: 現行 L119-130 の Native Auth 節の後に、以下ブロックを追加する
+（実際のコメント文言は tasks.md / 実装 PR で確定）:
+
+```dotenv
+# Passkey / WebAuthn 設定（Issue #216: /api/passkey/*, AASA / Issue #229: Web パスキー導線）
+# WEBAUTHN_RP_ID は WebAuthn Relying Party ID（scheme / port を含まないドメイン、例: "example.com"）。
+# 空文字（未設定）だと passkey handler が生成されず /api/passkey/* / /api/passkey/capability が
+# 404 になる（fail-closed）。既存デプロイで passkey を使わない場合は未設定のまま起動可。
+# WEBAUTHN_RP_ID=
+# WEBAUTHN_RP_DISPLAY_NAME はブラウザに表示される RP display name（既定: "Feedman"）。
+# WEBAUTHN_RP_DISPLAY_NAME=Feedman
+# WEBAUTHN_ORIGINS は WebAuthn ceremony が許容する origin リスト（カンマ区切り）。
+# 例: "https://example.com,https://staging.example.com,feedman://"。空文字だと fail-closed。
+# WEBAUTHN_ORIGINS=
+# WEBAUTHN_IOS_APP_ID は AASA（Apple App Site Association）に載せる iOS App ID
+# （"TEAM_ID.com.example.feedman" 形式）。空文字だと AASA が 404（iOS 連携 fail-closed）。
+# WEBAUTHN_IOS_APP_ID=
+# PASSKEY_CHALLENGE_TTL_SECONDS は WebAuthn challenge の有効期限（秒）。既定: 300。
+# PASSKEY_CHALLENGE_TTL_SECONDS=300
+```
+
+**`docker-compose.yml`**: `api` サービスの `environment` に以下を追加する（`worker` サービス
+は passkey に依存しないため対象外）:
+
+```yaml
+services:
+  api:
+    environment:
+      # ... 既存 env ...
+      - WEBAUTHN_RP_ID=${WEBAUTHN_RP_ID:-}
+      - WEBAUTHN_RP_DISPLAY_NAME=${WEBAUTHN_RP_DISPLAY_NAME:-Feedman}
+      - WEBAUTHN_ORIGINS=${WEBAUTHN_ORIGINS:-}
+      - WEBAUTHN_IOS_APP_ID=${WEBAUTHN_IOS_APP_ID:-}
+      - PASSKEY_CHALLENGE_TTL_SECONDS=${PASSKEY_CHALLENGE_TTL_SECONDS:-300}
+```
+
+すべて `${VAR:-<既定値または空>}` 形式で **既定値なし / 空文字 fail-closed** に統一し、
+NFR 3.1（既存挙動不変）を担保する（未設定なら env が空文字で渡り、config.go が空文字を
+検出して passkey handler を nil に倒す）。
+
+## Error Handling
+
+本差分は既存 error handling 方針を **踏襲** し、新規に追加するのは以下のみ:
+
+- **サーバ側**: `RegistrationService.FinishRegistrationNew` の auth_code 発行段階での失敗
+  （`AuthCodeCreator.Create` の infra エラー）は既存の `fmt.Errorf(...: %w, err)` wrap で
+  伝播し、handler で 500 INTERNAL_ERROR にマップする（既存
+  `AuthenticationService.FinishAuthentication` L332-333 と同経路）
+- **Web 側**: `PasskeyRegistrationErrorKind` に `registration_uncertain` を追加し、Dialog の
+  分岐に対応 UI を追加（§Delta 5 §UI 文言と復旧導線）
+
+秘密情報非漏出方針（NFR 2.1）は既存 §Security Considerations（#223）と本 spec §Delta 5
+§秘密情報の非漏出で担保される。
+
+## Testing Strategy
+
+### Server 側（Go / `go test`）
+
+- **Unit（`internal/passkey/registration_service_test.go` 拡張）**:
+  1. 正常系: begin → finish で `code_challenge` が envelope 経由で保持され、finish の
+     `authCodePlain` 戻り値が `AuthCodeCreator.Create` に渡された `AuthCode.PKCEChallenge` と
+     符合する
+  2. 正常系: `authCodePlain` が非空・base64url 形式（既存 `auth.GenerateAuthCode` の返り値
+     形式）である
+  3. 異常系: envelope 復元失敗（sessionData が破損）→ `ErrRegistrationFailed`
+  4. 異常系: envelope の `CodeChallenge` が空 → `ErrRegistrationFailed`
+  5. 異常系: `AuthCodeCreator.Create` が infra error → wrap して伝播（handler で 500）
+- **Unit（`internal/handler/passkey_handler_test.go` 拡張）**:
+  1. `TestPasskeyHandler_RegistrationFinish_Success` の期待レスポンスに `auth_code` を追加、
+     `user_id` が引き続き存在することを assert（iOS 互換性の回帰）
+  2. auth_code フィールドが非空 base64url 形式であることを assert
+- **Integration（`internal/handler/router_test.go` 拡張）**:
+  1. env 組合せ 4 行それぞれで `POST /api/auth/session` / `GET /api/passkey/capability` /
+     `POST /api/passkey/registration/begin` / `POST /api/passkey/authentication/begin` の
+     登録有無を fail-closed 表と符合させる（Delta 3 §fail-closed 表）
+  2. 特に `NATIVE unset + WEBAUTHN set` 行で `/api/passkey/registration/begin` および
+     `/api/passkey/authentication/begin` が 200 応答すること（iOS 継続稼働の回帰）を assert
+  3. 同行で `/api/passkey/capability` が 404 になること（capability 強化条件の回帰）
+
+### Web 側（Vitest + Testing Library）
+
+- **Unit（`web/src/hooks/use-passkey-registration.test.ts` 変更）**:
+  1. 正常系: begin → create → finish → session の 4 段のみが呼ばれ、`authentication/begin`
+     が呼ばれないこと（二度目 ceremony 除去の回帰）
+  2. 正常系: `finish` レスポンスの `auth_code` が `session` の request body に渡ること
+  3. `registration_uncertain` × fetch reject: finish が `TypeError` を throw → error.kind =
+     "registration_uncertain"
+  4. `registration_uncertain` × 5xx: finish が 500 応答 → error.kind = "registration_uncertain"
+  5. `registration_uncertain` × AbortError: finish が AbortError → error.kind = "registration_uncertain"
+  6. `server_rejected` × 400 REGISTRATION_FAILED: finish が 400 → error.kind = "server_rejected"
+     （uncertain と誤って判定されないことの回帰）
+  7. 既存 kind（`invalid_username` / `username_taken` / `cancelled` / `session_exchange_failed`）
+     の分岐は #223 テスト方針に従い維持
+- **Component（`web/src/components/passkey-signup-dialog.test.tsx` 変更）**:
+  1. `error.kind === "registration_uncertain"` で専用文言（「登録が完了したかどうかを
+     確認できませんでした」）が表示される
+  2. 「ログインで確認する」ボタン押下で `onOpenChange(false)` が呼ばれる（Dialog を閉じて
+     ログイン画面へ）
+  3. 「再度作成する」ボタン押下で `mutation.reset()` が呼ばれ Dialog が Idle 状態に戻る
+  4. 文言中にサーバ内部詳細（`error.body` の値・スタックトレースを想起させる文字列等）が
+     出現しないこと（Req 5.5 の回帰）
+- **Integration / Recovery（optional、`web/src/components/login-page-recovery.test.tsx`）**:
+  - `registration_uncertain` → 「ログインで確認する」→ `usePasskeyAuthentication` mutation
+    成功 → `AuthGuard` 再判定 → 2 ペイン UI 表示のフローが unit level で組めるなら追加
+    （組めない場合は E2E 側の担当として本 spec では追加しない）
+
+### iOS 契約の回帰
+
+- 本差分に伴う iOS 側の実装変更は無い（iOS の request 送信・response 受信ロジックを
+  変更しないため）
+- サーバ側の回帰テスト（`internal/handler/passkey_handler_test.go` L\* の
+  `registration/finish` response が `user_id` を含む assert）で iOS 互換性を担保する
+- iOS 側の contract test は #216 spec のスコープであり、本差分では追加・変更しない
+  （NFR 1.3）
+
+## Security Considerations
+
+Delta 4 §主防御要素表・§残余リスク・§決定記録 を参照。
+
+追加事項として、本 spec で追加する `RegistrationService.FinishRegistrationNew` の `auth_code`
+発行は既存 `AuthenticationService.FinishAuthentication` と **完全同一の経路**
+（`auth.GenerateAuthCode` → `auth.HashNativeSecret` → `AuthCodeCreator.Create` /
+`PKCEChallenge` = envelope の値）を用いる。したがって #216 で確定した native auth
+契約（60 秒 TTL / 単回消費 / PKCE 束縛）と一貫している。
+
+## Configuration
+
+Delta 6 を参照。**追加 env は無い**。既存 env の documentation（`.env.sample`）と
+container passthrough（`docker-compose.yml`）のみを整備する。
+
+## Supporting References
+
+- WebAuthn Level 2 §7.1 Registration Ceremony: <https://www.w3.org/TR/webauthn-2/#sctn-registering-a-new-credential>
+- RFC 7636 (PKCE for OAuth Public Clients): <https://datatracker.ietf.org/doc/html/rfc7636>
+- RFC 9700 (OAuth 2.0 Security Best Current Practice) §4.7 CSRF Protection:
+  <https://datatracker.ietf.org/doc/html/rfc9700>
+- Swift `JSONDecoder`（未知キーの既定挙動は「無視」）: <https://developer.apple.com/documentation/foundation/jsondecoder>
+- 既存 #216 サーバ設計: `docs/specs/216--app-store-4-8/design.md`
+- 既存 #223 Web 設計（本 spec が supersede する対象）: `docs/specs/223-feat-web-web/design.md`
+- 既存 `AuthenticationService.authnSession` 実装（本 spec の envelope パターンの前例）:
+  `internal/passkey/authentication_service.go` L57-66

--- a/docs/specs/231-design-web-auth/design.md
+++ b/docs/specs/231-design-web-auth/design.md
@@ -70,15 +70,15 @@ tasks.md は書き換えない**）へ差分を反映する。
   （上記 + PKCE 単回 60s TTL）を **分離** して明記し、PKCE が直接登録を防御しないことを述べる。
   既存 `/api/auth/session`（login）の Origin 検証も **Origin 不在・不一致・許可 Origin 未設定を
   拒否** する fail-closed へ補正する。
-- **Delta 5（Requirement 5）— 完了不明状態**: 「finish dispatch 後に確定的な pre-commit 4xx を
-  得られない」ケース（network reject / timeout / 送出後 Abort / 5xx / commit 済みを示唆する 2xx だが
+- **Delta 5（Requirement 5）— 完了不明状態**: 「finish の `fetch()` 呼出し後に確定的な pre-commit 4xx を
+  得られない」ケース（送達可否不明の network reject / timeout / fetch 中 Abort / 5xx / commit 済みを示唆する 2xx だが
   body 欠損・途中切断・parse 不能）を **第 3 の完了不明状態** `registration_uncertain` として定義する。
   この判別を成立させるため **API 層（`api.ts`）で dispatch 前の request preparation 失敗を
   `RequestPreparationError`、fetch 成功後の 2xx body parse 失敗を `ResponseParseError`（status 付き）に
   正規化**し、`fetch()` reject の plain `TypeError` を含む 3 起点を機械的に区別できるようにする（Blocker #1）。
-  さらに **discoverable ログインの一律 `AUTHENTICATION_FAILED` を auth hook の machine-readable kind に正規化**
+  さらに **discoverable ログインの finish 400 `AUTHENTICATION_FAILED` を auth hook の machine-readable kind に正規化**
   し（Blocker #3）、復旧は「**discoverable なパスキーログイン**（ユーザー名入力なし）で確認 → 成功なら完了 →
-  一律の `AUTHENTICATION_FAILED` の後にのみ再作成導線」に統一する。
+  finish の 400 `AUTHENTICATION_FAILED` の後にのみ再作成導線」に統一する。
 - **Delta 6（Requirement 6）— 運用 config 統合**: `.env.sample` / `docker-compose.yml` の記述差分を
   PR #229 のスコープに統合する（別 prerequisite PR に分離しない）。`CORS_ALLOWED_ORIGIN` の
   **既定を空へ変更**し、config が「明示設定された exact Origin のみを Web パスキーで信頼する」
@@ -223,8 +223,8 @@ Vitest）をそのまま使用する。session ID 生成は既存 `internal/auth
 | [N] | `internal/auth/session_factory.go` | 共有 session factory（ID + 単一 now + CreatedAt + ExpiresAt）。`SessionExchangeService` と RegistrationService が共有 |
 | [N] | `internal/auth/session_factory_test.go` | factory の ID / CreatedAt / ExpiresAt / 単一 now / generator 失敗を検証 |
 | [U] | `internal/auth/service.go` | `generateSessionID`（**unexported**）を本ファイルに定義済みのまま再利用。`session_factory.go` が同一 package（`internal/auth`）からそのまま参照するため #231 変更なし。旧 File Plan の「session_exchange.go から export」は誤りで、**薄い public `NewSessionID` は追加しない**（Blocker #2） |
-| [E] | `internal/auth/session_exchange.go` | session 構築を新 factory 呼び出しに差し替え（`SessionExchangeService` の外部契約・挙動は不変 / 差分等価） |
-| [E] | `internal/auth/session_exchange_test.go` | factory 差し替え後も既存アサーションが pass することを確認（CreatedAt / ExpiresAt 検証を追加） |
+| [E] | `internal/auth/session_exchange.go` | `now` / `sessionTTL` fields と TTL constructor 引数を `SessionFactoryFunc` 注入へ置換し、session 構築を factory 呼び出しに差し替え（auth_code 交換の外部挙動は不変） |
+| [E] | `internal/auth/session_exchange_test.go` | fake factory の userID 呼出し・生成 session 保存・factory failure 時の非保存を検証し、既存交換アサーションも維持 |
 | [E] | `internal/passkey/registration_service.go` | `FinishRegistrationNew` を既存 tx クロージャ内 session INSERT + `issueWebSession bool` + `*model.Session` 返却に拡張。session factory / session writer を注入、`WebSessionReady()` 追加 |
 | [E] | `internal/passkey/registration_service_test.go` | 新シグネチャ追従 + Web/iOS branch + 全 rollback + session の ID/CreatedAt/ExpiresAt 検証 |
 | [E] | `internal/handler/passkey_handler.go` | `allowedOrigin` + Cookie 設定 Option 注入、`RegistrationFinish` の mode 判定 / JSON Content-Type / readiness fail-closed / commit 後 `Set-Cookie`、`webRegistrationReady()` |
@@ -239,8 +239,8 @@ Vitest）をそのまま使用する。session ID 生成は既存 `internal/auth
 | [U] | `internal/handler/router_unauth_ratelimit_test.go` | PR #229 で追加済み。#231 変更なし（記録） |
 | [E] | `internal/handler/passkey_e2e_db_test.go` | 実 PostgreSQL で 3 行 commit / session 失敗時の全 rollback + Set-Cookie なし |
 | [E] | `internal/config/config.go` | `WebPasskeyAllowedOrigin`（`CORS_ALLOWED_ORIGIN` を **trim + strict exact-Origin validation** した値。未設定/空/malformed → `""` の fail-closed）を追加。`CORSAllowedOrigin` 既定は不変（新規 env は追加しない / Blocker #6） |
-| [E] | `internal/config/config_test.go` | `CORS_ALLOWED_ORIGIN` の set / unset / empty / **malformed（前後空白・末尾スラッシュ・path/query/fragment 付き・複数 origin）** での `WebPasskeyAllowedOrigin`（valid のみ採用 / それ以外 `""`）を検証。`CORSAllowedOrigin` は既定 localhost:3000 を維持（Blocker #6） |
-| [E] | `internal/app/app.go` | RegistrationService へ session writer / session factory / TTL を注入、PasskeyHandler へ `WebPasskeyAllowedOrigin` + Cookie 設定を注入（`NATIVE_AUTH_JWT_SECRET` 非依存で `WEBAUTHN_*` 設定時に配線） |
+| [E] | `internal/config/config_test.go` | `CORS_ALLOWED_ORIGIN` の set / 前後空白付き set（trim 後に valid）/ unset / empty / **malformed（内部空白・末尾スラッシュ・path/query/fragment/userinfo 付き・複数 origin）** での `WebPasskeyAllowedOrigin`（valid のみ正規化して採用 / それ以外 `""`）を検証。`CORSAllowedOrigin` は既定 localhost:3000 を維持（Blocker #6） |
+| [E] | `internal/app/app.go` | `SessionFactory` を 1 インスタンス生成し、`SessionExchangeService` と RegistrationService の双方へ共有注入。RegistrationService へ session writer、PasskeyHandler へ `WebPasskeyAllowedOrigin` + Cookie 設定も注入（registration 側は `NATIVE_AUTH_JWT_SECRET` 非依存で `WEBAUTHN_*` 設定時に配線） |
 
 ### Web（TypeScript）
 
@@ -248,19 +248,19 @@ Vitest）をそのまま使用する。session ID 生成は既存 `internal/auth
 |---|---|---|
 | [E] | `web/src/lib/api.ts` | 2xx の `response.json()` 失敗を status 付き `ResponseParseError` へ、dispatch 前の request preparation 失敗（`JSON.stringify` / URL 構築）を `RequestPreparationError` へ **それぞれ正規化**し、`fetch()` reject の plain `TypeError` と機械的に区別可能にする（Blocker #1） |
 | [E] | `web/src/lib/api.test.ts` | 2xx body 欠損/途中切断/parse 不能 → `ResponseParseError`（status 2xx）、request preparation 失敗 → `RequestPreparationError`、fetch reject → plain `TypeError` の 3 者が区別されることを検証（Blocker #1） |
-| [E] | `web/src/types/passkey.ts` | `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加。authentication error 種別に「finish の一律 `AUTHENTICATION_FAILED` のみを表す machine-readable kind」を追加（Blocker #3。raw body / 内部理由は保持しない）。`RegistrationFinishResponse` は `{user_id}` のまま（auth_code を追加しない） |
-| [E] | `web/src/hooks/use-passkey-registration.ts` | chain を「begin → create → finish → invalidateQueries」に短縮（二度目 ceremony / 登録用 `/api/auth/session` を除去）。finish の error を uncertain / rejected（全 4xx）/ server_error（`RequestPreparationError`）に分類（Blocker #1） |
+| [U] | `web/src/types/passkey.ts` | PR #229 追加済みの API DTO 定義を維持。`RegistrationFinishResponse` は `{user_id}` のまま（auth_code を追加しない）。domain error kind は実在する各 hook 内で定義されているため本ファイルへ移動・重複定義しない |
+| [E] | `web/src/hooks/use-passkey-registration.ts` | 本ファイルで定義済みの `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加。chain を「begin → create → finish → invalidateQueries」に短縮（二度目 ceremony / 登録用 `/api/auth/session` を除去）し、finish の error を uncertain / rejected（全 4xx）/ server_error（`RequestPreparationError`）に分類（Blocker #1） |
 | [E] | `web/src/hooks/use-passkey-registration.test.tsx` | 二度目 ceremony 不在回帰 + uncertain 4 サブケース + 全 4xx=rejected 回帰 + `RequestPreparationError`=server_error（ファイル拡張子は `.test.tsx` / PR #229 実体に一致） |
-| [E] | `web/src/hooks/use-passkey-authentication.ts` | discoverable ログイン復旧で再利用。**finish の一律 `AUTHENTICATION_FAILED` を表す machine-readable kind** を追加し、begin 拒否 / cancel / network / 5xx / session 交換失敗を別 kind に保つ（Blocker #3。内部理由・raw body は UI に渡さない） |
-| [E] | `web/src/hooks/use-passkey-authentication.test.tsx` | 一律 `AUTHENTICATION_FAILED` kind の付与と、begin 拒否 / cancel / network / 5xx / session 交換失敗が別 kind になる negative test（Blocker #3） |
-| [E] | `web/src/components/passkey-signup-dialog.tsx` | 完了不明状態 UI + discoverable ログイン復旧導線（段階提示） |
-| [E] | `web/src/components/passkey-signup-dialog.test.tsx` | uncertain 見出し / 段階提示 / 一律 `AUTHENTICATION_FAILED` 後のみ再作成 / 内部詳細非漏出の回帰 |
+| [E] | `web/src/hooks/use-passkey-authentication.ts` | 本ファイルで定義済みの `PasskeyAuthErrorKind` に、**authentication finish の 400 `AUTHENTICATION_FAILED` のみ**を表す machine-readable kind を追加。begin 拒否 / cancel / network / 5xx / session 交換失敗を別 kind に保つ（Blocker #3。内部理由・raw body は UI に渡さない） |
+| [E] | `web/src/hooks/use-passkey-authentication.test.tsx` | finish + 400 + `AUTHENTICATION_FAILED` の完全一致でのみ kind を付与し、begin の同一 code / finish の異なる status・code / cancel / network / 5xx / session 交換失敗は別 kind になる negative test（Blocker #3） |
+| [E] | `web/src/components/passkey-signup-dialog.tsx` | 完了不明状態 UI + discoverable ログイン復旧導線（段階提示）。legacy `registered` 自動 close より uncertain を優先 |
+| [E] | `web/src/components/passkey-signup-dialog.test.tsx` | uncertain 見出し / 初期の自動 close・callback・reset 不在 / 段階提示 / finish 400 `AUTHENTICATION_FAILED` 後のみ再作成 / 再作成時の registration・auth 両 mutation reset / 内部詳細非漏出の回帰 |
 | [E] | `web/src/components/login-page-recovery.test.tsx` | uncertain → discoverable ログイン成功 → 2 ペイン到達の recovery 整合 |
 | [U] | `web/src/hooks/use-passkey-authentication.contract.test.tsx` | PR #229 追加済み。#231 変更なし（記録） |
 | [U] | `web/src/components/login-page.tsx` | PR #229 追加済み。#231 変更なし |
 | [U] | `web/src/components/login-page.test.tsx` | PR #229 追加済み。#231 変更なし |
-| [U] | `web/src/components/passkey-buttons.tsx` | PR #229 追加済み。#231 変更なし |
-| [U] | `web/src/components/passkey-buttons.test.tsx` | PR #229 追加済み。#231 変更なし |
+| [E] | `web/src/components/passkey-buttons.tsx` | 新しい `authentication_failed` kind を既存 `server_rejected` と同じ generic 固定文言へ map し、通常の「パスキーでログイン」導線でエラー表示が消える回帰を防ぐ |
+| [E] | `web/src/components/passkey-buttons.test.tsx` | 通常ログインの `authentication_failed` が既存 generic 文言を表示し、`AUTHENTICATION_FAILED` や raw body を DOM に反射しない回帰テスト |
 | [U] | `web/src/hooks/use-passkey-capability.ts` | PR #229 追加済み。#231 変更なし |
 | [U] | `web/src/hooks/use-passkey-capability.test.tsx` | PR #229 追加済み。#231 変更なし |
 | [U] | `web/src/lib/webauthn.ts` | PR #229 追加済み。#231 変更なし |
@@ -296,7 +296,7 @@ Vitest）をそのまま使用する。session ID 生成は既存 `internal/auth
 | 1.2 | 二度目 ceremony を実装として採用しない | Delta 1 §Before → After |
 | 1.3 | 3 行単一 tx → commit → Set-Cookie（iOS は 2 行・Cookie なし） | Delta 1 §3 行トランザクション / §Set-Cookie / §iOS 契約維持 |
 | 1.4 | 2 ペイン UI 初期表示 | Delta 1 §Sequence（invalidateQueries → AuthGuard） |
-| 1.5 | ログイン導線への影響なし | Delta 1 §影響範囲（`use-passkey-authentication` 未変更） |
+| 1.5 | ログイン導線への影響なし | Delta 1 §影響範囲（auth hook の分類追加 + `PasskeyButtons` の generic 表示を含め、既存ログイン flow / 成功契約は不変） |
 | 2.1 | api.ts / api.test.ts を変更対象に明示 | File Structure Plan §Web |
 | 2.2 | .env.sample / docker-compose.yml を変更対象に明示 | File Structure Plan §運用 config |
 | 2.3 | needs-iteration 1 回で完結する粒度のタスク | tasks.md 全体 |
@@ -409,10 +409,11 @@ handler は challenge consume / DB mutation より **前** に、`Origin` ヘッ
 
 #### 共有 session factory（`internal/auth/session_factory.go` / New / Blocker #2 対応）
 
-login session 発行（`Service.createSession` / `SessionExchangeService`）と registration direct session が
-**同一の session 構築ロジック**（ID 生成 + 単一 `now` + `CreatedAt=now` + `ExpiresAt=now+TTL`）を
-共有するための最小 factory を新設する。RegistrationService には具体型ではなく最小 interface を
-注入する（interface segregation / テスト可能性）:
+パスキーログインの `SessionExchangeService` と registration direct session が
+**同一 factory インスタンスの session 構築ロジック**（ID 生成 + 単一 `now` + `CreatedAt=now` +
+`ExpiresAt=now+TTL`）を共有するための最小 factory を新設する。`Service.createSession`（Google OAuth）は
+既存実装を維持し、本 factory へ移行しない。RegistrationService と SessionExchangeService には具体型ではなく
+最小 interface を注入する（interface segregation / テスト可能性）:
 
 ```go
 // internal/auth/session_factory.go（New）
@@ -441,17 +442,25 @@ func (f *SessionFactory) NewSession(userID string) (*model.Session, error) {
     return &model.Session{ID: id, UserID: userID, CreatedAt: now, ExpiresAt: now.Add(f.ttl)}, nil
 }
 
-// RegistrationService が受ける最小 IF（interface segregation）
+// RegistrationService と SessionExchangeService が受ける最小 IF（interface segregation）
 type SessionFactoryFunc interface {
     NewSession(userID string) (*model.Session, error)
 }
 ```
 
-- `SessionExchangeService` は現在の inline 構築（`generateSessionID` + `now` + `CreatedAt` + `ExpiresAt`）を
-  `SessionFactory.NewSession` 呼び出しに差し替える（外部契約・挙動は不変 / 差分等価）
-- `Service.createSession`（Google OAuth login）も同 factory 採用が望ましいが、最小差分として
-  少なくとも `SessionExchangeService` と registration direct session の 2 経路で factory を共有する
-  （review Blocker #2 の要求「at least existing SessionExchangeService and registration direct session」）
+- `SessionExchangeService` は `now` / `sessionTTL` fields を `sessionFactory SessionFactoryFunc` に置き換え、
+  constructor を `NewSessionExchangeService(authCodes, sessions, sessionFactory)` に変更する。現在の inline
+  構築（`generateSessionID` + `now` + `CreatedAt` + `ExpiresAt`）は
+  `sessionFactory.NewSession(stored.UserID)` 呼び出しへ差し替える。auth_code 交換の外部挙動は不変
+- `app.go` は `sessionTTL := time.Duration(cfg.SessionMaxAge) * time.Second` と
+  `sessionFactory := auth.NewSessionFactory(sessionTTL)` を **`NATIVE_AUTH_JWT_SECRET` 条件の外で一度だけ**
+  構築する。NATIVE secret 設定時の `SessionExchangeService` と、WEBAUTHN 設定時の
+  `RegistrationService` の双方へ **同じ pointer** を注入する。これにより registration の direct session
+  発行は NATIVE secret の有無に依存しない
+- `Service.createSession`（Google OAuth login）は既存の独立した生成処理を維持する。共有対象は
+  `SessionExchangeService` と registration direct session の 2 経路であり、Google OAuth まで同一 factory
+  instance を共有するとはしない（review Blocker #2 の要求
+  「at least existing SessionExchangeService and registration direct session」）
 - `generateSessionID` は **`internal/auth/service.go`** に **unexported** で定義されている（旧 File Plan の
   「`session_exchange.go` から export」は誤り）。`session_factory.go` は同一 package（`internal/auth`）のため
   この unexported 関数を既定 `newID` としてそのまま参照でき、**`service.go` の変更も薄い public `NewSessionID` の
@@ -561,14 +570,15 @@ async function mutationFn({ username }: { username: string }) {
 
 - 変更: `RegistrationService.FinishRegistrationNew` / `PasskeyHandler.RegistrationFinish` /
   session repo `CreateExec` / 共有 session factory / 共有 Cookie builder /
-  `use-passkey-registration.ts` / `api.ts` / `passkey-signup-dialog.tsx` / `config.go` / `app.go`
+  `use-passkey-registration.ts` / `use-passkey-authentication.ts` / `api.ts` /
+  `passkey-signup-dialog.tsx` / `passkey-buttons.tsx` / `config.go` / `app.go`
 - **無変更で維持**:
   - #230 の `RegistrationTx` / `RegistrationTxBeginner` / `txBeginner` / user・credential Exec 変種 /
     `internal/repository/tx.go`（session ステップの追加以外は既存フローそのまま）
-  - `AuthenticationService` / `PasskeyButtons`（ログイン導線の**挙動**は影響を受けない / Req 1.5）。
-    `use-passkey-authentication.ts` は discoverable ログイン復旧で再利用しつつ、**復旧判定用に finish 一律
-    `AUTHENTICATION_FAILED` を表す machine-readable kind を追加する**のみで、既存ログイン flow の挙動・契約は不変
-    （Blocker #3 / Delta 5 §auth hook 判定）
+  - `AuthenticationService`（サーバの認証 ceremony は不変）。Web の
+    `use-passkey-authentication.ts` には復旧判定用の machine-readable kind を追加し、
+    `PasskeyButtons` にはその kind の generic 固定文言 mapping を追加するが、既存ログイン flow /
+    成功契約・ユーザー向け拒否文言の意味は不変（Req 1.5 / Blocker #3 / Delta 5 §auth hook 判定）
   - `SessionExchangeService` の外部契約（login の auth_code 交換として不変。session 構築のみ factory 化 /
     Delta 4 で Origin 検証の fail-closed 補正）
   - iOS 用 `registration/*` / `authentication/*`（#216 契約不変 / NFR 3.2）
@@ -778,7 +788,7 @@ fetch ベースの Web app では十分。残余リスクは同一オリジン X
 現行 `api.ts` の `request<T>` は、(a) request 送出前の `JSON.stringify(body)` / URL 構築で **plain `TypeError`** を、
 (b) `fetch()` の reject でも **plain `TypeError`** を、(c) 2xx（204/205 以外）末尾の `response.json()` 失敗で
 **plain `SyntaxError`** を投げ得る。(a) と (b) はどちらも plain `TypeError` のため、呼出側は「dispatch 前の
-request preparation 失敗（commit 不成立が確定）」と「dispatch 後の fetch reject（commit 済みの可能性が残る）」を
+request preparation 失敗（commit 不成立が確定）」と「fetch reject（実送達可否が不明で commit 済みの可能性も残る）」を
 発生位置の推測なしに区別できない。これは round3 item 1 が指摘した contract 不成立である。
 
 そこで `api.ts` で **2 種類の専用型** を導入し、3 つの失敗起点を機械的に分離する（「plain `TypeError` の発生
@@ -800,7 +810,7 @@ export class ResponseParseError extends Error {
 //   let init: RequestInit;
 //   try { init = buildInit(body); /* JSON.stringify / URL 構築を含む */ }
 //   catch (e) { throw new RequestPreparationError(e); }        // (a) dispatch 前 = commit 不成立が確定
-//   const response = await fetch(url, init);                   // (b) reject は plain TypeError（dispatch 後 = 不確定）
+//   const response = await fetch(url, init);                   // (b) reject は plain TypeError（送達可否不明 = 不確定）
 //   ... status handling / 204,205 分岐 ...
 //   try { return await response.json(); }
 //   catch { throw new ResponseParseError(response.status); }   // (c) 2xx だが body 不能 = 不確定
@@ -808,7 +818,8 @@ export class ResponseParseError extends Error {
 
 - これにより呼出側は 3 起点を確実に弁別できる:
   - `RequestPreparationError` = **dispatch 前**の serialize / URL 構築失敗 → **commit 不成立が確定** → `server_error`
-  - plain `TypeError`（`fetch()` の reject）= **dispatch 後**のネットワーク断 → **commit 済みの可能性が残る** → `registration_uncertain`
+  - plain `TypeError`（`fetch()` の reject）= fetch 呼出し後の transport 失敗。request が wire へ出たかは
+    ブラウザから判定不能で、**未送達・送達済みの双方があり得る** → commit 結果不明 → `registration_uncertain`
   - `ResponseParseError`（status 2xx）= **dispatch 後**の 2xx body 不能 → **commit 済み示唆だが確定不能** → `registration_uncertain`
 - `credentials: "include"` / 204/205 分岐など既存挙動は不変（request preparation を try/catch で囲み、末尾 json parse を
   try/catch で囲む差分等価。`fetch()` reject の plain `TypeError` はそのまま透過させる）
@@ -816,12 +827,12 @@ export class ResponseParseError extends Error {
 ### 状態定義（Req 5.1）
 
 `PasskeyRegistrationErrorKind` に **新規 kind** `registration_uncertain` を追加する。本 kind は
-「`registration/finish` の request dispatch **後**に確定的な pre-commit 4xx を得られなかった」場合に
+「`registration/finish` の `fetch()` 呼出し後に、commit 不成立を確定できる 4xx を得られなかった」場合に
 のみ設定される。具体条件:
 
-- fetch reject（`fetch()` が投げる plain `TypeError` = dispatch 後のネットワーク断 / 接続断 / DNS 失敗。
-  dispatch 前の `RequestPreparationError` とは別起点）
-- 送出後の Abort（`DOMException.name === "AbortError"`）/ timeout
+- fetch reject（`fetch()` が投げる plain `TypeError` = ネットワーク断 / 接続断 / DNS 失敗等。
+  request の実送達有無は不明であり、dispatch 前に確定する `RequestPreparationError` とは別起点）
+- finish の fetch 呼出し中の Abort（`DOMException.name === "AbortError"`）/ timeout（実送達可否は不明）
 - 5xx 応答（サーバが受理・commit した可能性があるが応答段で失敗）
 - **commit 済みを示唆する 2xx だが body 不能**（`ResponseParseError`。Set-Cookie は付いた可能性があり、
   成否をクライアント側で確定できない）
@@ -849,7 +860,7 @@ stateDiagram-v2
     Pending --> Cancelled: create DOMException (NotAllowed/Abort)
     Pending --> ServerRejected: finish 任意の 4xx（REGISTRATION_FAILED 等）
     Pending --> Uncertain: finish reject / timeout / AbortError / 5xx / ResponseParseError(2xx)
-    Pending --> Success: finish 2xx (Set-Cookie 受理)
+    Pending --> Success: finish の parse 可能な期待形 2xx (Set-Cookie 受理)
     Uncertain --> ConfirmLogin: user が「ログインで確認する」を選ぶ
     ConfirmLogin --> [*]: discoverable ログイン成功 → 2 ペイン UI
     ConfirmLogin --> UncertainFailed: 一律 AUTHENTICATION_FAILED
@@ -869,51 +880,60 @@ try {
   if (err instanceof RequestPreparationError) throw new PasskeyRegistrationError("server_error", err);
   if (err instanceof ResponseParseError) throw new PasskeyRegistrationError("registration_uncertain", err); // 2xx body 不能
   if (err instanceof DOMException && err.name === "AbortError")
-    throw new PasskeyRegistrationError("registration_uncertain", err);                                       // 送出後 Abort
+    throw new PasskeyRegistrationError("registration_uncertain", err);                                       // fetch 中 Abort（送達可否不明）
   if (err instanceof ApiError) {
     if (err.status >= 500) throw new PasskeyRegistrationError("registration_uncertain", err);                // 5xx
     if (err.status >= 400) throw new PasskeyRegistrationError("server_rejected", err);                       // 全 4xx = 拒否確定
     throw new PasskeyRegistrationError("server_error", err);
   }
-  // 残る plain TypeError は fetch() の reject（dispatch 後）のみ（preparation は上で分岐済み）→ uncertain
-  if (err instanceof TypeError) throw new PasskeyRegistrationError("registration_uncertain", err);           // fetch reject（送出後）
+  // 残る plain TypeError は fetch() の reject のみ（preparation は上で分岐済み）。
+  // wire への送達有無を判定できないため安全側に uncertain
+  if (err instanceof TypeError) throw new PasskeyRegistrationError("registration_uncertain", err);           // fetch reject（送達可否不明）
   throw new PasskeyRegistrationError("server_error", err);                                                   // その他の想定外
 }
 ```
 
-**安全側 fail 原則**: finish 送出後に「拒否が確定（4xx）」でない限り、commit 済みの可能性を排除できないため
+**安全側 fail 原則**: finish の fetch 呼出し後に「拒否が確定（4xx）」でない限り、commit 済みの可能性を排除できないため
 uncertain に倒す。dispatch 前の失敗は commit 不成立が確定するため uncertain にしない。`api.ts` が
 **dispatch 前の request preparation 失敗を `RequestPreparationError`、fetch 成功後の 2xx parse 失敗を
 `ResponseParseError`（status 2xx）** に正規化するため、hook は「plain `TypeError` の発生位置」を推測せずに
-「dispatch 前（`RequestPreparationError` → server_error）/ fetch reject（plain `TypeError` → uncertain）/
+「dispatch 前（`RequestPreparationError` → server_error）/ 送達可否不明の fetch reject
+（plain `TypeError` → uncertain）/
 2xx parse 失敗（`ResponseParseError` → uncertain）」を機械的に振り分けられる（Blocker #1）。
 
 ### discoverable ログイン結果の machine-readable 判定（`use-passkey-authentication.ts` / Blocker #3）
 
-完了不明状態の復旧は「discoverable ログイン → **一律 `AUTHENTICATION_FAILED` の後にのみ再作成導線**」に
+完了不明状態の復旧は「discoverable ログイン → **finish の 400 `AUTHENTICATION_FAILED` の後にのみ再作成導線**」に
 固定する（Req 5.4）。ところが PR #229 head の `usePasskeyAuthentication` は begin / finish の 400 / 409 を
-すべて `server_rejected` に畳み、status / code / phase を捨てるため、Dialog は「finish の一律
+すべて `server_rejected` に畳み、status / code / phase を捨てるため、Dialog は「finish の 400
 `AUTHENTICATION_FAILED`」を他の失敗（begin 拒否 / cancel / network / 5xx / session 交換失敗）から区別できない。
 File Plan で当該 hook を [U]（不変）としていたことと合わせ、そのままでは Req 5.4 を満たせない（Blocker #3）。
 
-そこで `usePasskeyAuthentication` に **authentication finish の一律 `AUTHENTICATION_FAILED` のみを表す
-machine-readable な error kind**（例: `authentication_failed`）を追加する。判定は既存の response から得られる
-status / code のみで行い、**raw body / 内部理由（credential 未解決 等）は UI に渡さない**（NFR 2.1）。他の失敗は
-既存 kind を保つ:
+そこで `usePasskeyAuthentication` 内で定義済みの `PasskeyAuthErrorKind` に
+**authentication finish の 400 `AUTHENTICATION_FAILED` のみ**を表す machine-readable な error kind
+`authentication_failed` を追加する。分類 predicate は
+`step === STEP_AUTH_FINISH && err instanceof ApiError && err.status === 400 &&
+extractApiErrorCode(err) === "AUTHENTICATION_FAILED"` の **完全一致**とする。code は安全な shape guard で
+文字列だけを読むが、**raw body / 内部理由（credential 未解決 等）は error や UI に渡さない**（NFR 2.1）。
+他の失敗は既存 kind を保つ:
 
 | discoverable ログインの失敗 | error kind（例） | 再作成導線 |
 |---|---|---|
-| finish の一律 `AUTHENTICATION_FAILED` | `authentication_failed`（**NEW**） | **提示する**（Req 5.4） |
-| begin の拒否（400 / 409 等） | 既存の begin 系 kind（`server_rejected` 等） | 提示しない |
+| finish の **400** `AUTHENTICATION_FAILED` | `authentication_failed`（**NEW**） | **提示する**（Req 5.4） |
+| begin の拒否（同じ 400/code を含む） | 既存の begin 系 kind（`server_rejected` 等） | 提示しない |
 | ユーザー cancel（`NotAllowedError` / `AbortError`） | `cancelled` | 提示しない |
 | ネットワーク断（fetch reject） | `network_error` | 提示しない |
-| 5xx | `server_error` | 提示しない |
+| finish の 400 以外（同じ code を持つ 5xx を含む） | 既存の `server_rejected` / `server_error` | 提示しない |
 | session 交換段（`/api/auth/session`）失敗 | 既存の交換系 kind（`session_exchange_failed` 等） | 提示しない |
 
-- Dialog は復旧ログインの結果 error の kind が `authentication_failed`（finish 一律失敗）**のときにのみ**
+- Dialog は復旧ログインの結果 error の kind が `authentication_failed`
+  （finish の 400 `AUTHENTICATION_FAILED`）**のときにのみ**
   「再度作成する」を提示する（Req 5.4）。上表の他 kind では再作成を出さない（Blocker #3 の negative 条件）
-- 本 kind は「finish の一律失敗」という **観察可能な単一事実** のみを表し、内部理由の細分は行わない
+- 本 kind は「finish の 400 uniform failure」という **観察可能な単一事実** のみを表し、内部理由の細分は行わない
   （Req 5.4 の「内部理由を区別して提示しない」と NFR 2.1 を同時に満たす）
+- 通常ログイン UI の `PasskeyButtons` は `authentication_failed` を既存 `server_rejected` と同じ
+  generic 固定文言へ明示 map する。`ERROR_MESSAGES` が `Partial<Record<...>>` のため、mapping を省くと
+  通常ログインでエラー表示自体が消えることを防ぐ。raw code / body は DOM に反射しない
 - 本補正により File Plan の `use-passkey-authentication.ts` / `use-passkey-authentication.test.tsx` は
   [U]→[E] に更新する（§File Structure Plan §Web）
 
@@ -938,11 +958,20 @@ status / code のみで行い、**raw body / 内部理由（credential 未解決
   1. 初期: 「ログインで確認する」ボタンのみ。押下で `usePasskeyAuthentication` の **discoverable ログイン**
      （`navigator.credentials.get()` を allowCredentials 空で実行 / ユーザー名入力なし）を起動する（Req 5.2）
   2. 成功: 通常の Cookie セッション認証に到達し 2 ペイン UI（Req 5.3）
-  3. 復旧ログインの結果 error kind が `authentication_failed`（finish 一律 `AUTHENTICATION_FAILED` /
+  3. 復旧ログインの結果 error kind が `authentication_failed`（finish の 400 `AUTHENTICATION_FAILED` /
      §auth hook 判定。内部理由を区別しない）の失敗: **その後にはじめて**「再度作成する」導線を提示する
-     （Req 5.4）。再作成は `mutation.reset()` で Idle に戻す。登録済みなら再試行時に `username_taken` になる旨も併記可
+     （Req 5.4）。再作成は registration mutation と recovery authentication mutation の **双方を reset**
+     して Idle に戻す（auth 側の古い `authentication_failed` を次の uncertain 表示へ持ち越さない）。
+     登録済みなら再試行時に `username_taken` になる旨も併記可
   - 再作成導線は **復旧ログインの kind が `authentication_failed` のときのみ**提示する。begin 拒否 / cancel /
     network / 5xx / session 交換失敗 / uncertain の初期画面には再作成を出さない（Blocker #3 / Blocker #8 の負ケース）
+- **既存 `registered` 自動 close との優先順位**: PR #229 の Dialog には
+  `isError && error.registered` で `onAccountCreatedNeedsLogin` / `onOpenChange(false)` / `reset()` を実行する
+  legacy effect がある。`registration_uncertain` はこの effect より **優先して専用 UI に留める**ため、
+  当該 kind を明示除外する（例: `registered && errorKind !== "registration_uncertain"`）。
+  初期 uncertain 表示では `onAccountCreatedNeedsLogin`、`onOpenChange(false)`、`mutation.reset()` の
+  いずれも呼ばない。直接 session 化で旧 post-finish ceremony / session-exchange 経路は消えるが、
+  legacy `registered` field / callback を残す場合もこの precedence を必須とする
 
 ### 秘密情報の非漏出（Req 5.5 / NFR 2.1）
 
@@ -990,8 +1019,9 @@ status / code のみで行い、**raw body / 内部理由（credential 未解決
   `WebPasskeyAllowedOrigin string` を **新設**し、`os.Getenv("CORS_ALLOWED_ORIGIN")` の値を
   **trim + strict exact-Origin validation** に通した結果を用いる（下記 §exact Origin validation）。
   **生値の `!= ""` だけで readiness を成立させない**（Blocker #6）: trim 後に空、または exact Origin として
-  invalid（scheme/host を欠く / path・query・fragment・userinfo を持つ / 末尾スラッシュ / 空白や複数 origin を
-  含む 等）な値は **`WebPasskeyAllowedOrigin = ""` に倒す**（= capability 404 / Origin 検証 403 の fail-closed）。
+  invalid（scheme/host を欠く / path・query・fragment・userinfo を持つ / 末尾スラッシュ / trim 後の内部空白や
+  複数 origin を含む 等）な値は **`WebPasskeyAllowedOrigin = ""` に倒す**
+  （= capability 404 / Origin 検証 403 の fail-closed）。前後空白だけは trim して正規化する。
   localhost へは default しない。パスキー系の Origin fail-closed 判定はすべて `WebPasskeyAllowedOrigin` を参照する
 - `docker-compose.yml`: `api` の `CORS_ALLOWED_ORIGIN=${CORS_ALLOWED_ORIGIN:-http://localhost:3000}` を
   `${CORS_ALLOWED_ORIGIN:-}` に変更。理由: 未設定の運用者にはコンテナへ **空文字** が渡り、
@@ -1009,22 +1039,25 @@ CORS ミドルウェアの既定挙動（localhost:3000）まで空に倒れ Goo
 ### exact Origin validation（`WebPasskeyAllowedOrigin` の readiness 判定 / Blocker #6）
 
 `WebPasskeyAllowedOrigin` は「Web パスキーが信頼する **唯一の exact Origin**」であり、単なる非空判定では
-malformed 値（末尾空白・path 付き・複数 origin 等）を 200 で通してしまい、capability=200 なのに実 finish が
+malformed 値（path 付き・複数 origin 等）を 200 で通してしまい、capability=200 なのに実 finish が
 Origin mismatch で ceremony 後に 500 / 403 破綻する（Req 3.6 違反）。これを避けるため、config load 時に
 `os.Getenv("CORS_ALLOWED_ORIGIN")` を以下で検証し、**valid な単一 exact Origin のみ**を採用する:
 
-1. **trim**: 前後空白（`" \t\r\n"`）を除去する
+1. **trim / normalize**: 前後空白（`" \t\r\n"`）を除去し、以後は trim 済み値を検証・採用する。
+   したがって `" https://example.com "` は valid で `https://example.com` に正規化される
 2. **非空**: trim 後が空なら invalid（→ `""`）
 3. **単一 origin**: 内部に空白・カンマを含む（複数 origin 列挙）なら invalid
 4. **scheme + host を持つ exact Origin**: `url.Parse` で scheme（`http` / `https`）と host（非空）を持ち、
-   **path が空**（`""` のみ許容。`"/"` や任意 path は不可）、**query / fragment / userinfo を持たない** こと。
-   末尾スラッシュ（`https://example.com/`）は path を持つため invalid
+   `User == nil` / `Opaque == ""` / `Path == ""` / `RawPath == ""` / `RawQuery == ""` /
+   `Fragment == ""` / `ForceQuery == false` をすべて満たすこと。さらに trim 済み入力が
+   **`scheme://host` の canonical serialization と完全一致**すること。`"/"` を含む末尾スラッシュ、
+   `?`、`#`、userinfo、path はすべて invalid
 5. 上記いずれか不成立なら **`WebPasskeyAllowedOrigin = ""`（fail-closed。capability 404 / Origin 検証 403）** とする
 
 - **fail-closed へ倒す（既定）**: invalid 値は起動を止めず `""` に正規化し、Web はパスキー導線を出さず Google
   単体へ縮退する。この結果 capability=404 となり「capability だけ 200 で signup 500」の不整合（Req 3.6）を
-  構造的に発生させない。運用者向けには invalid を検知した旨を **秘密値を含めず** ログ warn する（生 Origin 値は
-  設定ミスの調査に必要な範囲でのみ出し、session_id / secret は出さない / NFR 2.2）
+  構造的に発生させない。運用者向けには invalid を検知した旨だけを generic にログ warn し、
+  **生 Origin 値は一切出さない**（userinfo 等を誤設定した場合の資格情報漏出も防ぐ / NFR 2.2）
 - **代替（起動エラー）**: より厳格な運用では invalid 時に起動を fail させる選択も可能。本設計は既存の
   「未設定 → 空 → fail-closed」方針と一貫させるため **`""` 正規化を既定** とし、起動エラーは採らない
   （挙動を tasks / config test で固定する）
@@ -1073,15 +1106,17 @@ WebAuthn passthrough（`WEBAUTHN_*` / `PASSKEY_CHALLENGE_TTL_SECONDS`）は PR #
   既存 defer Rollback 後に handler へ返し、`ErrRegistrationFailed` は 400 REGISTRATION_FAILED、それ以外は
   500 INTERNAL_ERROR にマップ。応答・ログに内部詳細 / session ID 生値を反射しない（NFR 2.1）
 - **Web（API 層）**: `api.ts` は 2xx の body parse 失敗を `ResponseParseError`（status 付き）に正規化し、
-  dispatch 前失敗（plain `TypeError`）と区別可能にする（Delta 5）
+  dispatch 前失敗を `RequestPreparationError` に正規化して、送達可否不明の fetch reject
+  （plain `TypeError`）と区別可能にする（Delta 5）
 - **Web（hook）**: `PasskeyRegistrationErrorKind` に `registration_uncertain` を追加し、Dialog の段階提示に対応
 
 ## Security Considerations
 
 Delta 4 §主防御要素表・§WebAuthn の防御性質の正確化・§残余リスク・§決定記録 を参照。追加事項として、
-直接 session 発行は既存 Google OAuth Callback / `SessionExchangeService` と **同一の session factory
-（ID 生成器・now・TTL）・同一 Cookie 属性**（canonical builder 共有）を用いるため、session の秘匿性・
-属性は既存経路と一貫する。
+直接 session 発行と `SessionExchangeService` は **同一の session factory instance**
+（ID 生成器・now・TTL）を共有する。Google OAuth の `Service.createSession` は独立した既存生成処理を維持するが、
+同じ `generateSessionID` と TTL semantics を使う。3 経路の Cookie 属性は canonical builder を共有するため、
+session の秘匿性・属性は既存経路と一貫する。
 
 ## Testing Strategy
 
@@ -1114,9 +1149,11 @@ Delta 4 §主防御要素表・§WebAuthn の防御性質の正確化・§残余
 - **Unit（`native_auth_handler_test.go`）**: `/api/auth/session` の Origin 不在・不一致・許可 Origin
   未設定で 403（Delta 4 fail-closed 補正の回帰）
 - **Unit（`config_test.go`）**: `CORS_ALLOWED_ORIGIN` valid set → `WebPasskeyAllowedOrigin=正規化値` /
-  unset・empty・**malformed（前後空白 `" https://x "` / 末尾スラッシュ `https://x/` / path・query・fragment 付き /
-  複数 origin `a,b`）→ `WebPasskeyAllowedOrigin=""`（fail-closed）**、`CORSAllowedOrigin` は既定 localhost:3000 を
-  維持（Blocker #6 / Blocker #8）
+  前後空白付き valid（`" https://x "`）→ trim 済み `https://x` / unset・empty・whitespace-only →
+  `""` / **malformed（内部空白 / 末尾スラッシュ `https://x/` / path・query・fragment・userinfo・opaque・
+  ForceQuery 付き / 複数 origin `a,b`）→ `WebPasskeyAllowedOrigin=""`（fail-closed）**、
+  `CORSAllowedOrigin` は既定 localhost:3000 を維持し、invalid warn に生値を含めない
+  （Blocker #6 / Blocker #8）
 - **Integration（`router_test.go`）**: fail-closed 表 行 1〜5 の各 endpoint（列 A〜E）登録有無。特に
   行 2（W✓ N✗ C✓）で iOS registration/*・authentication/* が 200・capability が 404、
   行 3（W✓ N✓ C✗）で capability 404、partial wiring（webRegistrationReady 未充足）で capability が
@@ -1133,7 +1170,7 @@ Delta 4 §主防御要素表・§WebAuthn の防御性質の正確化・§残余
 - **Unit（`use-passkey-registration.test.tsx`）**:
   1. 正常系: begin → create → finish の 3 呼び出しのみ。`authentication/*` / 登録用 `/api/auth/session` が
      呼ばれない（二度目 ceremony 除去の回帰）
-  2. `registration_uncertain` × fetch reject（送出後 `TypeError`）
+  2. `registration_uncertain` × fetch reject（実送達可否不明の `TypeError`）
   3. `registration_uncertain` × 5xx
   4. `registration_uncertain` × AbortError
   5. `registration_uncertain` × `ResponseParseError`（2xx body 不能）
@@ -1143,19 +1180,26 @@ Delta 4 §主防御要素表・§WebAuthn の防御性質の正確化・§残余
      fetch reject の plain `TypeError`（uncertain）と取り違えられない（Blocker #1）
   8. begin 段の `invalid_username` / `username_taken` / `cancelled` は既存挙動維持
 - **Unit（`use-passkey-authentication.test.tsx` / Blocker #3）**:
-  1. discoverable ログインの finish 一律 `AUTHENTICATION_FAILED` が machine-readable kind
-     （例: `authentication_failed`）に分類される
-  2. begin 拒否 / cancel（`NotAllowedError`）/ network（fetch reject）/ 5xx / session 交換段
-     （`/api/auth/session`）失敗が **`authentication_failed` 以外の別 kind** になる（negative: 再作成条件に該当しない）
+  1. discoverable ログインの **finish + status 400 + code `AUTHENTICATION_FAILED`** の完全一致だけが
+     `authentication_failed` に分類される
+  2. begin の同一 400/code、finish の異なる status/code、cancel（`NotAllowedError`）、
+     network（fetch reject）、5xx（同じ code を含む）、session 交換段（`/api/auth/session`）失敗が
+     **`authentication_failed` 以外の別 kind** になる（negative: 再作成条件に該当しない）
   3. 内部理由 / raw body を error に含めない（NFR 2.1）
+- **Component（`passkey-buttons.test.tsx`）**: 通常ログインで `authentication_failed` が既存
+  `server_rejected` と同じ generic 文言を表示し、`AUTHENTICATION_FAILED` / raw body を DOM に出さない
 - **Component（`passkey-signup-dialog.test.tsx`）**:
   1. `registration_uncertain` で見出し「登録が完了したかどうかを確認できませんでした」が表示され、
-     初期に「再度作成する」が **表示されない**（同列並置しない / Req 5.2）
+     初期に「再度作成する」が **表示されない**。同時に legacy `registered=true` であっても
+     `onAccountCreatedNeedsLogin` / `onOpenChange(false)` / `mutation.reset()` が呼ばれず Dialog が開いたまま
+     である（同列並置・自動 close なし / Req 5.2）
   2. 「ログインで確認する」押下で discoverable ログイン（`usePasskeyAuthentication`）が起動
-  3. discoverable ログインが一律失敗した後に「再度作成する」が表示され、押下で `mutation.reset()`
+  3. discoverable ログインが finish の 400 `AUTHENTICATION_FAILED` になった後に
+     「再度作成する」が表示され、押下で registration / recovery authentication の両 mutation が reset される。
+     次に再び uncertain になっても古い auth error により再作成導線が初期表示されない
   4. 復旧ログインの kind が `authentication_failed` のときのみ「再度作成する」が出る。begin 拒否 / cancel /
-     network / 5xx / session 交換失敗では初期画面にも失敗後にも「再度作成する」が出ない（一律
-     `AUTHENTICATION_FAILED` の後のみ / Blocker #3 / Blocker #8）
+     network / 5xx / session 交換失敗では初期画面にも失敗後にも「再度作成する」が出ない
+     （finish の 400 `AUTHENTICATION_FAILED` の後のみ / Blocker #3 / Blocker #8）
   5. 文言中にサーバ内部詳細 / 他 kind の代表文言が含まれない（Req 5.5 / 5.6 回帰）
 - **Recovery（`login-page-recovery.test.tsx`）**: `registration_uncertain` → 「ログインで確認する」→
   discoverable ログイン成功 → 2 ペイン UI 到達（Req 5.3。unit で組めない場合は E2E 側へ委譲する旨を明記）

--- a/docs/specs/231-design-web-auth/design.md
+++ b/docs/specs/231-design-web-auth/design.md
@@ -4,123 +4,134 @@
 
 **Purpose**: 本設計は Issue #223（Web ログイン画面のパスキー導線追加）に対する
 **差分設計（normative delta）** である。#223 の実装 PR #229 レビューで発見された 5 件の
-不整合（登録直後の二度目 WebAuthn ceremony / File Structure Plan の欠落 /
-fail-closed 表の不正確さ / CSRF 記述の誤り / 完了不明状態の未定義）を、#223 spec の
-物理ファイルを一切変更せず、本 spec 内で normative に上書き（supersede）する。
+不整合と、運用 config 統合（Requirement 6）を、#223 spec の物理ファイルを一切変更せず、
+本 spec 内で normative に上書き（supersede）する。5 件の不整合は
+(1) 登録直後の二度目 WebAuthn ceremony、(2) File Structure Plan の欠落、
+(3) fail-closed 表の不正確さ、(4) CSRF 記述の誤り、(5) 完了不明状態の未定義。
+
+**中核決定（人間運用者による #231 決定 1.A）**: 新規作成の合流は **`POST /api/passkey/
+registration/finish` の検証成功から同一 DB トランザクションで user・credential・Web session の
+3 行を作成し、commit 後に同じ finish 応答で `Set-Cookie` する直接 session 方式** で行う。
+登録用 auth_code・二度目の `navigator.credentials.get()`・登録専用の `/api/auth/session`
+呼び出し・exchange artifact は **導入しない**。`/api/auth/session` は既存パスキー **ログイン**
+用（auth_code 交換）としてそのまま残す。本設計は初版 design（auth_code additive 案 = 仮案 B）を
+全面的に置き換える。
 
 **Users**: 未認証 Web 訪問者（パスキーで新規作成する層／ iOS #216 で作成したパスキーで Web
 にログインする層）と、既存 Google OAuth ユーザー、Feedman 運用者。iOS #216 ユーザーへの
-影響はゼロ（本差分は iOS の request/response 契約を破壊しない / 追加は additive のみ /
-NFR 3.2）。
+影響はゼロ（`/api/passkey/registration/*` / `/api/passkey/authentication/*` の request/response
+JSON を変更しない。Web の差分は `Set-Cookie` ヘッダのみ / NFR 3.2）。
 
 **Impact**: 本 spec は独立した実装 PR を作らない。design PR merge 後、PR #229 の
 `needs-iteration` 1 回で製品コード（`internal/passkey/` / `internal/handler/` /
-`web/src/hooks/` / `web/src/components/`）・テスト・spec の
-`impl-notes.md` / `context-map.md`（**#223 spec の requirements.md / design.md /
-tasks.md は書き換えない**）へ差分を反映する。#231 spec の tasks.md は「PR #229 に
-適用する差分作業」を独立コミット可能な粒度で列挙する（NFR 1.2）。
+`internal/repository/` / `web/src/`）・テスト・spec の `impl-notes.md` / `context-map.md`
+（**#223 / #216 spec の requirements.md / design.md / tasks.md は書き換えない**）へ差分を反映する。
 
-### 補正する 5 つの Delta サマリ
+### 補正する 6 つの Delta サマリ
 
-- **Delta 1（Requirement 1）**: 登録 finish で二度目の WebAuthn ceremony を廃止し、
-  `POST /api/passkey/registration/finish` の応答に **additive で `auth_code` を含める**方式に
-  改める。`internal/passkey/registration_service.go` の `RegistrationService` に、既存
-  `AuthenticationService.authnSession` と同型の `registrationSession` 封筒を導入して
-  begin 時の `code_challenge` を finish まで運び、既存 `auth.AuthCodeCreator` で auth_code を
-  発行する。iOS #216 の `registration/finish` レスポンスは既存 `{user_id}` に `auth_code` が
-  追加されるのみで、iOS の JSON 復号は未知フィールドを無視する慣行のため契約破壊にはならない。
-- **Delta 2（Requirement 2）**: PR #229 の実変更ファイル一覧を File Structure Plan 差分の
-  「変更対象」に完全列挙する（`web/src/lib/api.ts` / `api.test.ts` / `.env.sample` /
-  `docker-compose.yml` を含む）。#223 design の「api.ts 無変更」記述を訂正する。
-- **Delta 3（Requirement 3）**: fail-closed 表を env × 4 endpoint（session / capability /
-  iOS registration/* / iOS authentication/*）の独立列に組み直し、`NATIVE_AUTH_JWT_SECRET`
-  未設定時に iOS endpoint が **維持される** ことを表現する。合わせて Web 用 capability probe の
-  route 登録条件を `PasskeyHandler != nil` から **`PasskeyHandler != nil && NativeAuthHandler
-  != nil`** に強化し、Web で end-to-end 実行不能な env 構成では capability = 404 として
-  Google 単体表示に確実に縮退させる（router 側の小修正）。iOS endpoint 群の登録条件は
-  従来どおり `PasskeyHandler != nil` のみで変えないため #216 契約は破壊しない（NFR 3.2）。
-- **Delta 4（Requirement 4）**: 「攻撃者は (auth_code, code_verifier) ペアを取得できない」の
-  誤記述を撤回し、CSRF 主防御（exact Origin / JSON Content-Type / CORS preflight /
-  SameSite / PKCE + auth_code 単回 60s TTL）と 2 種の残余リスク（同一オリジン XSS 経由 /
-  攻撃者自身の credential による自アカウント誘引）を明記する。人間運用者決定として追加の
-  browser-bound state（transaction cookie / 追加 CSRF token / Origin-bound challenge 拡張）は
-  導入しない旨も決定記録として残す。**design 側の記述変更のみ**で製品コードへの挙動変更を
-  伴わない。
-- **Delta 5（Requirement 5）**: 「サーバは registration/finish を commit したがクライアントが
-  応答を受け取れなかった」ケースを **第 3 の完了不明状態** として定義し、`PasskeyRegistration
-  ErrorKind` に `registration_uncertain` を追加。UI では既存の
-  `invalid_username` / `username_taken` / `cancelled` / `server_rejected` /
-  `session_exchange_failed` と識別可能な文言で提示し、ログイン導線での確認 / 再作成の
-  復旧導線を提供する。
+- **Delta 1（Requirement 1）— 直接 Cookie session**: 登録 finish で二度目の WebAuthn ceremony を
+  廃止する。`internal/passkey/RegistrationService.FinishRegistrationNew` を、既存
+  `internal/repository/tx.go` のトランザクション基盤を用いて **user → credential → session の
+  3 行を単一トランザクションで作成** する構成に拡張し、handler が commit 後に既存 Cookie 属性で
+  `Set-Cookie` する。`registration/finish` の request/response JSON は Web / iOS とも `{user_id}`
+  のまま変更しない（Web だけ `Set-Cookie` が付く / NFR 3.2）。登録 begin の `code_challenge` は
+  #216 契約維持のためフィールドを残すが **形式検証のみ** で永続化・束縛しない。
+- **Delta 2（Requirement 2）— File Structure Plan 補正**: PR #229 の実変更ファイルを
+  File Structure Plan 差分に完全列挙する（`web/src/lib/api.ts` / `api.test.ts` /
+  `.env.sample` / `docker-compose.yml` を含む）。本設計で新規追加する session tx 対応
+  （`CreateExec` 群・共有 Cookie builder・実 DB tx test）も列挙する。
+- **Delta 3（Requirement 3）— fail-closed 表 5 列化**: fail-closed 表を
+  Web capability / Web login exchange / Web registration direct session / iOS registration/* /
+  iOS authentication/* の **5 列独立** で組み直す。router の capability / `/api/auth/session` gate は
+  PR #229 の `NativeAuthHandler.SessionReady()` を **維持**（`NativeAuthHandler != nil` に弱めない）し、
+  Origin 検証が不能な構成（`CORS_ALLOWED_ORIGIN` 未設定）でも fail-closed に倒す。
+- **Delta 4（Requirement 4）— CSRF / PKCE 正確化**: 「攻撃者は (auth_code, code_verifier) ペアを
+  取得できない」の誤記述を撤回する。直接登録 session の主防御（exact Origin / JSON Content-Type /
+  CORS preflight / SameSite / **必須ユーザー生体ジェスチャ**）と、ログイン auth_code 交換の主防御
+  （上記 + PKCE 単回 60s TTL）を **分離** して明記し、PKCE が直接登録を防御しないことを述べる。
+  既存 `/api/auth/session`（login）の Origin 検証も **Origin 不在・不一致・allowedOrigin 未設定を
+  拒否** する fail-closed へ補正する。
+- **Delta 5（Requirement 5）— 完了不明状態**: 「finish dispatch 後に確定的な pre-commit 4xx を
+  得られない」ケース（network reject / timeout / 送出後 Abort / 5xx / commit 済みを示唆する 2xx だが
+  body 欠損・途中切断・parse 不能）を **第 3 の完了不明状態** `registration_uncertain` として定義する。
+  復旧は「**discoverable なパスキーログイン**（ユーザー名入力なし）で確認 → 成功なら完了 →
+  一律の `AUTHENTICATION_FAILED` の後にのみ再作成導線」に統一する（login と再作成を初期画面に
+  同列並置しない）。
+- **Delta 6（Requirement 6）— 運用 config 統合**: `.env.sample` / `docker-compose.yml` の記述差分を
+  PR #229 のスコープに統合する（別 prerequisite PR に分離しない）。`CORS_ALLOWED_ORIGIN` の
+  未設定・不一致と fail-closed 挙動の接続を明示し、Verify に代表 env 値付き `docker compose config` を
+  追加する。
 
 ### Goals
 
 - 主要目標 1: 新規作成完了までに追加の WebAuthn ceremony を要求しない（Requirement 1）
-- 主要目標 2: iOS #216 の `/api/passkey/*` request/response 契約を破壊しない（NFR 3.2）
-- 主要目標 3: 完了不明状態を含む復旧導線を Web UX として明確化する（Requirement 5）
-- 主要目標 4: fail-closed 表と CSRF 記述を運用者・レビュワーが誤読しない粒度で明確化する
-  （Requirement 3 / 4）
+- 主要目標 2: registration finish の user / credential / session を **単一トランザクションで atomic**
+  に作成し、session 生成・保存失敗時も全ロールバックする（Requirement 1 / データ整合性）
+- 主要目標 3: iOS #216 の `/api/passkey/*` request/response 契約を破壊しない（NFR 3.2）
+- 主要目標 4: fail-closed 表・CSRF 記述・完了不明状態を運用者・レビュワーが誤読しない粒度で明確化
+  （Requirement 3 / 4 / 5）
 - 成功基準:
-  - PR #229 に本差分を反映した後の `go test ./...` と `web/npm test` が既存テストを含めて green
-  - `POST /api/passkey/registration/finish` のレスポンスが `{user_id, auth_code}` を含み、
-    web が二度目 WebAuthn ceremony なしで `POST /api/auth/session` 呼び出しに到達する
-  - `NATIVE_AUTH_JWT_SECRET` 未設定 + `WEBAUTHN_RP_ID/ORIGINS` 設定済み env で iOS 用
+  - PR #229 に本差分を反映した後の `go test ./...` / `go vet ./...` / `web` の test / lint / build が green
+  - `POST /api/passkey/registration/finish` が Web（Origin 一致）で 200 `{user_id}` + `Set-Cookie` を返し、
+    二度目 ceremony なしで 2 ペイン UI に到達する
+  - 実 PostgreSQL で「session 書込失敗時に user / credential も作成されない（3 行 atomic）」ことを検証
+  - `NATIVE_AUTH_JWT_SECRET` 未設定 + `WEBAUTHN_*` 設定済み env で iOS 用
     `/api/passkey/registration/*` / `/api/passkey/authentication/*` が引き続き 200 応答する
 
 ### Non-Goals
 
-- **#223 spec の物理ファイル書換え**（`docs/specs/223-feat-web-web/requirements.md` /
-  `design.md` / `tasks.md`）— 本 spec は差分宣言のみを行い、物理ファイルは触らない（NFR 1.1）
+- **#223 / #216 spec の物理ファイル書換え**（各 requirements.md / design.md / tasks.md）— 本 spec は
+  差分宣言のみを行い、物理ファイルは触らない（NFR 1.1 / 1.3）
 - **独立した実装 PR の作成** — 差分は PR #229 の needs-iteration 1 回で反映（NFR 1.2）
-- **#216 iOS パスキー API 契約の破壊的変更**（NFR 1.3 / NFR 3.2）
-- **Issue #230 相当の DB トランザクション統合実装**（本 spec は Delta 1 の合流方式要件までを
-  扱い、user / credential の単一トランザクション化は #230 に委ねる）
-- **browser-bound state（transaction cookie / 追加 CSRF token / Origin-bound challenge 拡張）
-  の導入**（Requirement 4 の決定事項として本 spec では要求しない）
-- **`.env.sample` / `docker-compose.yml` を別 prerequisite PR に分離すること**
-  （Requirement 6 の決定事項）
+- **#216 iOS パスキー API の request/response JSON 契約の破壊的変更**（NFR 1.3 / NFR 3.2）
+- **登録用 auth_code / 二度目 ceremony / 登録専用 session 交換 endpoint / exchange artifact の導入**
+  （決定 1.A により不採用）
+- **browser-bound state（transaction cookie / 追加 CSRF token / Origin-bound challenge 拡張）の導入**
+  （Requirement 4 の決定事項）
+- **`.env.sample` / `docker-compose.yml` を別 prerequisite PR に分離すること**（Requirement 6 の決定事項）
 
 ## Architecture
 
-### Existing Architecture Analysis
+### Existing Architecture Analysis（PR #229 head 実装に基づく）
 
-本差分は #223 design が確立した以下の既存アーキテクチャを **維持する前提** で、上記 5 点の
-不整合のみを補正する。責務境界・依存方向・fail-closed 判定ロジック本体は変更しない
-（Delta 3 の router 条件のみ 1 行相当を強化）:
+本差分は #216 / PR #229 が確立した以下の既存アーキテクチャを **維持する前提** で補正する。
+責務境界・依存方向は変更しない（`handler → service → repository → model` の一方向 / CLAUDE.md §1）:
 
-- **既存パターンの維持**:
-  - `handler → service → repository → model` の一方向依存（CLAUDE.md §1）
+- **維持する既存要素**:
   - `internal/passkey/` の ceremony 責務（`RegistrationService` / `AuthenticationService`）と
     `internal/handler/passkey_handler.go` の HTTP I/O 責務の分離（#216 で確立）
   - `challengeStore.Issue/Consume` を通じた TTL 付き単回消費（#216 で確立）
-  - `AuthenticationService` が既に採用している `authnSession` 封筒パターン（sessionData
-    バイト列を `{WebAuthnSession, CodeChallenge}` で opaque に運ぶ）→ **Delta 1 で
-    `RegistrationService` にも横展開**
-  - Web 側の `lib/` 純粋関数 → `hooks/` mutation → `components/` UI の 3 層構成（#223 で確立）
-  - fail-closed による route 未登録判定（`if deps.<Handler> != nil { register }` パターン）
+  - `internal/repository/tx.go` のトランザクション基盤（`SQLTx` / `BeginTx` / `Querier() DBTX` /
+    `Commit` / `Rollback`）と、repo の `*Exec(ctx, q DBTX, ...)` 変種パターン
+    （既存例: `PostgresUserRepo.DeleteByIDExec` / `PostgresSessionRepo.DeleteByUserIDExec`）
+  - `NativeAuthHandler.Session`（`POST /api/auth/session`）+ `auth.SessionExchangeService`
+    （auth_code → Web Cookie session 交換 / PR #229）と `SessionReady()` readiness
+  - `NativeAuthHandler.Session` の CSRF 防御（Content-Type application/json 必須 / Origin allowlist）
+  - Google OAuth Callback（`auth_handler.go::Callback`）の Cookie 属性
+    （`session_id` / HttpOnly / SameSite=Lax / Secure / Path=/ / Domain / Max-Age）
+  - fail-closed による route 未登録判定（`if <条件> { register }` パターン）
 - **本差分が変更する点**:
-  - `RegistrationService.BeginRegistrationNew` / `FinishRegistrationNew` の内部処理と
-    `FinishRegistrationNew` のシグネチャ（`(userID, error)` → `(userID, authCodePlain, error)`）
-  - `PasskeyHandler.RegistrationFinish` のレスポンス body に `auth_code` を additive 追加
-  - `router.go` の capability route 登録条件を「両 handler 非 nil」に強化
-  - Web hook `use-passkey-registration.ts` の内部 chain（二度目 ceremony 除去 +
-    `registration_uncertain` state 追加）
-  - Web UI `passkey-signup-dialog.tsx` の error state 分岐に uncertain 状態と復旧導線 UI を追加
-  - `.env.sample` / `docker-compose.yml` に既存 WebAuthn env の記述を整備（**新規 env 追加は
-    なし**、既存 env の documentation / passthrough のみ）
+  - `RegistrationService.FinishRegistrationNew` を **user → credential → session の単一トランザクション**
+    に拡張（session 発行は Web mode のみ）。シグネチャに `issueWebSession bool` を追加し、返り値に
+    `*model.Session`（Web session、iOS では nil）を追加
+  - `PasskeyHandler.RegistrationFinish` に Origin ベースの Web / iOS mode 判定と Web mode の
+    `Set-Cookie` を追加
+  - repo に session 作成の tx 変種 `PostgresSessionRepo.CreateExec(ctx, DBTX, *model.Session)` と、
+    user / credential の tx 変種 `CreateUserOnlyExec` / `CreateExec` を追加
+  - Cookie 生成を **canonical builder に集約**（`auth_handler.Callback` /
+    `native_auth_handler.Session` / `passkey_handler.RegistrationFinish` で共有 / 重複排除）
+  - `router.go` の capability route 登録条件に `CORS_ALLOWED_ORIGIN` 設定要件を追加（Origin 検証不能時の
+    fail-closed）
+  - `native_auth_handler.Session` の Origin 検証を fail-closed（不在・不一致・allowedOrigin 未設定を拒否）へ補正
+  - Web hook `use-passkey-registration.ts` の chain（二度目 ceremony 除去 + `registration_uncertain` 追加）
+  - Web UI `passkey-signup-dialog.tsx` の完了不明状態 UI と discoverable ログイン復旧導線
+  - `.env.sample` / `docker-compose.yml` の既存 WebAuthn env documentation / passthrough 整備
 - **尊重すべき制約**:
-  - iOS #216 の request/response 契約：`registration/begin` request `{username, email?, code_challenge}`,
-    `registration/finish` request `{challenge_id, credential}`, `authentication/begin` request
-    `{code_challenge}`, `authentication/finish` response `{auth_code}` の各フィールド構造は
-    そのまま維持する。**additive な optional response field 追加のみ許容**（`registration/finish`
-    レスポンスへの `auth_code` 追加）
-  - `#223` design.md の全 Components セクション（`SessionExchangeService` / `NativeAuthHandler.
-    Session` / `PasskeyHandler.Capability` / Web 側 hook/component 群）の責務・契約はそのまま
-    維持
-  - NFR 1.1（`#223` requirements.md / design.md / tasks.md の物理ファイル不変）
-  - NFR 1.3（#216 requirements.md / design.md / tasks.md および `/api/passkey/registration/*` /
-    `/api/passkey/authentication/*` の request/response 契約変更禁止 — 本差分の
-    `registration/finish` 応答への `auth_code` 追加は additive のため許容）
+  - iOS #216 の request/response 契約：`registration/begin` request `{username, email?, code_challenge}`、
+    `registration/finish` request `{challenge_id, credential}` / response `{user_id}`、
+    `authentication/*` の各フィールド構造をそのまま維持する（Web も response は `{user_id}` 不変。
+    差分は `Set-Cookie` ヘッダのみで JSON body には現れない）
+  - NFR 1.1（#223 spec 物理ファイル不変）/ NFR 1.3（#216 spec 物理ファイル・API 契約不変）
 
 ### 差分適用の運用境界
 
@@ -128,487 +139,412 @@ tasks.md は書き換えない**）へ差分を反映する。#231 spec の task
 flowchart LR
     subgraph This231 [#231 spec（本 design）]
         R231[requirements.md]
-        D231[design.md<br/>本ファイル<br/>Delta 1〜5]
+        D231[design.md<br/>Delta 1〜6]
         T231[tasks.md<br/>PR #229 への差分作業]
     end
-
     subgraph Existing223 [#223 spec（物理不変）]
-        R223[requirements.md]
         D223[design.md<br/>該当節を supersede]
-        T223[tasks.md<br/>tasks 追加なし]
     end
-
-    subgraph Existing216 [#216 spec（物理不変）]
-        R216[requirements.md]
+    subgraph Existing216 [#216 spec（物理不変 / API 契約不変）]
         D216[design.md]
-        T216[tasks.md]
     end
-
     subgraph PR229 [PR #229 実装]
         S229[製品コード<br/>internal/**, web/src/**]
-        SPEC229[spec 補助<br/>context-map.md<br/>impl-notes.md]
-        CONF229[運用 config<br/>.env.sample<br/>docker-compose.yml]
+        SPEC229[spec 補助<br/>context-map.md / impl-notes.md]
+        CONF229[運用 config<br/>.env.sample / docker-compose.yml]
     end
-
     D231 -.supersedes.-> D223
     T231 -->|needs-iteration 1| S229
     T231 -->|needs-iteration 1| SPEC229
     T231 -->|needs-iteration 1| CONF229
-    R231 -.non-invasive.-> R223
-    T231 -.non-invasive.-> T223
-    T231 -.non-invasive.-> R216
     T231 -.non-invasive.-> D216
-    T231 -.non-invasive.-> T216
 ```
-
-- `#231 design.md` は `#223 design.md` の該当節を supersede する（本ファイル内の Delta 1〜5 で
-  before → after を明示）
-- `#231 tasks.md` は PR #229 に適用する製品コード / テスト / 運用 config / spec 補助
-  （`impl-notes.md` / `context-map.md`）への差分作業のみを列挙し、**`#223` / `#216` の
-  requirements.md / design.md / tasks.md を書き換えるタスクを含まない**
-- `#216` spec 全体は本差分の対象外（NFR 1.3）
 
 ### Technology Stack
 
 本差分は **技術スタック追加なし**。既存の技術選定（Go 1.25 / chi/v5 / PostgreSQL 16 /
-go-webauthn / Next.js 15 / TanStack Query / shadcn/ui / Vitest）をそのまま使用する。
+go-webauthn / `database/sql` トランザクション / Next.js 15 / TanStack Query / shadcn/ui /
+Vitest）をそのまま使用する。session ID 生成は既存 `auth.SessionExchangeService` /
+Google OAuth Callback と同一の生成器を再利用する（重複しない）。
 
 ## File Structure Plan（PR #229 に適用する差分の変更対象 / 新規追加）
 
-本セクションは PR #229 の `needs-iteration` 1 回で反映する対象ファイルを **変更対象**
-（既存 or PR #229 で既に追加済み → 本差分でさらに編集）と **新規追加**（本差分で初めて
-生成）に分けて明示する。**#223 design.md「File Structure Plan」節を supersede する**
-（Requirement 2）。
+本セクションは PR #229 の `needs-iteration` 1 回で反映する対象ファイルを **変更対象** と
+**新規追加** に分けて明示する。**#223 design.md「File Structure Plan」節を supersede する**
+（Requirement 2）。Reviewer は本節を canonical として PR #229 の全変更ファイル被覆を確認できる
+（Requirement 2.5）。
 
-### Modified Files（PR #229 に対する編集対象）
+### Modified Files（サーバ側）
 
-#### サーバ側
+- `internal/repository/tx.go` — **変更**（3 行 tx orchestration の helper 追加）
+  - closure 型のトランザクション実行ヘルパー `WithinTx(ctx, fn func(q DBTX) error) error` を
+    `SQLTxBeginner` に追加（`BeginTx` → `fn(tx.Querier())` → 正常時 `Commit` / エラー・panic 時
+    `Rollback`）。既存 `SQLTx` / `BeginTx` / `Querier` / `Commit` / `Rollback` は変更しない
+- `internal/repository/postgres_session_repo.go` — **変更**
+  - `CreateExec(ctx, q DBTX, s *model.Session) error` を追加（既存 `DeleteByUserIDExec` の
+    DBTX 変種パターンに準拠）。既存 `Create(ctx, s)` は `CreateExec(ctx, r.db, s)` へ委譲に変更
+    （差分等価 / 挙動不変）
+- `internal/repository/postgres_user_repo.go` — **変更**
+  - `CreateUserOnlyExec(ctx, q DBTX, u *model.User) error` を追加。既存 `CreateUserOnly` は
+    `CreateUserOnlyExec(ctx, r.db, u)` へ委譲（`ErrUsernameTaken` 正規化は変えない）
+- `internal/repository/postgres_passkey_credential_repo.go` — **変更**
+  - `CreateExec(ctx, q DBTX, c *model.PasskeyCredential) error` を追加。既存 `Create` は
+    `CreateExec(ctx, r.db, c)` へ委譲（`ErrCredentialAlreadyRegistered` 正規化は変えない）
+- `internal/passkey/registration_service.go` — **変更**（Delta 1 サーバ中核）
+  - 最小 IF を追加/拡張: `SessionWriter{CreateExec}`、`UserWriter` に `CreateUserOnlyExec`、
+    `PasskeyCredentialWriter` に `CreateExec`、tx 実行 IF `txRunner{WithinTx}`
+  - 構造体に `sessions SessionWriter` / `tx txRunner` / `newSessionID func() (string, error)` /
+    `sessionTTL time.Duration` を追加（**auth_code 関連依存は追加しない**）
+  - `FinishRegistrationNew` を単一 tx + `issueWebSession bool` 対応に変更（後述 §Delta 1）
+  - `WebSessionReady() bool`（session writer / tx / 生成器が非 nil）を追加
+- `internal/passkey/registration_service_test.go` — **変更**（新シグネチャ追従 + branch/正規化テスト）
+- `internal/handler/session_cookie.go` — **新規**（後述 §New Files）
+- `internal/handler/passkey_handler.go` — **変更**（Delta 1 handler + Delta 3）
+  - `PasskeyHandler` に `allowedOrigin string` と Cookie 設定（domain / secure / maxAge）を
+    Option で注入（既存 `NativeAuthHandler` の `WithSession*` Option idiom を踏襲）
+  - `RegistrationFinish` に Origin ベース mode 判定・Web mode の JSON Content-Type 検証・
+    readiness fail-closed・commit 後 `Set-Cookie` を追加（response は 200 `{user_id}` 不変）
+- `internal/handler/passkey_handler_test.go` — **変更**（mode 判定 / Set-Cookie / iOS `{user_id}` 回帰）
+- `internal/handler/native_auth_handler.go` — **変更**（Delta 4 login Origin fail-closed 補正）
+  - `Session` の Origin 検証を「Origin 不在・不一致・allowedOrigin 未設定を拒否（403）」に補正
+- `internal/handler/native_auth_handler_test.go` — **変更**（Origin fail-closed の異常系追加）
+- `internal/handler/router.go` — **変更**（Delta 3）
+  - capability route 条件に `deps.CORSAllowedOrigin != ""` を追加（`SessionReady()` は維持）
+  - `/api/auth/session` 条件は既存 `NativeAuthHandler != nil && SessionReady()` を維持
+  - iOS `/api/passkey/registration/*` / `/api/passkey/authentication/*`（および Web と共有する
+    `registration/finish`）は `PasskeyHandler != nil` を維持（#216 契約 / NFR 3.2）
+- `internal/handler/router_test.go` — **変更**（fail-closed 5 列に対応する route 登録テスト）
+- `internal/handler/passkey_e2e_db_test.go` — **変更**（実 PostgreSQL で 3 行 commit / rollback 原子性）
+- `internal/auth/session_exchange.go` — **変更**（session ID 生成器を `auth.GenerateSessionID` として
+  export し RegistrationService と共有 / 重複排除。`SessionExchangeService` の契約は不変）
+- `internal/app/app.go` — **変更**（wiring）
+  - `passkey.NewRegistrationService(...)` に `sessionRepo`（SessionWriter）/ tx runner /
+    `auth.GenerateSessionID` / `sessionTTL` を注入
+  - `handler.NewPasskeyHandler(...)` に `allowedOrigin`（`cfg.CORSAllowedOrigin`）と Cookie 設定
+    （`cfg.CookieDomain` / `cfg.CookieSecure` / `cfg.SessionMaxAge`）を注入
+  - 注記: session 発行依存（sessionRepo / cookie / origin）は `NATIVE_AUTH_JWT_SECRET` に依存せず、
+    `WEBAUTHN_*` 設定時（passkey handler 生成時）に常時配線する
 
-- `internal/passkey/registration_service.go` — **変更**（Delta 1 / #216 で main 済み）
-  - `registrationSession` 封筒構造体を追加（`{WebAuthnSession json.RawMessage,
-    CodeChallenge string}`、既存 `authentication_service.go::authnSession` と同型）
-  - `BeginRegistrationNew` を修正: 検証済み `code_challenge` を封筒に格納し
-    `challengeStore.Issue(sessionData=封筒 marshal)` として運ぶ
-  - `FinishRegistrationNew` のシグネチャを **`(userID string, error) → (userID string,
-    authCodePlain string, error)`** に変更（additive: 呼び出し側は handler のみ）
-  - `FinishRegistrationNew` に auth_code 発行ロジック追加（`auth.GenerateAuthCode` +
-    `auth.HashNativeSecret` + `AuthCodeCreator.Create` — `authentication_service.go` と
-    完全同経路）
-  - `RegistrationService` 構造体に `authCodes auth.AuthCodeCreator` フィールドを追加、
-    `NewRegistrationService` シグネチャに `authCodes` を追加（wiring 側で
-    `PostgresAuthCodeRepo` を注入）
-- `internal/passkey/registration_service_test.go` — **変更**
-  - 既存ケースの assertion を新シグネチャに追従（`userID` に加え `authCodePlain` を返す）
-  - 新規ケース: 正常系で `AuthCodeCreator.Create` が `envelope.CodeChallenge` を PKCE として
-    紐付ける AuthCode を受け取ることを stub で検証
-  - 新規ケース: `code_challenge` を封筒 → sessionData → 復元まで往復させて begin/finish 間で
-    保持されることを検証
-- `internal/handler/passkey_handler.go` — **変更**（Delta 1 handler 側 + Delta 3 不変）
-  - `RegistrationFinish` ハンドラ内で `RegistrationService.FinishRegistrationNew` の 2 番目
-    返り値（`authCodePlain`）をレスポンス body へ additive に組み込む
-    （`{user_id, auth_code}` の形式）
-  - `Capability` ハンドラ（PR #229 で新規追加済み）は本差分では変更しない（route 側の登録
-    条件のみ router.go で変更）
-- `internal/handler/passkey_handler_test.go` — **変更**
-  - `TestPasskeyHandler_RegistrationFinish` の assertion に `body.auth_code` の存在確認・
-    形式検証（base64url 43 文字以上、既存 `HashNativeSecret` 入力形式）・**iOS ignore-unknown
-    互換の観点で追加フィールドのみ増えたことを確認する**回帰ケースを追加
-- `internal/handler/router.go` — **変更**（Delta 3 router 登録条件強化）
-  - 現状想定される `if deps.PasskeyHandler != nil { r.With(...).Get("/api/passkey/capability",
-    deps.PasskeyHandler.Capability) }` を **`if deps.PasskeyHandler != nil &&
-    deps.NativeAuthHandler != nil`** に強化する（NATIVE 系 env が未設定なら Web 側 probe を
-    404 に倒し Google 単体に確実に縮退させる）
-  - iOS 用 `/api/passkey/registration/*` および `/api/passkey/authentication/*` の登録条件は
-    従来どおり `PasskeyHandler != nil` のみで **変更しない**（#216 契約維持 / NFR 3.2）
-- `internal/handler/router_test.go` — **変更**
-  - fail-closed 表の 4 環境行に対応する route 登録有無テストを追加:
-    - 全 env 設定済み → `/api/auth/session` 204 / capability 200 / iOS registration/* /
-      authentication/* いずれも登録
-    - NATIVE unset + WEBAUTHN set → session 404 / capability 404 / iOS 系登録
-    - NATIVE set + WEBAUTHN unset → session 登録 / capability 404 / iOS 系 404
-    - 両 unset → 全 404
-- `internal/handler/router_unauth_ratelimit_test.go` — 既存テスト維持（本差分で追加変更なし）
-- `internal/handler/native_auth_handler.go` — 既存 PR #229 実装を維持（本差分で追加変更なし）
-- `internal/handler/native_auth_handler_test.go` — 既存 PR #229 実装を維持
-- `internal/auth/session_exchange.go` — 既存 PR #229 実装を維持
-- `internal/auth/session_exchange_test.go` — 既存 PR #229 実装を維持
-- `internal/app/app.go` — **変更**
-  - `passkey.NewRegistrationService` の呼び出しに `authCodes`（`repository.PostgresAuthCodeRepo`）
-    を注入する（既存 `AuthenticationService` の wiring と同じ具体依存を再利用）
+### Modified Files（Web 側）
 
-#### Web 側
-
-- `web/src/hooks/use-passkey-registration.ts` — **変更**（Delta 1 web + Delta 5 hook）
-  - 現行 PR #229 の chain は「begin → create → finish → `<認証 chain>: begin → get → finish
-    → session`」であり、finish 200 後に **二度目の WebAuthn ceremony**（`navigator.credentials
-    .get`）を実行している。本差分ではこの二度目 ceremony を **完全除去** し、finish の応答
-    body の `auth_code` を直接 `POST /api/auth/session {auth_code, code_verifier}` に渡す
-  - `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加（Delta 5）
-  - error 分類ロジックを step index ベースで再構成し、`step === registration_finish` かつ
-    `fetch reject`（`TypeError`） / 5xx / タイムアウト時に `registration_uncertain` を返す
-    （詳細は §Delta 5「状態遷移と判定」）
-- `web/src/hooks/use-passkey-registration.test.ts` — **変更**
-  - 既存の「登録 → 認証 → session」正常系 test を「登録 → session」正常系に書き換え
-    （二度目 ceremony が呼ばれないことを assert）
-  - 新規: `registration_uncertain` を 3 サブケース（fetch reject / 5xx / abort）で誘発する test
-  - 既存 error kind 分岐（`invalid_username` / `username_taken` / `cancelled` /
-    `server_rejected` / `session_exchange_failed`）の test はシグネチャに追従して維持
-- `web/src/components/passkey-signup-dialog.tsx` — **変更**（Delta 5 UI）
-  - `error.kind === "registration_uncertain"` 分岐を追加し、Delta 5 §UI 文言と復旧導線
-    （「ログイン画面で確認する」「再度作成する」の 2 ボタン）を表示
-  - 既存 error kind 分岐は文言・挙動を維持（Requirement 5.6 の弁別性を担保）
+- `web/src/hooks/use-passkey-registration.ts` — **変更**（Delta 1 Web + Delta 5 hook）
+  - chain を「begin → create → finish（2xx + Set-Cookie）→ invalidateQueries」に短縮
+    （`authentication/begin` / `get` / `authentication/finish` / 登録用 `/api/auth/session` を除去）
+  - `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加。registration 経路は
+    `session_exchange_failed` を発生させない（直接 session 化により該当段が消滅）
+- `web/src/hooks/use-passkey-registration.test.ts` — **変更**（uncertain 4 サブケース + 二度目 ceremony 不在回帰）
+- `web/src/components/passkey-signup-dialog.tsx` — **変更**（Delta 5 UI: 完了不明 + discoverable 復旧導線）
 - `web/src/components/passkey-signup-dialog.test.tsx` — **変更**
-  - `registration_uncertain` 分岐の文言表示と復旧ボタンの callback 呼び出しを検証する test を追加
-- `web/src/components/login-page.tsx` — 既存 PR #229 実装を維持（本差分で追加変更なし）
-- `web/src/components/login-page.test.tsx` — 既存 PR #229 実装を維持
-- `web/src/components/login-page-recovery.test.tsx` — **変更**（PR #229 で追加済み）
-  - `registration_uncertain` → ログイン試行 → 成功時に 2 ペイン UI に到達する recovery E2E-ish
-    テストの追加を検討（Requirement 5.3）。ユニットレベルで実現困難な場合は既存
-    login-page.test.tsx 側のカバレッジで代替してよい（本テスト新規は必須ではない / 詳細は
-    tasks.md 側で判断）
-- `web/src/lib/api.ts` — **変更**（Requirement 2.1 / 現行 #223 design が誤って「無変更」と
-  記述している）
-  - PR #229 で `credentials: "include"` 経路の追加拡張・エラー body 保持形式の変更・
-    `ApiError.code` 判定強化などが行われた形跡。本差分では PR #229 で既に加えた変更を
-    File Structure Plan に **正確に列挙する**（本差分自身が api.ts をさらに触る必要はない）
-- `web/src/lib/api.test.ts` — **変更**（PR #229 で追加済みだが #223 design 未列挙）
-  - 上記 api.ts 変更に対応するテストが PR #229 に含まれる。File Structure Plan に列挙する
-- `web/src/lib/webauthn.ts` / `web/src/lib/webauthn.test.ts` — 既存 PR #229 実装を維持
-- `web/src/lib/pkce.ts` / `web/src/lib/pkce.test.ts` — 既存 PR #229 実装を維持
-- `web/src/lib/passkey-capability.ts` / `web/src/lib/passkey-capability.test.ts` — 既存維持
-- `web/src/hooks/use-passkey-capability.ts` / `.test.ts` — 既存維持
-- `web/src/hooks/use-passkey-authentication.ts` / `.test.ts` / `.contract.test.ts` — 既存維持
-- `web/src/components/passkey-buttons.tsx` / `.test.tsx` — 既存維持
-- `web/src/types/passkey.ts` — **変更**
-  - `RegistrationFinishResponse` 型に `auth_code: string` フィールドを additive 追加
-    （`user_id` は既存維持）
+- `web/src/hooks/use-passkey-authentication.ts` — 既存維持（discoverable ログイン復旧で **再利用**、変更なし）
+- `web/src/components/login-page.tsx` / `login-page.test.tsx` / `login-page-recovery.test.tsx` —
+  **変更**（PR #229 で追加済み。完了不明 → discoverable ログイン → 成功で 2 ペイン到達の recovery テスト整合）
+- `web/src/lib/api.ts` — **変更対象として列挙**（Requirement 2.1 / #223 design の「無変更」記述を訂正。
+  PR #229 で `credentials: "include"` 経路等が変更済み。本差分自身は api.ts をさらに触る必要はない）
+- `web/src/lib/api.test.ts` — **変更対象として列挙**（PR #229 で追加済みだが #223 design 未列挙 / Req 2.1）
+- `web/src/types/passkey.ts` — **変更**（`PasskeyRegistrationErrorKind` に uncertain 追加。
+  `RegistrationFinishResponse` は `{user_id}` のまま **auth_code を追加しない**）
+- `web/src/lib/webauthn.ts` / `pkce.ts` / `passkey-capability.ts` / `use-passkey-capability.ts` /
+  `passkey-buttons.tsx`（各 `.test`）— 既存維持（変更なし）
 
-#### 運用 config（PR #229 のスコープに含める / Requirement 6）
+### Modified Files（運用 config / Requirement 6）
 
-- `.env.sample` — **変更**（Requirement 6.1 / 現行 #223 design が「追加 env 無し」と記述
-  しつつ既存 WebAuthn 系 env の documentation が未整備）
-  - `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_DISPLAY_NAME` / `WEBAUTHN_ORIGINS` /
-    `WEBAUTHN_IOS_APP_ID` / `PASSKEY_CHALLENGE_TTL_SECONDS` の 5 変数を **既存 env として
-    documentation**（コメントアウト行 + fail-closed 挙動の解説）を追加する
-  - **新規 env の追加は行わない**（Requirement 6.5 と #223 Scope の維持）
-- `docker-compose.yml` — **変更**（Requirement 6.2）
-  - `api` サービスの `environment` に `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_DISPLAY_NAME` /
-    `WEBAUTHN_ORIGINS` / `WEBAUTHN_IOS_APP_ID` / `PASSKEY_CHALLENGE_TTL_SECONDS` の
-    passthrough を追加（すべて `${VAR:-}` 形式で **既定値なし**、未設定なら空文字で fail-closed）
-  - **新規 env の追加は行わない**
+- `.env.sample` — **変更**（既存 WebAuthn env 群と `CORS_ALLOWED_ORIGIN` の documentation 整備 / 新規 env なし）
+- `docker-compose.yml` — **変更**（`api` サービスへ WebAuthn env passthrough 追加 / 新規 env なし）
 
-#### spec 補助（`docs/specs/223-feat-web-web/` 配下 — requirements/design/tasks 本体は不変）
+### Modified Files（spec 補助 / #223 spec の本体 3 文書は不変）
 
-- `docs/specs/223-feat-web-web/impl-notes.md` — **変更**
-  - 「#231 の normative delta を適用済み」旨の追記と、Delta 1〜5 に対応する PR #229 側の
-    実装差分の要約を追記する（confirm 事項ではなく事後の記録）
-- `docs/specs/223-feat-web-web/context-map.md` — **変更**
-  - 二度目 WebAuthn ceremony 除去に伴う経路図の更新、fail-closed 表の supersede 記録、
-    完了不明状態の遷移追加
+- `docs/specs/223-feat-web-web/impl-notes.md` — **変更**（#231 delta 適用結果の追記）
+- `docs/specs/223-feat-web-web/context-map.md` — **変更**（`finish → Cookie session` へ経路更新 /
+  fail-closed 表 supersede / 完了不明状態の遷移追加）
 
 ### New Files（本差分で新規追加）
 
-なし。すべての差分は既存ファイル（PR #229 が既に追加した / 既に main 済みのもの含む）への
-編集で完結する。
+- `internal/handler/session_cookie.go` — **新規**: canonical な `session_id` Cookie builder
+  `buildSessionCookie(name, value, domain string, secure bool, maxAge int) *http.Cookie` を定義し、
+  `auth_handler.Callback` / `native_auth_handler.Session` / `passkey_handler.RegistrationFinish` の
+  3 箇所で共有する（Cookie 属性の重複定義を排除 / Delta 4 §Cookie 属性の維持）。
+  同ファイルに `session_cookie_test.go` を近接配置し、属性が Google OAuth Callback と一致することを検証する
 
 ## Requirements Traceability
 
 | Requirement | Summary | Traced to |
 |-------------|---------|-----------|
-| 1.1 | 登録 finish 後の追加 WebAuthn ceremony 禁止 | Delta 1 §Registration Service / §Web Hook |
-| 1.2 | 二度目 ceremony を実装として採用しない | Delta 1 §before → after 図 |
-| 1.3 | 登録トランザクションに紐付いた合流経路 | Delta 1 §envelope パターン |
-| 1.4 | 2 ペイン UI 初期表示 | Delta 1 §Sequence 図 |
-| 1.5 | ログイン導線への影響なし | Delta 1 §影響範囲、`use-passkey-authentication` 未変更 |
-| 2.1 | api.ts / api.test.ts を変更対象に明示 | File Structure Plan §Modified Files |
-| 2.2 | .env.sample / docker-compose.yml を変更対象に明示 | File Structure Plan §Modified Files |
-| 2.3 | needs-iteration 1 回で完結する粒度のタスク | tasks.md 全体（6 タスク） |
-| 2.4 | #223 spec 書換タスクを含まない | tasks.md 全体（#223 requirements/design/tasks の編集タスク不在） |
-| 2.5 | Reviewer が変更ファイルを突合できる状態 | File Structure Plan §Modified Files（PR #229 変更 25 ファイル全列挙） |
-| 3.1 | session endpoint の登録・未登録を独立列に | Delta 3 §fail-closed 表（列: `/api/auth/session`） |
-| 3.2 | capability endpoint の登録・未登録を独立列に | Delta 3 §fail-closed 表（列: `/api/passkey/capability`） |
-| 3.3 | NATIVE unset + WEBAUTHN set で iOS 継続 | Delta 3 §env 行 2 と router 変更 |
-| 3.4 | WEBAUTHN unset で capability 404 + iOS 停止 | Delta 3 §env 行 3 / 4 |
-| 3.5 | iOS request/response 契約破壊禁止 | Delta 3 §iOS 契約維持論証 / Delta 1 §additive 論証 |
-| 4.1 | CSRF 主防御要素を要素ごとに明記 | Delta 4 §主防御要素表 |
+| 1.1 | 登録 finish 後の追加 WebAuthn ceremony 禁止 | Delta 1 §Sequence / §Web Hook |
+| 1.2 | 二度目 ceremony を実装として採用しない | Delta 1 §Before → After |
+| 1.3 | 登録トランザクションに紐付いた合流経路 | Delta 1 §3 行トランザクション / §Set-Cookie |
+| 1.4 | 2 ペイン UI 初期表示 | Delta 1 §Sequence（invalidateQueries → AuthGuard） |
+| 1.5 | ログイン導線への影響なし | Delta 1 §影響範囲（`use-passkey-authentication` 未変更） |
+| 2.1 | api.ts / api.test.ts を変更対象に明示 | File Structure Plan §Web 側 |
+| 2.2 | .env.sample / docker-compose.yml を変更対象に明示 | File Structure Plan §運用 config |
+| 2.3 | needs-iteration 1 回で完結する粒度のタスク | tasks.md 全体 |
+| 2.4 | #223 / #216 spec 書換タスクを含まない | tasks.md（spec 本体編集タスク不在） |
+| 2.5 | Reviewer が変更ファイルを突合できる状態 | File Structure Plan §Modified/New Files |
+| 3.1 | Web login session 交換 endpoint を独立列に | Delta 3 §fail-closed 表（列 B） |
+| 3.2 | Web capability probe を独立列に | Delta 3 §fail-closed 表（列 A） |
+| 3.3 | NATIVE unset + WEBAUTHN set で iOS 継続 | Delta 3 §fail-closed 表 行 2 / §iOS 契約維持 |
+| 3.4 | WEBAUTHN unset で Web 縮退 + iOS 停止 | Delta 3 §fail-closed 表 行 4 / 5 |
+| 3.5 | iOS request/response 契約破壊禁止 | Delta 1 §iOS 契約維持 / Delta 3 §登録条件不変 |
+| 4.1 | CSRF 主防御要素を要素ごと・endpoint ごとに明記 | Delta 4 §主防御要素表（登録直接 / login 交換） |
 | 4.2 | 旧誤記述の撤回と正しい前提の明記 | Delta 4 §旧記述の撤回 |
 | 4.3 | 残余リスクの列挙 | Delta 4 §残余リスク |
 | 4.4 | browser-bound state 不要の決定明記 | Delta 4 §決定記録 |
-| 4.5 | Cookie 属性の既存 Google OAuth 一致維持 | Delta 4 §Cookie 属性維持 |
+| 4.5 | Cookie 属性の既存 Google OAuth 一致維持 | Delta 4 §Cookie 属性の維持 / New Files（共有 builder） |
 | 4.6 | 将来検討導線を残す | Delta 4 §将来検討導線 |
-| 5.1 | 第 3 の完了不明状態としてユーザーに提示 | Delta 5 §状態定義 / §Hook error kind 追加 |
-| 5.2 | ログインで確認する旨の復旧案内を同一画面に | Delta 5 §UI 文言と復旧導線 |
-| 5.3 | 復旧ログインで成功時に 2 ペイン UI | Delta 5 §状態遷移図（成功遷移） |
-| 5.4 | 復旧ログイン失敗時に再作成導線 | Delta 5 §状態遷移図（失敗遷移） |
+| 5.1 | 第 3 の完了不明状態としてユーザーに提示 | Delta 5 §状態定義 / §Hook 判定 |
+| 5.2 | discoverable ログイン確認を提示（再作成は同列不可） | Delta 5 §UI 文言と復旧導線 |
+| 5.3 | 復旧ログイン成功で 2 ペイン UI | Delta 5 §状態遷移図（成功） |
+| 5.4 | 一律失敗の後にのみ再作成導線 | Delta 5 §状態遷移図（失敗） |
 | 5.5 | サーバ内部詳細を反射しない | Delta 5 §UI 文言（generic 固定） |
-| 5.6 | 他状態と混同されない文言 | Delta 5 §既存 error kind との弁別表 |
-| 6.1 | .env.sample を変更対象に明示 | File Structure Plan §運用 config |
-| 6.2 | docker-compose.yml を変更対象に明示 | File Structure Plan §運用 config |
-| 6.3 | needs-iteration 1 回で完結する config タスク | tasks.md Task 5 |
+| 5.6 | 他状態と混同されない文言 | Delta 5 §既存 error kind との弁別 |
+| 6.1 | .env.sample を変更対象に明示 | Delta 6 §反映内容 / File Structure Plan |
+| 6.2 | docker-compose.yml を変更対象に明示 | Delta 6 §反映内容 / File Structure Plan |
+| 6.3 | needs-iteration 1 回で完結する config タスク | tasks.md Task 6 |
 | 6.4 | 別 prerequisite PR に分離しない決定明記 | Delta 6 §決定記録 |
-| 6.5 | 既存 env 流用に留め新規 env 追加なしを担保 | File Structure Plan §運用 config 本文 |
-| NFR 1.1 | #223 spec 物理ファイル不変 | File Structure Plan（#223 spec 編集タスク不在）+ Non-Goals |
-| NFR 1.2 | 独立実装 PR を作らず PR #229 needs-iteration 1 回で反映 | Non-Goals + tasks.md 全体 |
-| NFR 1.3 | #216 契約を破壊するタスクを含まない | Delta 1 §additive 論証 + File Structure Plan（#216 spec 編集タスク不在） |
-| NFR 2.1 | 完了不明状態の秘密情報非漏出 | Delta 5 §秘密情報の非漏出 |
+| 6.5 | 既存 env 流用に留め新規 env 追加なしを担保 | Delta 6 §既存 env 流用 |
+| NFR 1.1 | #223 spec 物理ファイル不変 | Non-Goals / File Structure Plan（#223 本体編集タスク不在） |
+| NFR 1.2 | 独立実装 PR を作らず PR #229 needs-iteration 1 回で反映 | Non-Goals / tasks.md 全体 |
+| NFR 1.3 | #216 契約を破壊するタスクを含まない | Delta 1 §iOS 契約維持 / File Structure Plan（#216 本体編集タスク不在） |
+| NFR 2.1 | 完了不明状態・session 発行の秘密情報非漏出 | Delta 1 §NFR / Delta 5 §秘密情報の非漏出 |
 | NFR 2.2 | CSRF / fail-closed 記述に秘密値を例示しない | Delta 3 / Delta 4（例示値なし） |
-| NFR 3.1 | Google OAuth 既存挙動を破壊しない | 全 Delta（既存 Google 経路無変更）+ File Structure Plan（auth_handler.go / use-auth.ts 未変更） |
-| NFR 3.2 | iOS #216 request/response 契約不変 | Delta 1 §additive 論証 + Delta 3 §iOS 契約維持論証 |
+| NFR 3.1 | Google OAuth 既存挙動を破壊しない | 全 Delta（Google 経路無変更）/ File Structure Plan（auth 経路本体未変更） |
+| NFR 3.2 | iOS #216 request/response 契約不変 | Delta 1 §iOS 契約維持 / Delta 3 §登録条件不変 |
 
-## Delta 1: 登録 finish 直後のセッション合流（Requirement 1）
+## Delta 1: 登録 finish の直接 Cookie session（Requirement 1）
 
 ### Supersedes（#223 design.md の該当節）
 
-- `#223 design.md` §Flows「新規作成フロー（Sequence / 抜粋）」（line ~957-999）— 特に
-  L993 の `HR->>HR: <認証 chain>: begin → get → finish → session` の記述と、それに続く
-  L994-996 のシーケンス
-- `#223 design.md` §`use-passkey-registration.ts` の「5. **直後に認証 chain**」以降（L655-661）
-- `#223 tasks.md` L177-179 の task 8 (5) 「**直後に認証 chain**」記述
+- `#223 design.md` §Flows「新規作成フロー（Sequence / 抜粋）」— finish 後の
+  `authentication: begin → get → finish → session` 経路と二度目 `navigator.credentials.get()`
+- `#223 design.md` §`use-passkey-registration.ts` の「直後に認証 chain」以降のステップ
+- 初版 #231 design（auth_code additive 案 = 仮案 B）全体を本 Delta で置き換える
 
 ### Before → After Sequence
 
-#### Before（現行 #223 design / PR #229 の実装）
+#### Before（PR #229 head の現行実装 = 仮案 B の系譜）
 
 ```mermaid
 sequenceDiagram
     autonumber
     participant U as User
     participant HR as usePasskeyRegistration
-    participant PK as lib/pkce
     participant NC as navigator.credentials
     participant SVR as Feedman API
-
     U->>HR: mutate({username})
-    HR->>PK: generatePkcePair()
-    PK-->>HR: {code_verifier, code_challenge}
-    HR->>SVR: POST /api/passkey/registration/begin
+    HR->>SVR: POST /api/passkey/registration/begin {username, email:"", code_challenge}
     SVR-->>HR: 200 {challenge_id, options}
     HR->>NC: create({publicKey})  %% 1 回目 ceremony
-    NC-->>HR: PublicKeyCredential (attestation)
-    HR->>SVR: POST /api/passkey/registration/finish
+    NC-->>HR: attestation
+    HR->>SVR: POST /api/passkey/registration/finish {challenge_id, credential}
     SVR-->>HR: 200 {user_id}
     Note over HR,SVR: 二度目 ceremony（除去対象）
-    HR->>SVR: POST /api/passkey/authentication/begin
+    HR->>SVR: POST /api/passkey/authentication/begin {code_challenge}
     SVR-->>HR: 200 {challenge_id, options}
-    HR->>NC: get({publicKey})  %% 2 回目 ceremony（Face ID / Touch ID プロンプト再発火）
-    NC-->>HR: PublicKeyCredential (assertion)
+    HR->>NC: get({publicKey})  %% 2 回目 ceremony（Face ID/Touch ID 再発火）
+    NC-->>HR: assertion
     HR->>SVR: POST /api/passkey/authentication/finish
     SVR-->>HR: 200 {auth_code}
     HR->>SVR: POST /api/auth/session {auth_code, code_verifier}
     SVR-->>HR: 204 + Set-Cookie
-    HR->>HR: invalidateQueries(["auth","me"])
 ```
 
-#### After（本 Delta 1 で確定する挙動）
+#### After（本 Delta 1 で確定する挙動 = 決定 1.A）
 
 ```mermaid
 sequenceDiagram
     autonumber
     participant U as User
     participant HR as usePasskeyRegistration
-    participant PK as lib/pkce
     participant NC as navigator.credentials
-    participant SVR as Feedman API
-
+    participant PH as PasskeyHandler.RegistrationFinish
+    participant RS as RegistrationService
+    participant DB as PostgreSQL (single tx)
     U->>HR: mutate({username})
-    HR->>PK: generatePkcePair()
-    PK-->>HR: {code_verifier, code_challenge}
-    HR->>SVR: POST /api/passkey/registration/begin {username, email:"", code_challenge}
-    Note over SVR: BeginRegistrationNew:<br/>PKCE 検証 + registrationSession 封筒に code_challenge を格納
-    SVR-->>HR: 200 {challenge_id, options}
-    HR->>NC: create({publicKey})  %% 1 回目 ceremony（唯一の生体認証プロンプト）
-    NC-->>HR: PublicKeyCredential (attestation)
-    HR->>SVR: POST /api/passkey/registration/finish {challenge_id, credential}
-    Note over SVR: FinishRegistrationNew:<br/>envelope 復元 → user 作成 → credential 保存<br/>→ auth_code 発行（code_challenge を PKCE として紐付け）
-    SVR-->>HR: 200 {user_id, auth_code}  %% additive に auth_code 追加
-    HR->>SVR: POST /api/auth/session {auth_code, code_verifier}
-    SVR-->>HR: 204 + Set-Cookie
-    HR->>HR: invalidateQueries(["auth","me"])
+    HR->>PH: POST /api/passkey/registration/begin {username, email:"", code_challenge}
+    Note over RS: code_challenge は形式検証のみ（永続化・束縛しない）
+    PH-->>HR: 200 {challenge_id, options}
+    HR->>NC: create({publicKey})  %% 唯一の生体認証プロンプト
+    NC-->>HR: attestation
+    HR->>PH: POST /api/passkey/registration/finish {challenge_id, credential}<br/>(Origin: 許可オリジン)
+    Note over PH: JSON Content-Type / exact Origin を mutation 前に検証<br/>→ Web mode 判定
+    PH->>RS: FinishRegistrationNew(..., issueWebSession=true)
+    RS->>DB: BEGIN
+    RS->>DB: INSERT user
+    RS->>DB: INSERT credential
+    RS->>DB: INSERT session (generateSessionID)
+    RS->>DB: COMMIT  %% いずれか失敗で全 ROLLBACK
+    RS-->>PH: (user_id, *Session)
+    PH-->>HR: 200 {user_id} + Set-Cookie session_id  %% commit 後のみ
+    HR->>HR: invalidateQueries(["auth","me"]) → AuthGuard → 2 ペイン UI
 ```
 
-追加のブラウザ生体認証プロンプト（`navigator.credentials.get`）が消滅し、ユーザーが体験する
-ceremony は登録時の `create` の 1 回のみになる。
+追加のブラウザ生体認証プロンプト（`navigator.credentials.get`）が消滅し、体験する ceremony は
+登録時の `create` 1 回のみになる（Requirement 1.1 / 1.2）。
+
+### Web / iOS mode 判定（`PasskeyHandler.RegistrationFinish`）
+
+handler は challenge consume / DB mutation より **前** に、`Origin` ヘッダで mode を判定する
+（推奨境界。別実装でも「JSON body 追加・exchange artifact なしで直接 session」を満たせば可）:
+
+| `Origin` ヘッダ | `allowedOrigin`（`CORS_ALLOWED_ORIGIN`） | 判定 | 挙動 |
+|---|---|---|---|
+| 一致（`origin == allowedOrigin`） | 設定済 | **Web mode** | JSON Content-Type 検証 → readiness 確認 → `issueWebSession=true` |
+| 不在（`""`） | 任意 | **native/iOS mode** | 既存挙動（session 発行なし / `issueWebSession=false`） |
+| 非空・不一致、または `allowedOrigin` 未設定 | — | **拒否** | 403 FORBIDDEN_ORIGIN（mutation・consume なし / fail-closed） |
+
+- Web mode の追加検証（いずれも mutation 前）:
+  - **JSON Content-Type 必須**（不一致は 415 UNSUPPORTED_MEDIA_TYPE）。native/iOS mode には
+    本検証を **課さない**（#216 既存クライアント互換 / NFR 3.2）
+  - **readiness**（`PasskeyHandler.webRegistrationReady()` = `allowedOrigin != "" && Cookie 設定済み &&
+    RegistrationService.WebSessionReady()`）が false なら fail-closed（500 相当、mutation なし）。
+    通常 wiring では `WEBAUTHN_*` 設定時に session 発行依存が常時配線されるため、実質は
+    `allowedOrigin` 設定有無が支配的
+- iOS はネイティブ HTTP クライアントで `Origin` を送らないため native mode に落ち、session / Cookie を
+  作らず `{user_id}` のみを返す（#216 と差分等価 / NFR 3.2）
 
 ### Server 側の実装差分
 
 #### `internal/passkey/registration_service.go`（Modified）
 
-`AuthenticationService` に既に存在する `authnSession` 封筒パターンを踏襲する
-（`internal/passkey/authentication_service.go` L57-66 と同型）。`model.PasskeyChallenge` /
-`WebAuthnAdapter` / `challengeStore` の interface は変更せず、sessionData バイト列に
-`{WebAuthnSession, CodeChallenge}` を JSON marshal して opaque に運ぶ。
-
 ```go
-// internal/passkey/registration_service.go に追加（authentication_service.go::authnSession と同型）
-
-// registrationSession は registration_new kind の challenge に紐付ける封筒。
-// begin 時の code_challenge を finish まで運び、auth_code の PKCEChallenge として紐付ける
-// （Req 1.3 の「登録トランザクションと結び付いた合流経路」）。
-type registrationSession struct {
-    // WebAuthnSession は adapter.BeginRegistration が返す webauthn.SessionData の JSON bytes。
-    // FinishRegistration にそのまま渡すため RawMessage で無改変に保持する。
-    WebAuthnSession json.RawMessage `json:"webauthn_session"`
-    // CodeChallenge は begin 時に検証した PKCE S256 challenge（base64url 43 文字）。
-    // finish 時に auth_code の PKCEChallenge として設定される。
-    CodeChallenge string `json:"code_challenge"`
+// 追加/拡張する最小 IF（interface segregation / CLAUDE.md §5）
+type SessionWriter interface {
+    CreateExec(ctx context.Context, q repository.DBTX, s *model.Session) error
+}
+// UserWriter に追加: CreateUserOnlyExec(ctx, q repository.DBTX, u *model.User) error
+// PasskeyCredentialWriter に追加: CreateExec(ctx, q repository.DBTX, c *model.PasskeyCredential) error
+type txRunner interface {
+    WithinTx(ctx context.Context, fn func(q repository.DBTX) error) error
 }
 
-// RegistrationService に authCodes フィールドを追加
+// 構造体に追加（auth_code 関連は追加しない）
 type RegistrationService struct {
-    adapter     WebAuthnAdapter
-    challenges  challengeStore
-    users       UserWriter
-    credentials PasskeyCredentialWriter
-    authCodes   auth.AuthCodeCreator  // 新規: auth_code 発行（authentication_service.go と同じ具体依存）
-    now         func() time.Time
+    // ... 既存 adapter / challenges / users / credentials / now ...
+    sessions     SessionWriter
+    tx           txRunner
+    newSessionID func() (string, error) // = auth.GenerateSessionID（SessionExchangeService と共有）
+    sessionTTL   time.Duration          // = time.Duration(cfg.SessionMaxAge) * time.Second
 }
 
-// NewRegistrationService のシグネチャに authCodes を追加（wiring 側で調整）
-func NewRegistrationService(
-    adapter WebAuthnAdapter, challenges challengeStore,
-    users UserWriter, credentials PasskeyCredentialWriter,
-    authCodes auth.AuthCodeCreator, now func() time.Time,
-) *RegistrationService
+// WebSessionReady は Web mode の直接 session 発行が配線済みかを返す（defense-in-depth）。
+func (s *RegistrationService) WebSessionReady() bool {
+    return s.sessions != nil && s.tx != nil && s.newSessionID != nil
+}
 
-// BeginRegistrationNew: PKCE 検証済み code_challenge を封筒に格納
-//   - PKCE 形式検証（既存挙動、変更なし / Req 1.5 の early validation 継続）
-//   - envelope := registrationSession{WebAuthnSession: sessionData, CodeChallenge: codeChallenge}
-//   - envelopeBytes := json.Marshal(envelope)
-//   - challenges.Issue(sessionData=envelopeBytes, ...) として保存
-//   - 戻り値は既存と同じ (challengeID string, options []byte, error)
-func (s *RegistrationService) BeginRegistrationNew(
-    ctx context.Context, rawUsername string, optionalEmail string, codeChallenge string,
-) (string, []byte, error)
-
-// FinishRegistrationNew:
-//   - シグネチャ変更: (string, error) → (string, string, error)
-//     - 1 番目: userID
-//     - 2 番目: authCodePlain（NEW）
-//     - 3 番目: error
-//   - challenges.Consume で PasskeyChallenge を取得
-//   - envelope を json.Unmarshal し、WebAuthnSession と CodeChallenge を復元
-//     （破損 / 不完全は ErrRegistrationFailed / uniform 拒否）
-//   - 既存の adapter.FinishRegistration → CreateUserOnly → credentials.Create フローを維持
-//   - **auth_code 発行を末尾に追加**:
-//       plain, _ := auth.GenerateAuthCode()  // authentication_service.go L320 と同じ
-//       codeHash := auth.HashNativeSecret(plain)
-//       authCode := &model.AuthCode{
-//         ID:            uuid.New().String(),
-//         CodeHash:      codeHash,
-//         UserID:        newUser.ID,
-//         PKCEChallenge: envelope.CodeChallenge,  // Req 1.3 の合流点
-//         ExpiresAt:     s.now().Add(auth.NativeAuthCodeTTL),
-//       }
-//       s.authCodes.Create(ctx, authCode)
-//   - 平文 plain を戻り値としてのみ返す（NFR 2.1 準拠、authentication_service.go と同方針）
-//   - ログには hash 先頭 8 文字のみ（authentication_service.go L338-341 と同方針）
+// FinishRegistrationNew: 単一 tx で user → credential →（Web mode のみ）session を作成。
+//   - 既存 challenge consume / adapter.FinishRegistration（attestation 検証）は変更しない
+//   - user UNIQUE 衝突 → ErrRegistrationFailed / credential 重複 → ErrRegistrationFailed（既存正規化を維持）
+//   - session ID 生成失敗・session INSERT 失敗も含め、いずれかの失敗で全 ROLLBACK（3 行 atomic）
+//   - iOS（issueWebSession=false）は user + credential のみ作成し、webSession=nil を返す
 func (s *RegistrationService) FinishRegistrationNew(
-    ctx context.Context, challengeID string, requestBody []byte,
-) (userID string, authCodePlain string, err error)
+    ctx context.Context, challengeID string, requestBody []byte, issueWebSession bool,
+) (userID string, webSession *model.Session, err error) {
+    // ... consume challenge / rebuild WebAuthnUser / adapter.FinishRegistration（既存どおり）...
+    newUser := &model.User{ ID: pendingUserID, Email: "", Username: normalized, UsernameNormalized: normalized }
+    cred := &model.PasskeyCredential{ /* parsed から既存どおり */ }
+
+    txErr := s.tx.WithinTx(ctx, func(q repository.DBTX) error {
+        if e := s.users.CreateUserOnlyExec(ctx, q, newUser); e != nil {
+            if errors.Is(e, repository.ErrUsernameTaken) { return ErrRegistrationFailed }
+            return fmt.Errorf("failed to create user: %w", e)
+        }
+        if e := s.credentials.CreateExec(ctx, q, cred); e != nil {
+            if errors.Is(e, repository.ErrCredentialAlreadyRegistered) { return ErrRegistrationFailed }
+            return fmt.Errorf("failed to save passkey credential: %w", e)
+        }
+        if issueWebSession {
+            sid, e := s.newSessionID()
+            if e != nil { return fmt.Errorf("failed to generate session id: %w", e) }
+            webSession = &model.Session{ ID: sid, UserID: newUser.ID, ExpiresAt: s.now().Add(s.sessionTTL) }
+            if e := s.sessions.CreateExec(ctx, q, webSession); e != nil {
+                return fmt.Errorf("failed to create session: %w", e)
+            }
+        }
+        return nil
+    })
+    if txErr != nil {
+        webSession = nil // 部分状態を返さない（全 ROLLBACK 済み）
+        if errors.Is(txErr, ErrRegistrationFailed) { return "", nil, ErrRegistrationFailed }
+        return "", nil, txErr
+    }
+    return newUser.ID, webSession, nil
+}
 ```
 
-- Preconditions: `authCodes` は `NewRegistrationService` 時に non-nil で注入されている
-  （`app.go` の wiring で `PostgresAuthCodeRepo` を渡す。既存 `AuthenticationService` と同経路）
+- Preconditions: `sessions` / `tx` / `newSessionID` は passkey handler 生成時（`WEBAUTHN_*` 設定時）に
+  非 nil で注入されている
 - Postconditions:
-  - 成功時: user / credential / auth_code の 3 レコードが永続化される
-    （single-transaction 統合は #230 のスコープで本 spec の対象外 / Out of Scope）
-  - 失敗時: 部分保存は `#216` の既存挙動と同じ（追加の rollback ロジックは持たない）
-- Invariants:
-  - `envelope.CodeChallenge` が空 or 復元不能なら `ErrRegistrationFailed`（uniform 拒否）
-  - `auth_code` 平文をログ・エラーメッセージに残さない（NFR 2.1 / `authentication_service.go`
-    L336-341 の既存方針を踏襲）
+  - 成功（Web mode）: user / credential / session の **3 行が同一 tx で永続化**される
+  - 成功（iOS mode）: user / credential の 2 行のみ永続化（session なし / `{user_id}` 応答）
+  - 失敗: 部分保存は残さない（tx の atomic rollback。#216 の「非 tx で部分保存し得る」旧挙動を改善）
+- Invariants: `auth_code` 平文 / session ID 生値をログ・エラー・レスポンスに残さない（NFR 2.1。
+  session ID は Set-Cookie でのみクライアントへ渡し、ログには出さない）
 
 #### `internal/handler/passkey_handler.go`（Modified）
 
 ```go
-// PasskeyHandler.RegistrationFinish（新シグネチャに追従）
-
-// レスポンス body 型を additive に拡張
-type registrationFinishResponse struct {
-    UserID   string `json:"user_id"`
-    AuthCode string `json:"auth_code"`  // NEW: additive フィールド
-}
-
-// 内部ロジック（イメージ）:
-//   userID, authCode, err := h.regService.FinishRegistrationNew(ctx, req.ChallengeID, req.Credential)
-//   if err != nil { ... 既存の error mapping（400 REGISTRATION_FAILED / 500）... }
-//   respond 200 registrationFinishResponse{UserID: userID, AuthCode: authCode}
+// RegistrationFinish（イメージ）:
+//   origin := r.Header.Get("Origin")
+//   webMode := false
+//   switch {
+//   case origin == "":
+//       // native/iOS: 既存挙動（JSON Content-Type 追加検証なし）
+//   case h.allowedOrigin != "" && origin == h.allowedOrigin:
+//       if !hasJSONContentType(r) { 415; return }          // mutation 前
+//       if !h.webRegistrationReady() { 500; return }        // fail-closed / mutation 前
+//       webMode = true
+//   default:
+//       middleware.WriteErrorResponse(w, 403, forbiddenOriginError()); return  // mutation 前
+//   }
+//   // decode {challenge_id, credential}（既存）
+//   userID, sess, err := h.regService.FinishRegistrationNew(ctx, req.ChallengeID, req.Credential, webMode)
+//   // 既存 error mapping（ErrRegistrationFailed → 400 REGISTRATION_FAILED / infra → 500）
+//   if sess != nil {
+//       http.SetCookie(w, buildSessionCookie(sessionCookieName, sess.ID, h.cookieDomain, h.cookieSecure, h.cookieMaxAge))
+//   }
+//   respond 200 {user_id: userID}   // JSON は Web / iOS とも不変
 ```
 
-#### iOS #216 契約が破壊されない論証
+#### iOS #216 契約が破壊されない論証（NFR 3.2 / Req 3.5）
 
-- iOS の `POST /api/passkey/registration/finish` レスポンス期待値は `#216 design.md` L708 で
-  `{user_id}` と規定されている。本差分では **既存 `user_id` フィールドを削除せず維持し、
-  `auth_code` を additive に追加する** のみである。
-- Swift の JSON decoding（`Codable` / `JSONDecoder`）は既定で未知フィールドを **無視する**
-  （`JSONDecoder` は `allowsJSON5` / `dateDecodingStrategy` などのオプションはあるが、
-  「未知キー拒否」は既定オプションに存在しない）。iOS 実装が意図的に strict-mode の decoder を
-  組んでいない限り、追加フィールドは黙って無視される。#216 iOS design（`docs/specs/216--app-store-4-8/`）
-  でも strict decode の記述はない。
-- iOS の登録フローは `#216 design.md` L681-685 の記述どおり、`registration/finish` の後に
-  authentication ceremony を走らせて `authentication/finish` で `auth_code` を取得する経路を
-  採る（Web 実装より 1 ceremony 多い）。iOS はこの経路を維持できる（`authentication/*` endpoint
-  も無変更）。
-- したがって本差分は **iOS の request/response 契約を破壊しない**（NFR 1.3 / NFR 3.2）。
+- iOS の `registration/finish` レスポンス期待値は `{user_id}` で不変。Web でも JSON body は `{user_id}` の
+  ままで、差分は HTTP **ヘッダ** の `Set-Cookie` のみ（iOS は Origin を送らず native mode に落ちるため
+  Cookie を受け取らない）
+- request JSON（`{challenge_id, credential}`）・`registration/begin` の JSON も不変。登録 begin の
+  `code_challenge` はフィールドを維持（形式検証のみ）
+- JSON Content-Type / Origin の追加検証は **Web mode のみ** に課すため、iOS の既存リクエスト経路は不変
 
-### Web 側の実装差分
-
-`web/src/hooks/use-passkey-registration.ts` の内部 mutation chain を以下に整理する。
-`#223 design.md` §`use-passkey-registration.ts` の「5. **直後に認証 chain**」以降 4 ステップを
-除去する。
+### Web 側の実装差分（`use-passkey-registration.ts`）
 
 ```typescript
-// use-passkey-registration.ts の mutationFn（イメージ、実装コードではない）
-
-// Before（現行 PR #229）: 6 段の chain（登録 → 認証 → session）
-// After（本差分）: 4 段の chain（登録 → session）
-
+// mutationFn（イメージ、実装コードではない）
 async function mutationFn({ username }: { username: string }) {
-  const { codeVerifier, codeChallenge } = await generatePkcePair();
-
-  // 1. registration/begin
-  const beginRes = await apiClient.post<PasskeyBeginResponse>(
-    "/api/passkey/registration/begin",
-    { username, email: "", code_challenge: codeChallenge }
-  );
-
-  // 2. navigator.credentials.create（唯一の WebAuthn ceremony）
-  const creationOptions = decodeCreationOptions(beginRes.options);
-  const cred = await navigator.credentials.create(creationOptions);
-
-  // 3. registration/finish → **additive な auth_code を受け取る**
-  const finishRes = await apiClient.post<RegistrationFinishResponse>(
-    "/api/passkey/registration/finish",
-    { challenge_id: beginRes.challenge_id, credential: encodeAttestationResponse(cred) }
-  );
-  // finishRes.auth_code を直接次段へ渡す（二度目 ceremony 廃止）
-
-  // 4. session 交換
-  await apiClient.post(
-    "/api/auth/session",
-    { auth_code: finishRes.auth_code, code_verifier: codeVerifier }
-  );
-
+  // #216 契約維持のため code_challenge は送るが、直接 session 化により code_verifier は使用しない
+  const { codeChallenge } = await generatePkcePair();
+  const begin = await apiClient.post("/api/passkey/registration/begin",
+    { username, email: "", code_challenge: codeChallenge });
+  const cred = await navigator.credentials.create(decodeCreationOptions(begin.options));
+  // finish の 2xx + Set-Cookie で session 確定（追加 request なし / 二度目 ceremony なし）
+  await apiClient.post("/api/passkey/registration/finish",
+    { challenge_id: begin.challenge_id, credential: encodeAttestationResponse(cred) });
   await queryClient.invalidateQueries({ queryKey: ["auth", "me"] });
 }
 ```
 
-- `code_verifier` は closure 変数のみに保持（NFR 2.1 準拠、`#223 design.md` §NFR 1.1 準拠）
-- `auth_code` は `finishRes` から `apiClient.post("/api/auth/session", ...)` に渡す 1 request 間
-  のみメモリ保持し、それ以降は参照されない
-- error 分類は §Delta 5 で `registration_uncertain` を追加する形で拡張する
+- `authentication/begin` / `navigator.credentials.get` / `authentication/finish` / 登録用
+  `POST /api/auth/session` の 4 呼び出しを **完全削除**（Req 1.1 / 1.2）
+- `apiClient` は `credentials: "include"` で Cookie を受理・送出する（既存 PR #229 の api.ts 経路）
+- error 分類は §Delta 5 で `registration_uncertain` を追加
 
 ### 影響範囲
 
-- 変更対象コンポーネント: `RegistrationService` / `PasskeyHandler.RegistrationFinish` /
-  `router.go`（Delta 3 と合わせて）/ `use-passkey-registration.ts` /
-  `passkey-signup-dialog.tsx`（Delta 5 と合わせて）/ `types/passkey.ts` / `app.go`（wiring）
-- **無変更で維持する既存要素**:
-  - `AuthenticationService` / `use-passkey-authentication.ts` / `PasskeyButtons`（ログイン
-    導線は影響を受けない / Requirement 1.5）
-  - `SessionExchangeService` / `NativeAuthHandler.Session`（受け取る `auth_code` の由来が
-    「authentication 由来」→「registration 由来」に増えるだけで、契約自体は不変）
-  - iOS 用 `authentication/*` endpoint（iOS は従来経路を維持）
+- 変更: `RegistrationService` / `PasskeyHandler.RegistrationFinish` / repo Exec 変種 / tx helper /
+  共有 Cookie builder / `use-passkey-registration.ts` / `passkey-signup-dialog.tsx` / `app.go`
+- **無変更で維持**:
+  - `AuthenticationService` / `use-passkey-authentication.ts` / `PasskeyButtons`
+    （ログイン導線は影響を受けない。discoverable ログイン復旧で再利用のみ / Req 1.5）
+  - `SessionExchangeService` / `NativeAuthHandler.Session`（login の auth_code 交換として不変。
+    Delta 4 で Origin 検証の fail-closed 補正のみ）
+  - iOS 用 `registration/*` / `authentication/*`（#216 契約不変 / NFR 3.2）
   - Google OAuth 経路一式（NFR 3.1）
 
 ## Delta 2: File Structure Plan の補正（Requirement 2）
@@ -616,199 +552,180 @@ async function mutationFn({ username }: { username: string }) {
 ### Supersedes
 
 - `#223 design.md` §File Structure Plan の以下記述:
-  - L255: `api.ts # 既存（無変更）` → **変更**（`web/src/lib/api.ts` は PR #229 で変更されている）
-  - `.env.sample` / `docker-compose.yml` が File Structure Plan に **列挙されていない** →
-    **列挙する**
-  - `web/src/lib/api.test.ts` が File Structure Plan に **列挙されていない** → **列挙する**
+  - `web/src/lib/api.ts` を「無変更」と記述した箇所 → **変更対象**
+  - `web/src/lib/api.test.ts` / `.env.sample` / `docker-compose.yml` が未列挙 → **列挙**
 
-### 補正後の変更対象表（本 spec §File Structure Plan §Modified Files が canonical）
+### canonical 定義
 
-上記「File Structure Plan」節が本 Delta の実質的な canonical 定義であり、Reviewer は同節を
-参照して PR #229 の全変更ファイルの被覆を確認できる（Requirement 2.5）。#223 design.md の
-「api.ts # 既存（無変更）」記述は本 delta で supersede される。
+本 spec §File Structure Plan（Modified/New Files）が canonical。Reviewer は同節と PR #229 の
+`git diff --name-only` を突き合わせ、以下を確認できる（Requirement 2.5）:
 
-### Reviewer 突合の観点（Requirement 2.5）
+1. PR #229 の全変更ファイルが Modified/New Files に列挙されている
+2. Modified/New Files に列挙されているが PR #229 に含まれないファイルがない（過剰な予告なし）
+3. `web/src/lib/api.ts` / `api.test.ts` / `.env.sample` / `docker-compose.yml` が列挙されている
+   （旧 #223 design の見落としを訂正済み）
+4. 本差分で追加する session tx 対応（`tx.go` の `WithinTx` / 各 repo の `CreateExec` /
+   `session_cookie.go` / `passkey_e2e_db_test.go` の 3 行原子性テスト）が列挙されている
 
-Reviewer は PR #229 の変更ファイル一覧（`git diff --name-only`）を本 File Structure Plan §
-Modified Files と突き合わせ、以下を確認できる:
-
-1. PR #229 の全変更ファイルが `Modified Files` セクションに列挙されている
-2. `Modified Files` に列挙されているが PR #229 に含まれないファイルがない（過剰な予告なし）
-3. `web/src/lib/api.ts` / `api.test.ts` / `.env.sample` / `docker-compose.yml` が
-   Modified Files に含まれている（旧 #223 design の見落としを訂正済み）
-
-## Delta 3: fail-closed 表の補正と capability 登録条件の強化（Requirement 3）
+## Delta 3: fail-closed 表の 5 列補正と gate 維持（Requirement 3）
 
 ### Supersedes
 
-- `#223 design.md` §Configuration §fail-closed 挙動の表（L1158-1162）—
-  `NATIVE_AUTH_JWT_SECRET` 未設定行で `POST /api/passkey/*` を「未登録 (404)」と
-  誤って記述している箇所
+- `#223 design.md` §Configuration §fail-closed 挙動の表 —
+  `NATIVE_AUTH_JWT_SECRET` 未設定時に iOS 用 `/api/passkey/*` を「未登録 (404)」と誤って
+  表現していた箇所。および初版 #231 design の「capability を `PasskeyHandler != nil &&
+  NativeAuthHandler != nil` に強化」という **`SessionReady()` を弱めた誤記述**
 
-### 補正後の fail-closed 表
+### 補正後の fail-closed 表（5 列独立）
 
-env 組合せごとに **各 endpoint を独立列** として表現し、iOS 用 endpoint と Web 用 endpoint の
-提供状態を混同しない形に組み直す。
+env 3 軸 — **W**=`WEBAUTHN_RP_ID`+`WEBAUTHN_ORIGINS`、**N**=`NATIVE_AUTH_JWT_SECRET`、
+**C**=`CORS_ALLOWED_ORIGIN`（exact Origin） — の代表組合せごとに、各 endpoint を独立列で示す。
 
-| Env 状態 | `POST /api/auth/session`（Web） | `GET /api/passkey/capability`（Web probe） | iOS `/api/passkey/registration/*` | iOS `/api/passkey/authentication/*` | Web 挙動 | iOS 挙動 |
-|---|---|---|---|---|---|---|
-| **NATIVE_AUTH_JWT_SECRET 設定 + WEBAUTHN_RP_ID/ORIGINS 設定** | 登録済 (204) | 登録済 (200) | 登録済 (200) | 登録済 (200) | パスキー導線 2 種 + Google 導線 | 通常稼働 |
-| **NATIVE_AUTH_JWT_SECRET 未設定 + WEBAUTHN_RP_ID/ORIGINS 設定** | 未登録 (404) | 未登録 (404) | 登録済 (200) | 登録済 (200) | Google 単体表示（capability = 404 で PasskeyButtons 非表示） | **通常稼働（Req 3.3）** |
-| **NATIVE_AUTH_JWT_SECRET 設定 + WEBAUTHN_RP_ID/ORIGINS 未設定** | 登録済 (204) | 未登録 (404) | 未登録 (404) | 未登録 (404) | Google 単体表示（capability = 404） | 停止（#216 で確定済み） |
-| **NATIVE_AUTH_JWT_SECRET 未設定 + WEBAUTHN_RP_ID/ORIGINS 未設定** | 未登録 (404) | 未登録 (404) | 未登録 (404) | 未登録 (404) | Google 単体表示 | 停止 |
+| # | W | N | C | A. capability (Web probe) | B. login exchange `/api/auth/session` | C. reg. direct session (finish Web mode) | D. iOS `registration/*` | E. iOS `authentication/*` |
+|---|---|---|---|---|---|---|---|---|
+| 1 | ✓ | ✓ | ✓ | 登録 (200) | 登録 (204) | 発行（Origin 一致で 200 + Set-Cookie） | 登録 (200) | 登録 (200) |
+| 2 | ✓ | ✗ | ✓ | **未登録 (404)** | 未登録 (404) | (capability 404 で Web UI 非表示のため未到達) | **登録 (200)** | **登録 (200)** |
+| 3 | ✓ | ✓ | ✗ | **未登録 (404)** | 全リクエスト拒否 (403 / Delta 4 補正) | Origin 検証不能 → **fail-closed (403)** | 登録 (200) | 登録 (200) |
+| 4 | ✗ | ✓ | ✓ | 未登録 (404) | 登録 (204) | (finish route 自体が未登録 404) | **未登録 (404)** | **未登録 (404)** |
+| 5 | ✗ | ✗ | * | 未登録 (404) | 未登録 (404) | 未登録 (404) | 未登録 (404) | 未登録 (404) |
 
-各列の登録条件（router.go の判定式）:
+- **行 2（W✓ N✗ C✓）が最重要回帰**: `NATIVE_AUTH_JWT_SECRET` 未設定でも iOS 用
+  `registration/*` / `authentication/*` は **200 を維持**（列 D/E）。Web は capability=404 で
+  パスキー UI を非表示にし Google 単体へ縮退する（列 A）。iOS を「停止」と誤読させない
+- **行 4（W✗）**: iOS 用 endpoint は `PasskeyHandler` に紐付くため、`WEBAUTHN_*` 未設定なら 404
+  （#216 で確定済みの挙動）。Web も縮退
+- **列 B と 列 C の独立性**: login exchange（列 B）は N に依存、registration direct session（列 C）は
+  N に **依存しない**（session 発行は auth_code を介さないため）。両者を別列に分けて誤読を防ぐ
 
-| Endpoint | 登録条件（`router.go` の判定） | 依拠 env |
+各列の登録・成立条件（`router.go` / handler の判定式）:
+
+| 列 | 条件 | 依拠 env |
 |---|---|---|
-| `POST /api/auth/session` | `deps.NativeAuthHandler != nil` | `NATIVE_AUTH_JWT_SECRET` |
-| `GET /api/passkey/capability` | `deps.PasskeyHandler != nil && deps.NativeAuthHandler != nil` **（強化）** | `WEBAUTHN_RP_ID` + `WEBAUTHN_ORIGINS` + `NATIVE_AUTH_JWT_SECRET` |
-| `POST /api/passkey/registration/*` | `deps.PasskeyHandler != nil` **（従来どおり / 変更なし）** | `WEBAUTHN_RP_ID` + `WEBAUTHN_ORIGINS` |
-| `POST /api/passkey/authentication/*` | `deps.PasskeyHandler != nil` **（従来どおり / 変更なし）** | `WEBAUTHN_RP_ID` + `WEBAUTHN_ORIGINS` |
+| A. `GET /api/passkey/capability` | `PasskeyHandler != nil && NativeAuthHandler != nil && NativeAuthHandler.SessionReady() && deps.CORSAllowedOrigin != ""` | W + N + C |
+| B. `POST /api/auth/session` | `NativeAuthHandler != nil && NativeAuthHandler.SessionReady()` **（`SessionReady()` 維持）** + handler 内 Origin fail-closed（Delta 4） | N（+ C で成立） |
+| C. `registration/finish` Web mode 発行 | route は `PasskeyHandler != nil`（iOS と共有）。Web mode 成立は `webRegistrationReady()`（session repo / Cookie / exact Origin） | W + C |
+| D. `POST /api/passkey/registration/*` | `PasskeyHandler != nil` **（変更なし）** | W |
+| E. `POST /api/passkey/authentication/*` | `PasskeyHandler != nil` **（変更なし）** | W |
 
-### capability 登録条件を強化する理由（設計判断）
+### gate を弱めない（Req 3.1 / 3.2 / review #3・#5 との整合）
 
-- **意図**: Web の capability probe は「Web で end-to-end に完了できるか」を答える endpoint と
-  して意味を持つべき。NATIVE 未設定環境で `capability = 200` を返すと、Web は PasskeyButtons を
-  表示するがユーザーが実行すると最後の `/api/auth/session` で 404 に遭遇し UX が悪化する
-  （Req 3.3 が言う「Google 単体表示に縮退する」の主旨に反する）。
-- **判断**: capability の登録条件を「両 handler 非 nil」に強化することで、Web は capability =
-  404 を受け取り PasskeyButtons を非表示にする（Requirement 5.2 の既存挙動を踏襲）。
-- **iOS への影響**: iOS 用 `registration/*` / `authentication/*` の登録条件は `PasskeyHandler
-  != nil` のみで **変更しないため、iOS 契約は不変**（NFR 3.2 / Req 3.5）。
+- capability（列 A）と `/api/auth/session`（列 B）の gate は PR #229 の
+  `NativeAuthHandler.SessionReady()` を **維持**する（`NativeAuthHandler != nil` に弱めない）。
+  本差分は capability に `deps.CORSAllowedOrigin != ""` を **追加** するのみ（Origin 検証不能な
+  構成で Web パスキー UI を出さないための fail-closed 強化。行 3 参照）
+- 直接登録 session（列 C）は独自の readiness（session repo / Cookie 設定 / exact Origin）を持ち、
+  未充足なら mutation 前に fail-closed する（§Delta 1 §mode 判定）
 
 ### iOS #216 契約が破壊されない論証（Req 3.5）
 
-- iOS が依存する 6 endpoint（`registration/{begin,finish,add/begin,add/finish}` /
-  `authentication/{begin,finish}`）はすべて `PasskeyHandler` に紐付いており、router.go での
-  登録条件は `PasskeyHandler != nil` のみで変更しない。
-- 本差分で新規に登録条件を強化するのは `/api/passkey/capability` のみで、これは PR #229 で
-  Web 用に追加した endpoint であり iOS は使用しない（#216 spec には capability endpoint への
-  依存記述がない）。
-- したがって iOS 用 endpoint 群の稼働条件は #216 と完全同一で、iOS の request/response
-  契約・提供状態の env 依存性ともに破壊されない。
+- iOS が依存する `registration/*` / `authentication/*` はすべて `PasskeyHandler` に紐付き、
+  router 登録条件は `PasskeyHandler != nil` のみで **変更しない**
+- 本差分で登録条件を強化するのは Web 用 capability（列 A への `C != ""` 追加）のみ。iOS は
+  capability を使用しない（#216 spec に依存記述なし）
+- したがって iOS 用 endpoint の稼働条件は #216 と完全同一（NFR 3.2 / Req 3.5）
 
 ## Delta 4: CSRF / PKCE 説明の正確化と残余リスクの明示（Requirement 4）
 
 ### Supersedes
 
-- `#223 design.md` §Security Considerations §CSRF 箇条書き（L1115-1121）— 特に L1119-1120 の
-  「攻撃者が事前に (auth_code, code_verifier) ペアを入手する経路が存在しない」記述
-- `#223 design.md` §`NativeAuthHandler.Session` §CSRF 対策（L862-867）— 同上の誤記述と、
-  「明示的 CSRF token は不要」の判断根拠
+- `#223 design.md` §Security Considerations §CSRF の「攻撃者が事前に (auth_code, code_verifier) ペアを
+  入手する経路が存在しない」記述、および `NativeAuthHandler.Session` §CSRF 対策の同旨の判断根拠
 
-### 旧記述の撤回
+### 旧記述の撤回（Req 4.2）
 
-以下の記述を **撤回する**:
+以下を **撤回する**:
 
 > auth_code は 60 秒 TTL + 単回消費 + PKCE 束縛 → クロスサイト攻撃者が事前に (auth_code,
 > code_verifier) ペアを入手する経路が存在しない
 
-**正しい前提**（Delta 4 §主防御要素表 §PKCE + auth_code 単回 60s TTL の役割で置き換え）:
+**正しい前提**: 攻撃者は **自身のブラウザで自身の credential を用いて完全な認証フローを走行させ、
+自分の (auth_code, code_verifier) ペアを取得できる**。RFC 7636 の PKCE は「同一クライアント内での
+authorization_code の中間者盗用を防ぐ」プロパティであり、攻撃者が **自身のセッションで正規に取得した
+ペア** を防ぐものではない。したがって PKCE 単独では「攻撃者アカウントへのログイン誘引（login CSRF）」を
+阻止できない。
 
-- 攻撃者は **自身のブラウザで自身のパスキー credential を用いて完全な認証フローを走行させ、
-  自分の (auth_code, code_verifier) ペアを取得できる**。RFC 7636 の PKCE は「同一クライアント
-  内での authorization_code の中間者盗用を防ぐ」プロパティであり、攻撃者が **自身のセッション
-  で正規に取得したペア** を防ぐものではない。
-- したがって PKCE 単独では「攻撃者による自アカウントへのログイン誘引（login CSRF）」を阻止
-  できない。これに対する主防御は SameSite Cookie / Origin 検証 / CORS preflight /
-  JSON Content-Type の複合による cross-origin 発火不能化である。
+### 主防御要素表（endpoint / 経路ごとに分離 / Req 4.1）
 
-### 主防御要素表（Web セッション交換 endpoint の CSRF 対策）
+セッションを発行する 2 経路を分けて防御要素を明記する（**PKCE の役割はログイン交換にのみ限定**）:
 
-| 防御要素 | 役割 | 何を防ぐか |
+| 経路 | 主防御要素 | 各要素の役割 |
 |---|---|---|
-| **exact Origin 検証** | ブラウザ fetch の Origin ヘッダを CORS で厳密検証 | クロスオリジンからの直接 `POST /api/auth/session` を preflight で拒否 |
-| **JSON Content-Type 要求** | `application/json` 以外の Content-Type を 400 で拒否 | classic な HTML form submit（`application/x-www-form-urlencoded`）による cross-site POST を無効化（form は Content-Type を任意に設定できない） |
-| **CORS preflight** | non-simple request の preflight OPTIONS 要求 | クロスオリジンの `application/json` POST は preflight を必ず経由するため、Origin 未許可なら本 request が発火しない |
-| **SameSite=Lax Cookie** | `session_id` Cookie の SameSite 属性 | 攻撃者サイトからの top-level ナビゲーションでも Cookie 送信を制限（既存 Google OAuth と同じ属性） |
-| **PKCE 束縛 + auth_code 単回 60 秒 TTL** | 特定の attacker-in-the-middle シナリオ | 「同一クライアント内で認証 flow を開始したセッション以外」が正しい code_verifier を持たないため、盗聴された auth_code を交換できない。ネットワーク中間経路での code 盗用に対する定番対策（RFC 7636 の本来目的） |
-| **HttpOnly Cookie** | `session_id` を JavaScript から不可視化 | XSS 発生時に Cookie 生値を script が読み出して外部送信するのを阻止 |
-| **auth_code の 60 秒 TTL + 単回消費** | 発行済み auth_code の有効期間・再利用防止 | replay / 盗聴された auth_code の遅延利用ウィンドウを最小化 |
+| **登録 直接 session**（`registration/finish` Web mode） | 必須ユーザー生体ジェスチャ + exact Origin + JSON Content-Type + CORS preflight + SameSite=Lax | 登録は `navigator.credentials.create()` の生体承認（user gesture）を **必須**とするため、被害者の明示操作なしに cross-site から silently 発火できない。加えて exact Origin / JSON Content-Type / CORS preflight が cross-origin 発火を封じ、SameSite=Lax が Cookie 送信を制限。**PKCE は本経路の防御に用いない**（code_challenge は #216 契約維持のため形式検証のみ） |
+| **ログイン auth_code 交換**（`POST /api/auth/session`） | exact Origin + JSON Content-Type + CORS preflight + SameSite=Lax + PKCE 束縛（auth_code 単回 60s TTL） | exact Origin / JSON Content-Type / CORS preflight / SameSite が cross-origin 発火を封じる主防御。PKCE + 単回 60s TTL は「同一クライアント外」による盗聴 auth_code の交換を防ぐ（RFC 7636 の本来目的。login CSRF そのものの防御ではない） |
+| **共通** | HttpOnly Cookie | 発行後の `session_id` を JavaScript から不可視化し、XSS 時の生値読出しを阻止 |
 
-### 残余リスク（受容する脅威）
+### login `/api/auth/session` の Origin 検証を fail-closed へ補正（Req 4.1 / review #2）
 
-上記主防御を受容した上で残る 2 種の残余リスクを明記する:
+PR #229 head の `NativeAuthHandler.Session` は「Origin 不在 or allowedOrigin 未設定なら検証を
+スキップ」する（false-reject 回避のため存在時のみ厳格化）。本差分ではこれを **fail-closed** に補正する:
 
-1. **同一オリジン XSS 経由の全フロー実行**
-   - 前提: 攻撃者が Feedman Web の同一オリジンに XSS を注入できた状態
-   - 攻撃: 注入 script が完全な passkey 認証フローを走行させ、被害者が Face ID を承認した
-     結果で被害者のセッションを乗っ取る、または攻撃者が用意した credential でログイン誘引
-   - 補足: 前提を満たす時点で Feedman Web の完全な同一オリジン権限を攻撃者が持つため、
-     どんな追加 CSRF token を導入しても同一 script から読める → 防御不能。この脅威の主対策は
-     既存 CSP / DOMPurify sanitize（#223 NFR 1.3 で維持）による XSS 発生確率の最小化。
-2. **攻撃者自身の credential によるアカウント誘引**
-   - 前提: 攻撃者が自身のブラウザで先に (auth_code, code_verifier) ペアを取得し、被害者を
-     誘導して被害者ブラウザで `POST /api/auth/session {攻撃者の auth_code, 攻撃者の code_verifier}`
-     を実行させる
-   - 攻撃: 被害者が **攻撃者アカウントとしてログインしてしまう**（login CSRF）
-   - 現状の主防御:
-     - `/api/auth/session` は同一オリジン fetch のみ（CORS + exact Origin）→ 被害者ブラウザ内の
-       攻撃者スクリプト経由でしか発火できない → **同一オリジン XSS がなければ発火不能**
-     - 直接的な cross-site form submit は JSON Content-Type 要求で拒否
-   - 補足: 純粋な cross-site 経路では本攻撃は成立しない。同一オリジン XSS を経由する経路は
-     上記 1 と同じ脅威モデルに収束する。
+- `allowedOrigin == ""`（`CORS_ALLOWED_ORIGIN` 未設定）→ 全リクエスト 403（検証不能なら発行しない）
+- `Origin` 不在 → 403（browser fetch は cross-origin で Origin を必ず送る前提。fail-closed）
+- `Origin != allowedOrigin` → 403（既存）
+- `Origin == allowedOrigin` のみ通過
+- トレードオフ: Origin ヘッダを落とす same-origin proxy 構成では `CORS_ALLOWED_ORIGIN` の適切な設定と
+  Origin フォワードが前提となる（人間運用者決定として fail-closed を優先）。同一の Origin fail-closed を
+  Web registration direct session（列 C）にも適用する
+
+### 残余リスク（受容する脅威 / Req 4.3）
+
+1. **同一オリジン XSS 経由の全フロー実行**: 攻撃者が Feedman Web の同一オリジンに XSS を注入できた場合、
+   注入 script が完全な passkey フローを走行させ得る。前提成立時点で同一オリジン権限を持つため、
+   どんな追加 CSRF token も同一 script から読める → 追加防御は無効。主対策は既存 CSP / DOMPurify に
+   よる XSS 発生確率の最小化（#223 NFR 維持）
+2. **攻撃者自身の credential による login 誘引（login CSRF）**: 攻撃者が自身の (auth_code, code_verifier) を
+   取得し、被害者ブラウザで `POST /api/auth/session` を実行させ攻撃者アカウントとしてログインさせる。
+   `/api/auth/session` は同一オリジン fetch のみ（exact Origin + JSON Content-Type + CORS）で、
+   純粋な cross-site 経路では成立せず、同一オリジン XSS 経路に収束する
+- **登録直接 session（列 C）の login CSRF 非該当**: 登録は被害者の authenticator による生体承認
+  （user gesture）を必須とするため、cross-site から silently に「被害者を新規登録させる」ことはできない
 
 ### 決定記録: 追加の browser-bound state を導入しない（Req 4.4）
 
-人間運用者の Issue コメント決定（2.A）として、以下を採用 **しない**:
-
-- transaction cookie（begin 時に発行 → finish 時に検証する Cookie）
-- 追加の CSRF token（同期トークンパターン）
-- Origin-bound challenge 拡張（WebAuthn Level 3 の `additionalUnknownAssertionInputs` 等）
-
-**理由**:
-- 現状の主防御（exact Origin + JSON Content-Type + CORS preflight + SameSite + PKCE）は
-  RFC 9700 (OAuth 2.0 Security BCP §4.7.1 CSRF) の推奨に整合しており、単一オリジン fetch
-  ベースの Web app では十分な CSRF 主防御となる
-- 残余リスクは同一オリジン XSS に収束するため、追加 state を導入しても XSS 発生時には同じく
-  読める → 追加防御コストに見合わない
-- WebAuthn Level 3 の browser-side origin binding（`ClientDataJSON.origin`）は WebAuthn
-  ceremony の中で既に検証済みで、passkey 発行段階の attester 認証には効いている
+人間運用者決定として、transaction cookie / 追加 CSRF token（同期トークン）/ Origin-bound challenge 拡張は
+**採用しない**。理由: 現状の主防御は RFC 9700（OAuth 2.0 Security BCP §4.7 CSRF）に整合し、単一オリジン
+fetch ベースの Web app では十分。残余リスクは同一オリジン XSS に収束するため、追加 state を入れても XSS 時
+には同じく読める → 追加コストに見合わない。
 
 ### Cookie 属性の維持（Req 4.5）
 
-- `POST /api/auth/session` が Set-Cookie で発行する `session_id` の各属性は、既存 Google OAuth
-  Callback（`auth_handler.go::Callback`）と **完全同一**:
-  - `Name = "session_id"`
-  - `HttpOnly = true`
-  - `SameSite = http.SameSiteLaxMode`
-  - `Secure = cookieSecure`（`COOKIE_SECURE` env と `BASE_URL` の https 判定に従う）
-  - `Path = "/"`
-  - `Domain = cookieDomain`（`COOKIE_DOMAIN` env）
-  - `Max-Age = sessionMaxAge`（`SESSION_MAX_AGE` env、既定 86400 秒）
-- PR #229 の `NativeAuthHandler.Session` 既存実装がこれを既に満たしている（本差分では変更しない）
+- `registration/finish`（Web mode）/ `POST /api/auth/session` / Google OAuth Callback が発行する
+  `session_id` の属性は **完全同一**: `Name="session_id"` / `HttpOnly=true` /
+  `SameSite=http.SameSiteLaxMode` / `Secure=cookieSecure` / `Path="/"` / `Domain=cookieDomain` /
+  `Max-Age=sessionMaxAge`
+- 属性重複を排すため、`internal/handler/session_cookie.go` の canonical builder
+  `buildSessionCookie(...)` を 3 箇所で共有する（§New Files）
 
 ### 将来検討導線（Req 4.6）
 
-将来、以下のいずれかを新規 Issue として切り出す前提を残す:
-
-- 同一オリジン XSS 由来の CSRF 突破が問題化した場合 → 追加 Origin-bound state（transaction
-  cookie + double-submit token）の導入検討
-- 攻撃者自身の credential による login CSRF が問題化した場合 → OAuth 2.0 の `state`
-  パラメータ相当を introspection 可能な形で追加する検討
-- WebAuthn Level 3 の `additionalUnknownAssertionInputs` によるチャレンジ拡張の実装検討
-
-これらは本差分では扱わず、必要性が生じた時点で別 Issue として起票する。
+同一オリジン XSS 由来の CSRF 突破、または攻撃者自身の credential による login CSRF が問題化した場合は、
+残余リスク列挙を出発点に追加防御（transaction cookie + double-submit token / OAuth 2.0 `state` 相当）を
+**別 Issue** として切り出す。本差分では扱わない。
 
 ## Delta 5: 登録完了不明状態と復旧導線（Requirement 5）
 
-### 状態定義
+### 状態定義（Req 5.1）
 
-現行 `PasskeyRegistrationErrorKind` に **新規 kind** `registration_uncertain` を追加する。
-本 kind は以下いずれかの条件を満たす場合にのみ設定される:
+`PasskeyRegistrationErrorKind` に **新規 kind** `registration_uncertain` を追加する。本 kind は
+「`registration/finish` の request dispatch **後**に確定的な pre-commit 4xx を得られなかった」場合に
+のみ設定される。具体条件:
 
-- `POST /api/passkey/registration/finish` の request 送出後、**レスポンスを受け取れなかった**
-  （fetch reject `TypeError` = ネットワーク断・DNS 失敗・接続断など）
-- `POST /api/passkey/registration/finish` の request 送出後、**5xx 応答**を受け取った
-  （サーバが request を受理して commit した可能性はあるが、応答段で失敗した状態）
-- `POST /api/passkey/registration/finish` の request が **タイムアウト**した
-  （fetch AbortController / signal timeout。Feedman Web は明示 timeout を持たないため実質
-  ネットワーク断と同じ扱いになるが、判定コードでは AbortError も含める）
+- fetch reject（`TypeError` = ネットワーク断 / 接続断 / DNS 失敗）
+- 送出後の Abort（`DOMException.name === "AbortError"`）/ timeout
+- 5xx 応答（サーバが受理・commit した可能性があるが応答段で失敗）
+- **commit 済みを示唆する 2xx だが応答 body が欠損 / 途中切断 / parse 不能**（Set-Cookie は付いた
+  可能性があり、成否をクライアント側で確定できない）
 
-上記以外の失敗（begin での 4xx / create の DOMException / finish の 400 REGISTRATION_FAILED /
-session 段の 400/500）は既存 kind（`invalid_username` / `username_taken` / `cancelled` /
-`server_rejected` / `session_exchange_failed`）で表現し、`registration_uncertain` にはしない。
+以下は **uncertain にしない**:
+
+- **dispatch 前のローカル失敗**（request 構築 / JSON serialize 等）→ `server_error` 等（commit していないことが確定）
+- **確定的な 4xx**（finish の 400 REGISTRATION_FAILED / begin の 400/409 等）→ `server_rejected` /
+  `invalid_username` / `username_taken`（拒否が確定）
+- begin / create 段の失敗（`cancelled` / `network_error` 等、finish 送出前）
+
+> 直接 session 化により、registration 経路の `session_exchange_failed`（旧 auth_code→session 段の失敗）は
+> **消滅**する。#223 Requirement 3.4 の「合流失敗時のログイン画面復帰」は、直接 session では finish の
+> 2xx（session 確定）/ 4xx（拒否確定）/ uncertain（不確定）の 3 分岐に吸収される。
 
 ### 状態遷移図
 
@@ -818,202 +735,133 @@ stateDiagram-v2
     Idle --> Pending: user clicks 作成
     Pending --> InvalidUsername: begin 400 INVALID_USERNAME
     Pending --> UsernameTaken: begin 409 USERNAME_TAKEN
-    Pending --> Cancelled: create DOMException (NotAllowed/Abort/InvalidState)
-    Pending --> ServerError: begin 500 / create pre-network 500
-    Pending --> NetworkError: begin fetch reject (pre-finish)
-    Pending --> ServerRejected: finish 400 REGISTRATION_FAILED
-    Pending --> RegistrationUncertain: finish fetch reject / 5xx / AbortError
-    Pending --> SessionExchangeFailed: session 400/500 (finish は 200 完了)
-    Pending --> Success: session 204
-    InvalidUsername --> Idle: user 修正
-    UsernameTaken --> Idle: user 別名で再試行
-    Cancelled --> Idle: mutation.reset()
-    ServerError --> Idle: user 再試行
-    NetworkError --> Idle: user 再試行
-    ServerRejected --> Idle: user 再試行
-    SessionExchangeFailed --> [*]: Dialog を閉じてログイン画面へ
-    RegistrationUncertain --> LoginAttempt: user が「ログインで確認」を選ぶ
-    RegistrationUncertain --> Idle: user が「再度作成する」を選ぶ
-    LoginAttempt --> [*]: ログイン成功 → 2 ペイン UI
-    LoginAttempt --> Idle: ログイン credential 未解決 → 再作成へ
-    Success --> [*]: Dialog close → AuthGuard 再判定
+    Pending --> Cancelled: create DOMException (NotAllowed/Abort)
+    Pending --> ServerRejected: finish 4xx REGISTRATION_FAILED
+    Pending --> Uncertain: finish reject / timeout / AbortError / 5xx / 2xx(body 不能)
+    Pending --> Success: finish 2xx (Set-Cookie 受理)
+    Uncertain --> ConfirmLogin: user が「ログインで確認する」を選ぶ
+    ConfirmLogin --> [*]: discoverable ログイン成功 → 2 ペイン UI
+    ConfirmLogin --> UncertainFailed: 一律 AUTHENTICATION_FAILED
+    UncertainFailed --> Idle: user が「再度作成する」を選ぶ（この時点で初めて提示）
+    Success --> [*]: invalidateQueries → AuthGuard → 2 ペイン UI
 ```
 
-### Hook 側の判定ロジック（`use-passkey-registration.ts` 内部）
+### Hook 側の判定ロジック（`use-passkey-registration.ts`）
 
 ```typescript
-// mutationFn 内の error catch（イメージ）:
-
+// finish request 段の catch（イメージ）:
 try {
-  // ... 1. generatePkcePair / 2. begin ...
-  // ... 3. create ...
-  let finishRes: RegistrationFinishResponse;
-  try {
-    finishRes = await apiClient.post("/api/passkey/registration/finish", {...});
-  } catch (err) {
-    // finish request 段の失敗は uncertain / server_rejected / network_error を弁別
-    if (err instanceof DOMException && err.name === "AbortError") {
-      throw new PasskeyRegistrationError("registration_uncertain", err);
-    }
-    if (err instanceof ApiError) {
-      if (err.status >= 500 && err.status <= 599) {
-        // 5xx: commit したかも / しなかったかも → uncertain
-        throw new PasskeyRegistrationError("registration_uncertain", err);
-      }
-      if (err.status === 400 && err.body?.code === "REGISTRATION_FAILED") {
-        throw new PasskeyRegistrationError("server_rejected", err);
-      }
-      throw new PasskeyRegistrationError("server_error", err);
-    }
-    if (err instanceof TypeError) {
-      // fetch reject（network drop / connection reset）
-      // finish request は送出済みの可能性が高いため uncertain 側に倒す
-      throw new PasskeyRegistrationError("registration_uncertain", err);
-    }
+  await apiClient.post("/api/passkey/registration/finish", {...});
+  // 2xx だが body parse に失敗した場合も uncertain（apiClient が parse エラーを投げる場合）
+} catch (err) {
+  if (err instanceof DOMException && err.name === "AbortError")
+    throw new PasskeyRegistrationError("registration_uncertain", err);
+  if (err instanceof ApiError) {
+    if (err.status >= 500) throw new PasskeyRegistrationError("registration_uncertain", err);       // 5xx
+    if (err.status === 400 && err.body?.code === "REGISTRATION_FAILED")
+      throw new PasskeyRegistrationError("server_rejected", err);                                    // 確定拒否
+    if (err.kind === "unparseable_2xx") throw new PasskeyRegistrationError("registration_uncertain", err); // 2xx body 不能
     throw new PasskeyRegistrationError("server_error", err);
   }
-  // ... 4. session 交換 ...
-} catch (err) {
-  // begin / create / session 段の失敗は既存分類（invalid_username / username_taken /
-  // cancelled / server_rejected / session_exchange_failed / server_error / network_error）
-  // registration_uncertain は上の finish catch 内でのみ発生する
+  if (err instanceof TypeError) throw new PasskeyRegistrationError("registration_uncertain", err);    // fetch reject
+  throw new PasskeyRegistrationError("server_error", err);
 }
 ```
 
-**判定原則（安全側 fail 原則 / Req 5.1）**:
+**安全側 fail 原則**: finish 送出後に「拒否が確定（4xx）」でない限り、commit 済みの可能性を排除できないため
+uncertain に倒す。送出前の失敗は commit 不成立が確定するため uncertain にしない。
 
-- finish の request が **送出済みでレスポンスが確定的に失敗（4xx）** した場合のみ、
-  「サーバが登録を拒否した = commit していない」と断定可能 → `server_rejected`
-- finish の request が **送出済みで response が確定できない**（fetch reject / 5xx / abort）
-  場合、サーバが commit したかもしれないし、していないかもしれない → `registration_uncertain`
-- finish 送出 **前** の失敗（begin での network error）は uncertain ではなく `network_error` /
-  `server_error` として扱う（commit していないことが確定するため）
+### UI 文言と復旧導線（`passkey-signup-dialog.tsx` / Req 5.2〜5.6）
 
-### UI 文言と復旧導線（`passkey-signup-dialog.tsx`）
+`error.kind === "registration_uncertain"` の初期表示は、**「ログインで確認する」を主導線**とし、
+再作成導線は **同列に並置しない**（Req 5.2）:
 
-`error.kind === "registration_uncertain"` の場合、Dialog は以下を提示する:
-
-- **メッセージ本文**（Req 5.1 / 5.5 / 5.6 の弁別性を担保）:
+- **メッセージ本文**（generic 固定 / Req 5.5 / 5.6）:
 
   ```
   登録が完了したかどうかを確認できませんでした。
 
-  この状態は、通信の一時的な問題により、サーバ側での登録の成否をブラウザ側で
-  判別できない場合に発生します。次のいずれかをお試しください:
+  通信の問題で、サーバ側の登録の成否をブラウザ側で判別できませんでした。
+  まずはログインで確認してください:
 
-  ・「ログインで確認する」— 入力したユーザー名でログインをお試しください。ログインが
-    成功すれば登録は完了しています。
-  ・「再度作成する」— ログインで解決しない場合、もう一度新規作成をお試しください。
-    登録済みのユーザー名は再利用できないため、この時はユーザー名重複エラーが表示
-    される可能性があります。
+  ・「ログインで確認する」— パスキーでログインをお試しください（ユーザー名の入力は不要です）。
+    ログインが成功すれば登録は完了しています。
   ```
 
-- **ボタン 2 種**:
-  - 「ログインで確認する」: Dialog を閉じ、`LoginPage` にフォーカスを戻す。ユーザーが
-    `PasskeyButtons` の「パスキーでログイン」を押下し、input なしの認証フローで credential
-    確認を行う（Req 5.3）。登録が実は完了していれば認証成功 → 2 ペイン UI に遷移する
-  - 「再度作成する」: `mutation.reset()` を呼び Dialog を Idle 状態に戻す（同じ username
-    で再試行すると多くの場合 `username_taken` になり登録済みが確認できる / Req 5.4）
+- **導線の段階提示**:
+  1. 初期: 「ログインで確認する」ボタンのみ。押下で `usePasskeyAuthentication` の **discoverable ログイン**
+     （`navigator.credentials.get()` を allowCredentials 空で実行 / ユーザー名入力なし）を起動する（Req 5.2）
+  2. 成功: 通常の Cookie セッション認証に到達し 2 ペイン UI（Req 5.3）
+  3. 一律 `AUTHENTICATION_FAILED`（内部理由を区別しない）で失敗: **その後にはじめて**「再度作成する」導線を
+     提示する（Req 5.4）。再作成は `mutation.reset()` で Idle に戻す。登録済みなら再試行時に
+     `username_taken` になる旨も併記可
 
 ### 秘密情報の非漏出（Req 5.5 / NFR 2.1）
 
-- 上記メッセージ本文にはサーバ側の内部詳細（スタックトレース・SQL 内部エラー・DB 名・
-  内部 URL・attestation バイト列・code_verifier・auth_code）を一切含まない
-- Hook 側で `PasskeyRegistrationError` の `body` は Dialog に渡さない（`kind` のみを判定
-  材料とする / #223 design §秘密情報の非漏出 と同方針）
-- `console.log` / `console.error` を追加しない
+- メッセージ本文にサーバ内部詳細（スタックトレース / SQL / DB 名 / 内部 URL / attestation バイト列 /
+  session ID 生値）を一切含めない
+- Hook は `PasskeyRegistrationError` の `body` を Dialog に渡さず `kind` のみを判定材料とする。
+  `console.*` を追加しない
 
 ### 既存 error kind との弁別（Req 5.6）
 
 | error.kind | 主要文言（要旨） | ユーザーに求める行動 |
 |---|---|---|
-| `invalid_username` | 「ユーザー名の形式が不正です（3〜32 文字、英数字・ハイフン・アンダースコアのみ）」 | ユーザー名を修正 |
-| `username_taken` | 「このユーザー名は既に使用されています」 | 別のユーザー名で再試行 |
-| `cancelled` | （エラー表示なし、Idle に戻る） | 再試行 |
-| `server_rejected` | 「認証に失敗しました。時間をおいて再度お試しください」 | 時間をおいて再試行 |
-| `session_exchange_failed` | 「ログインに問題が発生しました。ログイン画面から再度お試しください」 | ログイン画面へ遷移してログイン試行 |
-| **`registration_uncertain`（NEW）** | 「登録が完了したかどうかを確認できませんでした」+ 詳細案内 | 「ログインで確認する」または「再度作成する」を選ぶ |
-| `server_error` / `network_error` | 「エラーが発生しました。時間をおいて再度お試しください」 | 時間をおいて再試行 |
+| `invalid_username` | ユーザー名の形式が不正 | ユーザー名修正 |
+| `username_taken` | このユーザー名は既に使用されています | 別名で再試行 |
+| `cancelled` | （エラー表示なし、Idle 復帰） | 再試行 |
+| `server_rejected` | 認証に失敗しました | 時間をおいて再試行 |
+| **`registration_uncertain`（NEW）** | 登録が完了したかどうかを確認できませんでした | ログインで確認 →（失敗後）再作成 |
+| `server_error` / `network_error` | エラーが発生しました | 時間をおいて再試行 |
 
-7 種すべての文言が相互に区別可能（Req 5.6）。特に `registration_uncertain` は
-`session_exchange_failed` と紛らわしくならないよう、専用の説明文（「登録が完了したかどうかを
-確認できませんでした」）を採用する。
-
-### #223 Requirement 3.4 との関係整理
-
-- **#223 Req 3.4**（合流失敗時のログイン画面復帰）→ 本 spec の `session_exchange_failed` kind
-  が担当する。この場合 registration/finish は 200 完了しており、user と credential は
-  永続化済み。session 交換のみが失敗しているため、ユーザーはログイン画面から通常ログインで
-  復帰可能。
-- **#231 Req 5**（登録 commit の完了不明）→ 本 spec の `registration_uncertain` kind が担当
-  する。registration/finish 自体が確定応答を返さなかった状態で、commit の有無が不明。
-  Req 5.2 の「ログイン試行で確認」経路は、実は commit 済みなら `session_exchange_failed` 相当
-  の後続フロー（もう既に user は作成済み → ログイン成功）を経由する。
-
-両者は **finish 応答が確定したかどうか** で明確に分岐する（前者は 200 確定・後者は不確定）。
-状態遷移図と UI 文言で区別を担保する。
+`registration_uncertain` は専用の見出し（「登録が完了したかどうかを確認できませんでした」）で
+他 kind と区別可能（Req 5.6）。
 
 ## Delta 6: 運用 config を PR #229 に統合する境界（Requirement 6）
 
 ### 決定記録: 別 prerequisite PR に分離しない（Req 6.4）
 
-人間運用者の Issue コメント決定（3.A）として、以下を採用 **しない**:
-
-- `.env.sample` および `docker-compose.yml` の変更を **別 prerequisite PR** として PR #229 の
-  前に merge させる
-
-**理由**:
-- config 変更は既存 env の documentation / passthrough 整備のみで、独立した Issue にする
-  ほどの複雑度・レビュー観点を持たない
-- PR 分岐を単純化して 1 PR = 1 Issue の原則を維持する（CLAUDE.md）
-- iOS 側の稼働環境で `WEBAUTHN_*` env が既に設定されているデプロイでは、passthrough を
-  追加するだけで Web 側の capability 判定が正しく動作するため、config 反映と Web 動作は
-  同一 PR で reviewer が確認できたほうが妥当
+人間運用者決定として、`.env.sample` / `docker-compose.yml` の変更を別 prerequisite PR に切り出さない。
+理由: 既存 env の documentation / passthrough 整備のみで独立 Issue にする複雑度がなく、1 PR = 1 Issue を
+維持し、Web 動作と config を同一 PR で reviewer が確認できるのが妥当。
 
 ### 既存 env 流用に留める（Req 6.5）
 
-- `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_DISPLAY_NAME` / `WEBAUTHN_ORIGINS` /
-  `WEBAUTHN_IOS_APP_ID` / `PASSKEY_CHALLENGE_TTL_SECONDS` は **すべて #216 で追加済み**の
-  既存 env であり、`internal/config/config.go` L87-109 に既に読込ロジックが存在する
-- `NATIVE_AUTH_JWT_SECRET` / `NATIVE_AUTH_JWT_KID` は **#166 系で追加済み**の既存 env であり
-  現行 `.env.sample` L120-130 と `docker-compose.yml` L74-76 に既に記述されている
-- **新規追加する env は無い**。本差分の config 変更は「既に config.go / runtime が読み込む
-  env を、operator 向けの documentation（`.env.sample`）と container passthrough
-  （`docker-compose.yml`）に整備するのみ」の範囲
-- したがって `#223 requirements.md` の Scope（既存 env 流用に留め、新規 env は追加しない）を
-  破らない
+- `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_DISPLAY_NAME` / `WEBAUTHN_ORIGINS` / `WEBAUTHN_IOS_APP_ID` /
+  `PASSKEY_CHALLENGE_TTL_SECONDS`（#216 で追加済み）、`NATIVE_AUTH_JWT_SECRET`（#166 系）、
+  `CORS_ALLOWED_ORIGIN`（既存 CORS 層）はいずれも `internal/config` が既読み込み済みの **既存 env**
+- **新規 env は追加しない**。本差分は operator 向け documentation（`.env.sample`）と container passthrough
+  （`docker-compose.yml`）の整備のみ（#223 Scope 維持 / Req 6.5）
+
+### `CORS_ALLOWED_ORIGIN` と fail-closed の接続の明示
+
+- `CORS_ALLOWED_ORIGIN` は Delta 3 の列 A（capability）成立条件・Delta 1 の Web mode 判定・Delta 4 の
+  Origin 検証の **共通入力**である。未設定なら Web パスキー UI は非表示（capability 404）、
+  `/api/auth/session` と registration Web mode は fail-closed（403）に倒れる（行 3）。
+  `.env.sample` / `docker-compose.yml` にこの接続をコメントで明記する
 
 ### 反映内容（イメージ）
 
-**`.env.sample`**: 現行 L119-130 の Native Auth 節の後に、以下ブロックを追加する
-（実際のコメント文言は tasks.md / 実装 PR で確定）:
+**`.env.sample`**（Native Auth / CORS 節の後にブロック追加。文言は tasks / 実装 PR で確定）:
 
 ```dotenv
-# Passkey / WebAuthn 設定（Issue #216: /api/passkey/*, AASA / Issue #229: Web パスキー導線）
-# WEBAUTHN_RP_ID は WebAuthn Relying Party ID（scheme / port を含まないドメイン、例: "example.com"）。
-# 空文字（未設定）だと passkey handler が生成されず /api/passkey/* / /api/passkey/capability が
-# 404 になる（fail-closed）。既存デプロイで passkey を使わない場合は未設定のまま起動可。
-# WEBAUTHN_RP_ID=
-# WEBAUTHN_RP_DISPLAY_NAME はブラウザに表示される RP display name（既定: "Feedman"）。
+# Passkey / WebAuthn（Issue #216 iOS API / Issue #229 Web パスキー導線）
+# 空文字（未設定）だと passkey handler が生成されず /api/passkey/* が 404（fail-closed）。
+# WEBAUTHN_RP_ID=              # 例: example.com（scheme/port を含まないドメイン）
 # WEBAUTHN_RP_DISPLAY_NAME=Feedman
-# WEBAUTHN_ORIGINS は WebAuthn ceremony が許容する origin リスト（カンマ区切り）。
-# 例: "https://example.com,https://staging.example.com,feedman://"。空文字だと fail-closed。
-# WEBAUTHN_ORIGINS=
-# WEBAUTHN_IOS_APP_ID は AASA（Apple App Site Association）に載せる iOS App ID
-# （"TEAM_ID.com.example.feedman" 形式）。空文字だと AASA が 404（iOS 連携 fail-closed）。
-# WEBAUTHN_IOS_APP_ID=
-# PASSKEY_CHALLENGE_TTL_SECONDS は WebAuthn challenge の有効期限（秒）。既定: 300。
+# WEBAUTHN_ORIGINS=            # 例: https://example.com,feedman://（カンマ区切り）
+# WEBAUTHN_IOS_APP_ID=         # 例: TEAMID.com.example.feedman（AASA 用）
 # PASSKEY_CHALLENGE_TTL_SECONDS=300
+# CORS_ALLOWED_ORIGIN は Web パスキーの exact Origin 検証にも使用される。未設定だと
+# GET /api/passkey/capability は 404、POST /api/auth/session と Web registration は 403（fail-closed）。
 ```
 
-**`docker-compose.yml`**: `api` サービスの `environment` に以下を追加する（`worker` サービス
-は passkey に依存しないため対象外）:
+**`docker-compose.yml`**（`api` サービスの `environment` に追加。`worker` は passkey 非依存のため対象外）:
 
 ```yaml
 services:
   api:
     environment:
-      # ... 既存 env ...
       - WEBAUTHN_RP_ID=${WEBAUTHN_RP_ID:-}
       - WEBAUTHN_RP_DISPLAY_NAME=${WEBAUTHN_RP_DISPLAY_NAME:-Feedman}
       - WEBAUTHN_ORIGINS=${WEBAUTHN_ORIGINS:-}
@@ -1021,108 +869,92 @@ services:
       - PASSKEY_CHALLENGE_TTL_SECONDS=${PASSKEY_CHALLENGE_TTL_SECONDS:-300}
 ```
 
-すべて `${VAR:-<既定値または空>}` 形式で **既定値なし / 空文字 fail-closed** に統一し、
-NFR 3.1（既存挙動不変）を担保する（未設定なら env が空文字で渡り、config.go が空文字を
-検出して passkey handler を nil に倒す）。
+すべて `${VAR:-<既定 or 空>}` 形式で **未設定なら空文字 fail-closed**（NFR 3.1）。`CORS_ALLOWED_ORIGIN` は
+既存 passthrough 済みのため追加しない（コメントで用途を明記するのみ）。
 
 ## Error Handling
 
-本差分は既存 error handling 方針を **踏襲** し、新規に追加するのは以下のみ:
+既存方針を踏襲し、新規は以下:
 
-- **サーバ側**: `RegistrationService.FinishRegistrationNew` の auth_code 発行段階での失敗
-  （`AuthCodeCreator.Create` の infra エラー）は既存の `fmt.Errorf(...: %w, err)` wrap で
-  伝播し、handler で 500 INTERNAL_ERROR にマップする（既存
-  `AuthenticationService.FinishAuthentication` L332-333 と同経路）
-- **Web 側**: `PasskeyRegistrationErrorKind` に `registration_uncertain` を追加し、Dialog の
-  分岐に対応 UI を追加（§Delta 5 §UI 文言と復旧導線）
-
-秘密情報非漏出方針（NFR 2.1）は既存 §Security Considerations（#223）と本 spec §Delta 5
-§秘密情報の非漏出で担保される。
-
-## Testing Strategy
-
-### Server 側（Go / `go test`）
-
-- **Unit（`internal/passkey/registration_service_test.go` 拡張）**:
-  1. 正常系: begin → finish で `code_challenge` が envelope 経由で保持され、finish の
-     `authCodePlain` 戻り値が `AuthCodeCreator.Create` に渡された `AuthCode.PKCEChallenge` と
-     符合する
-  2. 正常系: `authCodePlain` が非空・base64url 形式（既存 `auth.GenerateAuthCode` の返り値
-     形式）である
-  3. 異常系: envelope 復元失敗（sessionData が破損）→ `ErrRegistrationFailed`
-  4. 異常系: envelope の `CodeChallenge` が空 → `ErrRegistrationFailed`
-  5. 異常系: `AuthCodeCreator.Create` が infra error → wrap して伝播（handler で 500）
-- **Unit（`internal/handler/passkey_handler_test.go` 拡張）**:
-  1. `TestPasskeyHandler_RegistrationFinish_Success` の期待レスポンスに `auth_code` を追加、
-     `user_id` が引き続き存在することを assert（iOS 互換性の回帰）
-  2. auth_code フィールドが非空 base64url 形式であることを assert
-- **Integration（`internal/handler/router_test.go` 拡張）**:
-  1. env 組合せ 4 行それぞれで `POST /api/auth/session` / `GET /api/passkey/capability` /
-     `POST /api/passkey/registration/begin` / `POST /api/passkey/authentication/begin` の
-     登録有無を fail-closed 表と符合させる（Delta 3 §fail-closed 表）
-  2. 特に `NATIVE unset + WEBAUTHN set` 行で `/api/passkey/registration/begin` および
-     `/api/passkey/authentication/begin` が 200 応答すること（iOS 継続稼働の回帰）を assert
-  3. 同行で `/api/passkey/capability` が 404 になること（capability 強化条件の回帰）
-
-### Web 側（Vitest + Testing Library）
-
-- **Unit（`web/src/hooks/use-passkey-registration.test.ts` 変更）**:
-  1. 正常系: begin → create → finish → session の 4 段のみが呼ばれ、`authentication/begin`
-     が呼ばれないこと（二度目 ceremony 除去の回帰）
-  2. 正常系: `finish` レスポンスの `auth_code` が `session` の request body に渡ること
-  3. `registration_uncertain` × fetch reject: finish が `TypeError` を throw → error.kind =
-     "registration_uncertain"
-  4. `registration_uncertain` × 5xx: finish が 500 応答 → error.kind = "registration_uncertain"
-  5. `registration_uncertain` × AbortError: finish が AbortError → error.kind = "registration_uncertain"
-  6. `server_rejected` × 400 REGISTRATION_FAILED: finish が 400 → error.kind = "server_rejected"
-     （uncertain と誤って判定されないことの回帰）
-  7. 既存 kind（`invalid_username` / `username_taken` / `cancelled` / `session_exchange_failed`）
-     の分岐は #223 テスト方針に従い維持
-- **Component（`web/src/components/passkey-signup-dialog.test.tsx` 変更）**:
-  1. `error.kind === "registration_uncertain"` で専用文言（「登録が完了したかどうかを
-     確認できませんでした」）が表示される
-  2. 「ログインで確認する」ボタン押下で `onOpenChange(false)` が呼ばれる（Dialog を閉じて
-     ログイン画面へ）
-  3. 「再度作成する」ボタン押下で `mutation.reset()` が呼ばれ Dialog が Idle 状態に戻る
-  4. 文言中にサーバ内部詳細（`error.body` の値・スタックトレースを想起させる文字列等）が
-     出現しないこと（Req 5.5 の回帰）
-- **Integration / Recovery（optional、`web/src/components/login-page-recovery.test.tsx`）**:
-  - `registration_uncertain` → 「ログインで確認する」→ `usePasskeyAuthentication` mutation
-    成功 → `AuthGuard` 再判定 → 2 ペイン UI 表示のフローが unit level で組めるなら追加
-    （組めない場合は E2E 側の担当として本 spec では追加しない）
-
-### iOS 契約の回帰
-
-- 本差分に伴う iOS 側の実装変更は無い（iOS の request 送信・response 受信ロジックを
-  変更しないため）
-- サーバ側の回帰テスト（`internal/handler/passkey_handler_test.go` L\* の
-  `registration/finish` response が `user_id` を含む assert）で iOS 互換性を担保する
-- iOS 側の contract test は #216 spec のスコープであり、本差分では追加・変更しない
-  （NFR 1.3）
+- **サーバ**: `FinishRegistrationNew` の tx 内失敗（user race / credential 重複 → `ErrRegistrationFailed`、
+  session ID 生成 / session INSERT / commit の infra 失敗 → `fmt.Errorf(...: %w, err)` wrap）は全 ROLLBACK 後に
+  handler へ返し、`ErrRegistrationFailed` は 400 REGISTRATION_FAILED、それ以外は 500 INTERNAL_ERROR にマップ。
+  応答・ログに内部詳細 / session ID 生値を反射しない（NFR 2.1）
+- **Web**: `PasskeyRegistrationErrorKind` に `registration_uncertain` を追加し、Dialog の段階提示に対応
 
 ## Security Considerations
 
-Delta 4 §主防御要素表・§残余リスク・§決定記録 を参照。
+Delta 4 §主防御要素表・§残余リスク・§決定記録 を参照。追加事項として、直接 session 発行は既存 Google OAuth
+Callback / `SessionExchangeService` と **同一の session ID 生成器・同一 Cookie 属性**（canonical builder 共有）を
+用いるため、session の秘匿性・属性は既存経路と一貫する。
 
-追加事項として、本 spec で追加する `RegistrationService.FinishRegistrationNew` の `auth_code`
-発行は既存 `AuthenticationService.FinishAuthentication` と **完全同一の経路**
-（`auth.GenerateAuthCode` → `auth.HashNativeSecret` → `AuthCodeCreator.Create` /
-`PKCEChallenge` = envelope の値）を用いる。したがって #216 で確定した native auth
-契約（60 秒 TTL / 単回消費 / PKCE 束縛）と一貫している。
+## Testing Strategy
+
+### Server（Go / `go test`）
+
+- **Unit（`registration_service_test.go`）**:
+  1. 正常系（Web mode）: user / credential / session が同一 tx で作成され、`webSession` に生成 ID・
+     `now+sessionTTL` の期限が入る（tx runner を fake し `WithinTx` 内の呼び出し順を検証）
+  2. 正常系（iOS mode）: `issueWebSession=false` で session を作らず `webSession=nil`・`{user_id}` 相当
+  3. 異常系: user UNIQUE 衝突 → `ErrRegistrationFailed`（session 未作成）
+  4. 異常系: credential 重複 → `ErrRegistrationFailed`（session 未作成）
+  5. 異常系: session ID 生成失敗 / session INSERT 失敗 → 全 ROLLBACK・`webSession=nil`・エラー伝播
+- **Integration（実 PostgreSQL / `passkey_e2e_db_test.go`）**:
+  1. Web mode finish 成功で users / passkey_credentials / sessions に **3 行がすべて存在**
+  2. session INSERT を失敗させた場合（例: 重複 session ID を注入）に users / passkey_credentials にも
+     **行が残らない（3 行 atomic rollback / orphan なし）**
+  3. iOS mode finish 成功で users / passkey_credentials の 2 行のみ存在（sessions なし）
+- **Unit（`passkey_handler_test.go`）**:
+  1. Origin 一致 → 200 `{user_id}` + `Set-Cookie session_id`（属性は Google OAuth Callback と一致）
+  2. Origin 不在（iOS）→ 200 `{user_id}`・`Set-Cookie` **なし**（#216 回帰）
+  3. Origin 非空不一致 / allowedOrigin 未設定 → 403、mutation 呼ばれず（regService stub 未呼出）
+  4. Web mode で Content-Type 非 JSON → 415、mutation 呼ばれず
+- **Unit（`native_auth_handler_test.go`）**: `/api/auth/session` の Origin 不在・不一致・allowedOrigin
+  未設定で 403（Delta 4 fail-closed 補正の回帰）
+- **Integration（`router_test.go`）**: fail-closed 表 行 1〜5 の各 endpoint（列 A〜E）登録有無。特に
+  行 2（W✓ N✗ C✓）で iOS registration/*・authentication/* が 200、capability が 404
+- **Unit（`session_cookie_test.go`）**: `buildSessionCookie` の属性が Google OAuth Callback と一致
+
+### Web（Vitest + Testing Library）
+
+- **Unit（`use-passkey-registration.test.ts`）**:
+  1. 正常系: begin → create → finish の 3 呼び出しのみ。`authentication/*` / 登録用 `/api/auth/session` が
+     呼ばれない（二度目 ceremony 除去の回帰）
+  2. `registration_uncertain` × fetch reject（`TypeError`）
+  3. `registration_uncertain` × 5xx
+  4. `registration_uncertain` × AbortError
+  5. `registration_uncertain` × 2xx body parse 不能
+  6. `server_rejected` × 400 REGISTRATION_FAILED（uncertain に誤分類されない回帰）
+  7. begin 段の `invalid_username` / `username_taken` / `cancelled` は既存挙動維持
+- **Component（`passkey-signup-dialog.test.tsx`）**:
+  1. `registration_uncertain` で見出し「登録が完了したかどうかを確認できませんでした」が表示され、
+     初期に「再度作成する」が **表示されない**（同列並置しない / Req 5.2）
+  2. 「ログインで確認する」押下で discoverable ログイン（`usePasskeyAuthentication`）が起動
+  3. discoverable ログインが一律失敗した後に「再度作成する」が表示され、押下で `mutation.reset()`
+  4. 文言中にサーバ内部詳細 / 他 kind の代表文言が含まれない（Req 5.5 / 5.6 回帰）
+- **Recovery（`login-page-recovery.test.tsx`）**: `registration_uncertain` → 「ログインで確認する」→
+  discoverable ログイン成功 → 2 ペイン UI 到達（Req 5.3。unit で組めない場合は E2E 側へ委譲する旨を明記）
+
+### iOS 契約の回帰
+
+- iOS 側の実装変更は無い。サーバ回帰（`passkey_handler_test.go` の Origin 不在 → `{user_id}` + Cookie なし）で
+  #216 互換を担保。iOS contract test は #216 スコープであり本差分では追加・変更しない（NFR 1.3）
 
 ## Configuration
 
-Delta 6 を参照。**追加 env は無い**。既存 env の documentation（`.env.sample`）と
-container passthrough（`docker-compose.yml`）のみを整備する。
+Delta 6 を参照。**追加 env は無い**。既存 env の documentation（`.env.sample`）と container passthrough
+（`docker-compose.yml`）のみ整備する。
 
 ## Supporting References
 
 - WebAuthn Level 2 §7.1 Registration Ceremony: <https://www.w3.org/TR/webauthn-2/#sctn-registering-a-new-credential>
 - RFC 7636 (PKCE for OAuth Public Clients): <https://datatracker.ietf.org/doc/html/rfc7636>
-- RFC 9700 (OAuth 2.0 Security Best Current Practice) §4.7 CSRF Protection:
-  <https://datatracker.ietf.org/doc/html/rfc9700>
-- Swift `JSONDecoder`（未知キーの既定挙動は「無視」）: <https://developer.apple.com/documentation/foundation/jsondecoder>
-- 既存 #216 サーバ設計: `docs/specs/216--app-store-4-8/design.md`
-- 既存 #223 Web 設計（本 spec が supersede する対象）: `docs/specs/223-feat-web-web/design.md`
-- 既存 `AuthenticationService.authnSession` 実装（本 spec の envelope パターンの前例）:
-  `internal/passkey/authentication_service.go` L57-66
+- RFC 9700 (OAuth 2.0 Security Best Current Practice) §4.7 CSRF: <https://datatracker.ietf.org/doc/html/rfc9700>
+- MDN Fetch: Origin header は cross-origin および unsafe method の same-origin で付与される:
+  <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin>
+- 既存 tx 基盤: `internal/repository/tx.go`（`SQLTx` / `BeginTx` / `Querier` / `Commit` / `Rollback`）
+- 既存 DBTX 変種の前例: `PostgresUserRepo.DeleteByIDExec` / `PostgresSessionRepo.DeleteByUserIDExec`
+- 既存 Web session 交換（login）: `internal/handler/native_auth_handler.go`（`Session` / `SessionReady`）,
+  `internal/auth/session_exchange.go`（`SessionExchangeService` / session ID 生成器）
+- 既存 #216 サーバ設計 / 既存 #223 Web 設計（本 spec が supersede する対象）:
+  `docs/specs/216--app-store-4-8/design.md` / `docs/specs/223-feat-web-web/design.md`

--- a/docs/specs/231-design-web-auth/requirements.md
+++ b/docs/specs/231-design-web-auth/requirements.md
@@ -1,0 +1,289 @@
+# Requirements Document
+
+## Introduction
+
+本 spec は Issue #223（Web ログイン画面のパスキー導線追加）に対する **差分設計（normative delta）**
+の prerequisite である。#223 の実装 PR #229 のレビュー過程で、#223 spec（requirements /
+design / tasks）と #229 の実挙動・実変更ファイルの間に 5 件の不整合が発見された。それらは
+いずれも #223 spec を上書きまたは補正しないと Reviewer 判定・後続保守が破綻するため、
+差分要件・差分設計・差分タスクを本 spec（`docs/specs/231-design-web-auth/`）に隔離して確定し、
+design PR merge 後に PR #229 の needs-iteration 1 回で製品コードと impl-notes / context-map
+へ反映する運用とする。
+
+本 spec は **#223 の requirements.md / design.md / tasks.md を書き換えない**（#223 spec の
+物理ファイルには一切手を入れない）。かわりに本 spec の各 Requirement 内で、どの
+#223 requirement / design 節を supersede（上書き・補正）するかを明記する。#223 spec の
+その他の要件・設計判断は本 spec の変更対象外であり、そのまま有効である。
+
+本 spec の対象範囲は「観察可能な契約・境界の補正」に限定する。#223 spec と同じく、実装詳細
+（内部関数名・具体 SQL・ライブラリ内部呼び出し）は書かない。ただし「追加の WebAuthn 認証操作を
+要求しない」「iOS パスキー API 契約を破壊しない」「特定 config ファイルを PR #229 の変更対象に
+含める」といった、ユーザー／運用者が観察できる契約・境界は本 spec で要件化する。
+
+人間運用者が Issue #231 コメントで確定した 3 つの決定事項（後述 Requirement 1 / 4 / 6 に反映）
+は本 spec の前提として組み込み済みであり、本 spec の Open Questions からは除外する。
+
+## Requirements
+
+### Requirement 1: 新規作成 finish 直後の追加 WebAuthn 操作の禁止
+
+**Objective:** As a パスキーで新規作成を完了しようとする Web 訪問者, I want 登録の生体認証を
+一度だけ行い、以降は追加のブラウザ生体認証プロンプトなしで Web の 2 ペイン UI に到達したい,
+so that 新規作成体験が「登録操作 → 完了」の 1 ステップとして完結する
+
+**Supersedes:** 本要件は #223 Requirement 2.3 および #223 Requirement 3.1 の「追加操作なしで
+Cookie セッション合流」の意味を、#223 design.md 「新規作成フロー（Sequence / 抜粋）」節が
+含む二度目の `navigator.credentials.get()` 呼び出しを **禁止する** 方向に補正する。#223 spec の
+2.3 / 3.1 の文言自体は維持され、本要件はその挙動具現化における「追加操作」の解釈を厳密化する。
+
+#### Acceptance Criteria
+
+1. When 新規作成の登録 finish がサーバから成功応答を受け取ったとき, the Web Passkey Registration
+   Flow shall 追加のブラウザ生体認証プロンプト（追加の WebAuthn 認証セレモニー）を
+   起動せずに、Cookie セッションベース認証状態への合流処理を進行させる
+2. If ブラウザまたはユーザーが登録セレモニーとは別の第 2 の認証セレモニー実行を要求される場合,
+   the Web Passkey Registration Flow shall そのフローを新規作成の正常系と扱わず、実装として
+   採用しない
+3. When 登録 finish の成功応答を受け取ったとき, the Web Passkey Registration Flow shall
+   登録トランザクションと結び付いた形で Cookie セッション合流に必要な情報を Web に返す経路を
+   利用し、ユーザーに追加操作を要求しない
+4. When 新規作成が完了し Cookie セッションに合流したとき, the Web App shall Google OAuth
+   経由でログインしたときと同一の 2 ペイン UI を初期表示する
+5. The Web Passkey Registration Flow shall #223 Requirement 4（既存パスキーによるログイン）で
+   ユーザーが明示的にログイン導線を選んだときの追加認証セレモニーの正当性には影響を与えない
+   （ログイン導線での認証プロンプト提示は依然として正常挙動）
+
+### Requirement 2: PR #229 の実変更対象ファイルの明示化
+
+**Objective:** As a #223 spec を参照して PR #229 のスコープを判定する Reviewer / Architect,
+I want File Structure Plan と tasks が PR #229 の実変更対象ファイルを漏れなく列挙している
+状態を得たい, so that 変更対象が spec の File Structure Plan と食い違う理由で Reviewer 判定が
+破綻しない
+
+**Supersedes:** 本要件は #223 design.md 「File Structure Plan」節の以下を補正する。
+`web/src/lib/api.ts` を「無変更」と記述していた箇所を「変更対象」に、`web/src/lib/api.test.ts`
+・`.env.sample`・`docker-compose.yml` を File Structure Plan に列挙されていなかった状態から
+「変更対象」に、それぞれ明示する。#223 requirements.md 側の要件見出しは変更しない。
+
+#### Acceptance Criteria
+
+1. The #231 Design shall PR #229 が変更する Web ファイル（`web/src/lib/api.ts` および
+   `web/src/lib/api.test.ts` を含む）を File Structure Plan 差分の「変更対象」区分に明示する
+2. The #231 Design shall PR #229 が変更する運用 config ファイル（`.env.sample` および
+   `docker-compose.yml`）を File Structure Plan 差分の「変更対象」区分に明示する
+3. The #231 Tasks shall 上記変更対象ファイルへの差分反映作業を、PR #229 の needs-iteration
+   1 回で完結できる粒度のタスクとして列挙する
+4. The #231 Tasks shall #223 spec 側の requirements.md / design.md / tasks.md を書き換える
+   タスクを **含まない**
+5. When Reviewer が PR #229 の変更ファイル一覧を #231 design の File Structure Plan と
+   突き合わせたとき, the Reviewer shall PR #229 の全変更ファイルが #231 design で
+   「変更対象」または「新規追加」として説明されている状態を確認できる
+
+### Requirement 3: fail-closed 挙動と iOS #216 パスキー API 契約の両立
+
+**Objective:** As a Feedman 運用者（env 組合せの異なる複数環境をデプロイし iOS クライアントも
+サポートする）, I want fail-closed 表が実際の Web 側縮退挙動と iOS 側 API 提供状態を正確に
+表現している状態を得たい, so that iOS 用パスキー API が停止していないのに「停止している」と
+運用が誤認する事故を避けられる
+
+**Supersedes:** 本要件は #223 design.md 「fail-closed 挙動」節の表を補正する。特に、Web 用
+セッション交換 endpoint の未提供と、iOS #216 が既に依存しているパスキー registration /
+authentication endpoint 群の提供状態を、env 組合せごとに **別列** として正確に表現する
+（現行 #223 design 表は Web 用 env 未設定時に全パスキー endpoint が 404 になると誤って表現
+している）。#216 requirements / design はそのまま維持し、本要件からは変更しない。
+
+#### Acceptance Criteria
+
+1. The #231 Design shall Web 用セッション交換 endpoint の登録・未登録を、パスキー
+   registration / authentication endpoint 群（iOS #216 が依存）の登録・未登録と **独立した
+   列** として fail-closed 表に表現する
+2. The #231 Design shall Web 用パスキー capability probe endpoint の登録・未登録を、
+   パスキー registration / authentication endpoint 群の登録・未登録と **独立した列** として
+   fail-closed 表に表現する
+3. When Web 用セッション交換に必要な env（native 認証系）のみが未設定で、パスキー
+   registration / authentication endpoint 群に必要な env（WebAuthn 系）が設定されている
+   環境で運用したとき, the Feedman API shall iOS #216 の request / response 契約を
+   維持したままパスキー registration / authentication endpoint 群を提供し続け、
+   Web 側は Google 単体表示に縮退する
+4. When パスキー registration / authentication endpoint 群に必要な env（WebAuthn 系）が
+   未設定の環境で運用したとき, the Feedman API shall Web 用 capability probe を 404 とし、
+   Web 側は Google 単体表示に縮退する（iOS 側からも当該 env 依存の endpoint は利用不能に
+   なるが、これは #216 で既に確定済みの挙動）
+5. The #231 Design shall iOS #216 の API 契約
+   （`/api/passkey/registration/*` / `/api/passkey/authentication/*` の request / response
+   の各フィールド構造）を破壊的に変更しないことを、fail-closed 表の記述および
+   File Structure Plan の変更対象から明示的に排除する形で示す
+
+### Requirement 4: CSRF / PKCE 説明の正確化と残余リスクの明示
+
+**Objective:** As a セキュリティレビューを行う運用者 / Reviewer, I want ログインフローの
+CSRF 対策の記述が実際に有効な防御要素と限界を正確に説明している状態を得たい, so that
+「攻撃者は auth_code + code_verifier ペアを取得できない」という不正確な前提に基づいて
+残余リスクを過小評価する事故を避けられる
+
+**Supersedes:** 本要件は #223 design.md 「Security Considerations」節の CSRF 記述および
+`NativeAuthHandler.Session` 節の「CSRF 対策」記述を補正する。特に、旧記述の「攻撃者が事前に
+(auth_code, code_verifier) ペアを入手する経路が存在しない」の主張を撤回し、正しい防御要素と
+残余リスクを記述する。#223 requirements.md の NFR 1.4（同一オリジンのみ実行）はそのまま維持
+される。
+
+人間運用者による決定事項として、追加の browser-bound state（transaction cookie / CSRF token /
+Origin-bound challenge 拡張）は本 spec では要求せず、下記に列挙する主防御を「受容」する構成を
+採用する。
+
+#### Acceptance Criteria
+
+1. The #231 Design shall Web セッション交換 endpoint に対する CSRF 主防御として、
+   同一オリジン Origin 検証・JSON Content-Type 要求・CORS preflight・SameSite Cookie 属性・
+   PKCE 束縛の各要素の役割を要素ごとに明記する
+2. The #231 Design shall 旧 #223 design の「攻撃者は (auth_code, code_verifier) ペアを取得
+   できない」旨の記述が不正確である旨と、正しい前提（攻撃者は自身のブラウザで自身の
+   auth_code + code_verifier を取得できる）を明記する
+3. The #231 Design shall 上記主防御を受容した上での残余リスクを列挙する（少なくとも、
+   同一オリジン内 XSS 経由 / 攻撃者自身の credential による攻撃者アカウントへの誘引の
+   2 種を含む）
+4. The #231 Design shall 追加の browser-bound state（transaction cookie / 追加 CSRF token /
+   Origin-bound challenge 拡張）を本 spec では要求しないことを、決定事項として明記する
+5. The #231 Design shall セッション交換 endpoint の Cookie 属性（HttpOnly / SameSite /
+   Secure / Path / Max-Age）を既存 Google OAuth Callback と一致させる規約を維持する
+6. If 将来 XSS 由来の CSRF 突破や credential 差し替え型攻撃を封じる必要が発生したとき,
+   the #231 Design shall 残余リスクとして列挙した箇所を出発点に再検討する導線を残す
+   （追加防御を導入する Issue を将来切り出す前提を明示する）
+
+### Requirement 5: 登録 finish の完了不明状態と復旧導線
+
+**Objective:** As a パスキー新規作成中にネットワーク断・サーバ 5xx を経験した Web 訪問者,
+I want 「登録が確定した／されていない」を単純な二値で誤って断定されず、次に取れる行動を
+案内される状態を得たい, so that 実際は登録済みなのに再登録を試みてユーザー名重複エラーで
+詰まる事故を避けられる
+
+**Supersedes:** 本要件は #223 spec が扱っていない新規要件を追加する。#223 Requirement 2.8 /
+3.4 は「サーバエラー時の汎用エラー表示」および「合流失敗時のログイン画面復帰」を規定するが、
+「サーバ側の登録 commit は成立したがクライアント側でレスポンスが失われた」ケースを
+第 3 の状態として明示していない。本要件はこのギャップを埋める形で追加される。
+
+#### Acceptance Criteria
+
+1. When 登録 finish のリクエスト送出後にクライアントがレスポンスを受け取れなかった
+   （ネットワーク断・timeout・サーバから応答なしの 5xx 等）とき, the Web Passkey
+   Registration Flow shall そのケースを「登録成功」「登録失敗」のいずれとも断定せず、
+   「登録が確定したかどうか判別できない」旨の第 3 の完了不明状態としてユーザーに提示する
+2. When 完了不明状態を提示するとき, the Web Passkey Registration Flow shall ユーザーが
+   次に取るべき行動として「ログイン導線から同じユーザー名でログインを試すことで、登録の
+   成否を確認する」旨の案内を同一画面上に提示する
+3. If 完了不明状態のユーザーがログイン導線でログイン試行して成功したとき, the Web App
+   shall 通常の Cookie セッション認証状態に到達し 2 ペイン UI を提示する
+4. If 完了不明状態のユーザーがログイン導線でログイン試行して credential 未解決を理由に
+   拒否されたとき, the Web Passkey Registration Flow shall ユーザーに再度新規作成を試みる
+   導線を提示する
+5. The Web Passkey Registration Flow shall 完了不明状態の表示テキストにサーバの内部詳細
+   （スタックトレース・内部エラー原因・SQL / DB 名等）を反射しない
+6. The Web Passkey Registration Flow shall 完了不明状態を、ユーザー名形式不正・
+   ユーザー名重複・キャンセル・サーバ拒否のいずれとも区別可能な文言で提示する
+   （既存の #223 Requirement 2.5 / 2.6 / 2.7 / 2.8 の表示と混同されないこと）
+
+### Requirement 6: 運用 config 変更を PR #229 に統合する運用境界
+
+**Objective:** As a PR #229 をレビューする Reviewer / #231 spec を参照する Architect,
+I want `.env.sample` と `docker-compose.yml` の変更を PR #229 に正式な変更対象として
+統合された状態を得たい, so that config 変更を別 prerequisite PR に分離することで PR 分岐が
+複雑化することを避けられる
+
+**Supersedes:** 本要件は #223 design.md 「Configuration」節の「Web 側: 追加 env 無し」および
+「サーバ側: 追加 env 無し」の記述を補正する。#223 spec 全体を「env 追加なし」で通す既定は
+維持するが、`.env.sample` および `docker-compose.yml` の記述差分（既存 env の記述整備・
+デプロイ表面の記述整合）は PR #229 のスコープに含まれることを本要件で明示する。
+
+人間運用者の決定事項として、この config 変更を別 prerequisite PR として分離することは
+採用しない。
+
+#### Acceptance Criteria
+
+1. The #231 Design shall `.env.sample` の記述差分を PR #229 の変更対象として File Structure
+   Plan 差分に明示する
+2. The #231 Design shall `docker-compose.yml` の記述差分を PR #229 の変更対象として File
+   Structure Plan 差分に明示する
+3. The #231 Tasks shall 上記 config 変更の反映作業を、PR #229 の needs-iteration 1 回で
+   完結できる粒度のタスクとして列挙する
+4. The #231 Design shall 上記 config 変更を別 prerequisite PR として分離しないことを、
+   決定事項として明記する
+5. The #231 Design shall 上記 config 変更が #223 requirements.md の Scope（既存 env 定義の
+   流用に留め、新規 env は追加しない）を破らないことを、変更差分の内容と併記する形で示す
+
+## Non-Functional Requirements
+
+### NFR 1: 差分適用の運用境界
+
+1. The #231 Spec shall #223 spec の requirements.md / design.md / tasks.md の物理ファイルを
+   一切書き換えず、本 spec 内（`docs/specs/231-design-web-auth/`）でのみ差分を宣言する
+2. The #231 Spec shall 独立した実装 PR を作らず、design PR merge 後に PR #229 の
+   needs-iteration 1 回で製品コード・テスト・`impl-notes.md` / `context-map.md` へ差分を反映
+   させる運用境界を維持する
+3. The #231 Tasks shall #216（iOS パスキー API）の requirements.md / design.md / tasks.md
+   の物理ファイル、および `/api/passkey/registration/*` / `/api/passkey/authentication/*` の
+   request / response 契約を変更するタスクを **含まない**
+
+### NFR 2: 機密情報の非漏出（#223 NFR 1 の踏襲）
+
+1. The Web Passkey Registration Flow shall Requirement 5 の完了不明状態の判定・表示・
+   復旧導線に関わるすべての経路で、attestation 生バイト列・チャレンジ識別子・auth_code
+   平文・code_verifier 平文をブラウザのコンソールログ・localStorage / sessionStorage・
+   URL クエリ文字列・エラー表示テキストに残さない
+2. The #231 Design shall CSRF 記述および fail-closed 表の記述で、内部の秘密値（session_id
+   生値・auth_code 平文・RP ID の運用固有値など）を例示に用いない
+
+### NFR 3: 既存挙動の後方互換
+
+1. The Web App shall #231 の差分適用後も、#223 Requirement 6（既存 Google OAuth ログイン
+   挙動の後方互換）に規定される既存 UI・既存機能・既存テストのいずれをも本差分導入前と
+   同一に動作させる
+2. The Feedman API shall #231 の差分適用後も、#216（iOS パスキー API）の request / response
+   契約を破壊的に変更しない
+
+## Out of Scope
+
+- Issue #230 で扱う「user レコードと credential レコードの単一 DB トランザクションでの
+  作成」実装（本 spec は Requirement 1 の合流方式の要件宣言までを扱い、その実装形態は
+  #230 に委ねる）
+- 本 spec 内で PR #229 の製品コード（`internal/**` / `web/src/**` の実装ファイル）を直接
+  変更すること（実反映は design PR merge 後の PR #229 needs-iteration 1 回で行う）
+- #216 で確定済みの iOS 向けパスキー API 契約
+  （`/api/passkey/registration/*` / `/api/passkey/authentication/*` の request / response
+  フィールド構造）の破壊的置換
+- 追加の browser-bound state（transaction cookie / 追加 CSRF token / Origin-bound challenge
+  拡張）の導入（Requirement 4 の決定事項として本 spec では要求しない）
+- 別 prerequisite PR として `.env.sample` / `docker-compose.yml` 変更を切り出すこと
+  （Requirement 6 の決定事項として本 spec では採用しない）
+- パスキー credential のセルフサービス管理 UI・アカウント統合・Sign in with Apple の Web
+  導入など、#223 spec が既に Out of Scope としている事項
+
+## Open Questions
+
+- **登録 finish の応答形態を additive に変更する具体方式**: Requirement 1 を「追加の WebAuthn
+  ceremony なしで」満たすための、`POST /api/passkey/registration/finish` の応答に auth_code
+  相当を additive に含めるか、別 endpoint を切って登録トランザクションから直接 session を
+  発行するか、その他か、の具体方式は #231 design.md（Architect）の領分とする。本 spec は
+  「登録トランザクションに紐付いた形で追加操作なく合流する」という user-observable な
+  要件までを規定する
+- **完了不明状態の UI 実現方式**: Requirement 5.1 / 5.2 の「第 3 状態」を提示する UI 実現
+  （dialog 内での状態表示か、ログイン画面への遷移＋メッセージか、専用完了画面か）は
+  design 判断とする
+- **PKCE 束縛を維持したまま登録トランザクションと合流する方式**: 現行 #216 の PKCE 契約
+  （認証 begin リクエストで `code_challenge` を必須とし、finish 応答で得た auth_code を
+  code_verifier と併せて交換する形式）を維持したまま、Requirement 1 の「追加 ceremony
+  なし」を満たす合流方式（登録 begin で code_challenge を先渡し、finish 応答で PKCE
+  束縛済み auth_code を返す方式など）の具体は design 判断とする
+- **fail-closed 表の env 分割粒度**: Requirement 3.1 / 3.2 の「独立した列」を、既存
+  `NATIVE_AUTH_JWT_SECRET` / `WEBAUTHN_RP_ID` / `WEBAUTHN_ORIGINS` の 3 変数を組み合わせた
+  行として表現するか、Web 用セッション交換 env と WebAuthn 系 env の 2 グループとして
+  表現するかは design 判断とする（本 spec は「iOS API が独立に維持される」ことを
+  user-observable / operator-observable に要件化するに留める）
+- **完了不明状態と Requirement 3.4 の関係**: #223 Requirement 3.4（合流失敗時のログイン画面
+  復帰）と本 spec Requirement 5（登録 commit 済み・応答喪失）の状態遷移・表示重複関係は
+  design で整理する
+
+## 関連
+
+- Parent: #223
+- Split from: #223
+- Related: #224 #229 #230

--- a/docs/specs/231-design-web-auth/requirements.md
+++ b/docs/specs/231-design-web-auth/requirements.md
@@ -164,18 +164,21 @@ I want 「登録が確定した／されていない」を単純な二値で誤�
 
 #### Acceptance Criteria
 
-1. When 登録 finish のリクエスト送出後にクライアントがレスポンスを受け取れなかった
-   （ネットワーク断・timeout・サーバから応答なしの 5xx 等）とき, the Web Passkey
-   Registration Flow shall そのケースを「登録成功」「登録失敗」のいずれとも断定せず、
-   「登録が確定したかどうか判別できない」旨の第 3 の完了不明状態としてユーザーに提示する
+1. When 登録 finish のリクエスト送出後に確定的な pre-commit の 4xx 応答を得られなかった
+   （ネットワーク断・timeout・送出後 Abort・応答なしの 5xx・commit 済みを示唆する 2xx だが
+   応答 body が欠損／途中切断／parse 不能）とき, the Web Passkey Registration Flow shall
+   そのケースを「登録成功」「登録失敗」のいずれとも断定せず、「登録が確定したかどうか判別
+   できない」旨の第 3 の完了不明状態としてユーザーに提示する
 2. When 完了不明状態を提示するとき, the Web Passkey Registration Flow shall ユーザーが
-   次に取るべき行動として「ログイン導線から同じユーザー名でログインを試すことで、登録の
-   成否を確認する」旨の案内を同一画面上に提示する
-3. If 完了不明状態のユーザーがログイン導線でログイン試行して成功したとき, the Web App
-   shall 通常の Cookie セッション認証状態に到達し 2 ペイン UI を提示する
-4. If 完了不明状態のユーザーがログイン導線でログイン試行して credential 未解決を理由に
-   拒否されたとき, the Web Passkey Registration Flow shall ユーザーに再度新規作成を試みる
-   導線を提示する
+   次に取るべき行動として「ログイン導線から discoverable なパスキーログイン（ユーザー名の
+   入力を伴わない）を試すことで、登録の成否を確認する」旨の案内を提示し、再作成導線は
+   同列に並置せず、この確認ログインが失敗した後にのみ提示する
+3. If 完了不明状態のユーザーが discoverable なパスキーログインを試行して成功したとき,
+   the Web App shall 通常の Cookie セッション認証状態に到達し 2 ペイン UI を提示する
+4. If 完了不明状態のユーザーが discoverable なパスキーログインを試行して一律の認証失敗
+   （AUTHENTICATION_FAILED）で拒否されたとき, the Web Passkey Registration Flow shall
+   内部理由（credential 未解決等）を区別して提示せず、その一律失敗の後にはじめてユーザーに
+   再度新規作成を試みる導線を提示する
 5. The Web Passkey Registration Flow shall 完了不明状態の表示テキストにサーバの内部詳細
    （スタックトレース・内部エラー原因・SQL / DB 名等）を反射しない
 6. The Web Passkey Registration Flow shall 完了不明状態を、ユーザー名形式不正・
@@ -242,9 +245,11 @@ I want `.env.sample` と `docker-compose.yml` の変更を PR #229 に正式な�
 
 ## Out of Scope
 
-- Issue #230 で扱う「user レコードと credential レコードの単一 DB トランザクションでの
-  作成」実装（本 spec は Requirement 1 の合流方式の要件宣言までを扱い、その実装形態は
-  #230 に委ねる）
+- Issue #230 が扱う範囲は「user レコードと credential レコードの作成」までであり、Web 直接
+  session（Requirement 1）で必要となる **session 行を含む単一 DB トランザクションへの拡張
+  （3 行 atomic）は本 spec / PR #229 の責務**である（#230 に委ねない）。本 spec は
+  Requirement 1 の合流方式（追加 ceremony なしで finish 応答が Cookie session を確定する）を
+  要件として宣言し、その 3 行トランザクション化の設計形態は #231 design.md で確定する
 - 本 spec 内で PR #229 の製品コード（`internal/**` / `web/src/**` の実装ファイル）を直接
   変更すること（実反映は design PR merge 後の PR #229 needs-iteration 1 回で行う）
 - #216 で確定済みの iOS 向けパスキー API 契約
@@ -257,30 +262,36 @@ I want `.env.sample` と `docker-compose.yml` の変更を PR #229 に正式な�
 - パスキー credential のセルフサービス管理 UI・アカウント統合・Sign in with Apple の Web
   導入など、#223 spec が既に Out of Scope としている事項
 
+## 確定済み決定事項（人間運用者による #231 決定）
+
+以下は Issue #231 の人間運用者コメントで確定済みであり、本 spec の前提として組み込む
+（Open Questions からは除外する）:
+
+- **合流方式**: Requirement 1 は **`POST /api/passkey/registration/finish` の検証成功から
+  同一 DB トランザクションで user・credential・Web session の 3 行を作成し、commit 後に同じ
+  finish 応答で `Set-Cookie` する直接 session 方式**で満たす。登録用 auth_code / 二度目の
+  `navigator.credentials.get()` / 登録専用の `/api/auth/session` 呼び出し / exchange artifact は
+  導入しない。`/api/auth/session` は既存パスキー **ログイン** 用（auth_code 交換）として残す
+- **#216 JSON 契約**: `registration/begin` / `registration/finish` の request / response JSON
+  フィールドは変更しない（finish 応答は Web / iOS とも `{user_id}` のまま。Web の差分は
+  `Set-Cookie` ヘッダのみ）。iOS には session 行も Cookie も作らない
+- **PKCE の役割分離**: 登録 begin の `code_challenge` は #216 契約維持のためフィールドを残すが
+  **形式検証のみ**で永続化・束縛しない。PKCE は直接登録経路を防御せず、ログイン auth_code
+  交換にのみ役割を持つ
+- **fail-closed 表の列**: Web capability / Web login exchange / Web registration direct session /
+  iOS registration/* / iOS authentication/* を **別列** として表現する（env 軸は
+  `WEBAUTHN_RP_ID`+`WEBAUTHN_ORIGINS` / `NATIVE_AUTH_JWT_SECRET` / `CORS_ALLOWED_ORIGIN`）
+
 ## Open Questions
 
-- **登録 finish の応答形態を additive に変更する具体方式**: Requirement 1 を「追加の WebAuthn
-  ceremony なしで」満たすための、`POST /api/passkey/registration/finish` の応答に auth_code
-  相当を additive に含めるか、別 endpoint を切って登録トランザクションから直接 session を
-  発行するか、その他か、の具体方式は #231 design.md（Architect）の領分とする。本 spec は
-  「登録トランザクションに紐付いた形で追加操作なく合流する」という user-observable な
-  要件までを規定する
 - **完了不明状態の UI 実現方式**: Requirement 5.1 / 5.2 の「第 3 状態」を提示する UI 実現
-  （dialog 内での状態表示か、ログイン画面への遷移＋メッセージか、専用完了画面か）は
-  design 判断とする
-- **PKCE 束縛を維持したまま登録トランザクションと合流する方式**: 現行 #216 の PKCE 契約
-  （認証 begin リクエストで `code_challenge` を必須とし、finish 応答で得た auth_code を
-  code_verifier と併せて交換する形式）を維持したまま、Requirement 1 の「追加 ceremony
-  なし」を満たす合流方式（登録 begin で code_challenge を先渡し、finish 応答で PKCE
-  束縛済み auth_code を返す方式など）の具体は design 判断とする
-- **fail-closed 表の env 分割粒度**: Requirement 3.1 / 3.2 の「独立した列」を、既存
-  `NATIVE_AUTH_JWT_SECRET` / `WEBAUTHN_RP_ID` / `WEBAUTHN_ORIGINS` の 3 変数を組み合わせた
-  行として表現するか、Web 用セッション交換 env と WebAuthn 系 env の 2 グループとして
-  表現するかは design 判断とする（本 spec は「iOS API が独立に維持される」ことを
-  user-observable / operator-observable に要件化するに留める）
+  （dialog 内での状態表示か、専用完了画面か）は design 判断とする。ただし「discoverable
+  ログインで確認 → 一律失敗の後にのみ再作成導線」という提示順序（Requirement 5.2 / 5.4）は
+  確定済みで、UI 実現方式はこの順序を満たす範囲に限定される
 - **完了不明状態と Requirement 3.4 の関係**: #223 Requirement 3.4（合流失敗時のログイン画面
   復帰）と本 spec Requirement 5（登録 commit 済み・応答喪失）の状態遷移・表示重複関係は
-  design で整理する
+  design で整理する（直接 session 化により registration 経路の「session 交換段の失敗」は
+  消滅し、両者は finish 応答が確定したか否かで分岐する）
 
 ## 関連
 

--- a/docs/specs/231-design-web-auth/requirements.md
+++ b/docs/specs/231-design-web-auth/requirements.md
@@ -27,8 +27,10 @@ design PR merge 後に PR #229 の needs-iteration 1 回で製品コードと im
 
 ### Requirement 1: 新規作成 finish 直後の追加 WebAuthn 操作の禁止
 
-**Objective:** As a パスキーで新規作成を完了しようとする Web 訪問者, I want 登録の生体認証を
-一度だけ行い、以降は追加のブラウザ生体認証プロンプトなしで Web の 2 ペイン UI に到達したい,
+**Objective:** As a パスキーで新規作成を完了しようとする Web 訪問者, I want 登録の authorization
+gesture（パスキー作成の WebAuthn ceremony。現設定は user verification を必須化しないため、必ずしも
+生体認証プロンプトではない）を一度だけ行い、以降は追加のブラウザ WebAuthn プロンプト（追加の
+authorization gesture）なしで Web の 2 ペイン UI に到達したい,
 so that 新規作成体験が「登録操作 → 完了」の 1 ステップとして完結する
 
 **Supersedes:** 本要件は #223 Requirement 2.3 および #223 Requirement 3.1 の「追加操作なしで
@@ -39,8 +41,8 @@ Cookie セッション合流」の意味を、#223 design.md 「新規作成フ�
 #### Acceptance Criteria
 
 1. When 新規作成の登録 finish がサーバから成功応答を受け取ったとき, the Web Passkey Registration
-   Flow shall 追加のブラウザ生体認証プロンプト（追加の WebAuthn 認証セレモニー）を
-   起動せずに、Cookie セッションベース認証状態への合流処理を進行させる
+   Flow shall 追加のブラウザ WebAuthn プロンプト（追加の authorization gesture / WebAuthn 認証
+   セレモニー）を起動せずに、Cookie セッションベース認証状態への合流処理を進行させる
 2. If ブラウザまたはユーザーが登録セレモニーとは別の第 2 の認証セレモニー実行を要求される場合,
    the Web Passkey Registration Flow shall そのフローを新規作成の正常系と扱わず、実装として
    採用しない
@@ -161,6 +163,8 @@ Origin-bound challenge 拡張）は本 spec では要求せず、下記に列挙
    発行経路を防御しないこと（登録 begin の `code_challenge` は #216 契約維持のための形式検証
    のみで、永続化・束縛せず、session 発行に用いない）を明記し、PKCE の役割を login auth_code
    交換経路（`POST /api/auth/session`）に限定して記述する
+
+### Requirement 5: 登録完了不明状態（第 3 状態）の提示と discoverable ログイン復旧導線
 
 **Objective:** As a パスキー新規作成中にネットワーク断・サーバ 5xx を経験した Web 訪問者,
 I want 「登録が確定した／されていない」を単純な二値で誤って断定されず、次に取れる行動を

--- a/docs/specs/231-design-web-auth/requirements.md
+++ b/docs/specs/231-design-web-auth/requirements.md
@@ -44,9 +44,12 @@ Cookie セッション合流」の意味を、#223 design.md 「新規作成フ�
 2. If ブラウザまたはユーザーが登録セレモニーとは別の第 2 の認証セレモニー実行を要求される場合,
    the Web Passkey Registration Flow shall そのフローを新規作成の正常系と扱わず、実装として
    採用しない
-3. When 登録 finish の成功応答を受け取ったとき, the Web Passkey Registration Flow shall
-   登録トランザクションと結び付いた形で Cookie セッション合流に必要な情報を Web に返す経路を
-   利用し、ユーザーに追加操作を要求しない
+3. When Web（許可オリジンからのリクエスト）の登録 finish が検証に成功したとき, the Feedman
+   API shall user・credential・Web session の 3 行を **単一 DB トランザクション**で作成し、
+   commit 後に同一 finish 応答（JSON body は `{user_id}` のまま不変）へ session Cookie を
+   `Set-Cookie` で付与し、追加の request・追加 ceremony・auth_code 交換を一切要求しない
+   （native/iOS からの同一 endpoint は user・credential の **2 行のみ**を作成し、session 行も
+   Cookie も発行しない）
 4. When 新規作成が完了し Cookie セッションに合流したとき, the Web App shall Google OAuth
    経由でログインしたときと同一の 2 ペイン UI を初期表示する
 5. The Web Passkey Registration Flow shall #223 Requirement 4（既存パスキーによるログイン）で
@@ -113,6 +116,11 @@ authentication endpoint 群の提供状態を、env 組合せごとに **別列*
    （`/api/passkey/registration/*` / `/api/passkey/authentication/*` の request / response
    の各フィールド構造）を破壊的に変更しないことを、fail-closed 表の記述および
    File Structure Plan の変更対象から明示的に排除する形で示す
+6. If Web 直接登録 session の発行に必要な readiness（許可 exact Origin・session 書込・
+   登録トランザクション・session factory・正の TTL / Cookie MaxAge のいずれか）が未充足の
+   環境で運用したとき, the Feedman API shall Web 用 capability probe を 404 とし
+   （公式 UI からパスキー導線を出さない fail-closed）、登録 endpoint が 200 を返すのに
+   capability だけ 200 になって signup が 500 で破綻する不整合を発生させない
 
 ### Requirement 4: CSRF / PKCE 説明の正確化と残余リスクの明示
 
@@ -149,8 +157,10 @@ Origin-bound challenge 拡張）は本 spec では要求せず、下記に列挙
 6. If 将来 XSS 由来の CSRF 突破や credential 差し替え型攻撃を封じる必要が発生したとき,
    the #231 Design shall 残余リスクとして列挙した箇所を出発点に再検討する導線を残す
    （追加防御を導入する Issue を将来切り出す前提を明示する）
-
-### Requirement 5: 登録 finish の完了不明状態と復旧導線
+7. The #231 Design shall PKCE（`code_challenge` / `code_verifier`）が Web 直接登録 session の
+   発行経路を防御しないこと（登録 begin の `code_challenge` は #216 契約維持のための形式検証
+   のみで、永続化・束縛せず、session 発行に用いない）を明記し、PKCE の役割を login auth_code
+   交換経路（`POST /api/auth/session`）に限定して記述する
 
 **Objective:** As a パスキー新規作成中にネットワーク断・サーバ 5xx を経験した Web 訪問者,
 I want 「登録が確定した／されていない」を単純な二値で誤って断定されず、次に取れる行動を
@@ -281,17 +291,15 @@ I want `.env.sample` と `docker-compose.yml` の変更を PR #229 に正式な�
 - **fail-closed 表の列**: Web capability / Web login exchange / Web registration direct session /
   iOS registration/* / iOS authentication/* を **別列** として表現する（env 軸は
   `WEBAUTHN_RP_ID`+`WEBAUTHN_ORIGINS` / `NATIVE_AUTH_JWT_SECRET` / `CORS_ALLOWED_ORIGIN`）
-
-## Open Questions
-
-- **完了不明状態の UI 実現方式**: Requirement 5.1 / 5.2 の「第 3 状態」を提示する UI 実現
-  （dialog 内での状態表示か、専用完了画面か）は design 判断とする。ただし「discoverable
-  ログインで確認 → 一律失敗の後にのみ再作成導線」という提示順序（Requirement 5.2 / 5.4）は
-  確定済みで、UI 実現方式はこの順序を満たす範囲に限定される
-- **完了不明状態と Requirement 3.4 の関係**: #223 Requirement 3.4（合流失敗時のログイン画面
-  復帰）と本 spec Requirement 5（登録 commit 済み・応答喪失）の状態遷移・表示重複関係は
-  design で整理する（直接 session 化により registration 経路の「session 交換段の失敗」は
-  消滅し、両者は finish 応答が確定したか否かで分岐する）
+- **完了不明状態の UI 実現方式（旧 Open Question / design で確定）**: Requirement 5.1 / 5.2 の
+  「第 3 状態」は **既存 `passkey-signup-dialog.tsx` 内の状態分岐**（専用完了画面を新設しない）で
+  提示する。提示順序は「discoverable ログインで確認 → 一律 `AUTHENTICATION_FAILED` の後にのみ
+  再作成導線」に固定する（design.md §Delta 5 §状態遷移図で確定）。未決事項として残さない
+- **完了不明状態と Requirement 3.4 の関係（旧 Open Question / design で確定）**: 直接 session 化に
+  より registration 経路の「session 交換段の失敗」は消滅するため、#223 Requirement 3.4（合流
+  失敗時のログイン画面復帰）と本 spec Requirement 5 は **finish 応答が確定したか否か**で分岐する
+  （2xx=成功 / 確定 4xx=拒否 / それ以外=uncertain）。両者の状態遷移は design.md §Delta 5 §状態
+  遷移図に統合済みで、表示重複は生じない。未決事項として残さない
 
 ## 関連
 

--- a/docs/specs/231-design-web-auth/requirements.md
+++ b/docs/specs/231-design-web-auth/requirements.md
@@ -178,8 +178,9 @@ I want 「登録が確定した／されていない」を単純な二値で誤�
 
 #### Acceptance Criteria
 
-1. When 登録 finish のリクエスト送出後に確定的な pre-commit の 4xx 応答を得られなかった
-   （ネットワーク断・timeout・送出後 Abort・応答なしの 5xx・commit 済みを示唆する 2xx だが
+1. When 登録 finish の `fetch()` 呼出し後に確定的な pre-commit の 4xx 応答を得られなかった
+   （実送達可否を判定できないネットワーク断・timeout・fetch 中 Abort・5xx 応答・
+   commit 済みを示唆する 2xx だが
    応答 body が欠損／途中切断／parse 不能）とき, the Web Passkey Registration Flow shall
    そのケースを「登録成功」「登録失敗」のいずれとも断定せず、「登録が確定したかどうか判別
    できない」旨の第 3 の完了不明状態としてユーザーに提示する
@@ -189,8 +190,8 @@ I want 「登録が確定した／されていない」を単純な二値で誤�
    同列に並置せず、この確認ログインが失敗した後にのみ提示する
 3. If 完了不明状態のユーザーが discoverable なパスキーログインを試行して成功したとき,
    the Web App shall 通常の Cookie セッション認証状態に到達し 2 ペイン UI を提示する
-4. If 完了不明状態のユーザーが discoverable なパスキーログインを試行して一律の認証失敗
-   （AUTHENTICATION_FAILED）で拒否されたとき, the Web Passkey Registration Flow shall
+4. If 完了不明状態のユーザーが discoverable なパスキーログインを試行し、authentication finish が
+   HTTP 400 `AUTHENTICATION_FAILED` で拒否されたとき, the Web Passkey Registration Flow shall
    内部理由（credential 未解決等）を区別して提示せず、その一律失敗の後にはじめてユーザーに
    再度新規作成を試みる導線を提示する
 5. The Web Passkey Registration Flow shall 完了不明状態の表示テキストにサーバの内部詳細
@@ -297,12 +298,14 @@ I want `.env.sample` と `docker-compose.yml` の変更を PR #229 に正式な�
   `WEBAUTHN_RP_ID`+`WEBAUTHN_ORIGINS` / `NATIVE_AUTH_JWT_SECRET` / `CORS_ALLOWED_ORIGIN`）
 - **完了不明状態の UI 実現方式（旧 Open Question / design で確定）**: Requirement 5.1 / 5.2 の
   「第 3 状態」は **既存 `passkey-signup-dialog.tsx` 内の状態分岐**（専用完了画面を新設しない）で
-  提示する。提示順序は「discoverable ログインで確認 → 一律 `AUTHENTICATION_FAILED` の後にのみ
-  再作成導線」に固定する（design.md §Delta 5 §状態遷移図で確定）。未決事項として残さない
+  提示する。提示順序は「discoverable ログインで確認 → authentication finish の HTTP 400
+  `AUTHENTICATION_FAILED` の後にのみ再作成導線」に固定する
+  （design.md §Delta 5 §状態遷移図で確定）。未決事項として残さない
 - **完了不明状態と Requirement 3.4 の関係（旧 Open Question / design で確定）**: 直接 session 化に
   より registration 経路の「session 交換段の失敗」は消滅するため、#223 Requirement 3.4（合流
   失敗時のログイン画面復帰）と本 spec Requirement 5 は **finish 応答が確定したか否か**で分岐する
-  （2xx=成功 / 確定 4xx=拒否 / それ以外=uncertain）。両者の状態遷移は design.md §Delta 5 §状態
+  （parse 可能な期待形の 2xx=成功 / 確定 4xx=拒否 / それ以外=uncertain）。両者の状態遷移は
+  design.md §Delta 5 §状態
   遷移図に統合済みで、表示重複は生じない。未決事項として残さない
 
 ## 関連

--- a/docs/specs/231-design-web-auth/tasks.md
+++ b/docs/specs/231-design-web-auth/tasks.md
@@ -32,16 +32,22 @@ PR #229 が本差分を needs-iteration で取り込む**。
     同一 package の unexported `generateSessionID`）** をいずれもテスト差し替え可能な seam として持たせる。
     **`internal/auth/service.go` は変更しない**（`generateSessionID` は unexported のまま同一 package から参照する。
     薄い public `NewSessionID` は追加しない / Blocker #2）
-  - `internal/auth/session_exchange.go` の session 構築を `SessionFactory.NewSession` 呼び出しに差し替える
-    （`SessionExchangeService` の外部契約・挙動は不変 / 差分等価）
+  - `internal/auth/session_exchange.go` の `now` / `sessionTTL` fields を
+    `sessionFactory SessionFactoryFunc` に置き換え、constructor を
+    `NewSessionExchangeService(authCodes, sessions, sessionFactory)` に変更する。session 構築を
+    `sessionFactory.NewSession(stored.UserID)` 呼び出しに差し替える
+    （auth_code 交換の外部挙動は不変 / 差分等価）
   - `internal/handler/session_cookie.go` を **新規追加**し、canonical builder
     `buildSessionCookie(name, value, domain string, secure bool, maxAge int) *http.Cookie` を定義する。
     既存 `auth_handler.go::Callback` / `native_auth_handler.go::Session` のインライン Cookie 生成を
     本 builder 呼び出しに差し替える（属性は現行と完全一致・差分等価）
   - `internal/config/config.go` に `WebPasskeyAllowedOrigin string` を **新規追加**する
     （`os.Getenv("CORS_ALLOWED_ORIGIN")` を **trim + strict exact-Origin validation** に通した値。
-    trim 後空 / scheme・host を欠く / path・query・fragment・userinfo 付き / 末尾スラッシュ / 空白・カンマで
-    複数 origin を含む、のいずれかは **`""` に倒す**（fail-closed）。localhost へ default しない / Blocker #6）。
+    前後空白だけは trim して採用する。trim 後空 / scheme が http(s) 以外 / host を欠く /
+    userinfo・opaque・path・RawPath・query・fragment・ForceQuery 付き / 末尾スラッシュ /
+    trim 後の内部空白・カンマで複数 origin を含む / `scheme://host` の canonical serialization と不一致、
+    のいずれかは **`""` に倒す**（fail-closed）。localhost へ default しない / Blocker #6）。
+    invalid warn は generic とし **生 Origin 値をログしない**
     既存 `CORSAllowedOrigin`（CORS 層。既定 `http://localhost:3000`）は **変更しない**。新規 env は追加しない
   - テスト:
     - `internal/handler/session_cookie_test.go`（新規）: `buildSessionCookie` の属性
@@ -49,11 +55,14 @@ PR #229 が本差分を needs-iteration で取り込む**。
     - `internal/auth/session_factory_test.go`（新規）: `NewSession` が ID / `CreatedAt` / `ExpiresAt=CreatedAt+TTL`
       を単一 `now` で返し、**`newID` seam に失敗関数を注入**して ID 生成失敗時に error（部分構築なし）を検証する
       （`crypto/rand.Reader` の global 差替えをしない / Blocker #2）
-    - `internal/auth/session_exchange_test.go`（既存編集）: factory 差し替え後も既存アサーションが pass し、
-      `CreatedAt` / `ExpiresAt` 検証を追加
+    - `internal/auth/session_exchange_test.go`（既存編集）: constructor に fake factory を注入し、
+      `NewSession(stored.UserID)` の呼出し・生成 session の保存を検証する。factory 失敗時は保存せず error を返し、
+      既存 auth_code 交換アサーションも pass する
     - `internal/config/config_test.go`（既存編集）: `CORS_ALLOWED_ORIGIN` valid set → `WebPasskeyAllowedOrigin=正規化値` /
-      unset・empty・**malformed（前後空白 / 末尾スラッシュ / path・query・fragment 付き / 複数 origin）→ `""`**（fail-closed / Blocker #6）、
-      `CORSAllowedOrigin` は既定 localhost:3000 を維持
+      前後空白付き valid → trim 済み値 / unset・empty・whitespace-only → `""` /
+      **malformed（内部空白 / 末尾スラッシュ / path・RawPath・query・fragment・userinfo・opaque・ForceQuery 付き /
+      複数 origin）→ `""`**（fail-closed / Blocker #6）、`CORSAllowedOrigin` は既定 localhost:3000 を維持し、
+      invalid warn に生値を含めない
     - session repo `CreateExec` の委譲は既存 `Create` テストの差分等価で担保
   - _Requirements: 1.3, 3.6, 4.5, 6.5, NFR 2.1, NFR 3.1_
   - _Boundary: repository/postgres_session_repo, auth/session_factory, auth/session_exchange, handler/session_cookie, handler/auth_handler, handler/native_auth_handler, config/config_
@@ -75,10 +84,14 @@ PR #229 が本差分を needs-iteration で取り込む**。
       同一 tx へ INSERT する。session 生成失敗 / INSERT 失敗 / commit 失敗は既存 defer Rollback により
       全取消し `webSession=nil` で伝播する（3 行 atomic / design §Delta 1）
     - session ID 生値・auth_code 平文をログ・エラー・レスポンスに残さない（NFR 2.1）
-  - `internal/app/app.go`: `passkey.NewRegistrationService(...)` に `sessionRepo`（SessionWriter）と
-    `auth.NewSessionFactory(sessionTTL)`（`sessionTTL = time.Duration(cfg.SessionMaxAge) * time.Second`）を
-    注入する。これらは `NATIVE_AUTH_JWT_SECRET` に依存せず `WEBAUTHN_*` 設定時（passkey handler 生成時）に
-    常時配線する。既存の `passkeyRegistrationTxBeginnerAdapter`（#230）注入はそのまま維持する
+  - `internal/app/app.go`: `sessionTTL := time.Duration(cfg.SessionMaxAge) * time.Second` と
+    `sessionFactory := auth.NewSessionFactory(sessionTTL)` を **`NATIVE_AUTH_JWT_SECRET` 条件の外で 1 回だけ**
+    構築する。NATIVE secret 設定時は同じ `sessionFactory` を
+    `auth.NewSessionExchangeService(authCodeRepo, sessionRepo, sessionFactory)` へ渡し、WEBAUTHN 設定時は
+    `passkey.NewRegistrationService(...)` へ `sessionRepo`（SessionWriter）と **同一 instance** を渡す。
+    RegistrationService の配線は NATIVE secret に依存しない。既存の
+    `passkeyRegistrationTxBeginnerAdapter`（#230）注入はそのまま維持する。
+    Google OAuth の `auth.Service.createSession` は既存の独立実装を変更しない
   - `internal/passkey/registration_service_test.go`:
     - 既存テストを新シグネチャ（4 引数 / 3 戻り値）に追従させる
     - 正常系（Web mode）: `issueWebSession=true` で fake tx の user → credential → session の呼び出し順を検証し、
@@ -145,23 +158,24 @@ PR #229 が本差分を needs-iteration で取り込む**。
     `request<T>` の **request preparation（`JSON.stringify` / URL 構築）を try/catch で囲んで `RequestPreparationError`**
     に、**末尾 `response.json()` を try/catch で囲んで 2xx parse 失敗を `ResponseParseError`** に正規化する
     （204/205 分岐・`credentials: "include"` は不変 / 差分等価。`fetch()` reject の plain `TypeError` はそのまま透過）。
-    これにより「dispatch 前の preparation 失敗（commit 不成立確定）/ fetch reject（dispatch 後・不確定）/ 2xx parse
-    失敗（不確定）」の 3 起点を呼出側が **plain TypeError の発生位置を推測せず** 区別できる（Blocker #1）
+    これにより「dispatch 前の preparation 失敗（commit 不成立確定）/ fetch reject
+    （request の実送達可否が不明・不確定）/ 2xx parse 失敗（不確定）」の 3 起点を呼出側が
+    **plain TypeError の発生位置を推測せず** 区別できる（Blocker #1）
   - `web/src/lib/api.test.ts`: 2xx body 欠損/途中切断/parse 不能 → `ResponseParseError`（status 2xx）、
     dispatch 前の preparation 失敗（`JSON.stringify` 循環参照 / URL 構築失敗）→ `RequestPreparationError`、
     `fetch()` reject → plain `TypeError` の **3 起点が機械的に区別できる**ことを検証する（Blocker #1）
-  - `web/src/types/passkey.ts`: `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加する。
-    さらに authentication error 種別に **finish の一律 `AUTHENTICATION_FAILED` のみを表す machine-readable kind**
-    （例: `authentication_failed`）を追加する（Blocker #3。raw body / 内部理由は保持しない）。
-    `RegistrationFinishResponse` は `{user_id}` のまま **auth_code を追加しない**
+  - `web/src/types/passkey.ts`: PR #229 の API DTO 定義を維持する。
+    `RegistrationFinishResponse` は `{user_id}` のまま **auth_code を追加しない**。
+    domain error kind は実在する各 hook 内の定義を拡張し、本 DTO ファイルへ移動・重複定義しない
   - `web/src/hooks/use-passkey-registration.ts`:
+    - 本ファイル内の `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加する
     - `mutationFn` chain を「begin → create → finish → invalidateQueries」に短縮し、
       `authentication/begin` / `navigator.credentials.get` / `authentication/finish` / 登録用
       `POST /api/auth/session` を **完全に削除**する（Req 1.1 / 1.2）。`code_challenge` は #216 契約維持のため
       送るが `code_verifier` は使用しない。registration 経路は `session_exchange_failed` を発生させない
     - finish 段の error を分類する（`RequestPreparationError` を最優先で判定）: `RequestPreparationError`
       （dispatch 前 = commit 不成立確定）→ `server_error`。`ResponseParseError`（2xx body 不能）/ `AbortError` / 5xx /
-      **`fetch()` reject の plain `TypeError`（dispatch 後）** → `registration_uncertain`。**全 4xx（400/401/403/404/409/422 等）→
+      **`fetch()` reject の plain `TypeError`（実送達可否不明）** → `registration_uncertain`。**全 4xx（400/401/403/404/409/422 等）→
       `server_rejected`（拒否確定。400 だけに限定しない）**（design §Delta 5 §安全側 fail 原則 / Blocker #1）
     - `code_verifier` / attestation 生値を `console.*` / storage / URL に書かない（NFR 2.1）
   - `web/src/hooks/use-passkey-registration.test.tsx`:
@@ -173,39 +187,61 @@ PR #229 が本差分を needs-iteration で取り込む**。
       plain `TypeError`（uncertain）と取り違えられない（Blocker #1）
     - begin 段の `invalid_username` / `username_taken` / `cancelled` は既存挙動維持
   - _Requirements: 1.1, 1.2, 1.4, 1.5, 5.1, 5.5, NFR 2.1, NFR 3.1_
-  - _Boundary: lib/api, hooks/use-passkey-registration, types/passkey_
+  - _Boundary: lib/api, hooks/use-passkey-registration（types/passkey は DTO 契約確認のみ・変更なし）_
   - _Depends: 3_
 
 - [ ] 6. Web: discoverable ログイン結果を machine-readable kind に正規化し、`passkey-signup-dialog.tsx` に完了不明状態 UI と段階提示の復旧導線を追加する
   - `web/src/hooks/use-passkey-authentication.ts`（既存編集 / Blocker #3）:
-    - discoverable ログインの **finish 一律 `AUTHENTICATION_FAILED` のみを表す machine-readable kind**
-      （例: `authentication_failed`）を付与する。判定は response の status / code のみで行い、
-      **raw body / 内部理由（credential 未解決 等）を error に含めない**（NFR 2.1）
-    - begin 拒否 / cancel（`NotAllowedError`）/ network（fetch reject）/ 5xx / session 交換段
+    - 本ファイル内の `PasskeyAuthErrorKind` に `authentication_failed` を追加する。
+      **`step === STEP_AUTH_FINISH && err instanceof ApiError && err.status === 400 &&
+      extractApiErrorCode(err) === "AUTHENTICATION_FAILED"` の完全一致だけ**をこの kind に分類する。
+      code は安全な shape guard で文字列だけを読み、**raw body / 内部理由（credential 未解決 等）を
+      error に含めない**（NFR 2.1）
+    - begin の同じ 400/code / finish の異なる status または code / cancel（`NotAllowedError`）/
+      network（fetch reject）/ 5xx（同じ code を含む）/ session 交換段
       （`/api/auth/session`）失敗は **`authentication_failed` 以外の別 kind** に保つ（再作成条件に該当させない）
   - `web/src/hooks/use-passkey-authentication.test.tsx`（既存編集 / Blocker #3）:
-    - finish 一律 `AUTHENTICATION_FAILED` → `authentication_failed` kind
-    - begin 拒否 / cancel / network / 5xx / session 交換失敗が別 kind になる negative test
+    - finish + status 400 + code `AUTHENTICATION_FAILED` → `authentication_failed` kind
+    - begin の同一 400/code、finish の異なる status/code、cancel、network、同じ code の 5xx、
+      session 交換失敗が別 kind になる negative test
     - error に内部理由 / raw body が含まれない（NFR 2.1）
+  - `web/src/components/passkey-buttons.tsx`: `authentication_failed` を既存 `server_rejected` と同じ
+    generic 固定文言へ明示 map する（`Partial<Record>` の mapping 欠落で通常ログインのエラー表示を
+    消さない）。raw code / body は DOM に反射しない
+  - `web/src/components/passkey-buttons.test.tsx`: 通常ログインの `authentication_failed` で generic 文言が
+    表示され、`AUTHENTICATION_FAILED` / raw body が表示されないことを検証する
   - `web/src/components/passkey-signup-dialog.tsx`:
     - `error.kind === "registration_uncertain"` 分岐を追加する。初期表示は見出し「登録が完了したかどうかを
       確認できませんでした」+ 「ログインで確認する」ボタンのみとし、**「再度作成する」を同列に並置しない**（Req 5.2）
+    - PR #229 既存の `isError && registered` 自動 close effect より uncertain 分岐を優先し、
+      `registration_uncertain` を当該 effect から明示除外する。初期 uncertain では
+      `onAccountCreatedNeedsLogin` / `onOpenChange(false)` / `mutation.reset()` を呼ばず Dialog を開いたままにする。
+      直接 flow で到達不能になる旧 post-finish エラーとの互換用に `registered` field を残す場合も、この優先順位を守る
     - 「ログインで確認する」押下で `usePasskeyAuthentication` の **discoverable ログイン**
       （ユーザー名入力なし）を起動する（Req 5.2）。成功時は通常の Cookie セッションに到達（Req 5.3）
-    - discoverable ログインの結果 error kind が `authentication_failed`（finish 一律失敗 / §auth hook）の **後にのみ**
-      「再度作成する」を提示し、押下で `mutation.reset()` で Idle に戻す（Req 5.4）。他 kind では提示しない
+    - discoverable ログインの結果 error kind が `authentication_failed`
+      （finish の 400 `AUTHENTICATION_FAILED` / §auth hook）の **後にのみ**
+      「再度作成する」を提示する。押下時は registration mutation と recovery authentication mutation の
+      **双方を reset** して Idle に戻し、古い `authentication_failed` を次の uncertain 表示へ持ち越さない
+      （Req 5.4）。他 kind では提示しない
     - 文言にサーバ内部詳細（スタックトレース / SQL / DB 名 / session ID 生値）を含めない（Req 5.5 / NFR 2.1）
   - `web/src/components/passkey-signup-dialog.test.tsx`:
-    - `registration_uncertain` で専用見出しが表示され、初期に「再度作成する」が表示されない（Req 5.2）
+    - `registration_uncertain`（legacy `registered=true` を含む）で専用見出しが表示され、初期に
+      「再度作成する」が表示されず、`onAccountCreatedNeedsLogin` / `onOpenChange(false)` /
+      `mutation.reset()` が呼ばれない（Req 5.2）
     - 「ログインで確認する」押下で discoverable ログインが起動
-    - discoverable ログイン一律失敗の後に「再度作成する」が表示され `mutation.reset()` が呼ばれる（Req 5.4）
+    - discoverable ログインが finish の 400 `AUTHENTICATION_FAILED` になった後に
+      「再度作成する」が表示され、押下で registration / recovery authentication の両 mutation が reset される。
+      その後の新しい uncertain 初期表示に古い auth error が持ち越されない（Req 5.4）
     - 復旧ログインの kind が `authentication_failed` のときのみ「再度作成する」が出る。begin 拒否 / cancel /
-      network / 5xx / session 交換失敗では初期画面にも失敗後にも出ない（一律 `AUTHENTICATION_FAILED` の後のみ / Blocker #3）
+      network / 5xx / session 交換失敗では初期画面にも失敗後にも出ない
+      （finish の 400 `AUTHENTICATION_FAILED` の後のみ / Blocker #3）
     - 文言中にサーバ内部詳細 / 他 kind の代表文言が含まれない（Req 5.5 / 5.6）
   - `web/src/components/login-page-recovery.test.tsx`: `registration_uncertain` →「ログインで確認する」→
     discoverable ログイン成功 → 2 ペイン UI 到達（Req 5.3。unit で組めない場合は E2E 委譲を PR 本文に明記）
   - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, NFR 2.1_
-  - _Boundary: hooks/use-passkey-authentication, components/passkey-signup-dialog, components/login-page-recovery_
+  - _Boundary: hooks/use-passkey-authentication, components/passkey-buttons,
+    components/passkey-signup-dialog, components/login-page-recovery_
   - _Depends: 5_
 
 - [ ] 7. Config: `.env.sample` に CORS_ALLOWED_ORIGIN の fail-closed 接続を明記し、`docker-compose.yml` の `api` CORS 既定を空へ変更する（新規 env なし）

--- a/docs/specs/231-design-web-auth/tasks.md
+++ b/docs/specs/231-design-web-auth/tasks.md
@@ -5,85 +5,98 @@
 user・credential・session の 3 行を作成し、commit 後に `Set-Cookie` する **直接 Cookie
 session**）に基づく。**登録用 auth_code / 二度目 ceremony / 登録専用 session 交換は導入しない**。
 
-**#223 spec（`docs/specs/223-feat-web-web/requirements.md` / `design.md` / `tasks.md`）および
-#216 spec の物理ファイルを書き換えるタスクは含まない**（NFR 1.1 / 1.3）。反映対象は
-`internal/**` / `web/src/**` の製品コードとテスト、運用 config（`.env.sample` /
-`docker-compose.yml`）、#223 spec の補助（`impl-notes.md` / `context-map.md`）に限定する。
+**先行実装の前提（運用順序）**: user + credential を単一トランザクションで INSERT する基盤
+（`passkey.RegistrationTx` / `RegistrationTxBeginner` / `RegistrationService.txBeginner` /
+`UserWriter.CreateUserOnlyExec` / `PasskeyCredentialWriter.CreateExec` /
+`passkeyRegistrationTxBeginnerAdapter`）は **Issue #230（PR #232）が実装済み**である。本タスク群は
+その既存トランザクションを **session 行まで拡張**する（新しい tx 実行機構を作らない。
+`internal/repository/tx.go` は変更しない）。運用順序は **#230（PR #232）を develop に merge →
+PR #229 が本差分を needs-iteration で取り込む**。
+
+**#223 spec（`docs/specs/223-feat-web-web/requirements.md` / `design.md` / `tasks.md` /
+`review-notes.md`）および #216 / #230 spec の物理ファイルを書き換えるタスクは含まない**
+（NFR 1.1 / 1.3）。反映対象は `internal/**` / `web/src/**` の製品コードとテスト、運用 config
+（`.env.sample` / `docker-compose.yml`）、#223 spec の補助（`impl-notes.md` / `context-map.md`）に限定する。
 
 各タスクは実装 + 対応テストを同一 commit で完結させる（`_Requirements_partial:_` は本ドラフトで
 宣言なし = 全 AC が同一タスク内テスト必須）。
 
-- [ ] 1. サーバ基盤: トランザクション実行ヘルパー・各 repo の DBTX 変種 Create・共有 Cookie builder・session ID 生成器の共有化を追加する
-  - `internal/repository/tx.go` に closure 実行ヘルパー
-    `func (b *SQLTxBeginner) WithinTx(ctx context.Context, fn func(q DBTX) error) error` を追加する
-    （`BeginTx` → `fn(tx.Querier())` → 正常時 `Commit` / エラー・panic 時 `Rollback`）。既存
-    `SQLTx` / `BeginTx` / `Querier` / `Commit` / `Rollback` は変更しない
+- [ ] 1. サーバ基盤: session 作成の tx 変種・共有 session factory・共有 Cookie builder・`WebPasskeyAllowedOrigin` config を追加する（#230 の tx 基盤・user/credential Exec 変種は再利用し追加しない）
   - `internal/repository/postgres_session_repo.go` に
-    `CreateExec(ctx, q DBTX, s *model.Session) error` を追加し、既存 `Create` を
+    `CreateExec(ctx, q DBTX, s *model.Session) error` を **新規追加**し、既存 `Create` を
     `CreateExec(ctx, r.db, s)` への委譲に変更する（差分等価 / 既存 `DeleteByUserIDExec` の DBTX 変種
-    パターンに準拠）
-  - `internal/repository/postgres_user_repo.go` に
-    `CreateUserOnlyExec(ctx, q DBTX, u *model.User) error` を追加し、既存 `CreateUserOnly` を委譲に
-    変更する（`ErrUsernameTaken` 正規化を変えない）
-  - `internal/repository/postgres_passkey_credential_repo.go` に
-    `CreateExec(ctx, q DBTX, c *model.PasskeyCredential) error` を追加し、既存 `Create` を委譲に
-    変更する（`ErrCredentialAlreadyRegistered` 正規化を変えない）
-  - `internal/handler/session_cookie.go` を新規追加し、canonical builder
+    パターンに準拠）。**#230 由来の `CreateUserOnlyExec` / credential `CreateExec` / `tx.go` は変更しない**
+  - `internal/auth/service.go` の `generateSessionID` を参照可能にする export helper
+    `NewSessionID() (string, error)` を同ファイルに追加する（既存 `createSession` の挙動は差分等価）
+  - `internal/auth/session_factory.go` を **新規追加**し、`SessionFactory`（`NewSession(userID) (*model.Session, error)`
+    が ID + 単一 `now` + `CreatedAt=now` + `ExpiresAt=now+TTL` を一貫生成）と、RegistrationService が受ける
+    最小 IF `SessionFactoryFunc` を定義する。`now` はテスト差し替え可（既定 `time.Now`）
+  - `internal/auth/session_exchange.go` の session 構築を `SessionFactory.NewSession` 呼び出しに差し替える
+    （`SessionExchangeService` の外部契約・挙動は不変 / 差分等価）
+  - `internal/handler/session_cookie.go` を **新規追加**し、canonical builder
     `buildSessionCookie(name, value, domain string, secure bool, maxAge int) *http.Cookie` を定義する。
     既存 `auth_handler.go::Callback` / `native_auth_handler.go::Session` のインライン Cookie 生成を
     本 builder 呼び出しに差し替える（属性は現行と完全一致・差分等価）
-  - `internal/auth/session_exchange.go` の session ID 生成器を `auth.GenerateSessionID` として export
-    （または既存 export を確認）し、`SessionExchangeService` と後続の RegistrationService が同一生成器を
-    共有できるようにする（`SessionExchangeService` の外部契約は不変）
-  - テスト: `internal/handler/session_cookie_test.go` を新規追加し、`buildSessionCookie` の属性
-    （Name / HttpOnly / SameSite=Lax / Secure / Path / Domain / Max-Age）が Google OAuth Callback と
-    一致することを検証する。各 `*_Exec` 変種の委譲は既存 repo テストの差分等価（既存 `Create` /
-    `CreateUserOnly` テストが引き続き pass）で担保する
-  - _Requirements: 1.3, 4.5, NFR 2.1, NFR 3.1_
-  - _Boundary: repository/tx, repository/postgres_session_repo, repository/postgres_user_repo, repository/postgres_passkey_credential_repo, handler/session_cookie, auth/session_exchange_
+  - `internal/config/config.go` に `WebPasskeyAllowedOrigin string` を **新規追加**する
+    （`os.Getenv("CORS_ALLOWED_ORIGIN")` の生値。空/未設定 → `""`。localhost へ default しない）。
+    既存 `CORSAllowedOrigin`（CORS 層。既定 `http://localhost:3000`）は **変更しない**。新規 env は追加しない
+  - テスト:
+    - `internal/handler/session_cookie_test.go`（新規）: `buildSessionCookie` の属性
+      （Name / HttpOnly / SameSite=Lax / Secure / Path / Domain / Max-Age）が Google OAuth Callback と一致
+    - `internal/auth/session_factory_test.go`（新規）: `NewSession` が ID / `CreatedAt` / `ExpiresAt=CreatedAt+TTL`
+      を単一 now で返し、ID 生成失敗時に error（部分構築なし）
+    - `internal/auth/session_exchange_test.go`（既存編集）: factory 差し替え後も既存アサーションが pass し、
+      `CreatedAt` / `ExpiresAt` 検証を追加
+    - `internal/config/config_test.go`（既存編集）: `CORS_ALLOWED_ORIGIN` set → `WebPasskeyAllowedOrigin=値` /
+      unset・empty → `""`、`CORSAllowedOrigin` は既定 localhost:3000 を維持
+    - session repo `CreateExec` の委譲は既存 `Create` テストの差分等価で担保
+  - _Requirements: 1.3, 3.6, 4.5, 6.5, NFR 2.1, NFR 3.1_
+  - _Boundary: repository/postgres_session_repo, auth/session_factory, auth/session_exchange, auth/service, handler/session_cookie, config/config_
 
-- [ ] 2. サーバ: `RegistrationService.FinishRegistrationNew` を単一 tx で user → credential →（Web mode のみ）session の 3 行作成に拡張し、wiring を更新する
+- [ ] 2. サーバ: `RegistrationService.FinishRegistrationNew` を既存 #230 tx クロージャ内の session INSERT に拡張し、wiring を更新する
   - `internal/passkey/registration_service.go`:
-    - 最小 IF を追加/拡張: `SessionWriter{CreateExec}`、`UserWriter` に `CreateUserOnlyExec`、
-      `PasskeyCredentialWriter` に `CreateExec`、tx 実行 IF `txRunner{WithinTx}`
-    - 構造体に `sessions SessionWriter` / `tx txRunner` / `newSessionID func() (string, error)` /
-      `sessionTTL time.Duration` を追加する（**auth_code 関連依存は追加しない**）。
-      `NewRegistrationService` のシグネチャに追加し、`WebSessionReady() bool` を追加する
+    - 最小 IF を追加: `SessionWriter{CreateExec}`（session repo の tx 変種）。**#230 既存の `UserWriter` /
+      `PasskeyCredentialWriter` / `RegistrationTxBeginner` は再宣言しない**
+    - 構造体に `sessions SessionWriter` / `sessionFactory auth.SessionFactoryFunc` を追加する
+      （**auth_code 関連依存は追加しない**）。`NewRegistrationService` のシグネチャに追加し、
+      `WebSessionReady() bool`（sessions / sessionFactory / txBeginner が非 nil）を追加する
     - `FinishRegistrationNew` のシグネチャを
       `(ctx, challengeID, requestBody) (string, error)` →
       `(ctx, challengeID, requestBody, issueWebSession bool) (userID string, webSession *model.Session, err error)`
-      に変更する。既存の challenge consume / `adapter.FinishRegistration`（attestation 検証）は変更しない
-    - user 作成 / credential 保存 / （`issueWebSession` 時の）session 生成・保存を **`tx.WithinTx` の
-      単一クロージャ内**で実行する。user UNIQUE 衝突 → `ErrRegistrationFailed`、credential 重複 →
-      `ErrRegistrationFailed`（既存正規化を維持）、session ID 生成失敗 / session INSERT 失敗 / commit 失敗は
-      全 ROLLBACK し `webSession=nil` で伝播する（3 行 atomic / design §Delta 1）
+      に変更する。既存 challenge consume / `adapter.FinishRegistration` / `txBeginner.BeginTx` /
+      defer Rollback / `CreateUserOnlyExec` / credential `CreateExec` / `Commit` は **#230 のまま維持**する
+    - credential `CreateExec` の **後・`Commit` の前**に、`issueWebSession` のとき
+      `sessionFactory.NewSession(newUser.ID)` で session を作り `sessions.CreateExec(ctx, tx.Querier(), sess)` で
+      同一 tx へ INSERT する。session 生成失敗 / INSERT 失敗 / commit 失敗は既存 defer Rollback により
+      全取消し `webSession=nil` で伝播する（3 行 atomic / design §Delta 1）
     - session ID 生値・auth_code 平文をログ・エラー・レスポンスに残さない（NFR 2.1）
-  - `internal/app/app.go`: `passkey.NewRegistrationService(...)` に `sessionRepo`（SessionWriter）/
-    tx runner（`db` 由来の `SQLTxBeginner`）/ `auth.GenerateSessionID` / `sessionTTL`
-    （`time.Duration(cfg.SessionMaxAge) * time.Second`）を注入する。これらは
-    `NATIVE_AUTH_JWT_SECRET` に依存せず `WEBAUTHN_*` 設定時（passkey handler 生成時）に常時配線する
+  - `internal/app/app.go`: `passkey.NewRegistrationService(...)` に `sessionRepo`（SessionWriter）と
+    `auth.NewSessionFactory(sessionTTL)`（`sessionTTL = time.Duration(cfg.SessionMaxAge) * time.Second`）を
+    注入する。これらは `NATIVE_AUTH_JWT_SECRET` に依存せず `WEBAUTHN_*` 設定時（passkey handler 生成時）に
+    常時配線する。既存の `passkeyRegistrationTxBeginnerAdapter`（#230）注入はそのまま維持する
   - `internal/passkey/registration_service_test.go`:
     - 既存テストを新シグネチャ（4 引数 / 3 戻り値）に追従させる
-    - 正常系（Web mode）: `issueWebSession=true` で `WithinTx` 内の user → credential → session の呼び出し順を
-      fake で検証し、`webSession` に生成 ID と `now+sessionTTL` の期限が入る
+    - 正常系（Web mode）: `issueWebSession=true` で fake tx の user → credential → session の呼び出し順を検証し、
+      `webSession` に factory 生成の ID / `CreatedAt` / `ExpiresAt` が入る
     - 正常系（iOS mode）: `issueWebSession=false` で session を作らず `webSession=nil`
     - 異常系: user UNIQUE 衝突 → `ErrRegistrationFailed`（session 未作成）
     - 異常系: credential 重複 → `ErrRegistrationFailed`（session 未作成）
-    - 異常系: session ID 生成失敗 / session INSERT 失敗 → 全 ROLLBACK・`webSession=nil`・エラー伝播
+    - 異常系: session INSERT 失敗 / session factory の ID 生成失敗 → 全 Rollback・`webSession=nil`・エラー伝播
   - _Requirements: 1.1, 1.2, 1.3, 3.5, NFR 2.1, NFR 3.2_
   - _Boundary: passkey/RegistrationService, app.go wiring_
   - _Depends: 1_
 
-- [ ] 3. サーバ: `PasskeyHandler.RegistrationFinish` に Origin ベース Web/iOS mode 判定・Web mode の Set-Cookie を追加し、実 PostgreSQL で 3 行原子性を検証する
+- [ ] 3. サーバ: `PasskeyHandler.RegistrationFinish` に Origin ベース Web/iOS mode 判定・readiness・Web mode の Set-Cookie を追加し、実 PostgreSQL で 3 行原子性を検証する
   - `internal/handler/passkey_handler.go`:
-    - `PasskeyHandler` に `allowedOrigin string` と Cookie 設定（domain / secure / maxAge）を Option で
-      注入する（既存 `NativeAuthHandler` の `WithSession*` Option idiom を踏襲）。`webRegistrationReady()`
-      （`allowedOrigin != "" && Cookie 設定済み && regService.WebSessionReady()`）を追加する
+    - `PasskeyHandler` に `allowedOrigin string`（= `WebPasskeyAllowedOrigin`）と Cookie 設定
+      （domain / secure / maxAge）を Option で注入する（既存 `NativeAuthHandler` の `WithSession*` Option idiom を
+      踏襲）。`webRegistrationReady()`（`allowedOrigin != "" && cookieMaxAge > 0 && regService.WebSessionReady()`。
+      Domain 空・Secure=false は有効な構成として readiness 条件に含めない）を追加する
     - `RegistrationFinish` に mode 判定を追加する（challenge consume / mutation より前）:
       - `Origin` 不在 → native/iOS mode（`issueWebSession=false`、既存挙動 / JSON Content-Type 追加検証なし）
-      - `Origin == allowedOrigin`（allowedOrigin 設定済）→ Web mode。JSON Content-Type 非一致は 415、
+      - `Origin == allowedOrigin`（allowedOrigin 非空）→ Web mode。JSON Content-Type 非一致は 415、
         `!webRegistrationReady()` は fail-closed（500 相当）、いずれも mutation 前に返す
-      - `Origin` 非空不一致 or allowedOrigin 未設定 → 403 FORBIDDEN_ORIGIN（mutation なし）
+      - `Origin` 非空不一致 or allowedOrigin 未設定（空）→ 403 FORBIDDEN_ORIGIN（mutation なし）
     - `FinishRegistrationNew(ctx, challengeID, credential, webMode)` を呼び、`webSession != nil` のとき
       `buildSessionCookie(...)`（Task 1）で `Set-Cookie` する。レスポンスは Web / iOS とも 200 `{user_id}`（不変）
   - `internal/handler/passkey_handler_test.go`:
@@ -91,54 +104,65 @@ session**）に基づく。**登録用 auth_code / 二度目 ceremony / 登録�
     - Origin 不在（iOS）→ 200 `{user_id}`・`Set-Cookie` **なし**（#216 回帰）
     - Origin 非空不一致 / allowedOrigin 未設定 → 403、regService stub が呼ばれない（mutation なし）
     - Web mode で Content-Type 非 JSON → 415、mutation 呼ばれない
-  - `internal/handler/passkey_e2e_db_test.go`（実 PostgreSQL）:
+    - `webRegistrationReady()` false（session writer / factory 未配線）→ 500、mutation 呼ばれない
+  - `internal/handler/passkey_e2e_db_test.go`（実 PostgreSQL / 既存編集）:
     - Web mode finish 成功で users / passkey_credentials / sessions に **3 行がすべて存在**
     - session INSERT を失敗させた場合（重複 session ID 注入等）に users / passkey_credentials にも
-      **行が残らない（3 行 atomic rollback / orphan なし）**
+      **行が残らない（3 行 atomic rollback / orphan なし）かつ Set-Cookie が出ない**
     - iOS mode finish 成功で users / passkey_credentials の 2 行のみ存在（sessions なし）
-  - _Requirements: 1.1, 1.3, 1.4, 3.5, 4.5, NFR 2.1, NFR 3.2_
+    - Web session の `CreatedAt` / `ExpiresAt` が Cookie の Max-Age（= SessionMaxAge）と整合する
+  - _Requirements: 1.1, 1.3, 1.4, 3.5, 3.6, 4.5, NFR 2.1, NFR 3.2_
   - _Boundary: handler/PasskeyHandler, handler/passkey_e2e_db_test_
   - _Depends: 2_
 
-- [ ] 4. サーバ: `NativeAuthHandler.Session` の Origin 検証を fail-closed へ補正し、router の fail-closed 表 5 列を実装・検証する
+- [ ] 4. サーバ: `NativeAuthHandler.Session` の Origin 検証を fail-closed へ補正し、router の fail-closed 表 5 列・partial wiring を実装・検証する
   - `internal/handler/native_auth_handler.go`: `Session` の Origin 検証を
     「`allowedOrigin == ""` → 403 / `Origin` 不在 → 403 / `Origin != allowedOrigin` → 403 /
-    `Origin == allowedOrigin` のみ通過」に補正する（design §Delta 4）。Content-Type application/json 必須は
-    既存維持
-  - `internal/handler/router.go`: capability route 条件に `deps.CORSAllowedOrigin != ""` を **追加** する
-    （`NativeAuthHandler.SessionReady()` は **維持し弱めない**）。`/api/auth/session` 条件は
-    `NativeAuthHandler != nil && SessionReady()` を維持。iOS 用 `/api/passkey/registration/*` /
-    `/api/passkey/authentication/*`（および Web と共有する `registration/finish`）は `PasskeyHandler != nil` を
-    維持（#216 契約 / NFR 3.2）
-  - `internal/handler/native_auth_handler_test.go`: Origin 不在・不一致・allowedOrigin 未設定で 403 の異常系を追加
+    `Origin == allowedOrigin` のみ通過」に補正する（design §Delta 4）。注入する許可 Origin は
+    `WebPasskeyAllowedOrigin`。Content-Type application/json 必須は既存維持
+  - `internal/handler/router.go`: capability route 条件に `deps.WebPasskeyAllowedOrigin != ""` と
+    `deps.PasskeyHandler.webRegistrationReady()` を **追加**する（`NativeAuthHandler.SessionReady()` は
+    **維持し弱めない**）。`/api/auth/session` 条件は `NativeAuthHandler != nil && SessionReady()` を維持。
+    iOS 用 `/api/passkey/registration/*` / `/api/passkey/authentication/*`（および Web と共有する
+    `registration/finish`）は `PasskeyHandler != nil` を維持（#216 契約 / NFR 3.2）
+  - `internal/handler/native_auth_handler_test.go`: Origin 不在・不一致・許可 Origin 未設定で 403 の異常系を追加
   - `internal/handler/router_test.go`: fail-closed 表 行 1〜5 の各 endpoint（列 A capability / 列 B session /
     列 C registration route / 列 D iOS registration/* / 列 E iOS authentication/*）の登録有無を table-driven で
-    検証する。特に行 2（W✓ N✗ C✓）で iOS registration/*・authentication/* が 200、capability が 404、
-    行 3（W✓ N✓ C✗）で capability 404 を assert する
-  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 4.1, NFR 3.2_
+    検証する。特に行 2（W✓ N✗ C✓）で iOS registration/*・authentication/* が 200・capability が 404、
+    行 3（W✓ N✓ C✗）で capability 404、partial wiring（`webRegistrationReady()` 未充足）で capability が
+    未登録になることを assert する
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 4.1, NFR 3.2_
   - _Boundary: handler/native_auth_handler, handler/router_
   - _Depends: 1_
 
-- [ ] 5. Web: `use-passkey-registration.ts` から二度目 WebAuthn ceremony と登録用 session 交換を除去し、`registration_uncertain` を追加する
+- [ ] 5. Web: `api.ts` に 2xx parse 失敗の型付き正規化を追加し、`use-passkey-registration.ts` から二度目 ceremony を除去して `registration_uncertain` を分類する
+  - `web/src/lib/api.ts`: `ResponseParseError`（`status: number`）を追加し、`request<T>` 末尾の
+    `response.json()` を try/catch で包んで 2xx の parse 失敗を `ResponseParseError` に正規化する
+    （204/205 分岐・`credentials: "include"` は不変 / 差分等価）。これにより dispatch 前の plain `TypeError` と
+    「fetch 成功後の 2xx body parse 失敗」を呼出側が区別できる
+  - `web/src/lib/api.test.ts`: 2xx body 欠損/途中切断/parse 不能 → `ResponseParseError`（status 2xx）、
+    dispatch 前 serialize 失敗 → plain `TypeError` で両者が区別できることを検証する
   - `web/src/types/passkey.ts`: `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加する。
     `RegistrationFinishResponse` は `{user_id}` のまま **auth_code を追加しない**
   - `web/src/hooks/use-passkey-registration.ts`:
-    - `mutationFn` chain を「begin → create → finish（2xx + Set-Cookie）→ invalidateQueries」に短縮し、
+    - `mutationFn` chain を「begin → create → finish → invalidateQueries」に短縮し、
       `authentication/begin` / `navigator.credentials.get` / `authentication/finish` / 登録用
       `POST /api/auth/session` を **完全に削除**する（Req 1.1 / 1.2）。`code_challenge` は #216 契約維持のため
-      送るが `code_verifier` は使用しない
-    - finish 段の error を分類する: `TypeError`（fetch reject）/ `AbortError` / 5xx / 2xx で body parse 不能 →
-      `registration_uncertain`。400 REGISTRATION_FAILED → `server_rejected`。送出前ローカル失敗 → `server_error`
-      （design §Delta 5 §安全側 fail 原則）。registration 経路は `session_exchange_failed` を発生させない
+      送るが `code_verifier` は使用しない。registration 経路は `session_exchange_failed` を発生させない
+    - finish 段の error を分類する: `ResponseParseError`（2xx body 不能）/ `AbortError` / 5xx /
+      送出後 `TypeError`（fetch reject）→ `registration_uncertain`。**全 4xx（400/401/403/404/409/422 等）→
+      `server_rejected`（拒否確定。400 だけに限定しない）**。dispatch 前ローカル失敗 → `server_error`
+      （design §Delta 5 §安全側 fail 原則）
     - `code_verifier` / attestation 生値を `console.*` / storage / URL に書かない（NFR 2.1）
-  - `web/src/hooks/use-passkey-registration.test.ts`:
+  - `web/src/hooks/use-passkey-registration.test.tsx`:
     - 正常系: begin → create → finish の 3 呼び出しのみで `authentication/*` / 登録用 `/api/auth/session` が
       呼ばれない（二度目 ceremony 除去の回帰）
-    - `registration_uncertain` × fetch reject / 5xx / AbortError / 2xx body parse 不能 の 4 サブケース
-    - 回帰: `server_rejected`（400 REGISTRATION_FAILED）が uncertain に誤分類されない
+    - `registration_uncertain` × fetch reject / 5xx / AbortError / `ResponseParseError`(2xx) の 4 サブケース
+    - 回帰: 全 4xx（400/401/403/404/409/422）が `server_rejected` で uncertain に誤分類されない
+    - dispatch 前 `TypeError` が `server_error`（非-uncertain）に分類される
     - begin 段の `invalid_username` / `username_taken` / `cancelled` は既存挙動維持
   - _Requirements: 1.1, 1.2, 1.4, 1.5, 5.1, 5.5, NFR 2.1, NFR 3.1_
-  - _Boundary: hooks/use-passkey-registration, types/passkey_
+  - _Boundary: lib/api, hooks/use-passkey-registration, types/passkey_
   - _Depends: 3_
 
 - [ ] 6. Web: `passkey-signup-dialog.tsx` に完了不明状態 UI と discoverable ログイン復旧導線（段階提示）を追加する
@@ -154,6 +178,7 @@ session**）に基づく。**登録用 auth_code / 二度目 ceremony / 登録�
     - `registration_uncertain` で専用見出しが表示され、初期に「再度作成する」が表示されない（Req 5.2）
     - 「ログインで確認する」押下で discoverable ログインが起動
     - discoverable ログイン一律失敗の後に「再度作成する」が表示され `mutation.reset()` が呼ばれる（Req 5.4）
+    - login の cancel / network / 5xx では初期画面に「再度作成する」が出ない（一律 AUTHENTICATION_FAILED の後のみ）
     - 文言中にサーバ内部詳細 / 他 kind の代表文言が含まれない（Req 5.5 / 5.6）
   - `web/src/components/login-page-recovery.test.tsx`: `registration_uncertain` →「ログインで確認する」→
     discoverable ログイン成功 → 2 ペイン UI 到達（Req 5.3。unit で組めない場合は E2E 委譲を PR 本文に明記）
@@ -161,43 +186,49 @@ session**）に基づく。**登録用 auth_code / 二度目 ceremony / 登録�
   - _Boundary: components/passkey-signup-dialog, components/login-page-recovery_
   - _Depends: 5_
 
-- [ ] 7. Config: `.env.sample` と `docker-compose.yml` に既存 WebAuthn env 群の documentation / passthrough と CORS_ALLOWED_ORIGIN の fail-closed 接続を追加する（新規 env なし）
-  - `.env.sample`: Native Auth / CORS 節の後に、design §Delta 6 §反映内容 の canonical コメントブロックを
-    追加する。5 変数（`WEBAUTHN_RP_ID` / `WEBAUTHN_RP_DISPLAY_NAME` / `WEBAUTHN_ORIGINS` /
-    `WEBAUTHN_IOS_APP_ID` / `PASSKEY_CHALLENGE_TTL_SECONDS`）をコメントアウト行で documentation し、
-    例値には「例:」プレフィクスを付ける。`CORS_ALLOWED_ORIGIN` 未設定時に capability=404 /
-    `/api/auth/session`・Web registration=403（fail-closed）になる旨をコメントで明記する
-  - `docker-compose.yml`: `api` サービスの `environment` に 5 変数の passthrough を
-    `${VAR:-<既定 or 空>}` 形式で追加する（`worker` には追加しない）。`CORS_ALLOWED_ORIGIN` は既存 passthrough を
-    維持（新規追加しない）
-  - **新規 env は追加しない**（config.go / #216 で既読み込み済みの既存 env の documentation / passthrough に限定 / Req 6.5）
-  - 既存 `internal/config/config_test.go` の env 読込テストは変更しない（本タスクは `internal/config/*` を触らない）
+- [ ] 7. Config: `.env.sample` に CORS_ALLOWED_ORIGIN の fail-closed 接続を明記し、`docker-compose.yml` の `api` CORS 既定を空へ変更する（新規 env なし）
+  - `.env.sample`: 既存 CORS 節に「`CORS_ALLOWED_ORIGIN` は Web パスキーの exact Origin 検証にも使用され、
+    未設定（空）だと capability=404 / `/api/auth/session`・Web registration=403（fail-closed）になり Google 単体へ
+    縮退する」旨をコメントで明記する。WebAuthn env ブロックは PR #229 で追加済みのため記述整備のみ
+  - `docker-compose.yml`: `api` サービスの `CORS_ALLOWED_ORIGIN=${CORS_ALLOWED_ORIGIN:-http://localhost:3000}` を
+    `${CORS_ALLOWED_ORIGIN:-}` に変更する（未設定 → 空 → fail-closed 到達可能。CORS ミドルウェアは config.go の
+    既定で localhost:3000 に fall back / NFR 3.1）。WebAuthn passthrough（PR #229 追加済み）は変更しない
+  - **新規 env は追加しない**（既存 `CORS_ALLOWED_ORIGIN` env の documentation / 既定変更に限定 / Req 6.5）
+  - `internal/config/config_test.go` の `WebPasskeyAllowedOrigin` テストは Task 1 で追加済み（本タスクは env ファイルのみ）
   - _Requirements: 2.2, 6.1, 6.2, 6.3, 6.4, 6.5, NFR 3.1_
   - _Boundary: .env.sample, docker-compose.yml_
 
-- [ ] 8. Docs: `docs/specs/223-feat-web-web/impl-notes.md` と `context-map.md` に #231 delta の適用結果を追記する（#223 / #216 の本体 3 文書は不変）
+- [ ] 8. Docs: `docs/specs/223-feat-web-web/impl-notes.md` と `context-map.md` に #231 delta の適用結果を追記する（#223 / #216 / #230 の本体 3 文書は不変）
   - `impl-notes.md`: 「#231 normative delta 適用後の実装状態」節を追加し、Delta 1〜6 について「本 PR で反映した
     内容」と「#231 design.md 該当 Delta への参照」を 1〜3 行で記載する。#223 design の「新規作成フロー
-    （Sequence）」が #231 Delta 1（直接 Cookie session）で supersede される旨を明示する
+    （Sequence）」が #231 Delta 1（直接 Cookie session）で supersede される旨と、#230 tx を session まで拡張した旨を明示する
   - `context-map.md`: 新規作成フロー経路図を「二度目 ceremony 除去 → `finish → 3 行 tx → commit →
     Set-Cookie` の直接 session」に更新する。fail-closed 表を #231 Delta 3 の 5 列版で supersede し、
     Delta 4 の CSRF 主防御・残余リスク（同一オリジン XSS / login CSRF）と完了不明状態（`registration_uncertain`）の
     遷移を追加する
-  - **`docs/specs/223-feat-web-web/requirements.md` / `design.md` / `tasks.md` は書き換えない**（NFR 1.1）
-  - **`docs/specs/216--app-store-4-8/` 配下のいかなるファイルも書き換えない**（NFR 1.3）
-  - _Requirements: 2.1, 2.3, 2.4, 2.5, 4.2, 4.3, 4.4, 4.6, NFR 1.1, NFR 1.2, NFR 1.3_
+  - **`docs/specs/223-feat-web-web/requirements.md` / `design.md` / `tasks.md` / `review-notes.md` は書き換えない**（NFR 1.1）
+  - **`docs/specs/216--app-store-4-8/` / `docs/specs/230-fix-passkey-credential/` 配下のいかなるファイルも書き換えない**（NFR 1.3）
+  - _Requirements: 2.1, 2.3, 2.4, 2.5, 4.2, 4.3, 4.4, 4.6, 4.7, NFR 1.1, NFR 1.2, NFR 1.3_
   - _Boundary: docs/specs/223-feat-web-web/impl-notes, docs/specs/223-feat-web-web/context-map_
 
 ## Verify
 
 本 spec の実装反映後、watcher（stage-a-verify gate）が独立に再実行して build / test / lint を
 検証する。サーバ側は `go test ./...` + `go vet ./...`、Web 側は `npm test` + `npm run lint` +
-`npm run build`。加えて `docker-compose.yml` の env 追加は **Go の config テストでは検証されない**
+`npm run build`。加えて `docker-compose.yml` の CORS 既定変更は **Go の config テストでは検証されない**
 ため、代表 env 値を与えた `docker compose config`（YAML + env 置換の妥当性検証）を Verify に含める。
+
+`docker compose config` は `SESSION_SECRET` / `POSTGRES_PASSWORD` を必須（`:?...required`）とするため、
+両者に代表値を与える。`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` も既定を持たず空だと警告になるため
+代表値を与える（いずれもダミー値で config 検証のみ / 秘密値ではない）。
 
 <!-- stage-a-verify -->
 ```sh
 go test ./... && go vet ./... && \
-CORS_ALLOWED_ORIGIN=https://example.com NATIVE_AUTH_JWT_SECRET=dummy-secret WEBAUTHN_RP_ID=example.com WEBAUTHN_ORIGINS=https://example.com docker compose config >/dev/null && \
+SESSION_SECRET=dummy-session-secret POSTGRES_PASSWORD=dummy-postgres-pass \
+GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy \
+CORS_ALLOWED_ORIGIN=https://example.com NATIVE_AUTH_JWT_SECRET=dummy-secret \
+WEBAUTHN_RP_ID=example.com WEBAUTHN_ORIGINS=https://example.com \
+docker compose config >/dev/null && \
 ( cd web && npm test && npm run lint && npm run build )
 ```

--- a/docs/specs/231-design-web-auth/tasks.md
+++ b/docs/specs/231-design-web-auth/tasks.md
@@ -26,11 +26,12 @@ PR #229 が本差分を needs-iteration で取り込む**。
     `CreateExec(ctx, q DBTX, s *model.Session) error` を **新規追加**し、既存 `Create` を
     `CreateExec(ctx, r.db, s)` への委譲に変更する（差分等価 / 既存 `DeleteByUserIDExec` の DBTX 変種
     パターンに準拠）。**#230 由来の `CreateUserOnlyExec` / credential `CreateExec` / `tx.go` は変更しない**
-  - `internal/auth/service.go` の `generateSessionID` を参照可能にする export helper
-    `NewSessionID() (string, error)` を同ファイルに追加する（既存 `createSession` の挙動は差分等価）
   - `internal/auth/session_factory.go` を **新規追加**し、`SessionFactory`（`NewSession(userID) (*model.Session, error)`
     が ID + 単一 `now` + `CreatedAt=now` + `ExpiresAt=now+TTL` を一貫生成）と、RegistrationService が受ける
-    最小 IF `SessionFactoryFunc` を定義する。`now` はテスト差し替え可（既定 `time.Now`）
+    最小 IF `SessionFactoryFunc` を定義する。`now`（既定 `time.Now`）と **`newID func() (string, error)`（既定 =
+    同一 package の unexported `generateSessionID`）** をいずれもテスト差し替え可能な seam として持たせる。
+    **`internal/auth/service.go` は変更しない**（`generateSessionID` は unexported のまま同一 package から参照する。
+    薄い public `NewSessionID` は追加しない / Blocker #2）
   - `internal/auth/session_exchange.go` の session 構築を `SessionFactory.NewSession` 呼び出しに差し替える
     （`SessionExchangeService` の外部契約・挙動は不変 / 差分等価）
   - `internal/handler/session_cookie.go` を **新規追加**し、canonical builder
@@ -38,20 +39,24 @@ PR #229 が本差分を needs-iteration で取り込む**。
     既存 `auth_handler.go::Callback` / `native_auth_handler.go::Session` のインライン Cookie 生成を
     本 builder 呼び出しに差し替える（属性は現行と完全一致・差分等価）
   - `internal/config/config.go` に `WebPasskeyAllowedOrigin string` を **新規追加**する
-    （`os.Getenv("CORS_ALLOWED_ORIGIN")` の生値。空/未設定 → `""`。localhost へ default しない）。
+    （`os.Getenv("CORS_ALLOWED_ORIGIN")` を **trim + strict exact-Origin validation** に通した値。
+    trim 後空 / scheme・host を欠く / path・query・fragment・userinfo 付き / 末尾スラッシュ / 空白・カンマで
+    複数 origin を含む、のいずれかは **`""` に倒す**（fail-closed）。localhost へ default しない / Blocker #6）。
     既存 `CORSAllowedOrigin`（CORS 層。既定 `http://localhost:3000`）は **変更しない**。新規 env は追加しない
   - テスト:
     - `internal/handler/session_cookie_test.go`（新規）: `buildSessionCookie` の属性
       （Name / HttpOnly / SameSite=Lax / Secure / Path / Domain / Max-Age）が Google OAuth Callback と一致
     - `internal/auth/session_factory_test.go`（新規）: `NewSession` が ID / `CreatedAt` / `ExpiresAt=CreatedAt+TTL`
-      を単一 now で返し、ID 生成失敗時に error（部分構築なし）
+      を単一 `now` で返し、**`newID` seam に失敗関数を注入**して ID 生成失敗時に error（部分構築なし）を検証する
+      （`crypto/rand.Reader` の global 差替えをしない / Blocker #2）
     - `internal/auth/session_exchange_test.go`（既存編集）: factory 差し替え後も既存アサーションが pass し、
       `CreatedAt` / `ExpiresAt` 検証を追加
-    - `internal/config/config_test.go`（既存編集）: `CORS_ALLOWED_ORIGIN` set → `WebPasskeyAllowedOrigin=値` /
-      unset・empty → `""`、`CORSAllowedOrigin` は既定 localhost:3000 を維持
+    - `internal/config/config_test.go`（既存編集）: `CORS_ALLOWED_ORIGIN` valid set → `WebPasskeyAllowedOrigin=正規化値` /
+      unset・empty・**malformed（前後空白 / 末尾スラッシュ / path・query・fragment 付き / 複数 origin）→ `""`**（fail-closed / Blocker #6）、
+      `CORSAllowedOrigin` は既定 localhost:3000 を維持
     - session repo `CreateExec` の委譲は既存 `Create` テストの差分等価で担保
   - _Requirements: 1.3, 3.6, 4.5, 6.5, NFR 2.1, NFR 3.1_
-  - _Boundary: repository/postgres_session_repo, auth/session_factory, auth/session_exchange, auth/service, handler/session_cookie, config/config_
+  - _Boundary: repository/postgres_session_repo, auth/session_factory, auth/session_exchange, handler/session_cookie, handler/auth_handler, handler/native_auth_handler, config/config_
 
 - [ ] 2. サーバ: `RegistrationService.FinishRegistrationNew` を既存 #230 tx クロージャ内の session INSERT に拡張し、wiring を更新する
   - `internal/passkey/registration_service.go`:
@@ -136,54 +141,71 @@ PR #229 が本差分を needs-iteration で取り込む**。
   - _Depends: 1_
 
 - [ ] 5. Web: `api.ts` に 2xx parse 失敗の型付き正規化を追加し、`use-passkey-registration.ts` から二度目 ceremony を除去して `registration_uncertain` を分類する
-  - `web/src/lib/api.ts`: `ResponseParseError`（`status: number`）を追加し、`request<T>` 末尾の
-    `response.json()` を try/catch で包んで 2xx の parse 失敗を `ResponseParseError` に正規化する
-    （204/205 分岐・`credentials: "include"` は不変 / 差分等価）。これにより dispatch 前の plain `TypeError` と
-    「fetch 成功後の 2xx body parse 失敗」を呼出側が区別できる
+  - `web/src/lib/api.ts`: `ResponseParseError`（`status: number`）と `RequestPreparationError` を追加する。
+    `request<T>` の **request preparation（`JSON.stringify` / URL 構築）を try/catch で囲んで `RequestPreparationError`**
+    に、**末尾 `response.json()` を try/catch で囲んで 2xx parse 失敗を `ResponseParseError`** に正規化する
+    （204/205 分岐・`credentials: "include"` は不変 / 差分等価。`fetch()` reject の plain `TypeError` はそのまま透過）。
+    これにより「dispatch 前の preparation 失敗（commit 不成立確定）/ fetch reject（dispatch 後・不確定）/ 2xx parse
+    失敗（不確定）」の 3 起点を呼出側が **plain TypeError の発生位置を推測せず** 区別できる（Blocker #1）
   - `web/src/lib/api.test.ts`: 2xx body 欠損/途中切断/parse 不能 → `ResponseParseError`（status 2xx）、
-    dispatch 前 serialize 失敗 → plain `TypeError` で両者が区別できることを検証する
+    dispatch 前の preparation 失敗（`JSON.stringify` 循環参照 / URL 構築失敗）→ `RequestPreparationError`、
+    `fetch()` reject → plain `TypeError` の **3 起点が機械的に区別できる**ことを検証する（Blocker #1）
   - `web/src/types/passkey.ts`: `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加する。
+    さらに authentication error 種別に **finish の一律 `AUTHENTICATION_FAILED` のみを表す machine-readable kind**
+    （例: `authentication_failed`）を追加する（Blocker #3。raw body / 内部理由は保持しない）。
     `RegistrationFinishResponse` は `{user_id}` のまま **auth_code を追加しない**
   - `web/src/hooks/use-passkey-registration.ts`:
     - `mutationFn` chain を「begin → create → finish → invalidateQueries」に短縮し、
       `authentication/begin` / `navigator.credentials.get` / `authentication/finish` / 登録用
       `POST /api/auth/session` を **完全に削除**する（Req 1.1 / 1.2）。`code_challenge` は #216 契約維持のため
       送るが `code_verifier` は使用しない。registration 経路は `session_exchange_failed` を発生させない
-    - finish 段の error を分類する: `ResponseParseError`（2xx body 不能）/ `AbortError` / 5xx /
-      送出後 `TypeError`（fetch reject）→ `registration_uncertain`。**全 4xx（400/401/403/404/409/422 等）→
-      `server_rejected`（拒否確定。400 だけに限定しない）**。dispatch 前ローカル失敗 → `server_error`
-      （design §Delta 5 §安全側 fail 原則）
+    - finish 段の error を分類する（`RequestPreparationError` を最優先で判定）: `RequestPreparationError`
+      （dispatch 前 = commit 不成立確定）→ `server_error`。`ResponseParseError`（2xx body 不能）/ `AbortError` / 5xx /
+      **`fetch()` reject の plain `TypeError`（dispatch 後）** → `registration_uncertain`。**全 4xx（400/401/403/404/409/422 等）→
+      `server_rejected`（拒否確定。400 だけに限定しない）**（design §Delta 5 §安全側 fail 原則 / Blocker #1）
     - `code_verifier` / attestation 生値を `console.*` / storage / URL に書かない（NFR 2.1）
   - `web/src/hooks/use-passkey-registration.test.tsx`:
     - 正常系: begin → create → finish の 3 呼び出しのみで `authentication/*` / 登録用 `/api/auth/session` が
       呼ばれない（二度目 ceremony 除去の回帰）
     - `registration_uncertain` × fetch reject / 5xx / AbortError / `ResponseParseError`(2xx) の 4 サブケース
     - 回帰: 全 4xx（400/401/403/404/409/422）が `server_rejected` で uncertain に誤分類されない
-    - dispatch 前 `TypeError` が `server_error`（非-uncertain）に分類される
+    - dispatch 前の `RequestPreparationError` が `server_error`（非-uncertain）に分類され、fetch reject の
+      plain `TypeError`（uncertain）と取り違えられない（Blocker #1）
     - begin 段の `invalid_username` / `username_taken` / `cancelled` は既存挙動維持
   - _Requirements: 1.1, 1.2, 1.4, 1.5, 5.1, 5.5, NFR 2.1, NFR 3.1_
   - _Boundary: lib/api, hooks/use-passkey-registration, types/passkey_
   - _Depends: 3_
 
-- [ ] 6. Web: `passkey-signup-dialog.tsx` に完了不明状態 UI と discoverable ログイン復旧導線（段階提示）を追加する
+- [ ] 6. Web: discoverable ログイン結果を machine-readable kind に正規化し、`passkey-signup-dialog.tsx` に完了不明状態 UI と段階提示の復旧導線を追加する
+  - `web/src/hooks/use-passkey-authentication.ts`（既存編集 / Blocker #3）:
+    - discoverable ログインの **finish 一律 `AUTHENTICATION_FAILED` のみを表す machine-readable kind**
+      （例: `authentication_failed`）を付与する。判定は response の status / code のみで行い、
+      **raw body / 内部理由（credential 未解決 等）を error に含めない**（NFR 2.1）
+    - begin 拒否 / cancel（`NotAllowedError`）/ network（fetch reject）/ 5xx / session 交換段
+      （`/api/auth/session`）失敗は **`authentication_failed` 以外の別 kind** に保つ（再作成条件に該当させない）
+  - `web/src/hooks/use-passkey-authentication.test.tsx`（既存編集 / Blocker #3）:
+    - finish 一律 `AUTHENTICATION_FAILED` → `authentication_failed` kind
+    - begin 拒否 / cancel / network / 5xx / session 交換失敗が別 kind になる negative test
+    - error に内部理由 / raw body が含まれない（NFR 2.1）
   - `web/src/components/passkey-signup-dialog.tsx`:
     - `error.kind === "registration_uncertain"` 分岐を追加する。初期表示は見出し「登録が完了したかどうかを
       確認できませんでした」+ 「ログインで確認する」ボタンのみとし、**「再度作成する」を同列に並置しない**（Req 5.2）
     - 「ログインで確認する」押下で `usePasskeyAuthentication` の **discoverable ログイン**
       （ユーザー名入力なし）を起動する（Req 5.2）。成功時は通常の Cookie セッションに到達（Req 5.3）
-    - discoverable ログインが一律 `AUTHENTICATION_FAILED`（内部理由を区別しない）で失敗した **後にのみ**
-      「再度作成する」を提示し、押下で `mutation.reset()` で Idle に戻す（Req 5.4）
+    - discoverable ログインの結果 error kind が `authentication_failed`（finish 一律失敗 / §auth hook）の **後にのみ**
+      「再度作成する」を提示し、押下で `mutation.reset()` で Idle に戻す（Req 5.4）。他 kind では提示しない
     - 文言にサーバ内部詳細（スタックトレース / SQL / DB 名 / session ID 生値）を含めない（Req 5.5 / NFR 2.1）
   - `web/src/components/passkey-signup-dialog.test.tsx`:
     - `registration_uncertain` で専用見出しが表示され、初期に「再度作成する」が表示されない（Req 5.2）
     - 「ログインで確認する」押下で discoverable ログインが起動
     - discoverable ログイン一律失敗の後に「再度作成する」が表示され `mutation.reset()` が呼ばれる（Req 5.4）
-    - login の cancel / network / 5xx では初期画面に「再度作成する」が出ない（一律 AUTHENTICATION_FAILED の後のみ）
+    - 復旧ログインの kind が `authentication_failed` のときのみ「再度作成する」が出る。begin 拒否 / cancel /
+      network / 5xx / session 交換失敗では初期画面にも失敗後にも出ない（一律 `AUTHENTICATION_FAILED` の後のみ / Blocker #3）
     - 文言中にサーバ内部詳細 / 他 kind の代表文言が含まれない（Req 5.5 / 5.6）
   - `web/src/components/login-page-recovery.test.tsx`: `registration_uncertain` →「ログインで確認する」→
     discoverable ログイン成功 → 2 ペイン UI 到達（Req 5.3。unit で組めない場合は E2E 委譲を PR 本文に明記）
   - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, NFR 2.1_
-  - _Boundary: components/passkey-signup-dialog, components/login-page-recovery_
+  - _Boundary: hooks/use-passkey-authentication, components/passkey-signup-dialog, components/login-page-recovery_
   - _Depends: 5_
 
 - [ ] 7. Config: `.env.sample` に CORS_ALLOWED_ORIGIN の fail-closed 接続を明記し、`docker-compose.yml` の `api` CORS 既定を空へ変更する（新規 env なし）
@@ -215,20 +237,32 @@ PR #229 が本差分を needs-iteration で取り込む**。
 
 本 spec の実装反映後、watcher（stage-a-verify gate）が独立に再実行して build / test / lint を
 検証する。サーバ側は `go test ./...` + `go vet ./...`、Web 側は `npm test` + `npm run lint` +
-`npm run build`。加えて `docker-compose.yml` の CORS 既定変更は **Go の config テストでは検証されない**
-ため、代表 env 値を与えた `docker compose config`（YAML + env 置換の妥当性検証）を Verify に含める。
+`npm run build`。加えて `docker-compose.yml` の CORS 既定変更（`${CORS_ALLOWED_ORIGIN:-}` の
+default-empty 経路）は **Go の config テストでは検証されない**ため、代表 env 値を与えた
+`docker compose config` を **`CORS_ALLOWED_ORIGIN` set / unset の 2 通り**で実行し、api サービスへ
+展開された値（set=明示 origin / unset=空）を **exit 0 だけでなく実値で assertion** する（Blocker #7）。
 
 `docker compose config` は `SESSION_SECRET` / `POSTGRES_PASSWORD` を必須（`:?...required`）とするため、
 両者に代表値を与える。`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` も既定を持たず空だと警告になるため
-代表値を与える（いずれもダミー値で config 検証のみ / 秘密値ではない）。
+代表値を与える（いずれもダミー値で config 検証のみ / 秘密値ではない）。set ケースは
+`CORS_ALLOWED_ORIGIN=https://example.com` を与えて api の展開値が明示 origin であること、unset ケースは
+`CORS_ALLOWED_ORIGIN` を **unset** して `${CORS_ALLOWED_ORIGIN:-}` の default-empty を通り api の展開値が
+空になることを検証する（従来の明示設定のみの Verify では default-empty 経路を一度も通らなかった / Blocker #7）。
 
 <!-- stage-a-verify -->
 ```sh
-go test ./... && go vet ./... && \
-SESSION_SECRET=dummy-session-secret POSTGRES_PASSWORD=dummy-postgres-pass \
-GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy \
-CORS_ALLOWED_ORIGIN=https://example.com NATIVE_AUTH_JWT_SECRET=dummy-secret \
-WEBAUTHN_RP_ID=example.com WEBAUTHN_ORIGINS=https://example.com \
-docker compose config >/dev/null && \
-( cd web && npm test && npm run lint && npm run build )
+set -eu
+go test ./...
+go vet ./...
+COMMON="SESSION_SECRET=dummy-session-secret POSTGRES_PASSWORD=dummy-postgres-pass GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy NATIVE_AUTH_JWT_SECRET=dummy-secret WEBAUTHN_RP_ID=example.com WEBAUTHN_ORIGINS=https://example.com"
+# set: 明示 origin が api の CORS_ALLOWED_ORIGIN へ展開される（実値 assertion）
+set_cfg=$(env $COMMON CORS_ALLOWED_ORIGIN=https://example.com docker compose config)
+printf '%s\n' "$set_cfg" | grep -E '^[[:space:]]*CORS_ALLOWED_ORIGIN:[[:space:]]*"?https://example\.com"?[[:space:]]*$'
+# unset: ${CORS_ALLOWED_ORIGIN:-} の default-empty を通り api の値が空へ展開される（実値 assertion）
+unset_cfg=$(env -u CORS_ALLOWED_ORIGIN $COMMON docker compose config)
+printf '%s\n' "$unset_cfg" | grep -E '^[[:space:]]*CORS_ALLOWED_ORIGIN:[[:space:]]*("")?[[:space:]]*$'
+cd web
+npm test
+npm run lint
+npm run build
 ```

--- a/docs/specs/231-design-web-auth/tasks.md
+++ b/docs/specs/231-design-web-auth/tasks.md
@@ -1,227 +1,203 @@
 # Implementation Plan
 
 本タスクリストは **PR #229 の `needs-iteration` 1 回**で反映する差分作業を、独立コミット
-可能な粒度で列挙する。**#223 spec（`docs/specs/223-feat-web-web/requirements.md` /
-`design.md` / `tasks.md`）および #216 spec の物理ファイルを書き換えるタスクは含まない**
-（NFR 1.1 / 1.3）。反映対象は `internal/**` / `web/src/**` の製品コードとテスト、運用 config
-（`.env.sample` / `docker-compose.yml`）、および #223 spec の補助（`impl-notes.md` /
-`context-map.md`）に限定する。
+可能な粒度で列挙する。中核決定 1.A（`registration/finish` の同一 DB トランザクションで
+user・credential・session の 3 行を作成し、commit 後に `Set-Cookie` する **直接 Cookie
+session**）に基づく。**登録用 auth_code / 二度目 ceremony / 登録専用 session 交換は導入しない**。
 
-各タスクは実装 + 対応テストを同一 commit で完結させる（per-task ループ運用の入力契約 /
-`_Requirements_partial:_` は本ドラフトで宣言なし）。
+**#223 spec（`docs/specs/223-feat-web-web/requirements.md` / `design.md` / `tasks.md`）および
+#216 spec の物理ファイルを書き換えるタスクは含まない**（NFR 1.1 / 1.3）。反映対象は
+`internal/**` / `web/src/**` の製品コードとテスト、運用 config（`.env.sample` /
+`docker-compose.yml`）、#223 spec の補助（`impl-notes.md` / `context-map.md`）に限定する。
 
-- [ ] 1. サーバ: `RegistrationService` に `registrationSession` 封筒を導入し、`FinishRegistrationNew` が auth_code を additive に返す構成に変更する（Delta 1 サーバ側）
-  - `internal/passkey/registration_service.go` に `registrationSession` 構造体
-    （`{WebAuthnSession json.RawMessage, CodeChallenge string}`）を追加する。既存
-    `internal/passkey/authentication_service.go` L57-66 の `authnSession` と同型で作る
-  - `BeginRegistrationNew`: 既存の PKCE 早期検証を維持したまま、検証済み `codeChallenge` を
-    `registrationSession` に格納し `json.Marshal` で bytes 化した後、既存
-    `challenges.Issue(sessionData=envelopeBytes, ...)` に渡す
-  - `FinishRegistrationNew` の **シグネチャを変更**:
-    `(ctx, challengeID, requestBody) (string, error)` →
-    `(ctx, challengeID, requestBody) (userID string, authCodePlain string, err error)`
-  - `FinishRegistrationNew` 内部:
-    - `challenges.Consume` の戻り値 `SessionData` を `registrationSession` として
-      `json.Unmarshal` し、`envelope.WebAuthnSession` を既存 `adapter.FinishRegistration` に
-      渡す（既存 attestation 検証ロジックは変更なし）
-    - envelope 破損 / `envelope.CodeChallenge == ""` は `ErrRegistrationFailed` に uniform 化
-      （既存 authentication_service.go L230-241 と同方針）
-    - 既存の user 作成 / credential 保存フローを維持
-    - 末尾に auth_code 発行を追加: `plain, _ := auth.GenerateAuthCode()` →
-      `codeHash := auth.HashNativeSecret(plain)` →
-      `AuthCode{ID: uuid.New().String(), CodeHash: codeHash, UserID: newUser.ID,
-      PKCEChallenge: envelope.CodeChallenge, ExpiresAt: s.now().Add(auth.NativeAuthCodeTTL)}` →
-      `s.authCodes.Create(ctx, authCode)`（既存 `authentication_service.go` L320-334 と同経路）
-    - `slog.Info` に `user_id` と `auth_code_hash[:8]` のみを載せ、平文 auth_code / code_verifier /
-      code_challenge をログ・エラーメッセージに一切出さない（NFR 2.1 / 既存
-      authentication_service.go L338-341 と同方針）
-  - `RegistrationService` 構造体に `authCodes auth.AuthCodeCreator` フィールドを追加、
-    `NewRegistrationService` のシグネチャに `authCodes auth.AuthCodeCreator` を追加
-    （既存 `AuthenticationService` と同じ具体依存）
-  - `internal/passkey/registration_service_test.go` を変更:
-    - 既存テストを新シグネチャに追従（すべての `FinishRegistrationNew` 呼び出し箇所で
-      3 戻り値受け取りに変更）
-    - 新規テスト（正常系）: begin で渡した `codeChallenge` が finish の envelope 復元後に
-      `authCodes.Create` に渡された `AuthCode.PKCEChallenge` と一致すること（stub で AuthCode を
-      キャプチャして verify）
-    - 新規テスト（正常系）: `authCodePlain` 戻り値が非空・base64url 形式（`auth.GenerateAuthCode`
-      の返り値形式に整合）
-    - 新規テスト（異常系）: `challenges.Consume` が返す SessionData を破損させて
-      `json.Unmarshal` を失敗させる → `ErrRegistrationFailed`
-    - 新規テスト（異常系）: envelope の `CodeChallenge` を空文字にする → `ErrRegistrationFailed`
-    - 新規テスト（異常系）: `authCodes.Create` stub が infra error を返す → wrap されて伝播
-  - `internal/app/app.go` を変更: `passkey.NewRegistrationService(...)` の呼び出しに
-    `authCodes`（既存 `repository.NewPostgresAuthCodeRepo(...)` の返り値、既に
-    `AuthenticationService` に注入されている同じインスタンス）を追加する
+各タスクは実装 + 対応テストを同一 commit で完結させる（`_Requirements_partial:_` は本ドラフトで
+宣言なし = 全 AC が同一タスク内テスト必須）。
+
+- [ ] 1. サーバ基盤: トランザクション実行ヘルパー・各 repo の DBTX 変種 Create・共有 Cookie builder・session ID 生成器の共有化を追加する
+  - `internal/repository/tx.go` に closure 実行ヘルパー
+    `func (b *SQLTxBeginner) WithinTx(ctx context.Context, fn func(q DBTX) error) error` を追加する
+    （`BeginTx` → `fn(tx.Querier())` → 正常時 `Commit` / エラー・panic 時 `Rollback`）。既存
+    `SQLTx` / `BeginTx` / `Querier` / `Commit` / `Rollback` は変更しない
+  - `internal/repository/postgres_session_repo.go` に
+    `CreateExec(ctx, q DBTX, s *model.Session) error` を追加し、既存 `Create` を
+    `CreateExec(ctx, r.db, s)` への委譲に変更する（差分等価 / 既存 `DeleteByUserIDExec` の DBTX 変種
+    パターンに準拠）
+  - `internal/repository/postgres_user_repo.go` に
+    `CreateUserOnlyExec(ctx, q DBTX, u *model.User) error` を追加し、既存 `CreateUserOnly` を委譲に
+    変更する（`ErrUsernameTaken` 正規化を変えない）
+  - `internal/repository/postgres_passkey_credential_repo.go` に
+    `CreateExec(ctx, q DBTX, c *model.PasskeyCredential) error` を追加し、既存 `Create` を委譲に
+    変更する（`ErrCredentialAlreadyRegistered` 正規化を変えない）
+  - `internal/handler/session_cookie.go` を新規追加し、canonical builder
+    `buildSessionCookie(name, value, domain string, secure bool, maxAge int) *http.Cookie` を定義する。
+    既存 `auth_handler.go::Callback` / `native_auth_handler.go::Session` のインライン Cookie 生成を
+    本 builder 呼び出しに差し替える（属性は現行と完全一致・差分等価）
+  - `internal/auth/session_exchange.go` の session ID 生成器を `auth.GenerateSessionID` として export
+    （または既存 export を確認）し、`SessionExchangeService` と後続の RegistrationService が同一生成器を
+    共有できるようにする（`SessionExchangeService` の外部契約は不変）
+  - テスト: `internal/handler/session_cookie_test.go` を新規追加し、`buildSessionCookie` の属性
+    （Name / HttpOnly / SameSite=Lax / Secure / Path / Domain / Max-Age）が Google OAuth Callback と
+    一致することを検証する。各 `*_Exec` 変種の委譲は既存 repo テストの差分等価（既存 `Create` /
+    `CreateUserOnly` テストが引き続き pass）で担保する
+  - _Requirements: 1.3, 4.5, NFR 2.1, NFR 3.1_
+  - _Boundary: repository/tx, repository/postgres_session_repo, repository/postgres_user_repo, repository/postgres_passkey_credential_repo, handler/session_cookie, auth/session_exchange_
+
+- [ ] 2. サーバ: `RegistrationService.FinishRegistrationNew` を単一 tx で user → credential →（Web mode のみ）session の 3 行作成に拡張し、wiring を更新する
+  - `internal/passkey/registration_service.go`:
+    - 最小 IF を追加/拡張: `SessionWriter{CreateExec}`、`UserWriter` に `CreateUserOnlyExec`、
+      `PasskeyCredentialWriter` に `CreateExec`、tx 実行 IF `txRunner{WithinTx}`
+    - 構造体に `sessions SessionWriter` / `tx txRunner` / `newSessionID func() (string, error)` /
+      `sessionTTL time.Duration` を追加する（**auth_code 関連依存は追加しない**）。
+      `NewRegistrationService` のシグネチャに追加し、`WebSessionReady() bool` を追加する
+    - `FinishRegistrationNew` のシグネチャを
+      `(ctx, challengeID, requestBody) (string, error)` →
+      `(ctx, challengeID, requestBody, issueWebSession bool) (userID string, webSession *model.Session, err error)`
+      に変更する。既存の challenge consume / `adapter.FinishRegistration`（attestation 検証）は変更しない
+    - user 作成 / credential 保存 / （`issueWebSession` 時の）session 生成・保存を **`tx.WithinTx` の
+      単一クロージャ内**で実行する。user UNIQUE 衝突 → `ErrRegistrationFailed`、credential 重複 →
+      `ErrRegistrationFailed`（既存正規化を維持）、session ID 生成失敗 / session INSERT 失敗 / commit 失敗は
+      全 ROLLBACK し `webSession=nil` で伝播する（3 行 atomic / design §Delta 1）
+    - session ID 生値・auth_code 平文をログ・エラー・レスポンスに残さない（NFR 2.1）
+  - `internal/app/app.go`: `passkey.NewRegistrationService(...)` に `sessionRepo`（SessionWriter）/
+    tx runner（`db` 由来の `SQLTxBeginner`）/ `auth.GenerateSessionID` / `sessionTTL`
+    （`time.Duration(cfg.SessionMaxAge) * time.Second`）を注入する。これらは
+    `NATIVE_AUTH_JWT_SECRET` に依存せず `WEBAUTHN_*` 設定時（passkey handler 生成時）に常時配線する
+  - `internal/passkey/registration_service_test.go`:
+    - 既存テストを新シグネチャ（4 引数 / 3 戻り値）に追従させる
+    - 正常系（Web mode）: `issueWebSession=true` で `WithinTx` 内の user → credential → session の呼び出し順を
+      fake で検証し、`webSession` に生成 ID と `now+sessionTTL` の期限が入る
+    - 正常系（iOS mode）: `issueWebSession=false` で session を作らず `webSession=nil`
+    - 異常系: user UNIQUE 衝突 → `ErrRegistrationFailed`（session 未作成）
+    - 異常系: credential 重複 → `ErrRegistrationFailed`（session 未作成）
+    - 異常系: session ID 生成失敗 / session INSERT 失敗 → 全 ROLLBACK・`webSession=nil`・エラー伝播
   - _Requirements: 1.1, 1.2, 1.3, 3.5, NFR 2.1, NFR 3.2_
   - _Boundary: passkey/RegistrationService, app.go wiring_
-
-- [ ] 2. サーバ: `PasskeyHandler.RegistrationFinish` レスポンスに auth_code を additive 追加し、router.go で capability endpoint 登録条件を両 handler 非 nil に強化する（Delta 1 handler + Delta 3 router）
-  - `internal/handler/passkey_handler.go` を変更:
-    - `RegistrationFinish` ハンドラのレスポンス型を additive に拡張:
-      `{user_id string, auth_code string}`（現行は `{user_id}` のみ）。**`user_id` フィールドは
-      名称・位置ともに維持し、`auth_code` を末尾に追加**（iOS #216 の JSON decoder が未知
-      フィールドを無視する慣行に依拠 / NFR 3.2）
-    - `RegistrationService.FinishRegistrationNew` の新シグネチャ（3 戻り値）に追従し、
-      2 番目返り値 `authCodePlain` をレスポンス body の `AuthCode` フィールドに設定
-    - 既存の error mapping（`ErrRegistrationFailed` → 400 REGISTRATION_FAILED / infra → 500）は
-      維持
-  - `internal/handler/router.go` を変更:
-    - Web 用 `GET /api/passkey/capability` の登録条件を
-      `if deps.PasskeyHandler != nil && deps.NativeAuthHandler != nil` に強化する
-      （現行は `PasskeyHandler != nil` のみ想定）
-    - iOS 用 `/api/passkey/registration/*` および `/api/passkey/authentication/*` の登録条件は
-      **`PasskeyHandler != nil` のみを維持し変更しない**（#216 契約破壊禁止 / NFR 3.2）
-    - `/api/auth/session`（NativeAuthHandler.Session）の登録条件は既存 `NativeAuthHandler !=
-      nil` を維持
-  - `internal/handler/passkey_handler_test.go` を変更:
-    - `TestPasskeyHandler_RegistrationFinish` の期待レスポンス body に `auth_code` を追加、
-      `user_id` フィールドが引き続き存在することを assert（iOS ignore-unknown 互換の回帰）
-    - auth_code フィールドが非空 base64url 形式（`^[A-Za-z0-9_-]+$`）であること
-    - サーバ側の `RegistrationService` は本テストでは stub 化し、`authCodePlain` を
-      特定値で返して handler がそのまま body に含めることを検証
-  - `internal/handler/router_test.go` を変更:
-    - Delta 3 §fail-closed 表の 4 環境行それぞれで route 登録有無を検証する table-driven テストを追加:
-      1. `PasskeyHandler != nil && NativeAuthHandler != nil` → session 204 / capability 200 /
-         iOS registration/*+authentication/* 200
-      2. `PasskeyHandler != nil && NativeAuthHandler == nil` → session 404 / **capability 404
-         （強化条件の回帰）** / iOS registration/*+authentication/* 200 **（iOS 継続稼働の回帰）**
-      3. `PasskeyHandler == nil && NativeAuthHandler != nil` → session 204 / capability 404 /
-         iOS registration/*+authentication/* 404
-      4. 両 nil → 全 404
-  - _Requirements: 1.1, 1.3, 3.1, 3.2, 3.3, 3.4, 3.5, NFR 3.2_
-  - _Boundary: handler/PasskeyHandler, handler/router_
   - _Depends: 1_
 
-- [ ] 3. Web: `use-passkey-registration.ts` から二度目 WebAuthn ceremony を除去し、finish 応答の auth_code を直接 session 交換に渡す構成に変更する。`registration_uncertain` kind を追加する（Delta 1 Web + Delta 5 Hook）
-  - `web/src/types/passkey.ts` の `RegistrationFinishResponse` 型に `auth_code: string`
-    フィールドを additive に追加（`user_id` は既存維持）
-  - `web/src/hooks/use-passkey-registration.ts` の `mutationFn` chain を書き換え:
-    - 現行 6 段（begin → create → finish → authentication/begin → get → authentication/finish
-      → session）から **4 段（begin → create → finish → session）** に短縮
-    - `POST /api/passkey/registration/finish` の応答 `RegistrationFinishResponse` から
-      `auth_code` を取り出し、直後の `POST /api/auth/session` request body の `auth_code` に
-      直接渡す（`code_verifier` は closure 変数で保持済み）
-    - `authentication/begin` / `navigator.credentials.get` / `authentication/finish` の
-      3 呼び出しを **完全に削除**（二度目 ceremony の除去 / Req 1.1）
-  - `PasskeyRegistrationErrorKind` 型に `"registration_uncertain"` を追加
-  - error 分類ロジックを step index ベースで整理し、finish 段階の失敗を以下 3 分岐に細分化
-    （Delta 5 §Hook 側の判定ロジックに準拠）:
-    - `ApiError` かつ `status >= 400 && status < 500` かつ `body.code === "REGISTRATION_FAILED"`
-      → `server_rejected`
-    - `ApiError` かつ `status >= 500` → **`registration_uncertain`**（サーバが commit したか
-      不確定）
-    - `TypeError`（fetch reject）→ **`registration_uncertain`**（送出済み・応答なし）
-    - `DOMException` かつ `name === "AbortError"` → **`registration_uncertain`**
-    - その他 → `server_error`
-  - begin 段階 / create 段階 / session 段階の error 分類は既存挙動を維持（`registration_uncertain`
-    にしない / Delta 5 §安全側 fail 原則）
-  - `code_verifier` / `auth_code` / attestation 生値を `console.*` / storage / URL に書かない
-    （NFR 2.1）
-  - `web/src/hooks/use-passkey-registration.test.ts` を変更:
-    - 正常系: `authentication/begin` / `authentication/finish` が呼ばれないことを assert
-      （二度目 ceremony 除去の回帰）
-    - 正常系: finish 応答 body の `auth_code` が session request body の `auth_code` として
-      渡ることを assert
-    - 新規: `registration_uncertain` × fetch reject（finish が `TypeError` を throw）
-    - 新規: `registration_uncertain` × 500（finish が 500 応答）
-    - 新規: `registration_uncertain` × AbortError（finish が AbortError を throw）
-    - 回帰: `server_rejected`（finish が 400 REGISTRATION_FAILED）が `registration_uncertain`
-      に誤分類されない
-    - 既存 kind の分岐テスト（`invalid_username` / `username_taken` / `cancelled` /
-      `session_exchange_failed`）は新 chain に合わせて updates
-  - _Requirements: 1.1, 1.2, 1.3, 1.4, 5.1, 5.5, NFR 2.1, NFR 3.1_
-  - _Boundary: hooks/use-passkey-registration, types/passkey_
+- [ ] 3. サーバ: `PasskeyHandler.RegistrationFinish` に Origin ベース Web/iOS mode 判定・Web mode の Set-Cookie を追加し、実 PostgreSQL で 3 行原子性を検証する
+  - `internal/handler/passkey_handler.go`:
+    - `PasskeyHandler` に `allowedOrigin string` と Cookie 設定（domain / secure / maxAge）を Option で
+      注入する（既存 `NativeAuthHandler` の `WithSession*` Option idiom を踏襲）。`webRegistrationReady()`
+      （`allowedOrigin != "" && Cookie 設定済み && regService.WebSessionReady()`）を追加する
+    - `RegistrationFinish` に mode 判定を追加する（challenge consume / mutation より前）:
+      - `Origin` 不在 → native/iOS mode（`issueWebSession=false`、既存挙動 / JSON Content-Type 追加検証なし）
+      - `Origin == allowedOrigin`（allowedOrigin 設定済）→ Web mode。JSON Content-Type 非一致は 415、
+        `!webRegistrationReady()` は fail-closed（500 相当）、いずれも mutation 前に返す
+      - `Origin` 非空不一致 or allowedOrigin 未設定 → 403 FORBIDDEN_ORIGIN（mutation なし）
+    - `FinishRegistrationNew(ctx, challengeID, credential, webMode)` を呼び、`webSession != nil` のとき
+      `buildSessionCookie(...)`（Task 1）で `Set-Cookie` する。レスポンスは Web / iOS とも 200 `{user_id}`（不変）
+  - `internal/handler/passkey_handler_test.go`:
+    - Origin 一致 → 200 `{user_id}` + `Set-Cookie session_id`（属性一致）
+    - Origin 不在（iOS）→ 200 `{user_id}`・`Set-Cookie` **なし**（#216 回帰）
+    - Origin 非空不一致 / allowedOrigin 未設定 → 403、regService stub が呼ばれない（mutation なし）
+    - Web mode で Content-Type 非 JSON → 415、mutation 呼ばれない
+  - `internal/handler/passkey_e2e_db_test.go`（実 PostgreSQL）:
+    - Web mode finish 成功で users / passkey_credentials / sessions に **3 行がすべて存在**
+    - session INSERT を失敗させた場合（重複 session ID 注入等）に users / passkey_credentials にも
+      **行が残らない（3 行 atomic rollback / orphan なし）**
+    - iOS mode finish 成功で users / passkey_credentials の 2 行のみ存在（sessions なし）
+  - _Requirements: 1.1, 1.3, 1.4, 3.5, 4.5, NFR 2.1, NFR 3.2_
+  - _Boundary: handler/PasskeyHandler, handler/passkey_e2e_db_test_
   - _Depends: 2_
 
-- [ ] 4. Web: `passkey-signup-dialog.tsx` に `registration_uncertain` の UI 分岐と復旧導線（「ログインで確認する」「再度作成する」の 2 ボタン）を追加する（Delta 5 UI）
-  - `web/src/components/passkey-signup-dialog.tsx` を変更:
-    - `error.kind === "registration_uncertain"` 分岐を追加（既存の `invalid_username` /
-      `username_taken` / `cancelled` / `server_rejected` / `session_exchange_failed` /
-      `server_error` / `network_error` 分岐と並列に追加）
-    - 表示メッセージは Delta 5 §UI 文言と復旧導線 の canonical 文言に準拠。特に「登録が完了
-      したかどうかを確認できませんでした」の見出しで、他 kind と識別可能にする（Req 5.6）
-    - 2 ボタンの実装:
-      - 「ログインで確認する」: `onOpenChange(false)` を呼び Dialog を閉じる（LoginPage 側の
-        `PasskeyButtons` からユーザーが再度パスキーログインを試みる導線に戻す / Req 5.2 / 5.3）
-      - 「再度作成する」: `mutation.reset()` を呼び Dialog を Idle 状態に戻す（同じ username で
-        再試行すると `username_taken` になることを Delta 5 §UI 文言 で案内済 / Req 5.4）
-    - メッセージ本文に `error.body` の内容・スタックトレース・SQL / DB 名などのサーバ内部詳細を
-      **含めない**（Req 5.5 / NFR 2.1）
-    - `console.*` の呼び出しは追加しない（NFR 2.1）
-  - `web/src/components/passkey-signup-dialog.test.tsx` を変更:
-    - 新規: `error.kind === "registration_uncertain"` で見出し「登録が完了したかどうかを
-      確認できませんでした」が表示される
-    - 新規: 「ログインで確認する」ボタン押下で `onOpenChange(false)` が呼ばれる
-    - 新規: 「再度作成する」ボタン押下で `mutation.reset()` が呼ばれる
-    - 新規: 文言中に既存 error kind の代表文言（「ユーザー名の形式が不正です」「このユーザー名は
-      既に使用されています」「認証に失敗しました」等）が含まれない（Req 5.6 の弁別性回帰）
-    - 新規: 文言中にサーバ内部詳細を想起させる文字列（`Error:`, `Stack:`, `SQL`, スタック
-      トレース由来のプレフィックス）が含まれない（Req 5.5 の回帰）
-  - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, NFR 2.1_
-  - _Boundary: components/passkey-signup-dialog_
+- [ ] 4. サーバ: `NativeAuthHandler.Session` の Origin 検証を fail-closed へ補正し、router の fail-closed 表 5 列を実装・検証する
+  - `internal/handler/native_auth_handler.go`: `Session` の Origin 検証を
+    「`allowedOrigin == ""` → 403 / `Origin` 不在 → 403 / `Origin != allowedOrigin` → 403 /
+    `Origin == allowedOrigin` のみ通過」に補正する（design §Delta 4）。Content-Type application/json 必須は
+    既存維持
+  - `internal/handler/router.go`: capability route 条件に `deps.CORSAllowedOrigin != ""` を **追加** する
+    （`NativeAuthHandler.SessionReady()` は **維持し弱めない**）。`/api/auth/session` 条件は
+    `NativeAuthHandler != nil && SessionReady()` を維持。iOS 用 `/api/passkey/registration/*` /
+    `/api/passkey/authentication/*`（および Web と共有する `registration/finish`）は `PasskeyHandler != nil` を
+    維持（#216 契約 / NFR 3.2）
+  - `internal/handler/native_auth_handler_test.go`: Origin 不在・不一致・allowedOrigin 未設定で 403 の異常系を追加
+  - `internal/handler/router_test.go`: fail-closed 表 行 1〜5 の各 endpoint（列 A capability / 列 B session /
+    列 C registration route / 列 D iOS registration/* / 列 E iOS authentication/*）の登録有無を table-driven で
+    検証する。特に行 2（W✓ N✗ C✓）で iOS registration/*・authentication/* が 200、capability が 404、
+    行 3（W✓ N✓ C✗）で capability 404 を assert する
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 4.1, NFR 3.2_
+  - _Boundary: handler/native_auth_handler, handler/router_
+  - _Depends: 1_
+
+- [ ] 5. Web: `use-passkey-registration.ts` から二度目 WebAuthn ceremony と登録用 session 交換を除去し、`registration_uncertain` を追加する
+  - `web/src/types/passkey.ts`: `PasskeyRegistrationErrorKind` に `"registration_uncertain"` を追加する。
+    `RegistrationFinishResponse` は `{user_id}` のまま **auth_code を追加しない**
+  - `web/src/hooks/use-passkey-registration.ts`:
+    - `mutationFn` chain を「begin → create → finish（2xx + Set-Cookie）→ invalidateQueries」に短縮し、
+      `authentication/begin` / `navigator.credentials.get` / `authentication/finish` / 登録用
+      `POST /api/auth/session` を **完全に削除**する（Req 1.1 / 1.2）。`code_challenge` は #216 契約維持のため
+      送るが `code_verifier` は使用しない
+    - finish 段の error を分類する: `TypeError`（fetch reject）/ `AbortError` / 5xx / 2xx で body parse 不能 →
+      `registration_uncertain`。400 REGISTRATION_FAILED → `server_rejected`。送出前ローカル失敗 → `server_error`
+      （design §Delta 5 §安全側 fail 原則）。registration 経路は `session_exchange_failed` を発生させない
+    - `code_verifier` / attestation 生値を `console.*` / storage / URL に書かない（NFR 2.1）
+  - `web/src/hooks/use-passkey-registration.test.ts`:
+    - 正常系: begin → create → finish の 3 呼び出しのみで `authentication/*` / 登録用 `/api/auth/session` が
+      呼ばれない（二度目 ceremony 除去の回帰）
+    - `registration_uncertain` × fetch reject / 5xx / AbortError / 2xx body parse 不能 の 4 サブケース
+    - 回帰: `server_rejected`（400 REGISTRATION_FAILED）が uncertain に誤分類されない
+    - begin 段の `invalid_username` / `username_taken` / `cancelled` は既存挙動維持
+  - _Requirements: 1.1, 1.2, 1.4, 1.5, 5.1, 5.5, NFR 2.1, NFR 3.1_
+  - _Boundary: hooks/use-passkey-registration, types/passkey_
   - _Depends: 3_
 
-- [ ] 5. Config: `.env.sample` と `docker-compose.yml` に既存 WebAuthn env 群（新規 env なし）の documentation と passthrough を追加する（Delta 6 / Requirement 6）
-  - `.env.sample` を変更: Native Auth 節（現行 L119-130 付近）の後に、Delta 6 §反映内容 §.env.sample の
-    canonical コメントブロックを追加する。5 変数を **すべてコメントアウト行**として documentation
-    のみ記載し、デフォルト値の代入は行わない:
-    - `# WEBAUTHN_RP_ID=`
-    - `# WEBAUTHN_RP_DISPLAY_NAME=Feedman`
-    - `# WEBAUTHN_ORIGINS=`
-    - `# WEBAUTHN_IOS_APP_ID=`
-    - `# PASSKEY_CHALLENGE_TTL_SECONDS=300`
-  - 各コメントに fail-closed 挙動と例値・意味を明記（Delta 6 §反映内容 §.env.sample のサンプルを
-    参照）。RP_ID / ORIGINS / IOS_APP_ID の例値は運用者が誤ってコピペしないよう「例:」プレフィクスを
-    必ず付ける
-  - `docker-compose.yml` の `api` サービス `environment` セクションに以下 5 行を追加する
-    （既存 `NATIVE_AUTH_JWT_SECRET=${NATIVE_AUTH_JWT_SECRET:-}` の直後を推奨位置とする）:
-    - `- WEBAUTHN_RP_ID=${WEBAUTHN_RP_ID:-}`
-    - `- WEBAUTHN_RP_DISPLAY_NAME=${WEBAUTHN_RP_DISPLAY_NAME:-Feedman}`
-    - `- WEBAUTHN_ORIGINS=${WEBAUTHN_ORIGINS:-}`
-    - `- WEBAUTHN_IOS_APP_ID=${WEBAUTHN_IOS_APP_ID:-}`
-    - `- PASSKEY_CHALLENGE_TTL_SECONDS=${PASSKEY_CHALLENGE_TTL_SECONDS:-300}`
-  - `worker` サービスの `environment` には **追加しない**（worker は passkey に依存しない）
-  - **新規 env は追加しない**。追加は既存 env（config.go / #216 で既に読み込み済み）の
-    documentation と container passthrough に限定する（Req 6.5）
-  - config 変更に対する動作回帰は既存の `internal/config/config_test.go` の
-    `TestLoad_Passkey`（L411 以降）で保証されており、本タスクでは `internal/config/*` を
-    追加変更しない（既存テストが env 読込を検証済み）
-  - 手動確認手順（tasks 完了時に PR 本文の「確認事項」で言及するのみ、自動テスト化は不要）:
-    - `.env.sample` をコピーして `WEBAUTHN_RP_ID` などを実値に設定し `docker compose up` した
-      とき、api コンテナ内で当該 env が期待どおり参照できることを README 記載の起動手順で確認
+- [ ] 6. Web: `passkey-signup-dialog.tsx` に完了不明状態 UI と discoverable ログイン復旧導線（段階提示）を追加する
+  - `web/src/components/passkey-signup-dialog.tsx`:
+    - `error.kind === "registration_uncertain"` 分岐を追加する。初期表示は見出し「登録が完了したかどうかを
+      確認できませんでした」+ 「ログインで確認する」ボタンのみとし、**「再度作成する」を同列に並置しない**（Req 5.2）
+    - 「ログインで確認する」押下で `usePasskeyAuthentication` の **discoverable ログイン**
+      （ユーザー名入力なし）を起動する（Req 5.2）。成功時は通常の Cookie セッションに到達（Req 5.3）
+    - discoverable ログインが一律 `AUTHENTICATION_FAILED`（内部理由を区別しない）で失敗した **後にのみ**
+      「再度作成する」を提示し、押下で `mutation.reset()` で Idle に戻す（Req 5.4）
+    - 文言にサーバ内部詳細（スタックトレース / SQL / DB 名 / session ID 生値）を含めない（Req 5.5 / NFR 2.1）
+  - `web/src/components/passkey-signup-dialog.test.tsx`:
+    - `registration_uncertain` で専用見出しが表示され、初期に「再度作成する」が表示されない（Req 5.2）
+    - 「ログインで確認する」押下で discoverable ログインが起動
+    - discoverable ログイン一律失敗の後に「再度作成する」が表示され `mutation.reset()` が呼ばれる（Req 5.4）
+    - 文言中にサーバ内部詳細 / 他 kind の代表文言が含まれない（Req 5.5 / 5.6）
+  - `web/src/components/login-page-recovery.test.tsx`: `registration_uncertain` →「ログインで確認する」→
+    discoverable ログイン成功 → 2 ペイン UI 到達（Req 5.3。unit で組めない場合は E2E 委譲を PR 本文に明記）
+  - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, NFR 2.1_
+  - _Boundary: components/passkey-signup-dialog, components/login-page-recovery_
+  - _Depends: 5_
+
+- [ ] 7. Config: `.env.sample` と `docker-compose.yml` に既存 WebAuthn env 群の documentation / passthrough と CORS_ALLOWED_ORIGIN の fail-closed 接続を追加する（新規 env なし）
+  - `.env.sample`: Native Auth / CORS 節の後に、design §Delta 6 §反映内容 の canonical コメントブロックを
+    追加する。5 変数（`WEBAUTHN_RP_ID` / `WEBAUTHN_RP_DISPLAY_NAME` / `WEBAUTHN_ORIGINS` /
+    `WEBAUTHN_IOS_APP_ID` / `PASSKEY_CHALLENGE_TTL_SECONDS`）をコメントアウト行で documentation し、
+    例値には「例:」プレフィクスを付ける。`CORS_ALLOWED_ORIGIN` 未設定時に capability=404 /
+    `/api/auth/session`・Web registration=403（fail-closed）になる旨をコメントで明記する
+  - `docker-compose.yml`: `api` サービスの `environment` に 5 変数の passthrough を
+    `${VAR:-<既定 or 空>}` 形式で追加する（`worker` には追加しない）。`CORS_ALLOWED_ORIGIN` は既存 passthrough を
+    維持（新規追加しない）
+  - **新規 env は追加しない**（config.go / #216 で既読み込み済みの既存 env の documentation / passthrough に限定 / Req 6.5）
+  - 既存 `internal/config/config_test.go` の env 読込テストは変更しない（本タスクは `internal/config/*` を触らない）
   - _Requirements: 2.2, 6.1, 6.2, 6.3, 6.4, 6.5, NFR 3.1_
   - _Boundary: .env.sample, docker-compose.yml_
 
-- [ ] 6. Docs: `docs/specs/223-feat-web-web/impl-notes.md` と `context-map.md` に #231 normative delta の適用結果を追記する（#223 spec の requirements.md / design.md / tasks.md は書き換えない）
-  - `docs/specs/223-feat-web-web/impl-notes.md` を変更:
-    - 冒頭または「確認事項」節に「#231 normative delta 適用後の実装状態」旨のセクションを追加
-    - Delta 1〜5 それぞれについて 1〜3 行で「本 PR で反映した内容」と「#231 design.md の
-      該当 Delta セクションへの参照」を記載
-    - `#223 design.md` §Flows「新規作成フロー（Sequence / 抜粋）」の該当箇所は **#231 design.md
-      Delta 1 で supersede** されている旨を明示する
-  - `docs/specs/223-feat-web-web/context-map.md` を変更:
-    - 新規作成フローの経路図から「二度目 WebAuthn ceremony」を削除し、finish → session の
-      直接遷移に更新
-    - fail-closed 表を #231 design.md Delta 3 §補正後の fail-closed 表 のリンクに置換または
-      supersede 注釈を追加
-    - 完了不明状態（`registration_uncertain`）の遷移を hook / component / UI 文言の各層に
-      追加
-  - **`docs/specs/223-feat-web-web/requirements.md` / `design.md` / `tasks.md` は書き換えない**
-    （NFR 1.1）
+- [ ] 8. Docs: `docs/specs/223-feat-web-web/impl-notes.md` と `context-map.md` に #231 delta の適用結果を追記する（#223 / #216 の本体 3 文書は不変）
+  - `impl-notes.md`: 「#231 normative delta 適用後の実装状態」節を追加し、Delta 1〜6 について「本 PR で反映した
+    内容」と「#231 design.md 該当 Delta への参照」を 1〜3 行で記載する。#223 design の「新規作成フロー
+    （Sequence）」が #231 Delta 1（直接 Cookie session）で supersede される旨を明示する
+  - `context-map.md`: 新規作成フロー経路図を「二度目 ceremony 除去 → `finish → 3 行 tx → commit →
+    Set-Cookie` の直接 session」に更新する。fail-closed 表を #231 Delta 3 の 5 列版で supersede し、
+    Delta 4 の CSRF 主防御・残余リスク（同一オリジン XSS / login CSRF）と完了不明状態（`registration_uncertain`）の
+    遷移を追加する
+  - **`docs/specs/223-feat-web-web/requirements.md` / `design.md` / `tasks.md` は書き換えない**（NFR 1.1）
   - **`docs/specs/216--app-store-4-8/` 配下のいかなるファイルも書き換えない**（NFR 1.3）
-  - _Requirements: 2.3, 2.4, 2.5, NFR 1.1, NFR 1.2, NFR 1.3_
+  - _Requirements: 2.1, 2.3, 2.4, 2.5, 4.2, 4.3, 4.4, 4.6, NFR 1.1, NFR 1.2, NFR 1.3_
   - _Boundary: docs/specs/223-feat-web-web/impl-notes, docs/specs/223-feat-web-web/context-map_
 
 ## Verify
 
 本 spec の実装反映後、watcher（stage-a-verify gate）が独立に再実行して build / test / lint を
 検証する。サーバ側は `go test ./...` + `go vet ./...`、Web 側は `npm test` + `npm run lint` +
-`npm run build`。config 変更（`.env.sample` / `docker-compose.yml`）の妥当性は既存
-`internal/config/config_test.go` の `TestLoad_Passkey` および docker-compose YAML の schema で
-担保される。
+`npm run build`。加えて `docker-compose.yml` の env 追加は **Go の config テストでは検証されない**
+ため、代表 env 値を与えた `docker compose config`（YAML + env 置換の妥当性検証）を Verify に含める。
 
 <!-- stage-a-verify -->
 ```sh
-go test ./... && go vet ./... && cd web && npm test && npm run lint && npm run build
+go test ./... && go vet ./... && \
+CORS_ALLOWED_ORIGIN=https://example.com NATIVE_AUTH_JWT_SECRET=dummy-secret WEBAUTHN_RP_ID=example.com WEBAUTHN_ORIGINS=https://example.com docker compose config >/dev/null && \
+( cd web && npm test && npm run lint && npm run build )
 ```

--- a/docs/specs/231-design-web-auth/tasks.md
+++ b/docs/specs/231-design-web-auth/tasks.md
@@ -1,0 +1,227 @@
+# Implementation Plan
+
+本タスクリストは **PR #229 の `needs-iteration` 1 回**で反映する差分作業を、独立コミット
+可能な粒度で列挙する。**#223 spec（`docs/specs/223-feat-web-web/requirements.md` /
+`design.md` / `tasks.md`）および #216 spec の物理ファイルを書き換えるタスクは含まない**
+（NFR 1.1 / 1.3）。反映対象は `internal/**` / `web/src/**` の製品コードとテスト、運用 config
+（`.env.sample` / `docker-compose.yml`）、および #223 spec の補助（`impl-notes.md` /
+`context-map.md`）に限定する。
+
+各タスクは実装 + 対応テストを同一 commit で完結させる（per-task ループ運用の入力契約 /
+`_Requirements_partial:_` は本ドラフトで宣言なし）。
+
+- [ ] 1. サーバ: `RegistrationService` に `registrationSession` 封筒を導入し、`FinishRegistrationNew` が auth_code を additive に返す構成に変更する（Delta 1 サーバ側）
+  - `internal/passkey/registration_service.go` に `registrationSession` 構造体
+    （`{WebAuthnSession json.RawMessage, CodeChallenge string}`）を追加する。既存
+    `internal/passkey/authentication_service.go` L57-66 の `authnSession` と同型で作る
+  - `BeginRegistrationNew`: 既存の PKCE 早期検証を維持したまま、検証済み `codeChallenge` を
+    `registrationSession` に格納し `json.Marshal` で bytes 化した後、既存
+    `challenges.Issue(sessionData=envelopeBytes, ...)` に渡す
+  - `FinishRegistrationNew` の **シグネチャを変更**:
+    `(ctx, challengeID, requestBody) (string, error)` →
+    `(ctx, challengeID, requestBody) (userID string, authCodePlain string, err error)`
+  - `FinishRegistrationNew` 内部:
+    - `challenges.Consume` の戻り値 `SessionData` を `registrationSession` として
+      `json.Unmarshal` し、`envelope.WebAuthnSession` を既存 `adapter.FinishRegistration` に
+      渡す（既存 attestation 検証ロジックは変更なし）
+    - envelope 破損 / `envelope.CodeChallenge == ""` は `ErrRegistrationFailed` に uniform 化
+      （既存 authentication_service.go L230-241 と同方針）
+    - 既存の user 作成 / credential 保存フローを維持
+    - 末尾に auth_code 発行を追加: `plain, _ := auth.GenerateAuthCode()` →
+      `codeHash := auth.HashNativeSecret(plain)` →
+      `AuthCode{ID: uuid.New().String(), CodeHash: codeHash, UserID: newUser.ID,
+      PKCEChallenge: envelope.CodeChallenge, ExpiresAt: s.now().Add(auth.NativeAuthCodeTTL)}` →
+      `s.authCodes.Create(ctx, authCode)`（既存 `authentication_service.go` L320-334 と同経路）
+    - `slog.Info` に `user_id` と `auth_code_hash[:8]` のみを載せ、平文 auth_code / code_verifier /
+      code_challenge をログ・エラーメッセージに一切出さない（NFR 2.1 / 既存
+      authentication_service.go L338-341 と同方針）
+  - `RegistrationService` 構造体に `authCodes auth.AuthCodeCreator` フィールドを追加、
+    `NewRegistrationService` のシグネチャに `authCodes auth.AuthCodeCreator` を追加
+    （既存 `AuthenticationService` と同じ具体依存）
+  - `internal/passkey/registration_service_test.go` を変更:
+    - 既存テストを新シグネチャに追従（すべての `FinishRegistrationNew` 呼び出し箇所で
+      3 戻り値受け取りに変更）
+    - 新規テスト（正常系）: begin で渡した `codeChallenge` が finish の envelope 復元後に
+      `authCodes.Create` に渡された `AuthCode.PKCEChallenge` と一致すること（stub で AuthCode を
+      キャプチャして verify）
+    - 新規テスト（正常系）: `authCodePlain` 戻り値が非空・base64url 形式（`auth.GenerateAuthCode`
+      の返り値形式に整合）
+    - 新規テスト（異常系）: `challenges.Consume` が返す SessionData を破損させて
+      `json.Unmarshal` を失敗させる → `ErrRegistrationFailed`
+    - 新規テスト（異常系）: envelope の `CodeChallenge` を空文字にする → `ErrRegistrationFailed`
+    - 新規テスト（異常系）: `authCodes.Create` stub が infra error を返す → wrap されて伝播
+  - `internal/app/app.go` を変更: `passkey.NewRegistrationService(...)` の呼び出しに
+    `authCodes`（既存 `repository.NewPostgresAuthCodeRepo(...)` の返り値、既に
+    `AuthenticationService` に注入されている同じインスタンス）を追加する
+  - _Requirements: 1.1, 1.2, 1.3, 3.5, NFR 2.1, NFR 3.2_
+  - _Boundary: passkey/RegistrationService, app.go wiring_
+
+- [ ] 2. サーバ: `PasskeyHandler.RegistrationFinish` レスポンスに auth_code を additive 追加し、router.go で capability endpoint 登録条件を両 handler 非 nil に強化する（Delta 1 handler + Delta 3 router）
+  - `internal/handler/passkey_handler.go` を変更:
+    - `RegistrationFinish` ハンドラのレスポンス型を additive に拡張:
+      `{user_id string, auth_code string}`（現行は `{user_id}` のみ）。**`user_id` フィールドは
+      名称・位置ともに維持し、`auth_code` を末尾に追加**（iOS #216 の JSON decoder が未知
+      フィールドを無視する慣行に依拠 / NFR 3.2）
+    - `RegistrationService.FinishRegistrationNew` の新シグネチャ（3 戻り値）に追従し、
+      2 番目返り値 `authCodePlain` をレスポンス body の `AuthCode` フィールドに設定
+    - 既存の error mapping（`ErrRegistrationFailed` → 400 REGISTRATION_FAILED / infra → 500）は
+      維持
+  - `internal/handler/router.go` を変更:
+    - Web 用 `GET /api/passkey/capability` の登録条件を
+      `if deps.PasskeyHandler != nil && deps.NativeAuthHandler != nil` に強化する
+      （現行は `PasskeyHandler != nil` のみ想定）
+    - iOS 用 `/api/passkey/registration/*` および `/api/passkey/authentication/*` の登録条件は
+      **`PasskeyHandler != nil` のみを維持し変更しない**（#216 契約破壊禁止 / NFR 3.2）
+    - `/api/auth/session`（NativeAuthHandler.Session）の登録条件は既存 `NativeAuthHandler !=
+      nil` を維持
+  - `internal/handler/passkey_handler_test.go` を変更:
+    - `TestPasskeyHandler_RegistrationFinish` の期待レスポンス body に `auth_code` を追加、
+      `user_id` フィールドが引き続き存在することを assert（iOS ignore-unknown 互換の回帰）
+    - auth_code フィールドが非空 base64url 形式（`^[A-Za-z0-9_-]+$`）であること
+    - サーバ側の `RegistrationService` は本テストでは stub 化し、`authCodePlain` を
+      特定値で返して handler がそのまま body に含めることを検証
+  - `internal/handler/router_test.go` を変更:
+    - Delta 3 §fail-closed 表の 4 環境行それぞれで route 登録有無を検証する table-driven テストを追加:
+      1. `PasskeyHandler != nil && NativeAuthHandler != nil` → session 204 / capability 200 /
+         iOS registration/*+authentication/* 200
+      2. `PasskeyHandler != nil && NativeAuthHandler == nil` → session 404 / **capability 404
+         （強化条件の回帰）** / iOS registration/*+authentication/* 200 **（iOS 継続稼働の回帰）**
+      3. `PasskeyHandler == nil && NativeAuthHandler != nil` → session 204 / capability 404 /
+         iOS registration/*+authentication/* 404
+      4. 両 nil → 全 404
+  - _Requirements: 1.1, 1.3, 3.1, 3.2, 3.3, 3.4, 3.5, NFR 3.2_
+  - _Boundary: handler/PasskeyHandler, handler/router_
+  - _Depends: 1_
+
+- [ ] 3. Web: `use-passkey-registration.ts` から二度目 WebAuthn ceremony を除去し、finish 応答の auth_code を直接 session 交換に渡す構成に変更する。`registration_uncertain` kind を追加する（Delta 1 Web + Delta 5 Hook）
+  - `web/src/types/passkey.ts` の `RegistrationFinishResponse` 型に `auth_code: string`
+    フィールドを additive に追加（`user_id` は既存維持）
+  - `web/src/hooks/use-passkey-registration.ts` の `mutationFn` chain を書き換え:
+    - 現行 6 段（begin → create → finish → authentication/begin → get → authentication/finish
+      → session）から **4 段（begin → create → finish → session）** に短縮
+    - `POST /api/passkey/registration/finish` の応答 `RegistrationFinishResponse` から
+      `auth_code` を取り出し、直後の `POST /api/auth/session` request body の `auth_code` に
+      直接渡す（`code_verifier` は closure 変数で保持済み）
+    - `authentication/begin` / `navigator.credentials.get` / `authentication/finish` の
+      3 呼び出しを **完全に削除**（二度目 ceremony の除去 / Req 1.1）
+  - `PasskeyRegistrationErrorKind` 型に `"registration_uncertain"` を追加
+  - error 分類ロジックを step index ベースで整理し、finish 段階の失敗を以下 3 分岐に細分化
+    （Delta 5 §Hook 側の判定ロジックに準拠）:
+    - `ApiError` かつ `status >= 400 && status < 500` かつ `body.code === "REGISTRATION_FAILED"`
+      → `server_rejected`
+    - `ApiError` かつ `status >= 500` → **`registration_uncertain`**（サーバが commit したか
+      不確定）
+    - `TypeError`（fetch reject）→ **`registration_uncertain`**（送出済み・応答なし）
+    - `DOMException` かつ `name === "AbortError"` → **`registration_uncertain`**
+    - その他 → `server_error`
+  - begin 段階 / create 段階 / session 段階の error 分類は既存挙動を維持（`registration_uncertain`
+    にしない / Delta 5 §安全側 fail 原則）
+  - `code_verifier` / `auth_code` / attestation 生値を `console.*` / storage / URL に書かない
+    （NFR 2.1）
+  - `web/src/hooks/use-passkey-registration.test.ts` を変更:
+    - 正常系: `authentication/begin` / `authentication/finish` が呼ばれないことを assert
+      （二度目 ceremony 除去の回帰）
+    - 正常系: finish 応答 body の `auth_code` が session request body の `auth_code` として
+      渡ることを assert
+    - 新規: `registration_uncertain` × fetch reject（finish が `TypeError` を throw）
+    - 新規: `registration_uncertain` × 500（finish が 500 応答）
+    - 新規: `registration_uncertain` × AbortError（finish が AbortError を throw）
+    - 回帰: `server_rejected`（finish が 400 REGISTRATION_FAILED）が `registration_uncertain`
+      に誤分類されない
+    - 既存 kind の分岐テスト（`invalid_username` / `username_taken` / `cancelled` /
+      `session_exchange_failed`）は新 chain に合わせて updates
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 5.1, 5.5, NFR 2.1, NFR 3.1_
+  - _Boundary: hooks/use-passkey-registration, types/passkey_
+  - _Depends: 2_
+
+- [ ] 4. Web: `passkey-signup-dialog.tsx` に `registration_uncertain` の UI 分岐と復旧導線（「ログインで確認する」「再度作成する」の 2 ボタン）を追加する（Delta 5 UI）
+  - `web/src/components/passkey-signup-dialog.tsx` を変更:
+    - `error.kind === "registration_uncertain"` 分岐を追加（既存の `invalid_username` /
+      `username_taken` / `cancelled` / `server_rejected` / `session_exchange_failed` /
+      `server_error` / `network_error` 分岐と並列に追加）
+    - 表示メッセージは Delta 5 §UI 文言と復旧導線 の canonical 文言に準拠。特に「登録が完了
+      したかどうかを確認できませんでした」の見出しで、他 kind と識別可能にする（Req 5.6）
+    - 2 ボタンの実装:
+      - 「ログインで確認する」: `onOpenChange(false)` を呼び Dialog を閉じる（LoginPage 側の
+        `PasskeyButtons` からユーザーが再度パスキーログインを試みる導線に戻す / Req 5.2 / 5.3）
+      - 「再度作成する」: `mutation.reset()` を呼び Dialog を Idle 状態に戻す（同じ username で
+        再試行すると `username_taken` になることを Delta 5 §UI 文言 で案内済 / Req 5.4）
+    - メッセージ本文に `error.body` の内容・スタックトレース・SQL / DB 名などのサーバ内部詳細を
+      **含めない**（Req 5.5 / NFR 2.1）
+    - `console.*` の呼び出しは追加しない（NFR 2.1）
+  - `web/src/components/passkey-signup-dialog.test.tsx` を変更:
+    - 新規: `error.kind === "registration_uncertain"` で見出し「登録が完了したかどうかを
+      確認できませんでした」が表示される
+    - 新規: 「ログインで確認する」ボタン押下で `onOpenChange(false)` が呼ばれる
+    - 新規: 「再度作成する」ボタン押下で `mutation.reset()` が呼ばれる
+    - 新規: 文言中に既存 error kind の代表文言（「ユーザー名の形式が不正です」「このユーザー名は
+      既に使用されています」「認証に失敗しました」等）が含まれない（Req 5.6 の弁別性回帰）
+    - 新規: 文言中にサーバ内部詳細を想起させる文字列（`Error:`, `Stack:`, `SQL`, スタック
+      トレース由来のプレフィックス）が含まれない（Req 5.5 の回帰）
+  - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, NFR 2.1_
+  - _Boundary: components/passkey-signup-dialog_
+  - _Depends: 3_
+
+- [ ] 5. Config: `.env.sample` と `docker-compose.yml` に既存 WebAuthn env 群（新規 env なし）の documentation と passthrough を追加する（Delta 6 / Requirement 6）
+  - `.env.sample` を変更: Native Auth 節（現行 L119-130 付近）の後に、Delta 6 §反映内容 §.env.sample の
+    canonical コメントブロックを追加する。5 変数を **すべてコメントアウト行**として documentation
+    のみ記載し、デフォルト値の代入は行わない:
+    - `# WEBAUTHN_RP_ID=`
+    - `# WEBAUTHN_RP_DISPLAY_NAME=Feedman`
+    - `# WEBAUTHN_ORIGINS=`
+    - `# WEBAUTHN_IOS_APP_ID=`
+    - `# PASSKEY_CHALLENGE_TTL_SECONDS=300`
+  - 各コメントに fail-closed 挙動と例値・意味を明記（Delta 6 §反映内容 §.env.sample のサンプルを
+    参照）。RP_ID / ORIGINS / IOS_APP_ID の例値は運用者が誤ってコピペしないよう「例:」プレフィクスを
+    必ず付ける
+  - `docker-compose.yml` の `api` サービス `environment` セクションに以下 5 行を追加する
+    （既存 `NATIVE_AUTH_JWT_SECRET=${NATIVE_AUTH_JWT_SECRET:-}` の直後を推奨位置とする）:
+    - `- WEBAUTHN_RP_ID=${WEBAUTHN_RP_ID:-}`
+    - `- WEBAUTHN_RP_DISPLAY_NAME=${WEBAUTHN_RP_DISPLAY_NAME:-Feedman}`
+    - `- WEBAUTHN_ORIGINS=${WEBAUTHN_ORIGINS:-}`
+    - `- WEBAUTHN_IOS_APP_ID=${WEBAUTHN_IOS_APP_ID:-}`
+    - `- PASSKEY_CHALLENGE_TTL_SECONDS=${PASSKEY_CHALLENGE_TTL_SECONDS:-300}`
+  - `worker` サービスの `environment` には **追加しない**（worker は passkey に依存しない）
+  - **新規 env は追加しない**。追加は既存 env（config.go / #216 で既に読み込み済み）の
+    documentation と container passthrough に限定する（Req 6.5）
+  - config 変更に対する動作回帰は既存の `internal/config/config_test.go` の
+    `TestLoad_Passkey`（L411 以降）で保証されており、本タスクでは `internal/config/*` を
+    追加変更しない（既存テストが env 読込を検証済み）
+  - 手動確認手順（tasks 完了時に PR 本文の「確認事項」で言及するのみ、自動テスト化は不要）:
+    - `.env.sample` をコピーして `WEBAUTHN_RP_ID` などを実値に設定し `docker compose up` した
+      とき、api コンテナ内で当該 env が期待どおり参照できることを README 記載の起動手順で確認
+  - _Requirements: 2.2, 6.1, 6.2, 6.3, 6.4, 6.5, NFR 3.1_
+  - _Boundary: .env.sample, docker-compose.yml_
+
+- [ ] 6. Docs: `docs/specs/223-feat-web-web/impl-notes.md` と `context-map.md` に #231 normative delta の適用結果を追記する（#223 spec の requirements.md / design.md / tasks.md は書き換えない）
+  - `docs/specs/223-feat-web-web/impl-notes.md` を変更:
+    - 冒頭または「確認事項」節に「#231 normative delta 適用後の実装状態」旨のセクションを追加
+    - Delta 1〜5 それぞれについて 1〜3 行で「本 PR で反映した内容」と「#231 design.md の
+      該当 Delta セクションへの参照」を記載
+    - `#223 design.md` §Flows「新規作成フロー（Sequence / 抜粋）」の該当箇所は **#231 design.md
+      Delta 1 で supersede** されている旨を明示する
+  - `docs/specs/223-feat-web-web/context-map.md` を変更:
+    - 新規作成フローの経路図から「二度目 WebAuthn ceremony」を削除し、finish → session の
+      直接遷移に更新
+    - fail-closed 表を #231 design.md Delta 3 §補正後の fail-closed 表 のリンクに置換または
+      supersede 注釈を追加
+    - 完了不明状態（`registration_uncertain`）の遷移を hook / component / UI 文言の各層に
+      追加
+  - **`docs/specs/223-feat-web-web/requirements.md` / `design.md` / `tasks.md` は書き換えない**
+    （NFR 1.1）
+  - **`docs/specs/216--app-store-4-8/` 配下のいかなるファイルも書き換えない**（NFR 1.3）
+  - _Requirements: 2.3, 2.4, 2.5, NFR 1.1, NFR 1.2, NFR 1.3_
+  - _Boundary: docs/specs/223-feat-web-web/impl-notes, docs/specs/223-feat-web-web/context-map_
+
+## Verify
+
+本 spec の実装反映後、watcher（stage-a-verify gate）が独立に再実行して build / test / lint を
+検証する。サーバ側は `go test ./...` + `go vet ./...`、Web 側は `npm test` + `npm run lint` +
+`npm run build`。config 変更（`.env.sample` / `docker-compose.yml`）の妥当性は既存
+`internal/config/config_test.go` の `TestLoad_Passkey` および docker-compose YAML の schema で
+担保される。
+
+<!-- stage-a-verify -->
+```sh
+go test ./... && go vet ./... && cd web && npm test && npm run lint && npm run build
+```


### PR DESCRIPTION
## 概要

この PR は **設計レビュー専用**です。製品コードは含まず、Issue #223 / PR #229 に適用する normative delta として、`docs/specs/231-design-web-auth/` の requirements / design / tasks を確定します。

Refs #231

## 中核決定

- Web の登録完了は `POST /api/passkey/registration/finish` 内で user → credential → session を **同一 DB transaction** に保存し、commit 後に同じ応答へ `Set-Cookie` する
- 登録直後の二度目の WebAuthn ceremony、登録用 auth_code、登録専用 session exchange は導入しない
- iOS #216 の JSON 契約は維持し、Origin のない native request では session / Cookie を発行しない
- #230 / PR #232 の既存 transaction 基盤を再利用し、新しい transaction 実行機構は作らない

## 最終レビュー反映

round 3 の 7 指摘に加え、commit `4314480` で実コードとの最終整合監査により判明した実装上の抜けも一括で閉じました。

- request preparation / fetch reject（実送達可否不明）/ 2xx parse failure を型で区別
- session ID generator の局所的な failure seam を定義し、薄い public wrapper は追加しない
- `SessionFactory` を app で 1 instance 作り、`SessionExchangeService` と registration に共有注入。Google OAuth の既存 generator は独立維持
- domain error kind の実在場所を各 hook に合わせ、`types/passkey.ts` は DTO のみとする
- auth の新 kind は **finish + HTTP 400 + `AUTHENTICATION_FAILED` の完全一致だけ**。begin の同一 code、異なる status、cancel、network、5xx、session exchange は対象外
- 通常ログインの `PasskeyButtons` にも新 kind の generic 固定文言を追加し、エラー表示消失と raw body 漏出を防止
- `registration_uncertain` を既存 `registered` 自動 close より優先し、初期表示で close / callback / reset しない。再作成時は registration / recovery-auth の両 mutation を reset
- `CORS_ALLOWED_ORIGIN` は trim 後に strict exact-Origin validation。前後空白だけは正規化し、内部空白・userinfo・path/query/fragment・末尾 slash・複数 Origin 等は fail-closed。invalid 生値はログしない
- File Structure Plan を 1 file 1 row の exact path で同期し、`passkey-buttons*` を含む実変更対象を反映
- compose の set / unset 両ケースで展開値を assertion する Verify を明記

## 適用境界

独立した実装 PR は作りません。PR #232 は develop へ merge 済みです。本 PR を merge した後、develop を PR #229 の branch へ取り込み、`tasks.md` の 8 task を **PR #229 の needs-iteration 1 回**でまとめて実装します。Issue #231 から別 Developer run を起動する運用にはしません。

## 機械確認

- Requirement 1〜6 の見出しと AC 数（5 / 5 / 6 / 7 / 6 / 5）が traceability row 数と一致
- PR #229 の現行 diff path に対する File Plan 未列挙 0、重複 0
- [N] は 4 file のみで現時点では不存在、[E] / [U] は実在
- `git diff --check` clean

## 関連

- Parent: #223
- Implementation PR: #229
- Transaction prerequisite: #230 / #232

<!-- idd-claude:pr-iteration round=3 final-consistency-pass=4314480 -->