### PR TITLE
fix(#235): ログアウトボタンの fetch/303 不整合を content negotiation で修正

### DIFF
--- a/docs/specs/235-fix-web-fetch-303/impl-notes.md
+++ b/docs/specs/235-fix-web-fetch-303/impl-notes.md
@@ -1,0 +1,139 @@
+# Implementation Notes — Issue #235: Web ログアウトの fetch/303 事故修正
+
+## 実装アプローチの選定
+
+要件定義には実装方針が規定されておらず、Developer が Requirement 1〜6 の AC を満たす形で
+判断する契約になっている。以下の 3 候補を比較検討し、(A) を採用した。
+
+### 候補比較
+
+| 案 | 内容 | 採否 | 理由 |
+|---|---|---|---|
+| (A) サーバ side content negotiation + クライアント Accept 明示 | サーバは Accept ヘッダで JSON クライアントを識別し 204 を返す。fetch 側は `Accept: application/json` を送信する。 | **採用** | Req 6.2（form POST 経路の後方互換）を破らずに直接的に問題を解消できる。分岐が明快で仕様も自然。 |
+| (B) fetch を `redirect: "manual"` にして 303 を明示的にハンドリング | クライアント側のみで完結。サーバは変更しない。 | 不採用 | 303 レスポンスをクライアントで手動処理する分岐が煩雑。ユーザー側から見えるログアウトフローに「サーバは 303 で応答する」実装詳細が漏出する。 |
+| (C) サーバを常に 204 に変更 | 単純化されるがフォーム POST 経路の挙動を変える。 | 不採用 | Req 6.2（form POST 経路がある場合の挙動維持）に抵触する可能性が残る。 |
+
+### (A) 採用理由と副次効果
+
+- **プロトコル的にも自然**: HTTP の content negotiation は Accept ヘッダを識別条件として使うのが
+  標準的な設計。クライアントを明示的な JSON クライアントとして宣言し、サーバは JSON クライアントに
+  対しては 204 で「セッション破棄済み・遷移はクライアントで」というレスポンスを返す。
+- **JSON API クライアント全体の防衛**: `apiClient` に `Accept: application/json` を追加する
+  ことで、他エンドポイントが将来同様の content negotiation を導入した際にも自動的に整合する。
+- **既存 form POST 経路への影響ゼロ**: ブラウザ form POST は Accept に
+  `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8` を送るため、
+  `acceptsJSON` は false を返し、これまで通り 303 + Location が返る。
+
+## 変更内容（コミット単位）
+
+### コミット 1: `fix(auth): JSON クライアントには 204 を返し fetch リダイレクト事故を防ぐ`
+
+- `internal/handler/auth_handler.go`
+  - `Logout` を content-negotiation 対応に変更（Accept: application/json → 204、それ以外 → 303）
+  - 新規プライベート関数 `acceptsJSON(accept string) bool` を追加（カンマ区切り parse、
+    パラメータ除去、`application/json` を大小無視で完全一致比較）
+- `internal/handler/auth_handler_test.go` にサーバ側テストを追加:
+  - `TestAuthHandler_Logout_JSONAccept_ReturnsNoContent` — セッションあり + Accept: application/json → 204
+  - `TestAuthHandler_Logout_JSONAccept_NoSession_ReturnsNoContent` — セッションなし + Accept: application/json → 204
+  - `TestAuthHandler_Logout_FormPost_StillRedirects` — Accept 不在 / text/html / text/plain → 303（table-driven）
+
+### コミット 2: `fix(web/api): apiClient に Accept: application/json ヘッダを付与する`
+
+- `web/src/lib/api.ts` — `request<T>` のデフォルトヘッダに `Accept: application/json` を追加
+- `web/src/lib/api.test.ts` — 既存の全 `toHaveBeenCalledWith` 期待値を新ヘッダに合わせて更新。
+  追加テスト:
+  - `Accept ヘッダ（Issue #235）` describe > `全メソッドが Accept: application/json を送信すること` —
+    5 メソッド全経路の regression net
+- `web/src/hooks/use-feeds.test.tsx` — `toHaveBeenCalledWith` 期待値を新ヘッダに合わせて更新
+
+### コミット 3: `fix(web/logout): 遷移先を実在する `/` に修正しエラー時のフィードバックを追加`
+
+- `web/src/components/logout-button.tsx`
+  - 遷移先を `/login`（存在しない）→ `/`（AuthGuard 経由でログイン画面表示）に修正
+  - mutation エラー時に `role="alert"` のエラー表示を追加（固定文言。内部詳細は反射しない）
+  - コメントで Requirement 4 / 5.1 / 5.2 / 5.4 との対応を明示
+- `web/src/components/logout-button.test.tsx` — 既存テスト維持 + AC 対応テスト追加:
+  - `/` 遷移 / `/login` 非遷移（Req 4.1 / 4.2）
+  - QueryClient キャッシュクリア（Req 3.1）
+  - 多重クリック抑止（Req 1.4）
+  - ネットワーク失敗 / 5xx でのエラー表示 + 再活性化（Req 5.1 / 5.2）
+  - 内部詳細（スタック / code / status）を alert に露出しない（Req 5.4）
+- `web/src/hooks/use-auth.test.tsx` — `useLogout` に対する追加テスト:
+  - Accept: application/json 送信の regression net（Issue #235 の core）
+  - mutation success 時に `queryClient.clear()` が走ることを実キャッシュエントリの
+    消滅で確認（Req 3.1）
+
+## 各 Requirement / AC のカバレッジ
+
+| AC ID | 内容（要旨） | 担保箇所（テスト） |
+|---|---|---|
+| 1.1 | 1 クリックでサーバセッション破棄要求 | `TestAuthHandler_Logout_JSONAccept_ReturnsNoContent` の `service.Logout` 呼び出し確認 |
+| 1.2 | 追加操作なしでログイン画面表示 | `logout-button.test.tsx` の `ログアウト成功後は `/` に遷移し...` |
+| 1.3 | ログアウト後に保護ビュー再取得不可 | `logout-button.test.tsx` の `QueryClient のキャッシュがクリアされること` + `use-auth.test.tsx` の `useLogout は成功時に QueryClient のキャッシュをクリア...` （キャッシュ消滅により保護ビューは新規 `/auth/me` 401 まで再取得できない） |
+| 1.4 | 進行中の多重クリック抑止 | `logout-button.test.tsx` の `ログアウト処理中はボタンが非活性となり多重クリックを抑止する...` |
+| 2.1 / 2.2 / 2.3 | Google / パスキー / 認証方式不問 | 実装上 `useLogout` は認証方式を判別せず一律 `POST /auth/logout` を呼ぶ設計。既存の `TestAuthHandler_Logout_Success_ClearsCookieAndRedirects` および新規 JSON 系テストが認証方式非依存で成立することで担保。認証方式別の分岐が存在しないことは `use-auth.ts` と `logout-button.tsx` の実装（分岐なし）で構造的に保証。 |
+| 3.1 | クライアント側キャッシュクリア | `logout-button.test.tsx` の `QueryClient のキャッシュがクリアされること` + `use-auth.test.tsx` の同名テスト |
+| 3.2 | 別ユーザー切替時に前ユーザーデータ非表示 | 3.1 のキャッシュクリアで成立する派生 AC。`queryClient.clear()` により全キャッシュが除去されるため、後続ユーザーが同一ブラウザで表示するデータは新規 fetch から始まる。 |
+| 4.1 / 4.2 | 遷移先は実在パスでログイン画面 | `logout-button.test.tsx` の `ログアウト成功後は `/` に遷移し、`/login` には遷移しない...` |
+| 4.3 | 非実在パスへは遷移しない | 上記テストで `mockAssign` が `/login` で呼ばれないことを検証 |
+| 5.1 | ネットワーク失敗時のフィードバック | `logout-button.test.tsx` の `ネットワーク到達失敗時はエラー表示を提示し、ボタンを再操作可能に戻すこと` |
+| 5.2 | 5xx でのフィードバック | `logout-button.test.tsx` の `サーバ 5xx 応答時はエラー表示を提示し、ボタンを再操作可能に戻すこと` |
+| 5.3 | セッション期限切れ時もログイン画面到達 | サーバ実装により、`session.Logout` が失敗しても Cookie クリア + 204/303 を返す。すなわちクライアント側からは常に成功として観察され、ログイン画面に遷移する。`TestAuthHandler_Logout_JSONAccept_NoSession_ReturnsNoContent` がこの経路（session cookie 不在時にも 204）を担保。 |
+| 5.4 | エラー表示に内部詳細を反射しない | `logout-button.test.tsx` の `エラー表示にサーバ応答の内部詳細（メッセージ / status 数値）を反射しないこと` |
+| 6.1 | Cookie 属性・CSRF 前提維持 | `TestAuthHandler_Logout_JSONAccept_ReturnsNoContent` で HttpOnly / SameSite / MaxAge=-1 を assert。既存の `TestAuthHandler_Logout_Success_ClearsCookieAndRedirects` も保持。 |
+| 6.2 | 従来 form POST 経路の互換性維持 | `TestAuthHandler_Logout_FormPost_StillRedirects` が Accept ヘッダ不在 / text/html / text/plain の 3 パターンで従来通りの 303 + Location を担保 |
+| 6.3 | 対象外機能の既存挙動維持 | 全 Go / Web テストスイート pass（528 web + 全 Go handler）で担保 |
+| 6.4 | ログイン画面の要素・導線に変化なし | `login-page.test.tsx` 等の既存テストが引き続き pass（本 spec で `login-page.tsx` は無変更） |
+| NFR 1.1 | セッション ID・Cookie 値・PII をコンソール / エラー / URL に残さない | エラー表示は固定文言のみ（`5.4` テストで担保）。`onSuccess` の `window.location.assign("/")` はクエリ文字列なし |
+| NFR 1.2 | ログアウト応答本文にセッション識別子 / PII を含めない | サーバは 204 No Content（本文なし）または 303 + Location（本文なし）を返すため構造的に成立 |
+| NFR 2.1 / 2.2 / 2.3 | テスト容易性（正常系 / 異常系 / キャッシュ状態を実物到達なしで検証可能） | 追加した web テスト群は `mockFetch` / `window.location` モックで完結。Go テストは `httptest.NewRecorder` で完結 |
+
+## 実装上の判断
+
+- **API client への Accept 追加の副作用スコープ**: `apiClient` の変更は全 API リクエストに影響
+  するが、既存の JSON API エンドポイントは content-type 分岐を行っていないため実挙動は不変。
+  スキャン結果 `grep -r Content-Type.*application/json` で確認したテスト（api.test.ts /
+  use-feeds.test.tsx）のみを最小限に更新した。
+- **`acceptsJSON` の parse は defensive**: RFC 7231 の Accept ヘッダは q-value / パラメータ /
+  ワイルドカードを含むが、本ユースケースは「fetch クライアントが `Accept: application/json` を
+  明示的に送るかどうか」の 2 択判定なので、`application/*` や `*/*` の合致は敢えて **false** に
+  倒している。これにより form POST ブラウザの通常 Accept で誤判定が起きない。
+- **エラー表示のスタイル**: `text-destructive` / `text-xs` は shadcn/ui のテーマトークンをその
+  まま活用。既存の UI 規約に沿う。
+- **`role="alert"` の採用**: スクリーンリーダーに即座に読み上げられ、Requirement 5.1 / 5.2 が
+  求める「ユーザーに失敗した旨を認識可能な表示」を満たしやすい。
+
+## 実行コマンドと結果
+
+- `go test ./...` — 全パッケージ pass（handler / auth / middleware / worker 等すべて OK）
+- `go vet ./internal/handler/...` — 出力なし（clean）
+- `gofmt -l internal/handler/auth_handler.go internal/handler/auth_handler_test.go` — 出力なし
+  （本 PR で変更したファイルのみ gofmt-clean。事前に存在した format 差分は本 spec の scope 外
+  として温存）
+- `cd web && npm test -- --run` — 52 files / 528 tests pass
+- `cd web && npm run lint` — errors: 0（warnings 5 は既存の pre-existing、本 PR で追加 / 修正
+  したファイルに warning は無い）
+- `cd web && npm run build` — production build 成功（`/` route 76.3 kB / First Load 201 kB。
+  logout-button のバンドル寸法に増加なし）
+
+## 変更ファイル一覧
+
+- `internal/handler/auth_handler.go`（Logout ハンドラの content negotiation 対応 / `strings` import 追加 / `acceptsJSON` 追加）
+- `internal/handler/auth_handler_test.go`（3 テスト追加）
+- `web/src/lib/api.ts`（Accept ヘッダ追加）
+- `web/src/lib/api.test.ts`（既存 assert 更新 + 1 テスト追加）
+- `web/src/hooks/use-feeds.test.tsx`（既存 assert 更新）
+- `web/src/hooks/use-auth.test.tsx`（2 テスト追加）
+- `web/src/components/logout-button.tsx`（遷移先修正 + エラー表示追加）
+- `web/src/components/logout-button.test.tsx`（既存テスト整備 + 6 テスト追加）
+
+## 確認事項
+
+- なし。要件定義（`requirements.md`）と Issue 本文から実装方針の判断材料が十分に得られており、
+  仕様の解釈で PM / Architect に差し戻すべき曖昧箇所は発見しなかった。
+- pre-existing の gofmt 差分（`internal/handler/crossfeed_handler_test.go` /
+  `feed_handler_test.go` / `item_search_handler.go` / `router_full_test.go`）は本 spec の
+  scope 外として温存した（Req 6.3 の「対象外の機能の既存挙動を変化させない」に合致するよう、
+  format-only の書き換えを追加しない）。
+
+STATUS: complete

--- a/docs/specs/235-fix-web-fetch-303/requirements.md
+++ b/docs/specs/235-fix-web-fetch-303/requirements.md
@@ -1,0 +1,164 @@
+# Requirements Document
+
+## Introduction
+
+Feedman Web（Next.js）のログアウトボタンが実効的に機能しない不具合を修正する。現状、
+ボタンをクリックするとサーバ側はセッションを破棄しているにもかかわらず、Web 画面は認証済み
+のまま留まり、ユーザーが同じボタンを繰り返し連打する事象が発生している（staging 実機で
+2026-07-28 に確認、`POST /auth/logout` 303 応答が 11 連続でサーバに到達）。
+
+背景は「ブラウザ fetch API 経由で `POST /auth/logout` を呼び、サーバが form POST 前提の
+303 See Other + Location を返した結果、fetch が自動的にリダイレクトを追従してログイン画面の
+HTML を取得し、JSON 解析に失敗してクライアントが失敗扱いとなる」構造で、初期実装から潜在
+していたバグである。加えて、ログアウトボタン側の遷移先ハードコード `/login` は Feedman の
+Web ルーティング（`/` 上で AuthGuard が未認証時にログイン画面を出す構成）に存在しないため、
+仮にクライアント側の後続処理が走っても 404 に落ちる。
+
+本 spec は Google / パスキーいずれの認証セッションに対しても、ユーザーがログアウトボタンを
+1 クリックしただけでセッションが破棄されログイン画面に到達し、クライアント側キャッシュも
+クリアされるという **ユーザー観察可能な挙動** を要件化する。実装方針（サーバ側の応答方式、
+クライアント側の fetch オプション、遷移先ルート等）は本 spec では規定せず、実装フェーズに
+委ねる。ただし既存のセッション Cookie 属性（`HttpOnly` / `SameSite=Lax` / `Secure`）と
+CSRF 前提、および既存の form POST 経由ログアウト互換性の破壊は本 spec のスコープ外とする。
+
+## Requirements
+
+### Requirement 1: ワンクリックでのログアウト完了
+
+**Objective:** As a Feedman Web の認証済みユーザー, I want ログアウトボタンを 1 回クリック
+すれば認証が終了し、未認証のログイン画面が表示されること, so that セッション破棄が完了して
+いないと誤認して連打する必要が無くなる
+
+#### Acceptance Criteria
+
+1. When 認証済みユーザーがログアウトボタンを 1 回クリックしたとき, the Web Logout Flow shall
+   同一クリックの処理シーケンス内でサーバセッションの破棄要求を発行し、サーバ側でセッションが
+   破棄される
+2. When サーバ側でセッションが破棄されたとき, the Web Logout Flow shall 追加のユーザー操作を
+   要求せず、未認証状態のログイン画面を Web 画面に表示する
+3. When ログアウトフローが完了したとき, the Web App shall 直前まで認証済みだったブラウザから
+   保護されたビュー（フィード一覧・アイテム一覧等）を再度取得できない状態にする
+4. While ログアウトフローが進行中であるとき, the Logout Button shall 追加のログアウト要求を
+   受け付けず、多重クリックによるサーバへの重複要求送信を発生させない
+
+### Requirement 2: 認証方式に依存しない共通挙動
+
+**Objective:** As a Feedman Web の全ユーザー（Google OAuth / パスキーいずれの経路でログインした
+ユーザー）, I want どちらの認証方式でログインしていても同じログアウトボタンで同じ結果に到達
+したい, so that 認証方式による挙動差でユーザーが混乱しない
+
+#### Acceptance Criteria
+
+1. When Google OAuth 経由でログインしたユーザーがログアウトボタンをクリックしたとき, the Web
+   Logout Flow shall Requirement 1.1〜1.3 と同じ結果（サーバセッション破棄 + ログイン画面表示）に
+   到達する
+2. When パスキー認証経由でログインしたユーザーがログアウトボタンをクリックしたとき, the Web
+   Logout Flow shall Requirement 1.1〜1.3 と同じ結果（サーバセッション破棄 + ログイン画面表示）に
+   到達する
+3. The Web Logout Flow shall 認証方式（Google / パスキー）を判別してからログアウト処理を分岐
+   させない
+
+### Requirement 3: クライアント側キャッシュのクリア
+
+**Objective:** As a Feedman Web の運用者およびユーザー, I want ログアウト後に前ユーザーの
+データがクライアント側キャッシュに残存しないこと, so that 同一ブラウザで別ユーザーがログイン
+した際・またはログイン画面に戻った際に前ユーザーのフィード内容やユーザー情報が漏出しない
+
+#### Acceptance Criteria
+
+1. When Requirement 1.2 のログイン画面表示に到達したとき, the Web App shall 認証済みだった
+   ユーザーのフィード一覧・アイテム一覧・ユーザー情報などクライアント側の取得結果キャッシュを
+   クリアする
+2. When 同一ブラウザで別ユーザーが後続でログインしたとき, the Web App shall 前ユーザーの
+   キャッシュされたデータを画面に表示しない
+
+### Requirement 4: 遷移先の実在性
+
+**Objective:** As a Feedman Web のユーザー, I want ログアウト後に 404 ページや白画面ではなく
+Feedman の正規ログイン画面に到達したい, so that ログアウト後の再ログイン導線を迷わず利用
+できる
+
+#### Acceptance Criteria
+
+1. When ログアウトフローが遷移先の URL を決定するとき, the Web Logout Flow shall Feedman Web の
+   ルーティング上で実在するパスのみを遷移先として指定する
+2. When ログアウトフローが完了したとき, the Web App shall ログイン画面（未認証訪問者向けに
+   Google ログイン導線およびパスキー導線が表示される画面）を Web 画面に提示する
+3. If ログアウトフローの遷移先候補が Web ルーティング上に存在しないパスであるとき, the Web
+   Logout Flow shall そのパスへの遷移を発生させない
+
+### Requirement 5: 失敗時のユーザーフィードバック
+
+**Objective:** As a Feedman Web のユーザー, I want ネットワーク断絶やサーバエラーで
+ログアウトが完了しなかった場合にそれをユーザーが認識できるようにしたい, so that ボタンが
+「反応していないだけなのか」「サーバが受け付けていないのか」を切り分けられる
+
+#### Acceptance Criteria
+
+1. If ログアウト要求がネットワーク到達失敗（サーバに要求が到達しなかった場合）となったとき,
+   the Web Logout Flow shall ユーザーに失敗した旨を認識可能な表示を提示し、認証済み状態のまま
+   ログアウトボタンを再度操作可能にする
+2. If ログアウト要求に対してサーバがエラー応答（5xx 相当）を返したとき, the Web Logout Flow
+   shall ユーザーに失敗した旨を認識可能な表示を提示する
+3. If ログアウト要求時に既にセッションが期限切れ・未存在であることをサーバが示したとき,
+   the Web Logout Flow shall Requirement 1.2 と同じ結果（ログイン画面表示）に到達する
+4. If ログアウトフローがエラー表示を提示するとき, the Web Logout Flow shall サーバ応答の
+   内部詳細（スタックトレース・内部エラー原因）をユーザー可視のテキストに反射しない
+
+### Requirement 6: 既存挙動・互換性の維持
+
+**Objective:** As a Feedman Web / API の運用者, I want 本修正で既存の認証・セッション基盤の
+セキュリティ前提および form POST 経由ログアウト互換性が壊れないこと, so that 修正がリグレッ
+ションや別経路のログアウト機能停止を引き起こさない
+
+#### Acceptance Criteria
+
+1. The Web Logout Flow shall セッション Cookie の属性（`HttpOnly` / `SameSite=Lax` / `Secure`
+   相当）および CSRF 前提を本修正の前後で同一に維持する
+2. Where 従来 form POST 経由でログアウトを利用している経路が存在する場合, the Logout Endpoint
+   shall その経路のログアウト完了挙動を本修正の前後で同一に維持する
+3. The Web App shall 本修正の対象外の機能（フィード購読・アイテム閲覧・スター・検索・
+   はてブ連携・アカウント設定等）の既存挙動を本修正によって変化させない
+4. The Web Login Screen shall 本修正の前後で表示要素・導線（Google / パスキー）の一覧に
+   変化を生じさせない
+
+## Non-Functional Requirements
+
+### NFR 1: 機密情報の非漏出
+
+1. The Web Logout Flow shall セッション識別子・Cookie 値・ユーザー識別情報を、ブラウザの
+   コンソールログ・エラー表示テキスト・URL クエリ文字列に残さない
+2. The Logout Endpoint shall ログアウト応答のレスポンスボディにセッション識別子およびユーザー
+   個人情報（メールアドレス等）を含めない
+
+### NFR 2: テスト容易性
+
+1. The Web Logout Test Suite shall 正常系（1 クリックでログイン画面到達 + クライアント側
+   キャッシュクリア）を、ブラウザおよびサーバ実物への到達なしに検証可能にする
+2. The Web Logout Test Suite shall 異常系（サーバエラー応答時のユーザーフィードバック提示）を、
+   ブラウザおよびサーバ実物への到達なしに検証可能にする
+3. The Web Logout Test Suite shall ログアウトフロー完了後にクライアント側キャッシュがクリア
+   されていることを、キャッシュ状態を観測する形で検証可能にする
+
+## Out of Scope
+
+- パスキー再認証失敗（Issue #234）の修正
+- アカウント設定導線・アカウント削除フローの追加・変更
+- セッション管理方式そのものの変更（Cookie セッション → Bearer token 化等）
+- Cookie 属性（`HttpOnly` / `SameSite` / `Secure`）および CSRF 前提の変更
+- Google OAuth / パスキー登録・認証フロー本体（ログイン側）の挙動変更
+- ログアウト後の別ユーザー切替 UI（アカウント切替器）の追加
+- ログアウト完了トースト・確認モーダル等の追加 UX 拡張（本修正はワンクリック完了までを対象と
+  し、UI 上の演出は含まない）
+
+## Open Questions
+
+- なし（Issue 本文と現状コード（`web/src/hooks/use-auth.ts` / `web/src/components/logout-button.tsx` /
+  `web/src/lib/api.ts` / `internal/handler/auth_handler.go` の `Logout` ハンドラ）から要件は
+  一意に特定できる。実装方針（サーバ応答を 204 化する / クライアント側で `redirect: "manual"`
+  にする / 遷移先を `/` に変える 等）は本 spec では規定せず、Developer が Requirement 1〜6 の
+  AC を満たす形で判断する）
+
+## 関連
+
+- Related: #223 #234

--- a/docs/specs/235-fix-web-fetch-303/review-notes.md
+++ b/docs/specs/235-fix-web-fetch-303/review-notes.md
@@ -1,0 +1,42 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-07-28T20:32:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-235-impl-fix-web-fetch-303
+- HEAD commit: 426143f1ae6bd3b43d2948914433d124837a35be
+- Compared to: develop..HEAD
+- 備考: 本 Issue は `tasks.md` / `design.md` を持たない design-less impl。`_Boundary:_` アノテーションは存在せず、boundary 判定は requirements.md が示す scope（`auth_handler.go` の Logout / `web/src/lib/api.ts` / `web/src/components/logout-button.tsx`）との照合で実施。Feature Flag Protocol は `opt-out`（flag 観点は非適用）。
+
+## Verified Requirements
+
+- 1.1 — `auth_handler.go:248` Logout が `h.service.Logout` でセッション破棄要求を発行。`TestAuthHandler_Logout_JSONAccept_ReturnsNoContent`（`logoutCalledWith` を assert）
+- 1.2 — `logout-button.tsx` onSuccess → `window.location.assign("/")`（AuthGuard 経由でログイン画面）。`logout-button.test.tsx` の「ログアウト成功後は `/` に遷移し...」
+- 1.3 — `use-auth.ts` onSuccess の `queryClient.clear()` で全キャッシュ除去 + サーバセッション破棄。`logout-button.test.tsx` / `use-auth.test.tsx` のキャッシュクリアテスト
+- 1.4 — `logout-button.tsx` `disabled={logoutMutation.isPending}`。`logout-button.test.tsx` の「ログアウト処理中はボタンが非活性となり多重クリックを抑止する」（2 回目クリックで fetch 未発火を assert）
+- 2.1 / 2.2 / 2.3 — `useLogout` / `Logout` ともに認証方式で分岐しない単一経路。分岐不在が構造的に保証され、1.1〜1.3 の各テストが認証方式非依存で成立
+- 3.1 — `use-auth.ts` `queryClient.clear()`。`use-auth.test.tsx`「useLogout は成功時に QueryClient のキャッシュをクリア」+ `logout-button.test.tsx` の実キャッシュ消滅確認
+- 3.2 — 3.1 の `clear()`（全キャッシュ除去）で成立する派生 AC。クリア後は後続ユーザーが新規 fetch から開始
+- 4.1 / 4.3 — 遷移先を `/login`（非実在）→ `/` に修正。`logout-button.test.tsx` で `assign("/")` かつ `not.toHaveBeenCalledWith("/login")` を assert
+- 4.2 — 未認証で `/` → AuthGuard が LoginPage を提示（`login-page.tsx` は無変更で導線維持）
+- 5.1 — network reject → `mutation.isError` → `role="alert"` 表示 + ボタン再活性。`logout-button.test.tsx`「ネットワーク到達失敗時はエラー表示...再操作可能に戻す」
+- 5.2 — `api.ts` 非 OK 応答で `ApiError` throw → エラー表示。`logout-button.test.tsx`「サーバ 5xx 応答時...」
+- 5.3 — `Logout` はセッション未存在/破棄失敗でも Cookie クリア + 204 を返す。`TestAuthHandler_Logout_JSONAccept_NoSession_ReturnsNoContent`
+- 5.4 — エラー表示は固定文言のみ。`logout-button.test.tsx`「内部詳細（メッセージ / status 数値）を反射しない」（stack / code / 500 を not.toContain）
+- 6.1 — 両分岐で Cookie 属性（HttpOnly / SameSite=Lax / MaxAge=-1）を維持。`TestAuthHandler_Logout_JSONAccept_ReturnsNoContent` で assert
+- 6.2 — Accept 非 JSON は従来通り 303 + Location。`TestAuthHandler_Logout_FormPost_StillRedirects`（Accept 不在 / text/html / text/plain の table-driven）
+- 6.3 — `api.ts` の変更は Accept ヘッダ追加のみで既存 JSON エンドポイント挙動は不変。全 Go / web スイート pass
+- 6.4 — `login-page.tsx` 無変更、ログイン画面の要素・導線に変化なし
+- NFR 1.1 / 1.2 — エラー表示は固定文言・遷移 URL にクエリなし（5.4 テスト）/ 204・303 はボディなし（構造的）
+- NFR 2.1 / 2.2 / 2.3 — 追加テストは `mockFetch` / `window.location` モック・`httptest.NewRecorder` で完結し実物到達不要
+
+## Findings
+
+なし
+
+## Summary
+
+design-less impl として requirements.md の全 numeric AC（1.1〜6.4 / NFR 1・2）に対応する実装とテストを確認。変更は Logout ハンドラの content negotiation・apiClient の Accept 付与・logout-button の遷移先修正 + エラー表示に限定され scope 内。reviewer 再実行で Go handler tests / web logout tests（39 passed）とも green。
+
+RESULT: approve

--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/hitoshi/feedman/internal/auth"
 	"github.com/hitoshi/feedman/internal/model"
@@ -233,6 +234,17 @@ func (h *AuthHandler) handleNativeCallback(w http.ResponseWriter, r *http.Reques
 
 // Logout はセッションを破棄する。
 // POST /auth/logout
+//
+// レスポンス方式は Accept ヘッダで content negotiation する（Issue #235）:
+//   - Accept: application/json（fetch / XHR クライアント: Web 版 useLogout など）
+//     → 204 No Content。Location ヘッダは付与しない。
+//     fetch の既定 redirect: "follow" で 303 の Location を辿ると遷移先 HTML を
+//     取得し JSON パーサが SyntaxError となる（クライアントで失敗扱いになる）ため、
+//     JSON クライアントには redirect を返さず 204 で完了を伝える。
+//   - それ以外（HTML form POST 経由の従来クライアント等）
+//     → 303 See Other + Location: BaseURL（既存挙動と同一。Req 6.2 の後方互換）。
+//
+// セッション破棄と Cookie クリア（属性含む）は content negotiation の分岐に依らず同一。
 func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	// セッションCookieの取得
 	cookie, err := r.Cookie(sessionCookieName)
@@ -256,9 +268,38 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 		SameSite: http.SameSiteLaxMode,
 	})
 
+	// JSON クライアントは 204 No Content で完了を伝える（リダイレクトしない）。
+	if acceptsJSON(r.Header.Get("Accept")) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	// POST ログアウト後はリダイレクトを GET 化するため 303 See Other を用いる
 	// （307 だと method を保持し BaseURL へ再 POST してしまう）。
 	http.Redirect(w, r, h.config.BaseURL, http.StatusSeeOther)
+}
+
+// acceptsJSON は Accept ヘッダに application/json 型が明示的に含まれるかを判定する。
+//
+// カンマ区切りの各 media-type から q-value 等のパラメータを取り除き、名前部分を
+// 大小無視で比較する。ワイルドカード（*/*）や複合型（application/*）は「明示的な
+// application/json 要求」ではないとして false を返す。ブラウザの form POST が送る
+// "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8" のような
+// Accept 値では false になる（Req 6.2 の form POST 互換）。
+func acceptsJSON(accept string) bool {
+	if accept == "" {
+		return false
+	}
+	for _, part := range strings.Split(accept, ",") {
+		mediaType := strings.TrimSpace(part)
+		if idx := strings.Index(mediaType, ";"); idx >= 0 {
+			mediaType = strings.TrimSpace(mediaType[:idx])
+		}
+		if strings.EqualFold(mediaType, "application/json") {
+			return true
+		}
+	}
+	return false
 }
 
 // Me は現在のログインユーザー情報を返す。

--- a/internal/handler/auth_handler_test.go
+++ b/internal/handler/auth_handler_test.go
@@ -478,6 +478,145 @@ func TestAuthHandler_Logout_NoSession_StillRedirects(t *testing.T) {
 	}
 }
 
+// TestAuthHandler_Logout_JSONAccept_ReturnsNoContent は Accept: application/json を送る
+// fetch/XHR クライアント（Web 版 useLogout など）に対して 204 No Content を返し、
+// Location ヘッダを付与しないことを検証する（Issue #235 Requirement 1.1 / 1.2）。
+//
+// 従来 303 See Other + Location を返していたため、fetch の既定 redirect: "follow" で
+// クライアントが遷移先 HTML を取得し JSON パーサが SyntaxError を起こしてログアウトが
+// 失敗扱いになる不具合の中核修正。
+func TestAuthHandler_Logout_JSONAccept_ReturnsNoContent(t *testing.T) {
+	// Arrange
+	logoutCalledWith := ""
+	svc := &mockAuthService{
+		logoutFn: func(ctx context.Context, sessionID string) error {
+			logoutCalledWith = sessionID
+			return nil
+		},
+	}
+	h := NewAuthHandler(svc, AuthHandlerConfig{
+		BaseURL:       "http://localhost:3000",
+		CookieDomain:  "",
+		CookieSecure:  false,
+		SessionMaxAge: 86400,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.Header.Set("Accept", "application/json")
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: "session-json-client"})
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Logout(w, req)
+
+	// Assert: 204 No Content + Location ヘッダ不在（Req 1.1 / 1.2）
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+	if loc := resp.Header.Get("Location"); loc != "" {
+		t.Errorf("Location = %q, want empty (json client should not be redirected)", loc)
+	}
+
+	// セッション破棄が行われること（Req 1.1）
+	if logoutCalledWith != "session-json-client" {
+		t.Errorf("service.Logout called with %q, want %q", logoutCalledWith, "session-json-client")
+	}
+
+	// セッションCookieがクリアされること（NFR 1 / Req 6.1 の Cookie 属性維持）
+	var sessionCookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == "session_id" {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("expected session_id cookie to be cleared even for JSON client")
+	}
+	if sessionCookie.MaxAge != -1 {
+		t.Errorf("session cookie MaxAge = %d, want -1 (delete)", sessionCookie.MaxAge)
+	}
+	if !sessionCookie.HttpOnly {
+		t.Error("session cookie should remain HttpOnly (Req 6.1)")
+	}
+	if sessionCookie.SameSite != http.SameSiteLaxMode {
+		t.Errorf("session cookie SameSite = %v, want %v (Req 6.1)", sessionCookie.SameSite, http.SameSiteLaxMode)
+	}
+}
+
+// TestAuthHandler_Logout_JSONAccept_NoSession_ReturnsNoContent は Accept: application/json
+// で session Cookie を持たないクライアントに対しても 204 を返すことを検証する
+// （Req 5.3 セッション期限切れ・未存在時もログイン画面表示に到達）。
+func TestAuthHandler_Logout_JSONAccept_NoSession_ReturnsNoContent(t *testing.T) {
+	// Arrange: Cookie を付与しない
+	h := NewAuthHandler(&mockAuthService{}, AuthHandlerConfig{
+		BaseURL: "http://localhost:3000",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+
+	// Act
+	h.Logout(w, req)
+
+	// Assert: 204 でリダイレクトしない
+	resp := w.Result()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+	if loc := resp.Header.Get("Location"); loc != "" {
+		t.Errorf("Location = %q, want empty", loc)
+	}
+}
+
+// TestAuthHandler_Logout_FormPost_StillRedirects は Accept ヘッダに application/json を
+// 含まない従来クライアント（HTML form POST 経由等）に対しては、これまで通り 303 See Other +
+// Location を返すことを検証する（Req 6.2 の後方互換性維持）。
+func TestAuthHandler_Logout_FormPost_StillRedirects(t *testing.T) {
+	cases := []struct {
+		name   string
+		accept string
+	}{
+		{name: "Accept ヘッダ不在", accept: ""},
+		{name: "HTML を要求する form POST", accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"},
+		{name: "text/plain のみ", accept: "text/plain"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			svc := &mockAuthService{
+				logoutFn: func(ctx context.Context, sessionID string) error {
+					return nil
+				},
+			}
+			h := NewAuthHandler(svc, AuthHandlerConfig{
+				BaseURL:       "http://localhost:3000",
+				SessionMaxAge: 86400,
+			})
+			req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+			if tc.accept != "" {
+				req.Header.Set("Accept", tc.accept)
+			}
+			req.AddCookie(&http.Cookie{Name: "session_id", Value: "session-form-post"})
+			w := httptest.NewRecorder()
+
+			// Act
+			h.Logout(w, req)
+
+			// Assert: 従来通り 303 See Other + Location: BaseURL（Req 6.2）
+			resp := w.Result()
+			if resp.StatusCode != http.StatusSeeOther {
+				t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusSeeOther)
+			}
+			if loc := resp.Header.Get("Location"); loc != "http://localhost:3000" {
+				t.Errorf("Location = %q, want %q", loc, "http://localhost:3000")
+			}
+		})
+	}
+}
+
 func TestAuthHandler_Me_Authenticated_ReturnsUserJSON(t *testing.T) {
 	svc := &mockAuthService{
 		getCurrentUserFn: func(ctx context.Context, sessionID string) (*model.User, error) {

--- a/web/src/components/logout-button.test.tsx
+++ b/web/src/components/logout-button.test.tsx
@@ -16,7 +16,7 @@ Object.defineProperty(window, "location", {
   writable: true,
 });
 
-/** テスト用ラッパー */
+/** テスト用ラッパー。テストごとに新しい QueryClient を返す。 */
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -24,26 +24,32 @@ function createWrapper() {
       mutations: { retry: false },
     },
   });
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>
-        {children}
-      </QueryClientProvider>
-    );
+  return {
+    queryClient,
+    Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+    },
   };
 }
 
 describe("LogoutButton コンポーネント", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // 既定は 204 No Content 相当（サーバ #235 修正後の JSON クライアント応答）
     mockFetch.mockResolvedValue({
       ok: true,
+      status: 204,
       json: async () => ({}),
     });
   });
 
   it("ログアウトボタンが表示されること", () => {
-    render(<LogoutButton />, { wrapper: createWrapper() });
+    const { Wrapper } = createWrapper();
+    render(<LogoutButton />, { wrapper: Wrapper });
 
     expect(
       screen.getByRole("button", { name: "ログアウト" })
@@ -52,8 +58,9 @@ describe("LogoutButton コンポーネント", () => {
 
   it("ログアウトボタンをクリックするとAPIが呼ばれること", async () => {
     const user = userEvent.setup();
+    const { Wrapper } = createWrapper();
 
-    render(<LogoutButton />, { wrapper: createWrapper() });
+    render(<LogoutButton />, { wrapper: Wrapper });
 
     await user.click(screen.getByRole("button", { name: "ログアウト" }));
 
@@ -65,5 +72,170 @@ describe("LogoutButton コンポーネント", () => {
         })
       );
     });
+  });
+
+  // Issue #235 Requirement 1.2 / 4.1 / 4.2:
+  //   ログアウト成功時は Feedman ルーティング上に実在する `/` に遷移する
+  //   （`/login` は存在しないパスなので遷移してはならない）。
+  it("ログアウト成功後は `/` に遷移し、`/login` には遷移しないこと", async () => {
+    const user = userEvent.setup();
+    const { Wrapper } = createWrapper();
+
+    render(<LogoutButton />, { wrapper: Wrapper });
+
+    await user.click(screen.getByRole("button", { name: "ログアウト" }));
+
+    await waitFor(() => {
+      expect(mockAssign).toHaveBeenCalledWith("/");
+    });
+    expect(mockAssign).not.toHaveBeenCalledWith("/login");
+    expect(mockAssign).toHaveBeenCalledTimes(1);
+  });
+
+  // Requirement 3.1:
+  //   ログアウト完了時に前ユーザーのクライアント側キャッシュがクリアされること。
+  it("ログアウト成功後は QueryClient のキャッシュがクリアされること（Requirement 3.1）", async () => {
+    const user = userEvent.setup();
+    const { queryClient, Wrapper } = createWrapper();
+
+    // Arrange: 認証済みユーザーが観察していたキャッシュを事前に格納
+    queryClient.setQueryData(["auth", "me"], {
+      id: "user-1",
+      email: "prev@example.com",
+      name: "Prev User",
+    });
+    queryClient.setQueryData(["feeds"], [{ id: "feed-1", title: "F1" }]);
+
+    render(<LogoutButton />, { wrapper: Wrapper });
+
+    // sanity: 前提としてキャッシュに値が入っている
+    expect(queryClient.getQueryData(["auth", "me"])).toBeDefined();
+    expect(queryClient.getQueryData(["feeds"])).toBeDefined();
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "ログアウト" }));
+    await waitFor(() => {
+      expect(mockAssign).toHaveBeenCalledWith("/");
+    });
+
+    // Assert: ログアウト成功後、全キャッシュが除去されている
+    expect(queryClient.getQueryData(["auth", "me"])).toBeUndefined();
+    expect(queryClient.getQueryData(["feeds"])).toBeUndefined();
+  });
+
+  // Requirement 1.4:
+  //   ログアウト処理中はボタンが再クリックできない（多重クリック抑止）。
+  it("ログアウト処理中はボタンが非活性となり多重クリックを抑止すること", async () => {
+    const user = userEvent.setup();
+    const { Wrapper } = createWrapper();
+
+    // fetch を pending 状態にして isPending 分岐を観察できるようにする
+    let resolveFetch: (value: {
+      ok: true;
+      status: 204;
+      json: () => Promise<unknown>;
+    }) => void = () => undefined;
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    render(<LogoutButton />, { wrapper: Wrapper });
+    const button = screen.getByRole("button", { name: "ログアウト" });
+
+    // Act: 1 回目のクリックで pending に入る
+    await user.click(button);
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+    });
+
+    // Act: 2 回目のクリックを試みる（disabled なので fetch は発火しない想定）
+    await user.click(button);
+    // 追加 fetch が発火していないことを確認
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // クリーンアップ: pending を解放
+    resolveFetch({ ok: true, status: 204, json: async () => ({}) });
+    await waitFor(() => {
+      expect(mockAssign).toHaveBeenCalledWith("/");
+    });
+  });
+
+  // Requirement 5.1 (ネットワーク到達失敗) と Requirement 5.2 (5xx) の共通挙動:
+  //   ユーザーに失敗した旨を認識可能な表示を提示し、ボタンを再操作可能な状態に戻す。
+  it("ネットワーク到達失敗時はエラー表示を提示し、ボタンを再操作可能に戻すこと（Requirement 5.1）", async () => {
+    const user = userEvent.setup();
+    const { Wrapper } = createWrapper();
+
+    mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    render(<LogoutButton />, { wrapper: Wrapper });
+
+    await user.click(screen.getByRole("button", { name: "ログアウト" }));
+
+    // エラー表示が role="alert" で提示されること
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("ログアウトに失敗しました");
+
+    // 遷移していないこと（認証済み状態のまま留まる）
+    expect(mockAssign).not.toHaveBeenCalled();
+
+    // ボタンが再度活性化していること（再操作可能）
+    expect(
+      screen.getByRole("button", { name: "ログアウト" })
+    ).not.toBeDisabled();
+  });
+
+  it("サーバ 5xx 応答時はエラー表示を提示し、ボタンを再操作可能に戻すこと（Requirement 5.2）", async () => {
+    const user = userEvent.setup();
+    const { Wrapper } = createWrapper();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ message: "internal error" }),
+    });
+
+    render(<LogoutButton />, { wrapper: Wrapper });
+
+    await user.click(screen.getByRole("button", { name: "ログアウト" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("ログアウトに失敗しました");
+    expect(mockAssign).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "ログアウト" })
+    ).not.toBeDisabled();
+  });
+
+  // Requirement 5.4:
+  //   エラー表示にサーバ応答の内部詳細（スタックトレース・内部エラー原因）を
+  //   反射しないこと。ユーザー可視のテキストは固定文言のみ。
+  it("エラー表示にサーバ応答の内部詳細（メッセージ / status 数値）を反射しないこと（Requirement 5.4）", async () => {
+    const user = userEvent.setup();
+    const { Wrapper } = createWrapper();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({
+        // サーバ由来のスタック風文字列。ユーザーに露出してはならない。
+        message:
+          "stack trace: at internal.session_store.destroy(/opt/api/internal/session/store.go:42)",
+        code: "SESSION_STORE_INTERNAL_ERROR",
+      }),
+    });
+
+    render(<LogoutButton />, { wrapper: Wrapper });
+    await user.click(screen.getByRole("button", { name: "ログアウト" }));
+
+    const alert = await screen.findByRole("alert");
+    const text = alert.textContent ?? "";
+    expect(text).not.toContain("stack trace");
+    expect(text).not.toContain("SESSION_STORE_INTERNAL_ERROR");
+    expect(text).not.toContain("500");
+    expect(text).not.toContain("session/store.go");
   });
 });

--- a/web/src/components/logout-button.tsx
+++ b/web/src/components/logout-button.tsx
@@ -7,8 +7,15 @@ import { useLogout } from "@/hooks/use-auth";
 /**
  * ログアウトボタン
  *
- * POST /auth/logout を呼び出してセッションを破棄し、
- * ログインページにリダイレクトする。
+ * POST /auth/logout を呼び出してセッションを破棄し、Feedman Web のルート `/` に
+ * 遷移する。未認証状態で `/` にアクセスすると `AuthGuard` が `LoginPage` を表示
+ * するため、ユーザーにはログイン画面が提示される（Issue #235 Requirement 4）。
+ *
+ * 従来は存在しない `/login` に遷移していたため 404 に落ちていた。
+ *
+ * 失敗時（ネットワーク到達失敗 / 5xx）はエラーメッセージを表示し、ボタンを
+ * 再操作可能な状態に戻す（Requirement 5.1 / 5.2）。ボタンは処理中のみ非活性
+ * となり、多重クリックによる重複要求を抑止する（Requirement 1.4）。
  */
 export function LogoutButton() {
   const logoutMutation = useLogout();
@@ -16,21 +23,34 @@ export function LogoutButton() {
   const handleLogout = () => {
     logoutMutation.mutate(undefined, {
       onSuccess: () => {
-        // セッション破棄後にログインページへリダイレクト
-        window.location.assign("/login");
+        // セッション破棄後にルート `/` へ遷移する。
+        // 未認証で `/` にアクセスすると AuthGuard がログイン画面を表示する
+        // （Feedman Web のルーティングには `/login` は存在しない）。
+        window.location.assign("/");
       },
     });
   };
 
   return (
-    <Button
-      variant="ghost"
-      size="sm"
-      onClick={handleLogout}
-      disabled={logoutMutation.isPending}
-    >
-      <LogOut className="w-4 h-4" />
-      ログアウト
-    </Button>
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleLogout}
+        disabled={logoutMutation.isPending}
+      >
+        <LogOut className="w-4 h-4" />
+        ログアウト
+      </Button>
+      {logoutMutation.isError && (
+        <p
+          role="alert"
+          className="text-xs text-destructive"
+          data-testid="logout-error"
+        >
+          ログアウトに失敗しました。時間をおいて再度お試しください。
+        </p>
+      )}
+    </div>
   );
 }

--- a/web/src/hooks/use-auth.test.tsx
+++ b/web/src/hooks/use-auth.test.tsx
@@ -116,4 +116,62 @@ describe("useLogout", () => {
       })
     );
   });
+
+  // Issue #235:
+  //   fetch はサーバの content negotiation を成立させるため Accept: application/json を
+  //   送信する必要がある。これが無いと従来クライアントとして 303 + Location が返り、
+  //   fetch の既定 redirect: "follow" で遷移先 HTML が JSON パースに失敗する。
+  it("useLogout は Accept: application/json を送信すること（Issue #235 サーバ content negotiation 前提）", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+    });
+
+    const { result } = renderHook(() => useLogout(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate();
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = options.headers as Record<string, string>;
+    expect(headers.Accept).toBe("application/json");
+  });
+
+  // Requirement 3.1 の中核: mutation success 時にキャッシュをクリアする。
+  // useLogout フック側にも onSuccess 契約があり、logout-button の onSuccess とは
+  // 独立した責務（キャッシュクリア）を担う。
+  it("useLogout は成功時に QueryClient のキャッシュをクリアすること（Requirement 3.1）", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    queryClient.setQueryData(["auth", "me"], { id: "user-x" });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useLogout(), { wrapper });
+
+    result.current.mutate();
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // 保持していたキャッシュエントリが除去される
+    expect(queryClient.getQueryData(["auth", "me"])).toBeUndefined();
+  });
 });

--- a/web/src/hooks/use-feeds.test.tsx
+++ b/web/src/hooks/use-feeds.test.tsx
@@ -77,7 +77,7 @@ describe("useFeeds", () => {
     // /api/subscriptions への呼び出しがあること
     expect(mockFetch).toHaveBeenCalledWith("/api/subscriptions", {
       method: "GET",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
       credentials: "include",
     });
   });

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -29,6 +29,7 @@ describe("apiClient", () => {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
+          Accept: "application/json",
         },
         credentials: "include",
       });
@@ -57,6 +58,7 @@ describe("apiClient", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          Accept: "application/json",
         },
         credentials: "include",
         body: JSON.stringify({ url: "https://example.com/feed.xml" }),
@@ -72,6 +74,7 @@ describe("apiClient", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          Accept: "application/json",
         },
         credentials: "include",
       });
@@ -88,6 +91,7 @@ describe("apiClient", () => {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
+          Accept: "application/json",
         },
         credentials: "include",
         body: JSON.stringify({ is_read: true }),
@@ -105,6 +109,7 @@ describe("apiClient", () => {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
+          Accept: "application/json",
         },
         credentials: "include",
         body: JSON.stringify({ feed_url: "https://new-url.com" }),
@@ -122,6 +127,7 @@ describe("apiClient", () => {
         method: "DELETE",
         headers: {
           "Content-Type": "application/json",
+          Accept: "application/json",
         },
         credentials: "include",
       });
@@ -150,6 +156,7 @@ describe("apiClient", () => {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
+          Accept: "application/json",
         },
         credentials: "include",
       });
@@ -228,9 +235,33 @@ describe("apiClient", () => {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
+          Accept: "application/json",
         },
         credentials: "include",
       });
+    });
+  });
+
+  describe("Accept ヘッダ（Issue #235）", () => {
+    it("全メソッドが Accept: application/json を送信すること（サーバ側 content negotiation の識別条件）", async () => {
+      // Arrange
+      const api = createApiClient();
+
+      // Act: 各メソッドを一度ずつ呼び出す
+      await api.get("/api/x");
+      await api.post("/api/x");
+      await api.put("/api/x", {});
+      await api.patch("/api/x", {});
+      await api.delete("/api/x");
+
+      // Assert: 全 5 回の呼び出しで Accept: application/json が含まれる
+      // （POST /auth/logout の content negotiation を成立させるため / Req 1.1 起点）
+      for (const call of mockFetch.mock.calls) {
+        const options = call[1] as RequestInit;
+        const headers = options.headers as Record<string, string>;
+        expect(headers.Accept).toBe("application/json");
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(5);
     });
   });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -75,6 +75,11 @@ async function request<T>(
   try {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
+      // Accept: application/json をサーバに明示することで、サーバ側 content
+      // negotiation ハンドラ（例: POST /auth/logout / Issue #235）が form POST 経由の
+      // 従来クライアントと fetch / XHR 経由の JSON クライアントを識別できるようにする。
+      // 追加コストは 1 ヘッダのみで、既存 JSON API エンドポイントの応答挙動は変わらない。
+      Accept: "application/json",
     };
 
     options = {


### PR DESCRIPTION
## 概要

Feedman Web のログアウトボタンが機能しない不具合を修正する。

現状、ブラウザ fetch API 経由で `POST /auth/logout` を呼ぶと、サーバが form POST 前提の
303 See Other + Location を返し、fetch が自動的にリダイレクトを追従してログイン画面の HTML を
取得するため JSON 解析に失敗していた（staging 実機で 303 が 11 連続到達する事象を確認）。
加えてクライアント側の遷移先がハードコードの `/login`（Feedman Web のルーティングに存在しない
パス）になっており、仮に後続処理が動いても 404 に落ちていた。

本 PR ではサーバ側の content negotiation（Accept: application/json → 204 / それ以外 → 303）と
クライアント側の Accept ヘッダ明示・遷移先修正・エラーフィードバック追加により、1 クリックで
確実にログアウト完了しログイン画面に到達できる状態にする。

## 対応 Issue

Closes #235

## 関連 PR

- 設計 PR: なし（design-less impl）

## 実装内容

- (Req 1.1 / Task: auth_handler.go) `Logout` ハンドラに content negotiation を追加。Accept に
  `application/json` を含む場合は 204 No Content を返し、fetch リダイレクト追従事故を防ぐ
- (Req 6.2) Accept に JSON 以外（form POST・ブラウザ通常リクエスト）を含む場合は従来通り
  303 + Location を返し、既存経路の後方互換を維持
- (Req 1.2 / 1.3 / 4.1) `logout-button.tsx` の遷移先を `/login`（非実在）→ `/`（AuthGuard が
  未認証時にログイン画面を提示）に修正
- (Req 5.1 / 5.2 / 5.4) mutation エラー時に `role="alert"` のエラー表示を追加（固定文言。
  内部詳細は反射しない）
- (Req 1.3 / 3.1) `use-auth.ts` の `onSuccess` で `queryClient.clear()` によるキャッシュクリア
  （既存実装の確認・テスト補強）
- (NFR 2) `apiClient` に `Accept: application/json` をデフォルトヘッダとして追加
  （全 API リクエストの JSON クライアント明示）

## 受入基準チェック

- [x] Req 1.1: 1 クリックでサーバセッション破棄要求を発行 ← `TestAuthHandler_Logout_JSONAccept_ReturnsNoContent`（service.Logout 呼び出し assert）
- [x] Req 1.2: 追加操作なしでログイン画面表示 ← `logout-button.test.tsx`「ログアウト成功後は / に遷移し...」
- [x] Req 1.3: ログアウト後に保護ビュー再取得不可 ← `logout-button.test.tsx` / `use-auth.test.tsx`「QueryClient のキャッシュがクリアされること」
- [x] Req 1.4: 進行中の多重クリック抑止 ← `logout-button.test.tsx`「ログアウト処理中はボタンが非活性となり多重クリックを抑止する」
- [x] Req 2.1 / 2.2 / 2.3: 認証方式（Google / パスキー）に依存しない単一経路 ← 実装上分岐なし（構造的保証）
- [x] Req 3.1: クライアント側キャッシュクリア ← `use-auth.test.tsx`「useLogout は成功時に QueryClient のキャッシュをクリア」
- [x] Req 4.1 / 4.3: 遷移先は実在パス `/` ← `logout-button.test.tsx`「assign("/") かつ /login には遷移しない」
- [x] Req 5.1: ネットワーク失敗時のエラー表示 + 再活性化 ← `logout-button.test.tsx`「ネットワーク到達失敗時...」
- [x] Req 5.2: 5xx 時のエラー表示 ← `logout-button.test.tsx`「サーバ 5xx 応答時...」
- [x] Req 5.3: セッション未存在時もログイン画面到達 ← `TestAuthHandler_Logout_JSONAccept_NoSession_ReturnsNoContent`
- [x] Req 5.4: エラー表示に内部詳細を反射しない ← `logout-button.test.tsx`「stack / code / 500 を not.toContain」
- [x] Req 6.1: Cookie 属性・CSRF 前提を維持 ← `TestAuthHandler_Logout_JSONAccept_ReturnsNoContent`（HttpOnly / SameSite / MaxAge=-1 assert）
- [x] Req 6.2: form POST 経路の後方互換 ← `TestAuthHandler_Logout_FormPost_StillRedirects`（table-driven: Accept 不在 / text/html / text/plain → 303）
- [x] Req 6.3: 対象外機能の既存挙動維持 ← 全 Go / web テストスイート pass
- [x] NFR 1.1 / 1.2: 機密情報の非漏出 ← 固定文言エラー表示 / 204 No Content（本文なし）
- [x] NFR 2.1 / 2.2 / 2.3: テスト容易性 ← mockFetch / httptest.NewRecorder で実物未到達

## テスト結果

```
# Go
go test ./... — 全パッケージ pass（handler / auth / middleware / worker 等すべて OK）
go vet ./internal/handler/... — 出力なし（clean）
gofmt -l（変更ファイルのみ） — 出力なし

# Web (Next.js)
npm test -- --run — 52 files / 528 tests passed
npm run lint — errors: 0（warnings 5 は既存の pre-existing）
npm run build — production build 成功（/ route 76.3 kB / First Load 201 kB）
```

## 実装上の判断

- **content negotiation 方式を採用**（候補 A）: `redirect: "manual"` 方式（候補 B）や常時 204 化（候補 C）と比較し、form POST 後方互換（Req 6.2）を破らずに直接的に問題を解消できる方式を選択（詳細は `docs/specs/235-fix-web-fetch-303/impl-notes.md` を参照）
- **`acceptsJSON` の parse は defensive**: `application/*` / `*/*` は false に倒し、form POST ブラウザの通常 Accept での誤判定を防ぐ
- **pre-existing gofmt 差分は温存**: `crossfeed_handler_test.go` / `feed_handler_test.go` 等の既存 format 差分は Req 6.3 に従い本 spec の scope 外として変更しない

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- Reviewer レビュー結果: `docs/specs/235-fix-web-fetch-303/review-notes.md`（RESULT: approve）
- base: develop / baseRefName: develop / OK（PR 作成後に検証済み）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #235 のコメントを参照してください。
