### PR TITLE
feat(#236): アカウント設定への導線追加・WithdrawDialog 配線・退会エンドポイント修正

### DIFF
--- a/docs/specs/236-feat-web-withdrawdialog-ui/impl-notes.md
+++ b/docs/specs/236-feat-web-withdrawdialog-ui/impl-notes.md
@@ -1,0 +1,155 @@
+# Issue #236 実装ノート
+
+## 概要
+
+Web UI に「アカウント設定」への導線を追加し、既存の dead code だった `WithdrawDialog`
+を配線した。同時に、`WithdrawDialog` が呼び出していた退会エンドポイントが未登録の
+`/api/account` になっていた不整合を修正し、実 route である `DELETE /api/users/me` に
+差し替えた。パスキーのみアカウント（`email` が空文字）でも情報表示・退会が破綻しない
+状態にした。
+
+## 追加 / 変更ファイル
+
+| ファイル | 種別 | 責務 |
+|---|---|---|
+| `web/src/components/withdraw-dialog.tsx` | 変更 | 退会 API を `DELETE /api/users/me` に修正、失敗時のインライン通知を追加、多重送信防止（既存 `isPending` + `preventDefault`） |
+| `web/src/components/withdraw-dialog.test.tsx` | 変更 | エンドポイント assertion 更新、失敗時 / 多重送信防止テストを追加（9 ケース） |
+| `web/src/components/account-settings-dialog.tsx` | 新規 | ヘッダー配下ギアから開く Dialog、アカウント情報表示 + 退会導線を含む |
+| `web/src/components/account-settings-dialog.test.tsx` | 新規 | 単体テスト（10 ケース） |
+| `web/src/components/app-shell.tsx` | 変更 | ヘッダーに `<AccountSettingsDialog />` を配置（`LogoutButton` の隣） |
+| `web/src/components/app-shell.test.tsx` | 変更 | `/auth/me` モック追加、入口表示 / ダイアログ内容テストを追加（3 ケース） |
+| `web/src/components/auth-guard.test.tsx` | 変更 | 未認証時に入口が render されないこと / 認証時に render されることを検証（2 ケース） |
+
+## エンドポイント修正（`/api/account` → `/api/users/me`）の裏取り
+
+- 修正前: `WithdrawDialog` は `apiClient.delete("/api/account")` を呼んでいたが、
+  `internal/handler/router.go` L377-L388 の `/api/users` ルート配下に `/account` は
+  登録されていない。したがって既存の状態で配線しても 404 で退会不能だった
+- 修正後: `internal/handler/router.go` L382 の `r.Delete("/me", userHandler.Withdraw)`
+  に対応する `DELETE /api/users/me` を呼び出す
+- テストでも旧 `/api/account` 呼び出しが発生していないことを回帰テストで担保
+  （`withdraw-dialog.test.tsx` の「退会実行時に DELETE /api/users/me を送信すること」）
+
+## AC マッピング
+
+| AC | 対応コード | 対応テスト |
+|---|---|---|
+| Req 1.1 (認証済み画面から視認可能な入口) | `app-shell.tsx` ヘッダーの `<AccountSettingsDialog />` | `app-shell.test.tsx` "ヘッダーにアカウント設定入口が表示されること"、`auth-guard.test.tsx` "認証済み時はアカウント設定入口 ... render されること" |
+| Req 1.2 (情報表示 + 退会導線を含む画面) | `account-settings-dialog.tsx` `AccountSettingsBody` | `account-settings-dialog.test.tsx` "入口ボタンをクリックするとアカウント情報表示領域と退会導線を含むダイアログが開くこと"、`app-shell.test.tsx` "アカウント設定入口クリックで ... ダイアログが開くこと" |
+| Req 1.3 (未認証時に入口非表示) | 構造的保証: `AuthGuard` が `AppShell` を render しない | `auth-guard.test.tsx` "未認証時はアカウント設定入口 ... render されないこと" |
+| Req 1.4 (明示的な閉鎖) | radix-ui `Dialog` の Esc / overlay click / close button（既定挙動） | `account-settings-dialog.test.tsx` "ダイアログはユーザー操作 (Esc) で明示的に閉じられること" |
+| Req 2.1 (表示名表示) | `AccountInfoSection` 内 `data-testid="account-info-name"` | `account-settings-dialog.test.tsx` "表示名と email が表示されること"、`app-shell.test.tsx` "アカウント設定入口クリックで ..." |
+| Req 2.2 (email 有設定時表示) | `AccountInfoSection` の `emailIsSet` true 分岐 | `account-settings-dialog.test.tsx` "表示名と email が表示されること" |
+| Req 2.3 (email 空 → 「未設定」プレースホルダ) | `AccountInfoSection` の `emailIsSet` false 分岐、`EMAIL_UNSET_LABEL="未設定"` | `account-settings-dialog.test.tsx` "email が未設定（空文字）のとき「未設定」プレースホルダが表示され、空欄放置されないこと" |
+| Req 2.4 (取得失敗時通知) | `AccountSettingsBody` の `isError` 分岐（`role="alert"`、空 UI にしない） | `account-settings-dialog.test.tsx` "アカウント情報の取得に失敗したときエラー通知が表示され、空 UI にならないこと" |
+| Req 3.1 (退会起動要素の表示) | `WithdrawSection` 内蔵の `<WithdrawDialog />` の trigger button | `account-settings-dialog.test.tsx` "入口ボタンをクリックすると ... 退会導線を含むダイアログが開くこと" |
+| Req 3.2 (確認ダイアログ表示 + 取消不能明示) | `WithdrawDialog` の `<AlertDialog>` + description | `withdraw-dialog.test.tsx` "退会ボタンをクリックすると確認ダイアログが開くこと"、"確認ダイアログに削除・取り消し不能である旨の警告文が表示されること" |
+| Req 3.3 (キャンセルで送信しない) | `AlertDialogCancel` の既定 close 挙動 | `withdraw-dialog.test.tsx` "キャンセルボタンで退会要求が送信されないこと"、`account-settings-dialog.test.tsx` "退会確認ダイアログでキャンセルすると DELETE を送信せず ..." |
+| Req 3.4 (現行エンドポイントと整合する削除要求) | `withdraw-dialog.tsx` `apiClient.delete("/api/users/me")` | `withdraw-dialog.test.tsx` "退会実行時に DELETE /api/users/me を送信すること"、`account-settings-dialog.test.tsx` "退会確定で DELETE /api/users/me が発行され ..." |
+| Req 3.5 (成功時未認証遷移) | `withdraw-dialog.tsx` onSuccess: `queryClient.clear()` + `onWithdrawn?.()`、`account-settings-dialog.tsx` `handleWithdrawn = () => window.location.assign("/login")` | `withdraw-dialog.test.tsx` "退会成功時に onWithdrawn が呼ばれ ..."、`account-settings-dialog.test.tsx` "退会確定で DELETE ... 成功時に /login へリダイレクトされること" |
+| Req 3.6 (失敗時セッション維持 + 通知) | `withdraw-dialog.tsx` の `mutation.isError` 表示（`role="alert"`）、onSuccess 分離により `queryClient.clear()`/`onWithdrawn` は失敗時に呼ばれない | `withdraw-dialog.test.tsx` "退会失敗時（サーバ 500）に ..."、"退会失敗時（ネットワーク到達不能）でも ..."、`account-settings-dialog.test.tsx` "退会失敗時に /login へリダイレクトせず ..." |
+| Req 3.7 (email 空パスキーアカウントで同一フロー成功) | 退会フローは email に依存しない（`DELETE /api/users/me` は Cookie セッションで対象特定） | `account-settings-dialog.test.tsx` "email 未設定（空文字）のパスキーのみアカウントでも退会が同一フローで完了すること" |
+| Req 3.8 (多重送信防止) | `AlertDialogAction` の `disabled={withdrawMutation.isPending}` + `event.preventDefault()` で close 抑止 | `withdraw-dialog.test.tsx` "応答待機中は退会確定ボタンが disabled で多重送信されないこと" |
+| NFR 1.1 (2 ペイン挙動不変) | `app-shell.tsx` の変更範囲はヘッダー内のみで 2 ペイン分岐に触れていない | 既存 `app-shell.test.tsx` の 2 ペイン系ケース群（54 件が引き続き pass） |
+| NFR 1.2 (購読設定ダイアログ挙動不変) | `SubscriptionSettingsDialog` の import / 呼び出しは変更していない | 既存 `app-shell.test.tsx` の「購読解除フロー (task 6)」ケース群が引き続き pass |
+| NFR 1.3 (ヘッダー既存機能不変) | `LogoutButton` / `ThemeToggle` を残置、隣に追加 | `app-shell.test.tsx` "ヘッダーにアカウント設定入口が表示されること" 内で既存 2 ボタン存在も併せて assert |
+| NFR 2.1〜2.3 (自動テストによる検証可能性) | 上記 Req 2.1〜2.4 / 3.4〜3.7 / 1.1 / 1.3 の各テストで担保 | ↑ 参照 |
+
+## 検証結果
+
+作業ディレクトリ: `/home/hitoshi/.issue-watcher/worktrees/hitoshiichikawa-feedman/slot-1/web`
+
+| コマンド | 結果 | 備考 |
+|---|---|---|
+| `npx vitest run src/components/withdraw-dialog.test.tsx` | 9 pass / 9 total | エンドポイント修正 + 失敗ハンドリング + 多重送信防止 |
+| `npx vitest run src/components/account-settings-dialog.test.tsx` | 10 pass / 10 total | 新規コンポーネントの単体テスト |
+| `npx vitest run src/components/app-shell.test.tsx src/components/auth-guard.test.tsx src/components/account-settings-dialog.test.tsx src/components/withdraw-dialog.test.tsx` | 54 pass / 54 total | 変更に関連する 4 ファイル横串 |
+| `npx vitest run`（全 web テスト） | **536 pass / 536 total（53 ファイル）** | 既存テストの regression なし |
+| `npx eslint` | **0 errors** / 5 warnings（既存の `<img>` / 未使用変数警告のみ、本 PR で導入していない） | 本 PR の新規コードにエラー・警告なし |
+| `npx next build` | pass（`.next` 生成 / route `/` は 75.5 kB / 5 static pages） | 型エラーなし、build 通過 |
+
+Go 側は変更していないため `go test ./...` / `gofmt` / `go vet` は今回スコープ外
+（`internal/handler/router.go` は route 確認のため Read のみ）。
+
+## 実装上の判断
+
+### AlertDialogAction の close 抑止
+radix-ui `AlertDialogAction` は onClick 後に既定で dialog を close する。従来コードは
+成功時 `queryClient.clear()` により全 query が消えて `AuthGuard` が login にリダイレクト
+するため、実挙動としては close 動作が問題にならなかった。しかし失敗時の通知（Req 3.6）を
+ダイアログ内に残す必要が出たため、`event.preventDefault()` で既定 close を抑止し、
+成功時のみ明示的に `setOpen(false)`（`onSuccess` 内で実施）する構成に変更した。多重送信
+防止の `disabled` 表示更新にも同構成が有利。
+
+### AccountSettingsBody を internal function として抽出
+`AccountSettingsDialog` は open 制御のみを担い、`useCurrentUser` の state 別分岐を
+`AccountSettingsBody` に集約した。Dialog が閉じている間は radix-ui `Portal` により
+`AccountSettingsBody` はマウントされないため、不要な `/auth/me` 発火を避ける効果もある
+（既存キャッシュがある場合はネットワーク発火せず即座に render）。
+
+### 既存 LogoutButton パターンとの整合
+退会成功後のリダイレクトは `window.location.assign("/login")` で行う。これは既存
+`LogoutButton` と同一の遷移方式で、Web の未認証入口を統一する。仮に SPA 内遷移
+（`next/navigation` 経由）に変えると認証系 boundary で AuthGuard 再判定を挟むため
+挙動は等価だが、既存パターンを踏襲した。
+
+### email 未設定文言「未設定」の採用
+requirements.md Open Questions で PM が採用した「未設定」文言をそのまま採用（別文言
+案「(メールアドレス未登録)」は既存 UI コピー方針との整合が確認できなかったため
+保守的に requirements の記述を採用）。将来的な文言変更は本 PR とは別 Issue で扱う。
+
+### 取得失敗時の通知手段（Req 2.4 / 3.6）
+Open Questions で「トースト / インラインエラー等」が保留されていたが、既存
+`feed-register-dialog.tsx` / `passkey-signup-dialog.tsx` / `ManualRefreshBanner`
+がすべて **`role="alert"` の inline エラー領域** を採用しているため、本 PR も同様の
+パターンに揃えた。トーストコンポーネントは web/ に存在しない（`@testing-library/react`
+以外に toast lib を導入していない）ため、新規依存を増やさない選択でもある。
+
+## 確認事項（レビュワー判断ポイント）
+
+以下は requirements 未規定 / Open Questions 相当の点を Developer 裁量で確定した箇所です。
+requirements.md / 既存 spec は書き換えず本ノートに列挙します。
+
+1. **UI 形式は Dialog を採用**
+   Open Questions で「ヘッダー配下のポップオーバー / Dialog / 独立ページ」が保留され
+   ていたが、既存 `SubscriptionSettingsDialog` と同じく shadcn/ui `Dialog` を採用した。
+   独立ページ化した場合の URL 設計・戻り導線・Next.js App Router との整合が本 Issue
+   スコープを超えるため、既存パターンとの整合を優先した。将来的な独立ページ化への
+   移行障壁は低い（`AccountSettingsBody` を router page から呼び出せる形で分離済み）。
+
+2. **アイコンは `UserCog`（lucide-react）を採用**
+   既存で `UserCog` の利用箇所はなく、`LogoutButton` の `LogOut` アイコンと視覚的に
+   区別しやすい形で選択した。設定系メニューのアイコンとしても慣習的。
+
+3. **通知手段は inline `role="alert"` エリア（トースト非採用）**
+   前述「実装上の判断」で述べたとおり、既存パターンとの整合とライブラリ追加回避のため
+   inline 通知を選択。トーストへの将来的な統一が必要な場合は別 Issue で全画面横断的に
+   実施する方針が妥当。
+
+4. **`useCurrentUser` のキャッシュ透過性**
+   AppShell 経由で本ダイアログを開いた場合、`useCurrentUser` は AuthGuard がすでに
+   fetch 済みのキャッシュを直接返すため、通常運用ではロード表示は瞬時に消える。
+   `staleTime` を超えた場合の refetch もバックグラウンドで走り、期間中は既存データが
+   維持される（TanStack Query の既定挙動）。テスト側はキャッシュを持たない fresh
+   な QueryClient で render するため、loading / error 状態の分岐を明示的に検証できる。
+
+5. **`account-settings-trigger` の onClick 反応性**
+   本 button は `DialogTrigger asChild` に委譲されているため、独自の onClick は
+   実装せず radix-ui に open 制御を任せている。app-shell テストのボタン発火も
+   `userEvent.click` を通じて radix-ui 内部 handler が動く前提でパスしている。
+
+6. **退会失敗時に「確認ダイアログを開いたまま残す」設計**
+   Req 3.6 は「セッション破棄せず失敗通知」だけを求めており、確認ダイアログを閉じるか
+   残すかは規定されていない。ユーザーが「そのまま再試行できる」ことが自然と判断して
+   dialog を開いたまま alert を表示する構成にした。閉じてほしいという別要求が出た
+   場合は `mutation.isError` 判定を挙げる箇所で `setOpen(false)` を追加するだけで
+   切替可能。
+
+7. **未認証時の Req 1.3 は構造的保証で満たす**
+   `AuthGuard` が未認証で children を render しないため、`AppShell` 経由の入口は
+   自動的に非表示になる。この構造的保証を `auth-guard.test.tsx` で
+   `AccountSettingsDialog` を children に置いたケースで検証した。個別に「ボタンが
+   401 レスポンス時に自身で非表示化する」実装は追加していない（同ボタンは 2 か所
+   から呼ばれる想定がないため）。
+
+STATUS: complete

--- a/docs/specs/236-feat-web-withdrawdialog-ui/requirements.md
+++ b/docs/specs/236-feat-web-withdrawdialog-ui/requirements.md
@@ -1,0 +1,79 @@
+# Requirements Document
+
+## Introduction
+
+Web クライアントにはログイン後ユーザーの「アカウント設定」への導線が現状存在せず、実装済みの退会確認
+ダイアログもどこからも呼び出されない状態にある。さらに、その退会ダイアログが送信している削除要求先と、
+バックエンドが実際に受け付けている退会エンドポイントの経路に不整合があるため、単に配線するだけでは退会
+操作が完了しない状態にある。本要件では、認証済み画面からアカウント情報の確認と退会操作にアクセスできる
+最小限の UI を提供し、パスキーのみアカウント（email 空）でも表示・操作が破綻しないことを保証する。
+ログアウトの導線集約やパスキー credential 管理などは今回のスコープ外とする。
+
+## Requirements
+
+### Requirement 1: アカウント設定への導線
+
+**Objective:** As a 認証済みユーザー, I want ログイン後の画面からアカウント設定にアクセスできる導線を持ちたい, so that 自分のアカウント情報の確認や退会操作を Web UI 上で自力で開始できる
+
+#### Acceptance Criteria
+
+1. While 認証済みユーザーとしてアプリを閲覧しているとき, the Web Application shall アカウント設定への入口を認証済み画面から視認できる位置に表示する
+2. When ユーザーがアカウント設定への入口を操作したとき, the Account Settings UI shall アカウント情報表示領域と退会導線を含む画面を開く
+3. While 未認証状態でアプリを閲覧しているとき, the Web Application shall アカウント設定への入口を表示しない
+4. The Account Settings UI shall ユーザー操作で明示的に閉じることができる
+
+### Requirement 2: アカウント情報の表示
+
+**Objective:** As a 認証済みユーザー, I want アカウント設定からログイン中の自分のアカウント情報を確認できる, so that 現在ログインしている主体を把握し、意図しないアカウントで退会などの操作をしないことを担保できる
+
+#### Acceptance Criteria
+
+1. While Account Settings UI が開かれているとき, the Account Settings UI shall 現在ログイン中ユーザーの表示名を表示する
+2. While Account Settings UI が開かれており email が設定されているとき, the Account Settings UI shall 当該 email アドレスを表示する
+3. While Account Settings UI が開かれており email が未設定（空文字）であるとき, the Account Settings UI shall 「未設定」と識別可能なプレースホルダ表示を行い、空欄のまま放置しない
+4. If アカウント情報の取得に失敗したとき, the Account Settings UI shall 取得失敗である旨を利用者に通知し、アカウント設定 UI が空の状態で残らないようにする
+
+### Requirement 3: 退会導線
+
+**Objective:** As a 認証済みユーザー, I want アカウント設定から自分のアカウントを退会できる, so that 不要になったアカウントを自力で削除し、Feedman 側のデータを残さずサービス利用を終了できる
+
+#### Acceptance Criteria
+
+1. While Account Settings UI が開かれているとき, the Account Settings UI shall 退会操作の起動要素を表示する
+2. When ユーザーが退会起動要素を操作したとき, the Account Settings UI shall 退会内容（データ削除・取り消し不能）を明示した確認ダイアログを表示する
+3. When 確認ダイアログでユーザーがキャンセルを選択したとき, the Account Settings UI shall 退会要求を送信せず、認証状態と Account Settings UI の表示を維持する
+4. When 確認ダイアログでユーザーが退会を最終確定したとき, the Web Application shall バックエンドに対して現行の退会エンドポイントと整合する削除要求を送信し、成功応答を受領する
+5. When 退会が成功したとき, the Web Application shall 認証キャッシュを破棄し未認証状態へ遷移させ、ログイン画面が表示される状態にする
+6. If 退会リクエストがネットワークエラー・サーバエラー等で失敗したとき, the Web Application shall ユーザーに失敗した旨を通知し、既存の認証セッションを破棄しない
+7. When email 未設定（空文字）のパスキーのみアカウントで退会を最終確定したとき, the Web Application shall email 有設定アカウントと同一のフローで退会を完了させ、未認証状態へ遷移させる
+8. While 退会リクエストの応答を待機している間, the Account Settings UI shall 確認ダイアログの退会確定操作を非活性化し、多重送信を防止する
+
+## Non-Functional Requirements
+
+### NFR 1: 既存 UI との非破壊性
+
+1. The Web Application shall 既存の 2 ペインレイアウト（フィード一覧・記事一覧・記事詳細）の挙動を変更しない
+2. The Web Application shall 既存の購読設定ダイアログの起動経路と挙動を変更しない
+3. The Web Application shall ヘッダーの既存機能（テーマ切替・ログアウト等）の挙動を、本機能追加によって変更しない
+
+### NFR 2: 検証可能性
+
+1. The Web Application shall Requirement 2.1〜2.4 の各表示条件（表示名表示・email 有設定表示・email 空プレースホルダ表示・取得失敗通知）を自動テストで検証可能な形で実装する
+2. The Web Application shall Requirement 3.4〜3.7 の退会フロー（正常成功による未認証遷移・失敗時セッション維持・パスキーのみアカウントでの成功）を自動テストで検証可能な形で実装する
+3. The Web Application shall 認証済み画面での Requirement 1.1 入口表示と、未認証時の Requirement 1.3 非表示を自動テストで検証可能な形で実装する
+
+## Out of Scope
+
+- パスキー credential の一覧・削除・リネーム等の管理 UI
+- パスキー追加登録（registration/add）を起動する Web UI
+- プロフィール編集（表示名変更・email 追加・アイコン変更）
+- OAuth アカウントとパスキー credential のリンク／解除操作
+- ログアウトボタンのアカウント設定メニューへの集約（PM 判断: 最小スコープに絞るため既存 LogoutButton のヘッダー配置と挙動を維持し、本 Issue では退会導線とアカウント情報表示のみを配線対象とする。集約の要否は本機能リリース後の利用状況を見て別 Issue で判断する）
+- 退会確認画面での追加情報入力（理由アンケート・パスワード再入力等）
+- Web 以外（モバイル / API 直接利用）の退会 UX 改善
+
+## Open Questions
+
+- 「アカウント設定」の UI 形式（ヘッダー配下のポップオーバーメニューか、ダイアログか、独立ページか）は本要件では規定していない。design 層で選択し、Requirement 1・2・3 の観測可能な挙動を満たす形にすること
+- email 未設定時の表示文言として本要件では「未設定」を採用しているが、既存 UI コピー方針との整合上より適切な文言（例: 「(メールアドレス未登録)」等）があれば design/impl 段階で調整して差し支えない
+- 退会失敗時（Requirement 3.6）および取得失敗時（Requirement 2.4）の通知手段（トースト・インラインエラー等）の具体形式は design 層で決定する

--- a/docs/specs/236-feat-web-withdrawdialog-ui/review-notes.md
+++ b/docs/specs/236-feat-web-withdrawdialog-ui/review-notes.md
@@ -1,0 +1,45 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-8 timestamp=2026-07-28T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-236-impl-feat-web-withdrawdialog-ui
+- HEAD commit: 8d09d02f84e6755f1e261acb6669b5f002a63ab1
+- Compared to: develop..HEAD
+- 補足: 本 spec は `design.md` / `tasks.md` を持たない design-less impl。`_Boundary:_`
+  アノテーション不在のため boundary 判定は変更ファイルパスと requirements スコープの
+  突き合わせで実施。Feature Flag Protocol は CLAUDE.md 上 `opt-out` のため flag 観点は不適用。
+
+## Verified Requirements
+
+- 1.1 — `app-shell.tsx` ヘッダーに `<AccountSettingsDialog />` を配線。テスト: `app-shell.test.tsx` "ヘッダーにアカウント設定入口が表示されること"、`auth-guard.test.tsx` "認証済み時は...render されること"、`account-settings-dialog.test.tsx` "アカウント設定入口ボタンが表示されること"
+- 1.2 — `account-settings-dialog.tsx` が情報表示領域 + 退会導線を含む Dialog を開く。テスト: `account-settings-dialog.test.tsx` "入口ボタンをクリックすると...ダイアログが開くこと"、`app-shell.test.tsx` "アカウント設定入口クリックで..."
+- 1.3 — `AuthGuard` が未認証時に children を render しない構造的保証。テスト: `auth-guard.test.tsx` "未認証時は...render されないこと"
+- 1.4 — radix-ui `Dialog` の Esc/overlay/close 既定挙動。テスト: `account-settings-dialog.test.tsx` "ダイアログはユーザー操作 (Esc) で明示的に閉じられること"
+- 2.1 — `AccountInfoSection` `data-testid="account-info-name"`。テスト: `account-settings-dialog.test.tsx` "表示名と email が表示されること"、`app-shell.test.tsx` 表示名 assert
+- 2.2 — `emailIsSet` true 分岐。テスト: `account-settings-dialog.test.tsx` "表示名と email が表示されること"
+- 2.3 — `emailIsSet` false 分岐 + `EMAIL_UNSET_LABEL="未設定"`。テスト: `account-settings-dialog.test.tsx` "email が未設定（空文字）のとき「未設定」プレースホルダが表示され..."
+- 2.4 — `AccountSettingsBody` の `isError||!data` 分岐で `role="alert"` を表示し空 UI 化を防止。テスト: `account-settings-dialog.test.tsx` "アカウント情報の取得に失敗したときエラー通知が表示され、空 UI にならないこと"
+- 3.1 — `WithdrawSection` 内 `<WithdrawDialog />` の trigger。テスト: `withdraw-dialog.test.tsx` "退会ボタンが表示されること"、`account-settings-dialog.test.tsx` 退会導線 assert
+- 3.2 — `<AlertDialog>` + description「すべてのデータが削除されます。この操作は取り消せません。」。テスト: `withdraw-dialog.test.tsx` "退会ボタンをクリックすると確認ダイアログが開くこと"、"確認ダイアログに削除・取り消し不能である旨の警告文が表示されること"
+- 3.3 — `AlertDialogCancel` 既定 close で送信抑止。テスト: `withdraw-dialog.test.tsx` "キャンセルボタンで退会要求が送信されないこと"、`account-settings-dialog.test.tsx` "退会確認ダイアログでキャンセルすると DELETE を送信せず..."
+- 3.4 — `apiClient.delete("/api/users/me")`。実 route を `internal/handler/router.go:382`（`r.Delete("/me", userHandler.Withdraw)`）で確認、旧 `/api/account` 不在も確認。テスト: `withdraw-dialog.test.tsx` "退会実行時に DELETE /api/users/me を送信すること"（旧 endpoint 未呼び出し回帰含む）
+- 3.5 — onSuccess で `queryClient.clear()` + `onWithdrawn` → `window.location.assign("/login")`。テスト: `withdraw-dialog.test.tsx` "退会成功時に onWithdrawn が呼ばれ..."、`account-settings-dialog.test.tsx` "退会確定で DELETE...成功時に /login へリダイレクトされること"
+- 3.6 — `onError` 未宣言で `mutation.isError` 表示（`role="alert"`）、セッション破棄・リダイレクトを実行しない。テスト: `withdraw-dialog.test.tsx` "退会失敗時（サーバ 500）..."、"退会失敗時（ネットワーク到達不能）..."、`account-settings-dialog.test.tsx` "退会失敗時に /login へリダイレクトせず..."
+- 3.7 — 退会フローが email 非依存（Cookie セッションで対象特定）。テスト: `account-settings-dialog.test.tsx` "email 未設定（空文字）のパスキーのみアカウントでも退会が同一フローで完了すること"
+- 3.8 — `disabled={withdrawMutation.isPending}` + `event.preventDefault()`。テスト: `withdraw-dialog.test.tsx` "応答待機中は退会確定ボタンが disabled で多重送信されないこと"（2 回目以降 click で DELETE 呼び出しが増えないことを assert）
+- NFR 1.1 — `app-shell.tsx` 変更はヘッダー内のみで 2 ペイン分岐に非接触。既存 app-shell テスト群が引き続き pass
+- NFR 1.2 — `SubscriptionSettingsDialog` の import / 呼び出し不変
+- NFR 1.3 — `LogoutButton` / `ThemeToggle` 残置。テスト: `app-shell.test.tsx` "ヘッダーにアカウント設定入口が表示されること" 内で既存 2 機能存在も併せて assert
+- NFR 2.1–2.3 — 上記 Req 2.x / 3.x / 1.1 / 1.3 の自動テストで検証可能な形を担保
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric ID（Req 1.1〜3.8 / NFR 1.1〜2.3）に観測可能な実装と対応テストを確認。退会エンドポイントは実 route `DELETE /api/users/me` と整合し、旧 `/api/account` 呼び出しの回帰防止テストも存在。変更は `web/src/components/*` に限定され boundary 逸脱なし。impl-notes 記載の検証（536/536 pass）とコード内容が整合。
+
+RESULT: approve

--- a/web/src/components/account-settings-dialog.test.tsx
+++ b/web/src/components/account-settings-dialog.test.tsx
@@ -1,0 +1,366 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import { AccountSettingsDialog } from "./account-settings-dialog";
+
+// グローバル fetch のモック
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// window.location.assign のモック（退会成功時のリダイレクト検証用）
+const mockAssign = vi.fn();
+Object.defineProperty(window, "location", {
+  value: {
+    assign: mockAssign,
+    href: "http://localhost:3000",
+    pathname: "/",
+  },
+  writable: true,
+});
+
+/** テスト用ラッパー（QueryClient を fresh に生成） */
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+interface AuthMockOptions {
+  /** GET /auth/me の応答種別 */
+  auth: "ok" | "ok-empty-email" | "error";
+  /** DELETE /api/users/me の応答種別（省略時は成功） */
+  withdraw?: "success" | "fail" | "pending";
+}
+
+/**
+ * `/auth/me` と `/api/users/me` の応答を一括で組み立てる mockFetch セットアップ。
+ * 呼び出し履歴（`mockFetch.mock.calls`）で URL と method の観測ができる。
+ */
+function setupMockFetch(options: AuthMockOptions) {
+  const withdrawMode = options.withdraw ?? "success";
+  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+    if (url === "/auth/me") {
+      if (options.auth === "ok") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            id: "user-1",
+            email: "alice@example.com",
+            name: "Alice",
+            created_at: "2026-01-01T00:00:00Z",
+          }),
+        });
+      }
+      if (options.auth === "ok-empty-email") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            id: "user-2",
+            email: "",
+            name: "Passkey User",
+            created_at: "2026-01-02T00:00:00Z",
+          }),
+        });
+      }
+      // "error"
+      return Promise.resolve({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: "internal server error" }),
+      });
+    }
+    if (url === "/api/users/me" && init?.method === "DELETE") {
+      if (withdrawMode === "success") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+        });
+      }
+      if (withdrawMode === "fail") {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          json: async () => ({ error: "internal server error" }),
+        });
+      }
+      // pending: never resolve（多重送信テスト用）
+      return new Promise(() => {});
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+}
+
+/**
+ * ダイアログを開くヘルパ。open → 内容が render されるまで待つ。
+ */
+async function openDialog(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByTestId("account-settings-trigger"));
+  await waitFor(() => {
+    expect(screen.getByText("アカウント設定")).toBeInTheDocument();
+  });
+}
+
+describe("AccountSettingsDialog コンポーネント", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAssign.mockClear();
+  });
+
+  it("アカウント設定入口ボタンが表示されること (Req 1.1)", () => {
+    setupMockFetch({ auth: "ok" });
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId("account-settings-trigger")).toBeInTheDocument();
+  });
+
+  it("入口ボタンをクリックするとアカウント情報表示領域と退会導線を含むダイアログが開くこと (Req 1.2)", async () => {
+    setupMockFetch({ auth: "ok" });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+
+    // アカウント情報表示領域
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("account-info-section")
+      ).toBeInTheDocument();
+    });
+    // 退会導線
+    expect(
+      screen.getByTestId("account-withdraw-section")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("withdraw-trigger")).toBeInTheDocument();
+  });
+
+  it("ダイアログはユーザー操作 (Esc) で明示的に閉じられること (Req 1.4)", async () => {
+    setupMockFetch({ auth: "ok" });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+
+    // ヘッダーが描画されるのを待つ
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("account-info-section")
+      ).toBeInTheDocument();
+    });
+
+    // Esc で閉じられる（radix-ui Dialog の既定挙動）
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByText("アカウント設定")).not.toBeInTheDocument();
+    });
+  });
+
+  it("表示名と email が表示されること (Req 2.1, 2.2)", async () => {
+    setupMockFetch({ auth: "ok" });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("account-info-name")).toHaveTextContent(
+        "Alice"
+      );
+    });
+    expect(screen.getByTestId("account-info-email")).toHaveTextContent(
+      "alice@example.com"
+    );
+    // email 空プレースホルダは出ていない
+    expect(
+      screen.queryByTestId("account-info-email-unset")
+    ).not.toBeInTheDocument();
+  });
+
+  it("email が未設定（空文字）のとき「未設定」プレースホルダが表示され、空欄放置されないこと (Req 2.3)", async () => {
+    setupMockFetch({ auth: "ok-empty-email" });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("account-info-name")).toHaveTextContent(
+        "Passkey User"
+      );
+    });
+    // 未設定プレースホルダが表示され、通常 email 表示は出ない
+    expect(
+      screen.getByTestId("account-info-email-unset")
+    ).toHaveTextContent("未設定");
+    expect(screen.queryByTestId("account-info-email")).not.toBeInTheDocument();
+  });
+
+  it("アカウント情報の取得に失敗したときエラー通知が表示され、空 UI にならないこと (Req 2.4)", async () => {
+    setupMockFetch({ auth: "error" });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("account-settings-error")
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("account-settings-error")).toHaveTextContent(
+      "アカウント情報の取得に失敗しました"
+    );
+    // 表示名/退会セクションはレンダリングされない（データ不在時の空 UI 防止 = alert に置換）
+    expect(screen.queryByTestId("account-info-section")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("account-withdraw-section")
+    ).not.toBeInTheDocument();
+  });
+
+  it("退会確認ダイアログでキャンセルすると DELETE を送信せず認証状態と設定 UI が維持されること (Req 3.3)", async () => {
+    setupMockFetch({ auth: "ok" });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+    await waitFor(() => {
+      expect(screen.getByTestId("withdraw-trigger")).toBeInTheDocument();
+    });
+
+    // 退会入口 → 確認ダイアログ
+    await user.click(screen.getByTestId("withdraw-trigger"));
+    await waitFor(() => {
+      expect(screen.getByText("退会しますか？")).toBeInTheDocument();
+    });
+
+    // キャンセル
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    // DELETE は呼ばれない
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      "/api/users/me",
+      expect.objectContaining({ method: "DELETE" })
+    );
+    // window.location.assign によるリダイレクトも起きない
+    expect(mockAssign).not.toHaveBeenCalled();
+    // アカウント設定 UI は残る
+    expect(
+      screen.getByTestId("account-info-section")
+    ).toBeInTheDocument();
+  });
+
+  it("退会確定で DELETE /api/users/me が発行され、成功時に /login へリダイレクトされること (Req 3.4, 3.5)", async () => {
+    setupMockFetch({ auth: "ok", withdraw: "success" });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+    await waitFor(() => {
+      expect(screen.getByTestId("withdraw-trigger")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("withdraw-trigger"));
+    await waitFor(() => {
+      expect(screen.getByText("退会しますか？")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("withdraw-confirm"));
+
+    // DELETE /api/users/me が発行される
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/users/me",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+
+    // リダイレクト先が /login
+    await waitFor(() => {
+      expect(mockAssign).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("退会失敗時に /login へリダイレクトせず、ダイアログ内に失敗通知が表示されること (Req 3.6)", async () => {
+    setupMockFetch({ auth: "ok", withdraw: "fail" });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+    await waitFor(() => {
+      expect(screen.getByTestId("withdraw-trigger")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("withdraw-trigger"));
+    await waitFor(() => {
+      expect(screen.getByText("退会しますか？")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("withdraw-confirm"));
+
+    // DELETE は発行されるが失敗
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/users/me",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+
+    // 失敗通知
+    await waitFor(() => {
+      expect(screen.getByTestId("withdraw-error")).toBeInTheDocument();
+    });
+
+    // /login へのリダイレクトは起きない（セッション維持 / Req 3.6）
+    expect(mockAssign).not.toHaveBeenCalled();
+    // アカウント情報セクションはダイアログの背後で維持される
+    expect(
+      screen.getByTestId("account-info-section")
+    ).toBeInTheDocument();
+  });
+
+  it("email 未設定（空文字）のパスキーのみアカウントでも退会が同一フローで完了すること (Req 3.7)", async () => {
+    setupMockFetch({ auth: "ok-empty-email", withdraw: "success" });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("account-info-email-unset")
+      ).toBeInTheDocument();
+    });
+
+    // 退会フローを実行
+    await user.click(screen.getByTestId("withdraw-trigger"));
+    await waitFor(() => {
+      expect(screen.getByText("退会しますか？")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("withdraw-confirm"));
+
+    // 同一エンドポイント / 同一フローで DELETE 発行
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/users/me",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+    // 未認証遷移も成功する
+    await waitFor(() => {
+      expect(mockAssign).toHaveBeenCalledWith("/login");
+    });
+  });
+});

--- a/web/src/components/account-settings-dialog.tsx
+++ b/web/src/components/account-settings-dialog.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useState } from "react";
+import { UserCog } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useCurrentUser } from "@/hooks/use-auth";
+import { WithdrawDialog } from "@/components/withdraw-dialog";
+import type { User } from "@/types/auth";
+
+/**
+ * 未設定 email 表示用プレースホルダ（Req 2.3）。
+ *
+ * requirements.md の Open Questions に従い「未設定」を採用する。空欄放置しない
+ * ことで、パスキーのみ登録アカウントでも自分がどの主体でログインしているかを
+ * 明確に把握できるようにする。
+ */
+const EMAIL_UNSET_LABEL = "未設定";
+
+/**
+ * 退会成功時のリダイレクト先。
+ *
+ * 既存 LogoutButton と同じ `/login` へ遷移させ、Web の未認証入口を統一する
+ * （Req 3.5 / NFR 1.3 の既存ヘッダー機能非破壊性と整合）。
+ */
+const LOGIN_URL = "/login";
+
+/**
+ * アカウント設定ダイアログ
+ *
+ * ヘッダー配下のギア型トリガーから開かれる Dialog。中身は以下 2 セクション:
+ *
+ * 1. 現在ログイン中ユーザーの表示名 / email（未設定なら「{@link EMAIL_UNSET_LABEL}」）
+ * 2. 退会導線としての {@link WithdrawDialog}
+ *
+ * `useCurrentUser` の状態（loading / error / success）で本文を出し分けし、
+ * 取得失敗時には role="alert" のエラー表示に切替える（Req 2.4）。
+ * open state はローカル state のみで管理し、ヘッダー側の状態と切り離す。
+ */
+export function AccountSettingsDialog() {
+  const [open, setOpen] = useState(false);
+
+  /**
+   * 退会成功時のリダイレクト。既存 LogoutButton と同一の遷移方式を採用し、
+   * QueryClient 側のキャッシュクリアは {@link WithdrawDialog} 内で完了済み（Req 3.5）。
+   */
+  const handleWithdrawn = () => {
+    window.location.assign(LOGIN_URL);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          data-testid="account-settings-trigger"
+          aria-label="アカウント設定"
+        >
+          <UserCog className="w-4 h-4" />
+          アカウント
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>アカウント設定</DialogTitle>
+          <DialogDescription className="sr-only">
+            ログイン中のアカウント情報の確認と退会操作を行います。
+          </DialogDescription>
+        </DialogHeader>
+        <AccountSettingsBody onWithdrawn={handleWithdrawn} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** AccountSettingsBody の props */
+interface AccountSettingsBodyProps {
+  /** 退会完了時のコールバック（親のリダイレクト処理） */
+  onWithdrawn: () => void;
+}
+
+/**
+ * アカウント設定ダイアログの本文。
+ *
+ * useCurrentUser の状態別に描画を切替える。取得失敗時は role="alert" のエラー
+ * 表示で「空 UI にしない」ことを保証する（Req 2.4）。
+ */
+function AccountSettingsBody({ onWithdrawn }: AccountSettingsBodyProps) {
+  const { data, isLoading, isError } = useCurrentUser();
+
+  if (isLoading) {
+    return (
+      <div
+        data-testid="account-settings-loading"
+        className="text-sm text-muted-foreground"
+      >
+        読み込み中...
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div
+        data-testid="account-settings-error"
+        role="alert"
+        className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm"
+      >
+        <p className="font-medium text-destructive">
+          アカウント情報の取得に失敗しました
+        </p>
+        <p className="mt-1 text-muted-foreground">
+          通信状況を確認して、ダイアログを閉じてから再度お試しください。
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <AccountInfoSection user={data} />
+      <WithdrawSection onWithdrawn={onWithdrawn} />
+    </div>
+  );
+}
+
+/** ユーザー情報表示セクションの props */
+interface AccountInfoSectionProps {
+  /** useCurrentUser で取得したユーザー情報 */
+  user: User;
+}
+
+/**
+ * アカウント情報表示セクション（Req 2.1〜2.3）。
+ *
+ * 表示名を必ず表示し、email は空文字なら「未設定」ラベルに差替える。
+ */
+function AccountInfoSection({ user }: AccountInfoSectionProps) {
+  const emailIsSet = user.email !== "";
+
+  return (
+    <section
+      data-testid="account-info-section"
+      className="space-y-2 rounded-lg border p-4"
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-xs font-medium text-muted-foreground">
+          表示名
+        </span>
+        <span
+          data-testid="account-info-name"
+          className="text-sm font-medium break-all"
+        >
+          {user.name}
+        </span>
+      </div>
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-xs font-medium text-muted-foreground">
+          メールアドレス
+        </span>
+        {emailIsSet ? (
+          <span
+            data-testid="account-info-email"
+            className="text-sm font-medium break-all"
+          >
+            {user.email}
+          </span>
+        ) : (
+          <span
+            data-testid="account-info-email-unset"
+            className="text-sm font-medium text-muted-foreground italic"
+          >
+            {EMAIL_UNSET_LABEL}
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/** WithdrawSection の props */
+interface WithdrawSectionProps {
+  /** 退会完了時のコールバック */
+  onWithdrawn: () => void;
+}
+
+/**
+ * 退会導線セクション（Req 3.1）。
+ *
+ * 実際の確認ダイアログと DELETE 送信は {@link WithdrawDialog} が担う。本セクション
+ * はコンテキスト説明と入口配置のみを担当し、責務を単一に保つ。
+ */
+function WithdrawSection({ onWithdrawn }: WithdrawSectionProps) {
+  return (
+    <section
+      data-testid="account-withdraw-section"
+      className="space-y-2 rounded-lg border p-4"
+    >
+      <h3 className="text-sm font-medium">アカウントの削除</h3>
+      <p className="text-xs text-muted-foreground">
+        退会するとアカウントとすべてのデータが削除されます。
+      </p>
+      <div className="pt-1">
+        <WithdrawDialog onWithdrawn={onWithdrawn} />
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/app-shell.test.tsx
+++ b/web/src/components/app-shell.test.tsx
@@ -83,6 +83,20 @@ const CROSS_FEED_SINCE_TIME = "2026-05-26T10:00:00Z";
 /** mockFetchの設定ヘルパー */
 function setupMockFetch() {
   mockFetch.mockImplementation((url: string, options?: RequestInit) => {
+    // AccountSettingsDialog が開かれた際に useCurrentUser が発行する GET /auth/me。
+    // AppShell 自体は認証済み前提で render されるため、ここでは常に成功応答を返し、
+    // ダイアログ内容が安定して描画される状態を担保する。
+    if (url === "/auth/me") {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          id: "user-1",
+          email: "test@example.com",
+          name: "Test User",
+          created_at: "2026-01-01T00:00:00Z",
+        }),
+      });
+    }
     if (url === "/api/subscriptions") {
       return Promise.resolve({
         ok: true,
@@ -205,6 +219,46 @@ describe("AppShell コンポーネント", () => {
     await waitFor(() => {
       expect(screen.getByText("Feedman")).toBeInTheDocument();
     });
+  });
+
+  it("ヘッダーにアカウント設定入口が表示されること (Req 1.1 / NFR 1.3)", async () => {
+    render(<AppShell />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("account-settings-trigger")
+      ).toBeInTheDocument();
+    });
+
+    // 既存ヘッダー機能（ログアウト・テーマ切替）を破壊していないこと（NFR 1.3）
+    expect(screen.getByRole("button", { name: "ログアウト" })).toBeInTheDocument();
+    expect(screen.getByTestId("theme-toggle")).toBeInTheDocument();
+  });
+
+  it("アカウント設定入口クリックで情報表示領域と退会導線を含むダイアログが開くこと (Req 1.2)", async () => {
+    const user = userEvent.setup();
+    render(<AppShell />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("account-settings-trigger")
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("account-settings-trigger"));
+
+    await waitFor(() => {
+      expect(screen.getByText("アカウント設定")).toBeInTheDocument();
+    });
+    // アカウント情報表示領域と退会導線が同時に描画される
+    expect(screen.getByTestId("account-info-section")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("account-withdraw-section")
+    ).toBeInTheDocument();
+    // 現在ログイン中の表示名 (Req 2.1)
+    expect(screen.getByTestId("account-info-name")).toHaveTextContent(
+      "Test User"
+    );
   });
 
   it("左ペイン先頭に StarredNavItem「お気に入り」項目が表示されること（Req 1.1 / 1.3）", async () => {

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -12,6 +12,7 @@ import { CrossFeedItemList } from "@/components/cross-feed-item-list";
 import { StarredItemList } from "@/components/starred-item-list";
 import { StarredNavItem } from "@/components/starred-nav-item";
 import { LogoutButton } from "@/components/logout-button";
+import { AccountSettingsDialog } from "@/components/account-settings-dialog";
 import { SearchResults } from "@/components/search-results";
 import { SubscriptionSettingsDialog } from "@/components/subscription-settings-dialog";
 import { useTheme } from "@/components/theme-provider";
@@ -96,6 +97,9 @@ export function AppShell() {
         <HeaderSearchBar />
         <div className="flex items-center gap-2">
           <ThemeToggle />
+          {/* Req 1.1: アカウント設定入口。認証済みの AppShell 配下でのみ描画されるため、
+              未認証時は AuthGuard が LoginPage に切替えて本入口も表示されない（Req 1.3）。 */}
+          <AccountSettingsDialog />
           <LogoutButton />
         </div>
       </header>

--- a/web/src/components/auth-guard.test.tsx
+++ b/web/src/components/auth-guard.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthGuard } from "./auth-guard";
+import { AccountSettingsDialog } from "./account-settings-dialog";
 import type { ReactNode } from "react";
 
 // グローバルfetchのモック
@@ -90,6 +91,67 @@ describe("AuthGuard コンポーネント", () => {
     // ログインページへのリダイレクトが発生すること
     await waitFor(() => {
       expect(screen.getByTestId("auth-redirect")).toBeInTheDocument();
+    });
+  });
+
+  it("未認証時はアカウント設定入口 (children 内の AccountSettingsDialog) が render されないこと (Req 1.3)", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "/auth/me") {
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          json: async () => ({ message: "Unauthorized" }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <AuthGuard>
+        <AccountSettingsDialog />
+      </AuthGuard>,
+      { wrapper: createWrapper() }
+    );
+
+    // ログイン画面が表示されるまで待つ
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-redirect")).toBeInTheDocument();
+    });
+
+    // AccountSettingsDialog のトリガーは描画されない（AuthGuard により children が
+    // render されないため、Req 1.3「未認証状態で入口を表示しない」が満たされる）
+    expect(
+      screen.queryByTestId("account-settings-trigger")
+    ).not.toBeInTheDocument();
+  });
+
+  it("認証済み時はアカウント設定入口 (children 内の AccountSettingsDialog) が render されること (Req 1.1)", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "/auth/me") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "user-1",
+            email: "test@example.com",
+            name: "Test User",
+            created_at: "2026-01-01T00:00:00Z",
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(
+      <AuthGuard>
+        <AccountSettingsDialog />
+      </AuthGuard>,
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("account-settings-trigger")
+      ).toBeInTheDocument();
     });
   });
 

--- a/web/src/components/withdraw-dialog.test.tsx
+++ b/web/src/components/withdraw-dialog.test.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { WithdrawDialog } from "./withdraw-dialog";
 import type { ReactNode } from "react";
 
-// グローバルfetchのモック
+// グローバル fetch のモック
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
@@ -25,13 +25,38 @@ function createWrapper() {
   };
 }
 
+/**
+ * `/api/users/me` に対する DELETE のみを成功させる mockFetch を組み立てる。
+ * 他 URL は素の 200 応答を返す（副次呼び出しがテストを failさせないように）。
+ */
+function setupWithdrawMockFetch(status: "success" | "fail-server" | "fail-network") {
+  mockFetch.mockImplementation((url: string, options?: RequestInit) => {
+    if (url === "/api/users/me" && options?.method === "DELETE") {
+      if (status === "success") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+        });
+      }
+      if (status === "fail-server") {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          json: async () => ({ error: "internal server error" }),
+        });
+      }
+      // fail-network: fetch reject
+      return Promise.reject(new TypeError("Network error"));
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+}
+
 describe("WithdrawDialog コンポーネント", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({}),
-    });
+    setupWithdrawMockFetch("success");
   });
 
   it("退会ボタンが表示されること", () => {
@@ -40,7 +65,7 @@ describe("WithdrawDialog コンポーネント", () => {
     expect(screen.getByTestId("withdraw-trigger")).toBeInTheDocument();
   });
 
-  it("退会ボタンをクリックすると確認ダイアログが開くこと", async () => {
+  it("退会ボタンをクリックすると確認ダイアログが開くこと (Req 3.2)", async () => {
     const user = userEvent.setup();
 
     render(<WithdrawDialog />, { wrapper: createWrapper() });
@@ -52,7 +77,7 @@ describe("WithdrawDialog コンポーネント", () => {
     });
   });
 
-  it("確認ダイアログに警告メッセージが表示されること", async () => {
+  it("確認ダイアログに削除・取り消し不能である旨の警告文が表示されること (Req 3.2)", async () => {
     const user = userEvent.setup();
 
     render(<WithdrawDialog />, { wrapper: createWrapper() });
@@ -64,12 +89,16 @@ describe("WithdrawDialog コンポーネント", () => {
         screen.getByText(/すべてのデータが削除されます/)
       ).toBeInTheDocument();
     });
+    expect(screen.getByText(/取り消せません/)).toBeInTheDocument();
   });
 
-  it("キャンセルボタンで退会が実行されないこと", async () => {
+  it("キャンセルボタンで退会要求が送信されないこと (Req 3.3)", async () => {
     const user = userEvent.setup();
+    const onWithdrawn = vi.fn();
 
-    render(<WithdrawDialog />, { wrapper: createWrapper() });
+    render(<WithdrawDialog onWithdrawn={onWithdrawn} />, {
+      wrapper: createWrapper(),
+    });
 
     await user.click(screen.getByTestId("withdraw-trigger"));
 
@@ -79,28 +108,17 @@ describe("WithdrawDialog コンポーネント", () => {
 
     await user.click(screen.getByRole("button", { name: "キャンセル" }));
 
-    // 退会APIが呼ばれていないこと
+    // DELETE /api/users/me は呼ばれていない
     expect(mockFetch).not.toHaveBeenCalledWith(
-      "/api/account",
+      "/api/users/me",
       expect.objectContaining({ method: "DELETE" })
     );
+    // onWithdrawn も呼ばれていない（認証状態が維持される）
+    expect(onWithdrawn).not.toHaveBeenCalled();
   });
 
-  it("退会実行ボタンをクリックするとAPIが呼ばれること", async () => {
+  it("退会実行時に DELETE /api/users/me を送信すること (Req 3.4)", async () => {
     const user = userEvent.setup();
-
-    mockFetch.mockImplementation((url: string, options?: RequestInit) => {
-      if (url === "/api/account" && options?.method === "DELETE") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({}),
-        });
-      }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({}),
-      });
-    });
 
     render(<WithdrawDialog />, { wrapper: createWrapper() });
 
@@ -110,33 +128,24 @@ describe("WithdrawDialog コンポーネント", () => {
       expect(screen.getByText("退会しますか？")).toBeInTheDocument();
     });
 
-    // 退会実行ボタンをクリック
     await user.click(screen.getByTestId("withdraw-confirm"));
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(
-        "/api/account",
+        "/api/users/me",
         expect.objectContaining({ method: "DELETE" })
       );
     });
+    // 旧エンドポイント /api/account に対しては呼ばれない（回帰防止）
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      "/api/account",
+      expect.objectContaining({ method: "DELETE" })
+    );
   });
 
-  it("退会成功時にonWithdrawnコールバックが呼ばれること", async () => {
+  it("退会成功時に onWithdrawn が呼ばれ、確認ダイアログが閉じること (Req 3.5)", async () => {
     const user = userEvent.setup();
     const onWithdrawn = vi.fn();
-
-    mockFetch.mockImplementation((url: string, options?: RequestInit) => {
-      if (url === "/api/account" && options?.method === "DELETE") {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({}),
-        });
-      }
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({}),
-      });
-    });
 
     render(<WithdrawDialog onWithdrawn={onWithdrawn} />, {
       wrapper: createWrapper(),
@@ -151,7 +160,120 @@ describe("WithdrawDialog コンポーネント", () => {
     await user.click(screen.getByTestId("withdraw-confirm"));
 
     await waitFor(() => {
-      expect(onWithdrawn).toHaveBeenCalled();
+      expect(onWithdrawn).toHaveBeenCalledTimes(1);
     });
+    // 確認ダイアログが閉じている
+    await waitFor(() => {
+      expect(screen.queryByText("退会しますか？")).not.toBeInTheDocument();
+    });
+  });
+
+  it("退会失敗時（サーバ 500）に onWithdrawn を呼ばず、確認ダイアログ内にエラーが表示されること (Req 3.6)", async () => {
+    const user = userEvent.setup();
+    const onWithdrawn = vi.fn();
+    setupWithdrawMockFetch("fail-server");
+
+    render(<WithdrawDialog onWithdrawn={onWithdrawn} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByTestId("withdraw-trigger"));
+
+    await waitFor(() => {
+      expect(screen.getByText("退会しますか？")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("withdraw-confirm"));
+
+    // DELETE は発行されたが失敗
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/users/me",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+
+    // インラインでエラー通知が表示される
+    await waitFor(() => {
+      expect(screen.getByTestId("withdraw-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("withdraw-error")).toHaveTextContent(
+      "退会に失敗しました"
+    );
+
+    // onWithdrawn は呼ばれていない（セッション維持 / Req 3.6）
+    expect(onWithdrawn).not.toHaveBeenCalled();
+
+    // 確認ダイアログは開いたまま（再試行できるように残る）
+    expect(screen.getByText("退会しますか？")).toBeInTheDocument();
+  });
+
+  it("退会失敗時（ネットワーク到達不能）でも onWithdrawn が呼ばれず、エラー表示されること (Req 3.6 境界値)", async () => {
+    const user = userEvent.setup();
+    const onWithdrawn = vi.fn();
+    setupWithdrawMockFetch("fail-network");
+
+    render(<WithdrawDialog onWithdrawn={onWithdrawn} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByTestId("withdraw-trigger"));
+    await waitFor(() => {
+      expect(screen.getByText("退会しますか？")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("withdraw-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("withdraw-error")).toBeInTheDocument();
+    });
+    expect(onWithdrawn).not.toHaveBeenCalled();
+  });
+
+  it("応答待機中は退会確定ボタンが disabled で多重送信されないこと (Req 3.8)", async () => {
+    const user = userEvent.setup();
+    // DELETE は resolve せず pending 状態を維持する
+    let resolveFn: ((value: { ok: boolean; json: () => Promise<unknown> }) => void) | undefined;
+    const pendingPromise = new Promise<{
+      ok: boolean;
+      json: () => Promise<unknown>;
+    }>((resolve) => {
+      resolveFn = resolve;
+    });
+    mockFetch.mockImplementation((url: string, options?: RequestInit) => {
+      if (url === "/api/users/me" && options?.method === "DELETE") {
+        return pendingPromise;
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+
+    render(<WithdrawDialog />, { wrapper: createWrapper() });
+
+    await user.click(screen.getByTestId("withdraw-trigger"));
+    await waitFor(() => {
+      expect(screen.getByText("退会しますか？")).toBeInTheDocument();
+    });
+
+    // 1 回目の click で fetch 発行 & pending
+    await user.click(screen.getByTestId("withdraw-confirm"));
+
+    // disabled 状態になっている
+    await waitFor(() => {
+      expect(screen.getByTestId("withdraw-confirm")).toBeDisabled();
+    });
+    expect(screen.getByTestId("withdraw-confirm")).toHaveTextContent("処理中...");
+
+    // 2 回目の click は無効化されているため fetch は増えない
+    await user.click(screen.getByTestId("withdraw-confirm"));
+    await user.click(screen.getByTestId("withdraw-confirm"));
+
+    const deleteCalls = mockFetch.mock.calls.filter(
+      ([url, options]) =>
+        url === "/api/users/me" &&
+        (options as RequestInit | undefined)?.method === "DELETE"
+    );
+    expect(deleteCalls).toHaveLength(1);
+
+    // クリーンアップ: pending を resolve して leak を防ぐ
+    resolveFn?.({ ok: true, json: async () => ({}) });
   });
 });

--- a/web/src/components/withdraw-dialog.tsx
+++ b/web/src/components/withdraw-dialog.tsx
@@ -18,7 +18,12 @@ import { apiClient } from "@/lib/api";
 
 /** WithdrawDialog コンポーネントのプロパティ */
 interface WithdrawDialogProps {
-  /** 退会完了時のコールバック（リダイレクト処理などに使用） */
+  /**
+   * 退会完了時のコールバック。
+   *
+   * 退会が成功した後（キャッシュクリア済み）に呼ばれる。呼び出し元は通常この
+   * コールバックでログイン画面等への遷移を行う（Req 3.5）。
+   */
   onWithdrawn?: () => void;
 }
 
@@ -26,23 +31,38 @@ interface WithdrawDialogProps {
  * 退会確認ダイアログ
  *
  * ユーザーが退会を確認・実行するためのダイアログコンポーネント。
- * DELETE /api/account を呼び出してアカウントを削除する。
- * 成功時に認証解除とリダイレクトを行う。
+ * `DELETE /api/users/me` を呼び出してアカウントを削除する（Req 3.4）。
+ * 成功時に認証キャッシュを破棄し、`onWithdrawn` コールバックで呼び出し元へ
+ * 完了を通知する（Req 3.5）。失敗時はセッションを維持したままダイアログ内で
+ * エラーメッセージを表示する（Req 3.6）。応答待機中は退会確定操作を非活性化して
+ * 多重送信を防止する（Req 3.8）。
  */
 export function WithdrawDialog({ onWithdrawn }: WithdrawDialogProps) {
   const [open, setOpen] = useState(false);
   const queryClient = useQueryClient();
 
   const withdrawMutation = useMutation({
-    mutationFn: () => apiClient.delete("/api/account"),
+    mutationFn: () => apiClient.delete("/api/users/me"),
     onSuccess: () => {
-      // 全キャッシュをクリア（認証情報も含む）
+      // 全キャッシュをクリア（認証情報も含む / Req 3.5）
       queryClient.clear();
       setOpen(false);
-      // コールバックが指定されている場合に実行（リダイレクト処理など）
+      // コールバックが指定されている場合に実行（リダイレクト処理など / Req 3.5）
       onWithdrawn?.();
     },
+    // onError は宣言せず、mutation.isError を UI 側で参照して失敗表示に切替える。
+    // Req 3.6: 失敗時にセッション（cookie / query cache）を破棄しないため、
+    // onError 内で queryClient.clear() や onWithdrawn を呼ばないこと（既存 onSuccess の
+    // 分離に依拠して二重呼び出しを防ぐ）。
   });
+
+  /** 確認ダイアログの open/close 制御。閉じる際は前回のエラー表示状態も一緒にリセットする。 */
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) {
+      withdrawMutation.reset();
+    }
+  };
 
   return (
     <>
@@ -56,7 +76,7 @@ export function WithdrawDialog({ onWithdrawn }: WithdrawDialogProps) {
         退会
       </Button>
 
-      <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialog open={open} onOpenChange={handleOpenChange}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>退会しますか？</AlertDialogTitle>
@@ -65,11 +85,36 @@ export function WithdrawDialog({ onWithdrawn }: WithdrawDialogProps) {
               購読情報、記事の既読・スター状態がすべて失われます。
             </AlertDialogDescription>
           </AlertDialogHeader>
+
+          {/* 失敗時の通知（Req 3.6）。mutation.isError が真のときのみ表示し、
+              セッション破棄・リダイレクトは行わない。再試行は「退会する」ボタンから可能。 */}
+          {withdrawMutation.isError && (
+            <div
+              data-testid="withdraw-error"
+              role="alert"
+              className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm"
+            >
+              <p className="font-medium text-destructive">
+                退会に失敗しました
+              </p>
+              <p className="mt-1 text-muted-foreground">
+                通信状況を確認して、しばらくしてから再度お試しください。
+              </p>
+            </div>
+          )}
+
           <AlertDialogFooter>
-            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogCancel disabled={withdrawMutation.isPending}>
+              キャンセル
+            </AlertDialogCancel>
             <AlertDialogAction
               data-testid="withdraw-confirm"
-              onClick={() => withdrawMutation.mutate()}
+              onClick={(event) => {
+                // radix-ui の AlertDialogAction は既定で close するため、mutation の
+                // pending / error 状態を UI に反映するには close をキャンセルする必要がある。
+                event.preventDefault();
+                withdrawMutation.mutate();
+              }}
               disabled={withdrawMutation.isPending}
             >
               {withdrawMutation.isPending ? "処理中..." : "退会する"}


### PR DESCRIPTION
## 概要

Web クライアントにはログイン後ユーザーのアカウント設定への導線が存在せず、実装済みの `WithdrawDialog` もどこからも呼び出されていない状態だった。また `WithdrawDialog` が呼び出していた退会エンドポイントが実 route と不整合（`/api/account` → 実際は `DELETE /api/users/me`）のため、配線するだけでは退会操作が完了しない問題もあった。

本 PR では、ヘッダーにアカウント設定ダイアログの入口を追加し、アカウント情報（表示名・email）の確認と退会導線を提供する。パスキーのみアカウント（email 空）でも表示・操作が破綻しない状態にした。

## 対応 Issue

Closes #236

## 関連 PR

なし（Architect による設計 PR は走っていない design-less impl）

## 実装内容

- (Req 1.1 / NFR 1.3) `app-shell.tsx` ヘッダーに `<AccountSettingsDialog />` を配線（既存 `LogoutButton` / `ThemeToggle` は残置）
- (Req 1.2 / Req 2.1〜2.4) `account-settings-dialog.tsx` を新設（表示名・email 表示、取得失敗時 inline エラー通知）
- (Req 1.3) `AuthGuard` の構造的保証により未認証時は入口が render されない
- (Req 1.4) radix-ui `Dialog` 既定の Esc / overlay click / close button で閉鎖可能
- (Req 3.1〜3.8) `WithdrawDialog` の退会エンドポイントを `DELETE /api/users/me` に修正、失敗時 inline 通知・多重送信防止（`isPending` + `event.preventDefault()`）を追加
- (Req 3.7) 退会フローは email に依存せず Cookie セッションで対象特定（パスキーのみアカウントも同一フロー）

## 受入基準チェック

- [x] Req 1.1: While 認証済みユーザーとしてアプリを閲覧しているとき — `app-shell.test.tsx` "ヘッダーにアカウント設定入口が表示されること"
- [x] Req 1.2: When ユーザーがアカウント設定入口を操作したとき — `account-settings-dialog.test.tsx` "入口ボタンをクリックするとアカウント情報表示領域と退会導線を含むダイアログが開くこと"
- [x] Req 1.3: While 未認証状態 — `auth-guard.test.tsx` "未認証時はアカウント設定入口が render されないこと"
- [x] Req 1.4: ユーザー操作で閉じられる — `account-settings-dialog.test.tsx` "ダイアログはユーザー操作 (Esc) で明示的に閉じられること"
- [x] Req 2.1: 表示名表示 — `account-settings-dialog.test.tsx` "表示名と email が表示されること"
- [x] Req 2.2: email 有設定時表示 — 同上
- [x] Req 2.3: email 空 → 「未設定」プレースホルダ — `account-settings-dialog.test.tsx` "email が未設定（空文字）のとき..."
- [x] Req 2.4: 取得失敗時通知 — `account-settings-dialog.test.tsx` "アカウント情報の取得に失敗したときエラー通知が表示され..."
- [x] Req 3.1〜3.3: 退会起動要素・確認ダイアログ・キャンセル — `withdraw-dialog.test.tsx` 各ケース
- [x] Req 3.4: `DELETE /api/users/me` — `withdraw-dialog.test.tsx` "退会実行時に DELETE /api/users/me を送信すること"（旧 `/api/account` 未呼び出し回帰含む）
- [x] Req 3.5: 成功時 `queryClient.clear()` → `/login` リダイレクト — `account-settings-dialog.test.tsx` "退会確定で DELETE...成功時に /login へリダイレクトされること"
- [x] Req 3.6: 失敗時セッション維持・inline 通知 — `withdraw-dialog.test.tsx` "退会失敗時（サーバ 500）..."、"退会失敗時（ネットワーク到達不能）..."
- [x] Req 3.7: email 未設定パスキーアカウントでも同一フロー — `account-settings-dialog.test.tsx` "email 未設定（空文字）のパスキーのみアカウントでも退会が同一フローで完了すること"
- [x] Req 3.8: 多重送信防止（`disabled` + `preventDefault`）— `withdraw-dialog.test.tsx` "応答待機中は退会確定ボタンが disabled で多重送信されないこと"
- [x] NFR 1.1〜1.3: 既存 2 ペイン・購読設定・ヘッダー機能不変 — 既存 `app-shell.test.tsx` 群（54 件）が引き続き pass

## テスト結果

```
npx vitest run（全 web テスト）
536 pass / 536 total（53 ファイル）

npx eslint
0 errors / 5 warnings（既存の <img> / 未使用変数警告のみ。本 PR で導入した新規コードに警告なし）

npx next build
pass（型エラーなし、5 static pages 生成）
```

## 実装上の判断

- **AlertDialogAction の close 抑止**: 失敗時 inline 通知をダイアログ内に残すため `event.preventDefault()` で既定 close を抑止し、成功時のみ明示的に `setOpen(false)` する構成に変更
- **通知手段は inline `role="alert"` エリア**: 既存 `feed-register-dialog.tsx` / `passkey-signup-dialog.tsx` 等のパターンに揃えた。トーストコンポーネントが web/ に存在しないため新規依存を増やさない選択でもある
- **UI 形式は Dialog**: 既存 `SubscriptionSettingsDialog` と同じく shadcn/ui `Dialog` を採用。Open Questions の保留事項を既存パターンとの整合で確定
- 詳細は `docs/specs/236-feat-web-withdrawdialog-ui/impl-notes.md` / `review-notes.md` を参照

## 確認事項 / レビュワーへの依頼

- Reviewer（claude-opus-4-8）の独立レビュー結果は `docs/specs/236-feat-web-withdrawdialog-ui/review-notes.md` を参照（RESULT: approve）
- design-less impl: 単一 PR で完了のため Closes を採用
- base: develop / baseRefName: develop / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #236 のコメントを参照してください。
