### PR TITLE
feat(#242): 追加パスキー登録 UI（既存 registration/add API の Web 配線・ロスト対策）

### DIFF
--- a/docs/specs/242-feat-web-ui-registration-add-api-web/impl-notes.md
+++ b/docs/specs/242-feat-web-ui-registration-add-api-web/impl-notes.md
@@ -1,0 +1,134 @@
+# 実装ノート (Issue #242 追加パスキー登録 UI の Web 配線)
+
+## Implementation Notes
+
+本 Issue は design-less impl（Architect を介さず要件のみを入力）。既存 Issue #216 の
+サーバ側 add endpoint (`POST /api/passkey/registration/add/begin` / `finish`) は Web の
+既存 Cookie セッションでそのまま到達可能なため、バックエンド変更は含まない。
+
+### 変更ファイル一覧
+
+| ファイル | 責務 | 種別 |
+|---|---|---|
+| `web/src/hooks/use-passkey-add-registration.ts` | 追加パスキー登録の mutation chain（begin → create → finish）と 5 種のエラー分類（`cancelled` / `already_registered` / `server_rejected` / `server_error` / `network_error`） | 新規 |
+| `web/src/hooks/use-passkey-add-registration.test.tsx` | フックの単体テスト（成功系・キャンセル・重複・サーバ拒否・ネットワーク断・decode 失敗・auth/me 非 invalidate） | 新規 |
+| `web/src/components/passkey-add-section.tsx` | AccountSettings ダイアログ内の「パスキーを追加」セクション UI（起動要素・成功/エラー表示・ロスト対策説明） | 新規 |
+| `web/src/components/passkey-add-section.test.tsx` | セクション UI の単体テスト（起動・状態表示・重複と汎用エラーの分離・cancelled の非表示・再試行） | 新規 |
+| `web/src/components/account-settings-dialog.tsx` | `AccountSettingsBody` の `data` 取得成功後に `PasskeyAddSection` を差し込む配線 | 変更 |
+| `web/src/components/account-settings-dialog.test.tsx` | AccountSettingsDialog レベルでの Req 1.1 / 1.3 / 1.4 / 5.1 / 未認証相当（ダイアログ未展開時）確認テストを追加 | 変更 |
+
+上記に加え、本ドキュメント `docs/specs/242-feat-web-ui-registration-add-api-web/impl-notes.md`
+を新規追加している。requirements.md / 既存 spec は書き換えていない。
+
+### 各 AC / NFR とテストの対応
+
+| Req / NFR | 実装 | テスト |
+|---|---|---|
+| 1.1 認証済み時に起動要素を表示 | `AccountSettingsBody` が `data` を得た時のみ `<PasskeyAddSection />` を描画 | `account-settings-dialog.test.tsx` "認証済みユーザーがダイアログを開くとパスキー追加登録セクションが表示されること" |
+| 1.2 未認証時は表示しない | ダイアログを開かない限り DOM に存在しない構造で担保 | `account-settings-dialog.test.tsx` "入口ボタンを押さない（ダイアログを開かない）と追加登録起動要素は表示されないこと" |
+| 1.3 取得前は確定的な操作可能状態にしない | `isLoading` 中は loading プレースホルダで置換し、セクションを描画しない | `account-settings-dialog.test.tsx` "アカウント情報取得中はパスキー追加登録セクションが表示されないこと" |
+| 1.4 取得失敗時も同様 | `isError || !data` で `role=alert` に置換し、セクションを描画しない | `account-settings-dialog.test.tsx` "アカウント情報取得に失敗したときはパスキー追加登録セクションが表示されないこと" |
+| 1.5 起動要素操作で登録フロー開始 | `passkey-add-section.tsx` の `handleAdd()` で `mutate()` を呼び出す | `passkey-add-section.test.tsx` "起動要素をクリックすると mutation.mutate が呼ばれること" |
+| 2.1 追加登録用チャレンジ取得 | `apiClient.post("/api/passkey/registration/add/begin", {})` を空ボディで呼び出し | `use-passkey-add-registration.test.tsx` "begin→create→finish で成功し、認証系ceremony を呼ばず、begin は空ボディで送信されること" |
+| 2.2 ブラウザのパスキー作成 UI 起動 | `navigator.credentials.create(creationOptions)` を呼び出し | 同上 |
+| 2.3 credential 情報を確定処理へ提示 | `encodeAttestationResponse` で JSON 化して `/api/passkey/registration/add/finish` に送信 | 同上 |
+| 2.4 成功を視認できる形で提示 | `passkey-add-success` testid の `role=status` バナー表示 | `passkey-add-section.test.tsx` "成功時に成功フィードバックが視認できる形で表示されること" |
+| 2.5 認証済みセッション維持 | 成功時 `queryClient.invalidateQueries(auth/me)` を呼ばない | `use-passkey-add-registration.test.tsx` "成功時に auth/me query を invalidate しないこと" |
+| 3.1 重複を認識できる形で提示 | `already_registered` kind → `passkey-add-error-already-registered` testid の独自文言（「この認証器はすでに...」）| `passkey-add-section.test.tsx` "重複エラー時に他のエラーと区別できる文言・testid で提示されること" |
+| 3.2 重複時に finish を呼ばない | `navigator.credentials.create` の `InvalidStateError` を catch し STEP_NAV_CREATE で分類 → finish 未実行 | `use-passkey-add-registration.test.tsx` "同一 authenticator の重複時（InvalidStateError）は already_registered に分類し finish を呼ばないこと" |
+| 3.3 別 authenticator で再試行できる状態を維持 | エラー表示後も起動要素は disabled=false で残る | `passkey-add-section.test.tsx` "重複エラー時に..." で `passkey-add-trigger` が残ることを確認 |
+| 3.4 他のキャンセル・拒否理由と区別 | 重複は専用 testid + 専用文言、他エラーは共通 testid の汎用文言 | `passkey-add-section.test.tsx` "汎用エラー %s は共通の汎用文言で提示され、専用の重複エラー枠が出ないこと" |
+| 4.1 キャンセル時に画面を壊さず再試行提示 | `NotAllowedError` / `AbortError` / `null` を `cancelled` に集約し、UI でエラー表示を出さず `mutation.reset()` | `use-passkey-add-registration.test.tsx` "create のユーザーキャンセル..." / `passkey-add-section.test.tsx` "cancelled 発生時はエラー表示を出さず..." |
+| 4.2 サーバ拒否時に汎用エラー表示 | `ApiError` 4xx → `server_rejected` に集約、内部詳細を message に反射しない | `use-passkey-add-registration.test.tsx` "finish の %i は server_rejected として分類され..." |
+| 4.3 ネットワーク断・サーバ内部エラー時に再試行導線 | `TypeError` / `AbortError` → `network_error`, `ApiError` 5xx → `server_error`, いずれも起動要素は残る | `use-passkey-add-registration.test.tsx` "finish の 5xx / fetch reject / AbortError..." / `passkey-add-section.test.tsx` "汎用エラー %s は..." |
+| 4.4 pending 中の多重送信防止 | ボタン `disabled={isPending}`, 文言「登録中...」 | `passkey-add-section.test.tsx` "mutation pending 中は起動要素が disabled になり文言が「登録中...」になること" |
+| 4.5 終了後に再操作可能に戻す | mutation の `isPending` が false に戻ることで再有効化。isSuccess のまま次回起動時は `reset()` + `mutate()` で成功通知を隠す | `passkey-add-section.test.tsx` "mutation 終了後は起動要素が再操作可能な状態に戻ること" / "再試行時に成功通知が消え、mutate が再度呼ばれること" |
+| 4.6 キャンセル・失敗時のセッション維持 | mutation はサーバ拒否・断で session を変えない設計（`auth/me` を invalidate しない） | `passkey-add-section.test.tsx` "エラー分類のいずれでも起動要素が残り..." |
+| 5.1 Google 由来ユーザーでも同一位置・同一操作性 | `PasskeyAddSection` は `user.email` を条件に取らず、`data` 有無だけで表示される | `account-settings-dialog.test.tsx` "Google 由来（email 未設定含む）ユーザーでも同一位置にパスキー追加導線が表示されること" |
+| 5.2 Google 紐付けは解除・変更されない | 追加登録 chain はサーバ側で `user_id` に紐付く credential 追加のみで OAuth 紐付けを触らない（サーバ側 #216 実装）+ 成功時に `auth/me` を invalidate しない設計 | サーバ側は Issue #216 の既存テストで担保。Web 側は auth/me 非 invalidate（`use-passkey-add-registration.test.tsx`）で本 spec の Web 責務を担保 |
+| 5.3 既存パスキー持ち・初回パスキーで同一導線 | セクションは登録済み件数を判定材料にしない | 導線が常に表示される点を `passkey-add-section.test.tsx` "パスキー追加の起動要素とロスト対策説明を表示すること" で担保 |
+| 6.1 ロスト対策説明を表示 | `passkey-add-loss-prevention` testid で「別の端末や同期先を追加しておくと...」文言を表示 | `passkey-add-section.test.tsx` "パスキー追加の起動要素とロスト対策説明を表示すること" |
+| 6.2 説明文に機密情報を含めない | 説明文は固定文字列、credential/user id/email 等の識別子キーワードを含まない | `passkey-add-section.test.tsx` "ロスト対策説明文に credential 識別子等の機密情報を含めないこと" |
+| NFR 1.1〜1.4 既存機能非破壊 | 既存 `use-passkey-registration` / `AccountInfoSection` / `WithdrawSection` / 既存 fetch 動線は一切改変なし。追加コンポーネントのみを差し込み | 既存全 55 スイート 583 テストが green を維持 |
+| NFR 1.5 既存テスト green 維持 | 上記のとおり全既存テストが green | `npm test` 全 pass |
+| NFR 2.1 attestation・challenge 生値の非漏出 | フックの mutation 内 closure に閉じ込め、`console.*` / storage / URL / エラー message に一切書き出さない | ハンドラ・UI どちらのテストでも error.message に internal データが混入しないことを検査 |
+| NFR 2.2 サーバ拒否詳細の非反射 | `PasskeyAddRegistrationError` は `kind` のみで区別、`ApiError.body` の内部詳細を message に含めない | `use-passkey-add-registration.test.tsx` "finish の %i は server_rejected として分類され、内部 body が message に混入しないこと" / UI 側でも kind 名が DOM に反射しないことを検査 |
+| NFR 2.3 同一オリジンのみ | `apiClient`（`API_BASE_URL = ""`）経由で同一オリジン相対パス。他の URL を組み立てない | 既存 `apiClient` 契約に依拠（`web/src/lib/api.ts`） |
+| NFR 2.4 CSP / sanitize 方針の非緩和 | 追加なし。dangerouslySetInnerHTML / eval / 動的 script 追加なし | 実装ファイルの grep で明確 |
+| NFR 3.1 WebAuthn utility 再利用 | `decodeCreationOptions` / `encodeAttestationResponse` を `@/lib/webauthn` から import | フックのテストで両関数がモック経由で呼ばれることを確認 |
+| NFR 4.1 テスト容易性（ブラウザ・外部依存なしで検証可能） | `navigator.credentials` と `apiClient` を vi.stubGlobal / vi.mock で置換、jsdom 環境で完結 | フック 20 テスト + UI 13 テスト + ダイアログ統合 15 テスト |
+
+### 重要な設計判断
+
+1. **`InvalidStateError` を `cancelled` と別 kind に分離**（Req 3 の中核要件）
+   - 既存 `use-passkey-registration.ts` は `NotAllowedError` / `AbortError` / `InvalidStateError` を
+     まとめて `CANCEL_ERROR_NAMES` セットで `cancelled` に集約している（新規作成では
+     excludeCredentials が空のため、`InvalidStateError` の意味論的な役割が薄い）。
+   - 追加登録では `excludeCredentials` に登録済み credential ID が含まれるため、同一 authenticator
+     を選ぶと `InvalidStateError` がブラウザから明示的に発火する。本フックではこの意味を保存し、
+     `already_registered` として **独立分類**する。
+   - 既存フックの分類は **一切変更していない**（`use-passkey-registration.ts` の
+     `PasskeyRegistrationErrorKind` は温存 / requirements.md「Out of Scope」でも明記）。
+
+2. **finish の uncertain 状態を独立 kind に分けなかった理由**
+   - 新規作成では finish 失敗が「サーバに commit されたか不明」と UX 上重要（登録済かどうかで
+     次の導線が変わる）。
+   - 追加登録では finish が失敗しても、再試行 begin が返す `excludeCredentials` に既に登録済み
+     credential が含まれるため、同じ authenticator では `InvalidStateError` になり `already_registered`
+     に自然に集約される。ユーザーは別 authenticator で再試行できる（Req 3.3 と整合）。そのため
+     新規作成側の `registration_uncertain` 相当を持たず、`network_error` / `server_error` に集約した。
+
+3. **`204 No Content` を安全に受け取る仕組み**
+   - 既存 `apiClient` は 204/205 で `response.json()` を呼ばず `undefined` を返す契約
+     （`web/src/lib/api.ts` L114-121）。add/finish は `apiClient.post<void>` として呼び出し、
+     `ResponseParseError` を誘発しない。
+   - 過去 Issue #213 系で 204 のパスがすでに担保されているため、本 spec で追加の仕組みは不要。
+
+4. **成功後の再操作 UX**
+   - 一度成功した後に「もう 1 台追加する」ケースを想定し、`isSuccess` のまま再クリック
+     したときには `reset()` → `mutate()` を呼び、`useEffect(() => setDismissedSuccess(false), [isSuccess])`
+     で新たな成功が来たら通知を再表示する設計にした。テスト観点上、mock hook で
+     `isSuccess=true` のままの状態でも「クリックで mutate と reset が呼ばれる」ことを
+     検査できる。
+
+5. **成功時の `auth/me` 非 invalidate**（Req 2.5）
+   - 追加登録はセッションを変えないため `queryClient.invalidateQueries({queryKey: ["auth","me"]})`
+     を呼ばない。呼ぶとダイアログ外の UI（`AuthGuard` / ヘッダーのユーザ表示など）が再取得を
+     走らせ「他画面の表示・既存機能を変化させない」に反する。テストで invalidate が呼ばれない
+     ことを assert 済み。
+
+### 実行したテスト結果
+
+- **`npm test`**: 55 スイート / 583 テスト すべて pass（新規追加は 3 スイート合計 48 テスト。
+  内訳: hook 20 / UI 13 / dialog 統合 15）。所要時間 ~81 秒。
+- **`npm run lint`**: 新規/変更ファイル分の警告・エラー **なし**。既存の 5 件 warning（feed-favicon,
+  search-results, theme-provider.test.tsx, app-state.test.tsx 由来）は本 PR 対象外。
+- **`npm run build`**: production build 成功（`Compiled successfully` + `Generating static pages` 完了）。
+- **`npx tsc --noEmit`**: 新規/変更ファイル分のエラー **0 件**。既存の TypeScript エラー（39 行、
+  feed-list.test.tsx / starred-item-list.test.tsx / starred-nav-item.test.tsx / rewrites.test.ts）は
+  本 PR 前後で件数変化なし = 本 PR とは無関係な既存問題。
+
+### 確認事項
+
+- **UI コピー・強調度**: requirements.md「Open Questions」で `design で確定` とされていた
+  「ロスト対策説明の文言」「重複エラー文言」「成功フィードバック手段」は design がないため
+  実装者判断で以下を採用:
+  - ロスト対策: 「別の端末や同期先のパスキーを追加しておくと、片方の端末を失っても
+    アカウントにアクセスできなくなるリスクを下げられます。」
+  - 重複: 「この認証器はすでにアカウントに登録されています。別の端末や別のパスキー同期先を
+    選んでください。」
+  - 成功: `role=status` + 「パスキーを追加しました。」（インラインバナー）
+  - 汎用エラー: `role=alert` + 「パスキーの追加に失敗しました。時間をおいて再度お試しください。」
+  レビュワー判断でコピー・強調度は差し戻し可能。
+- **UI 配置**: Account Settings ダイアログ内で `AccountInfoSection` の直下、`WithdrawSection` の
+  直上に独立セクションとして配置した（退会と並列だが、ロスト対策文脈で登録直下が自然）。
+  Open Questions の「独立セクション / 既存セクション周辺」は独立セクション案を採用。
+- **追加登録件数の上限・可視化**: `Out of Scope`（credential 一覧 UI）に沿って登録済み件数を
+  表示しない。連続追加時は成功通知を再表示する UX で担保しているが、ユーザーが「今何個
+  登録されているか」を確認する導線は本 spec 対象外。将来の Issue で扱う想定。
+- **既存 `use-passkey-registration.ts` は変更していない**（Out of Scope の明記に従う）。
+  新規作成側で `InvalidStateError` を `cancelled` に含める現行挙動は、ログインフローの
+  「作成前は excludeCredentials が空のため InvalidStateError は理論上発生しない」性質を
+  前提としている。将来「作成前 InvalidStateError」観点を追加する場合は別 spec で。
+
+STATUS: complete

--- a/docs/specs/242-feat-web-ui-registration-add-api-web/requirements.md
+++ b/docs/specs/242-feat-web-ui-registration-add-api-web/requirements.md
@@ -1,0 +1,204 @@
+# Requirements Document
+
+## Introduction
+
+Feedman Web（Next.js）のアカウント設定には、認証済みユーザーが 2 つ目以降のパスキーを登録する
+導線が存在しない。既に本 spec 対象のサーバ側追加登録 API（`POST /api/passkey/registration/add/begin`
+と `POST /api/passkey/registration/add/finish`、excludeCredentials 付きチャレンジを含む）は
+Issue #216 で main に投入済みで、iOS 側でも同 endpoint を利用予定であり、当該 endpoint は
+既存の Web Cookie セッション認証で到達可能である（実装前調査で確認済み）。したがって本 spec の
+スコープはバックエンド変更を含まない **Web 配線のみ** となる。
+
+現状「パスキーのみで登録したアカウント」はパスキーを 1 つ失うとアカウントへのアクセス手段が
+完全に失われる。業界の主要なロスト対策は「同一アカウントに複数のパスキーを登録しておく」
+（別の端末・別の同期元でバックアップを持つ）ことであり、本 spec はこの導線を認証済みユーザーに
+提供する。追加後のログイン可否そのものはサーバ側の add endpoint 契約と既存パスキー認証フローで
+担保されるため、本 spec の受入基準は **Web 側から観測可能な「追加登録成功が伝達される」ことと
+「壊れた状態にならないこと」**に集中する。
+
+本 spec は Google 由来ログイン（パスキー未登録を含む）ユーザーが同じ導線からパスキーを追加できる
+ことも受入基準として要件化する。パスキー credential の一覧・削除・リネーム UI、リカバリコード、
+iOS 側の実装、サーバ側 API 変更は本 spec のスコープ外とする。
+
+## Requirements
+
+### Requirement 1: 追加パスキー登録導線の表示条件
+
+**Objective:** As a 認証済みユーザー, I want アカウント設定画面から「パスキーを追加」導線に
+アクセスしたい, so that 2 つ目以降のパスキーを自力で登録してアカウント喪失リスクを下げられる
+
+#### Acceptance Criteria
+
+1. While 認証済みユーザーが Account Settings UI を開いているとき, the Account Settings UI shall
+   パスキー追加登録の起動要素を表示する
+2. While 未認証状態でアプリを閲覧しているとき, the Web Application shall パスキー追加登録の起動
+   要素を表示しない
+3. While アカウント情報の取得が完了する前に Account Settings UI が開かれているとき, the Account
+   Settings UI shall パスキー追加登録の起動要素を確定的に操作可能な状態としては提示しない
+4. If アカウント情報の取得に失敗したとき, the Account Settings UI shall パスキー追加登録の起動
+   要素を確定的に操作可能な状態としては提示しない
+5. When ユーザーがパスキー追加登録の起動要素を操作したとき, the Account Settings UI shall
+   パスキー追加登録フロー（Requirement 2）を開始する
+
+### Requirement 2: 追加パスキー登録フローの完了と成功の伝達
+
+**Objective:** As a 認証済みユーザー, I want ブラウザのパスキー作成 UI から 2 つ目以降のパスキーを
+登録したい, so that 追加登録が成功したことを Web 画面上で確認できる
+
+#### Acceptance Criteria
+
+1. When ユーザーがパスキー追加登録を開始したとき, the Web Passkey Add Registration Flow shall
+   現在ログイン中のユーザー識別子に紐付いた追加登録用チャレンジをサーバから取得する
+2. When 追加登録用チャレンジを受領したとき, the Web Passkey Add Registration Flow shall
+   ブラウザのパスキー作成 UI を起動する
+3. When ブラウザのパスキー作成 UI が成功で完了したとき, the Web Passkey Add Registration Flow
+   shall 生成された credential 情報を現在ログイン中のユーザーとして追加登録用の確定処理へ提示する
+4. When サーバが追加登録応答を成功として受理したとき, the Account Settings UI shall 追加登録の
+   成功をユーザーが視認できる形で提示する
+5. When 追加登録が成功したとき, the Web Application shall ユーザーの認証済みセッションを維持し、
+   追加登録操作の前後で他画面の表示や既存機能の利用可否を変化させない
+
+### Requirement 3: 同一 authenticator の重複登録抑止とユーザー可読なエラー
+
+**Objective:** As a 認証済みユーザー, I want 既に登録済みの authenticator を誤って再登録しよう
+としたときに重複と分かる形でエラー表示されたい, so that 「登録に失敗したのか同じ端末を選んだの
+か」を混同せず、別の端末・別の同期先で再試行できる
+
+#### Acceptance Criteria
+
+1. When ブラウザが追加登録要求を「同一アカウントに既に登録済みの authenticator」であることを
+   理由に拒否したとき, the Account Settings UI shall 追加登録を確定させず、重複登録である旨を
+   ユーザーが認識できる形で提示する
+2. If 重複登録が発生したとき, the Web Passkey Add Registration Flow shall サーバ側の追加登録
+   確定処理を呼び出さない
+3. While 重複登録エラーが表示されているとき, the Account Settings UI shall ユーザーが別の
+   authenticator を用いて追加登録を再試行できる状態を維持する
+4. The Account Settings UI shall 重複登録エラーを、他のキャンセル・拒否理由（Requirement 4）と
+   ユーザーが区別できる形で提示する
+
+### Requirement 4: キャンセル・失敗時の UI 復旧と再試行
+
+**Objective:** As a 認証済みユーザー, I want 追加登録のキャンセル・失敗時に画面が壊れず再試行
+できる状態に戻ってほしい, so that 中途状態・誤操作・ネットワーク断で詰まらずに次の操作へ進める
+
+#### Acceptance Criteria
+
+1. If ユーザーがブラウザのパスキー作成 UI 上でキャンセルまたは拒否したとき, the Account Settings
+   UI shall 追加登録を確定させず、Account Settings UI の表示を維持したまま再試行操作を提示する
+2. If サーバが追加登録応答を拒否した（チャレンジ期限切れ・attestation 不正・レート制限超過等）
+   とき, the Account Settings UI shall 追加登録を確定させず、拒否理由の内部区別をユーザー画面
+   に反射しない汎用エラー表示を提示する
+3. If 追加登録処理中にネットワーク断・サーバ内部エラーが発生したとき, the Account Settings UI
+   shall 追加登録を確定させず、ユーザーが再試行操作を選択できる状態を提示する
+4. While 追加登録要求の応答を待機している間, the Account Settings UI shall 追加登録の起動要素を
+   非活性化し、多重送信を防止する
+5. When 追加登録処理が終了（成功・失敗・キャンセルのいずれか）したとき, the Account Settings UI
+   shall 追加登録の起動要素を再操作可能な状態に戻す
+6. When キャンセル・失敗が発生したとき, the Web Application shall ユーザーの認証済みセッション
+   を維持し、既存機能の利用可否を変化させない
+
+### Requirement 5: Google 由来アカウントからの追加登録
+
+**Objective:** As a Google OAuth 由来でログインしパスキー未登録を含む認証済みユーザー, I want
+同じ「パスキーを追加」導線から自分のアカウントにパスキーを登録したい, so that Google Sign-In
+だけでなくパスキーでもログインできる状態に移行できる
+
+#### Acceptance Criteria
+
+1. While Google OAuth 由来でログインした認証済みユーザーが Account Settings UI を開いていて、
+   当該ユーザーにまだパスキーが登録されていないとき, the Account Settings UI shall パスキー
+   追加登録の起動要素を Requirement 1.1 と同一の位置・同一の操作性で表示する
+2. When Google 由来ユーザーが初回のパスキー登録を成功で完了したとき, the Web Application shall
+   既存の Google 紐付けを解除・変更せず、当該アカウントを両方のログイン手段で利用可能な状態に
+   する
+3. When Google 由来ユーザーの初回パスキー登録を実行するとき, the Web Passkey Add Registration
+   Flow shall 既にパスキーを持つユーザーが追加登録する場合と同じ導線・同じ操作手順で処理を進行
+   させる
+
+### Requirement 6: ロスト対策コンテキストの提示
+
+**Objective:** As a 認証済みユーザー, I want パスキー追加登録がなぜ推奨されるのかを Web 画面上で
+読める, so that 「別の端末や同期先を追加しておくことがアカウント喪失リスクを下げる」ことを理解
+して意思決定できる
+
+#### Acceptance Criteria
+
+1. While Account Settings UI にパスキー追加登録の起動要素が表示されているとき, the Account
+   Settings UI shall 別の端末や同期先を追加しておくとアカウントを失いにくくなる旨の説明文を
+   同一画面上に表示する
+2. The Account Settings UI shall ロスト対策の説明文にユーザーの個人情報・credential 識別子等の
+   機密情報を含めない
+
+## Non-Functional Requirements
+
+### NFR 1: 既存機能の非破壊性
+
+1. The Account Settings UI shall 既存のアカウント情報表示・退会導線の表示と挙動を、パスキー
+   追加登録導線の追加によって変更しない
+2. The Web Application shall 既存の 2 ペインレイアウト（フィード一覧・記事一覧・記事詳細）の
+   挙動を、本機能追加によって変更しない
+3. The Web Application shall 既存の Google OAuth ログイン・パスキー新規作成・パスキーログイン・
+   ログアウトの各既存導線の挙動を、本機能追加によって変更しない
+4. The Web Application shall 認証済みでないユーザーが体感する挙動を、本機能追加によって変更しない
+5. The Web Test Suite shall 本機能追加前から存在する既存テストを green 状態のまま維持する
+
+### NFR 2: セキュリティ・機密情報の非漏出
+
+1. The Web Passkey Add Registration Flow shall 追加登録処理でブラウザから受け取る attestation
+   の生バイト列・サーバから受け取るチャレンジ識別子の平文を、ブラウザのコンソールログ・
+   localStorage / sessionStorage・URL クエリ文字列・エラー表示テキストに残さない
+2. The Web Passkey Add Registration Flow shall サーバの拒否・エラー応答の内部詳細（スタック
+   トレース・内部エラー原因・クエリ文字列等）をユーザー可視の画面やコンソールに反射しない
+3. The Web Passkey Add Registration Flow shall 追加登録処理を本 spec 導入前から Web が信頼して
+   いる同一オリジンのサーバに対してのみ実行する
+4. The Web Application shall 既存の Content Security Policy およびクライアント側 HTML sanitize
+   方針を本機能追加によって緩和しない
+
+### NFR 3: 実装共有・重複回避
+
+1. The Web Passkey Add Registration Flow shall 既存パスキー登録フローが依拠する WebAuthn の
+   encode/decode utility を再利用し、同等機能の重複実装を作らない
+
+### NFR 4: テスト容易性
+
+1. The Web Passkey Add Registration Test Suite shall 追加登録成功・ブラウザキャンセル・重複
+   authenticator による拒否・サーバ拒否・ネットワーク断・認証済み状態での導線表示・未認証状態
+   での導線非表示 の各ケースを、ブラウザおよび外部ネットワーク依存なしに検証可能にする
+
+## Out of Scope
+
+- パスキー credential のセルフサービス管理 UI（一覧表示・削除・リネーム・命名）
+- リカバリコード・リカバリメールなど、パスキー以外のロスト対策手段の追加
+- iOS クライアント側の実装（feedman-ios#117 スコープ）
+- サーバ側追加登録 API（`POST /api/passkey/registration/add/begin|finish`）の request /
+  response 契約の変更（実装前調査で Cookie session 認証にて到達可能と確認済みのため本 spec は
+  Web 配線のみに集中する）
+- Web ログイン画面（`/login`）自体の変更（本 spec はログイン後の認証済み画面のみを対象とする）
+- パスキー登録済み件数・登録日時など credential 一覧的な情報の表示
+- 既存 `usePasskeyRegistration` の新規作成用エラー分類（`PasskeyRegistrationErrorKind`）を書き
+  換えることによる新規作成フローの挙動変更（本 spec は追加登録専用のエラー区別のみを扱う）
+
+## Open Questions
+
+- **追加登録導線の UI 配置**: Account Settings UI 内の独立セクションとして提示するか、既存
+  セクション（アカウント情報 / 退会）の周辺に配置するかの UI 判断は design で確定する
+- **成功時のフィードバック手段**: Requirement 2.4 の「成功をユーザーが視認できる形」の具体的
+  表示手段（トースト / ダイアログ内インライン表示 / セクション内の状態表示等）は design で
+  確定する
+- **重複登録時のエラー表示手段と文言**: Requirement 3.1 / 3.4 の「重複と分かる」表示の具体的
+  な文言・強調度・提示位置は design / UI 判断とする
+- **キャンセル・汎用エラー時のフィードバック手段**: Requirement 4.1〜4.3 の再試行導線・エラー
+  表示の具体的な UI（トースト / インラインエラー / モーダル内表示等）は design で確定する
+- **ロスト対策説明文の具体コピー・強調度**: Requirement 6.1 の「アカウントを失いにくくなる旨」
+  の具体的な文言と表示位置は design / UI 判断とする
+- **重複エラーを Web からどのように識別するか**: excludeCredentials 由来のブラウザ拒否を
+  他のキャンセル系エラーと区別するための実装手段（DOMException の name 判別 / エラー種別
+  enum の拡張等）は design の実装詳細
+- **追加登録用チャレンジ取得時のリクエスト内容**: サーバ側 begin endpoint が受け付ける
+  リクエストボディの詳細（空ボディでの起動可否等）はサーバ既存契約に従い design で確定する
+
+## 関連
+
+- Parent: #216
+- Depends on: #216
+- Related: #223 #236 #241

--- a/docs/specs/242-feat-web-ui-registration-add-api-web/review-notes.md
+++ b/docs/specs/242-feat-web-ui-registration-add-api-web/review-notes.md
@@ -1,0 +1,86 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-8 timestamp=2026-07-29T05:29:51Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-242-impl-feat-web-ui-registration-add-api-web
+- HEAD commit: 69d6fa31a40f0e180d9c5a66d934ebdb6ea3f847
+- Compared to: develop..HEAD
+- 補足: 本 Issue は design-less impl（`tasks.md` / `design.md` 不在）。`_Boundary:_`
+  アノテーションが存在しないため、境界判定は CLAUDE.md のレイヤ配置ガイド
+  （`web/src/hooks/` / `web/src/components/`）に照らして実施した。Feature Flag
+  Protocol は本 repo で opt-out のため flag 観点の確認は行わない。
+
+## Verified Requirements
+
+- 1.1 — `account-settings-dialog.tsx` `AccountSettingsBody` が `data` 取得成功時のみ
+  `<PasskeyAddSection />` を描画 / test: account-settings-dialog.test.tsx
+  「認証済みユーザーがダイアログを開くとパスキー追加登録セクションが表示されること」
+- 1.2 — ダイアログ未展開・データ無しでは DOM に非在 / test: 同上
+  「入口ボタンを押さない（ダイアログを開かない）と追加登録起動要素は表示されないこと」
+- 1.3 — `isLoading` 中は loading プレースホルダに置換しセクション非描画 / test:
+  「アカウント情報取得中はパスキー追加登録セクションが表示されないこと」
+- 1.4 — `isError || !data` で `role=alert` に置換しセクション非描画 / test:
+  「アカウント情報取得に失敗したときはパスキー追加登録セクションが表示されないこと」
+- 1.5 — `passkey-add-section.tsx` `handleAdd()` → `mutate()` / test:
+  passkey-add-section.test.tsx「起動要素をクリックすると mutation.mutate が呼ばれること」
+- 2.1 — `apiClient.post("/api/passkey/registration/add/begin", {})`（空ボディ）/ test:
+  use-passkey-add-registration.test.tsx「begin→create→finish で成功し…begin は空ボディで送信されること」
+- 2.2 — `navigator.credentials.create(creationOptions)` / test: 同上（create 呼出を assert）
+- 2.3 — `encodeAttestationResponse` → `/add/finish` に credential 送信 / test: 同上（finish 呼出を assert）
+- 2.4 — `passkey-add-success`（`role=status`）バナー / test:
+  passkey-add-section.test.tsx「成功時に成功フィードバックが視認できる形で表示されること」
+- 2.5 — 成功時に `auth/me` を invalidate しない / test:
+  use-passkey-add-registration.test.tsx「成功時に auth/me query を invalidate しないこと」
+- 3.1 — `already_registered` → 専用 testid + 独自文言 / test: passkey-add-section.test.tsx
+  「重複エラー時に他のエラーと区別できる文言・testid で提示されること」
+- 3.2 — `InvalidStateError` を STEP_NAV_CREATE で catch し finish 未実行 / test:
+  use-passkey-add-registration.test.tsx「同一 authenticator の重複時…finish を呼ばないこと」
+- 3.3 — エラー表示後も `passkey-add-trigger` が残る / test: 3.1 のテスト内で trigger 残存を assert
+- 3.4 — 重複=専用 testid/文言、他=共通 testid の汎用文言 / test:
+  「汎用エラー %s は共通の汎用文言で提示され、専用の重複エラー枠が出ないこと」
+- 4.1 — `cancelled` はエラー非表示 + `mutation.reset()` / test:
+  「cancelled 発生時はエラー表示を出さず mutation.reset() を呼ぶ」+ hook のキャンセル分類テスト
+- 4.2 — 4xx → `server_rejected` 汎用文言、内部詳細非反射 / test:
+  「finish の %i は server_rejected として分類され、内部 body が message に混入しないこと」
+- 4.3 — 5xx/TypeError/AbortError → `server_error`/`network_error`、起動要素残存 / test:
+  hook の各分類テスト + section「汎用エラー %s は…再試行可能な状態が維持される」
+- 4.4 — ボタン `disabled={isPending}`「登録中...」/ test:
+  「mutation pending 中は起動要素が disabled になり文言が「登録中...」になること」
+- 4.5 — 終了後 `isPending` false で再有効化 / test:
+  「mutation 終了後は起動要素が再操作可能な状態に戻ること」「再試行時に成功通知が消え、mutate が再度呼ばれること」
+- 4.6 — エラー分類のいずれでも session 不変（auth/me 非 invalidate）/ test:
+  「エラー分類のいずれでも起動要素が残り…」+ hook 非 invalidate テスト
+- 5.1 — セクションは `email` を条件にせず `data` 有無のみで表示 / test:
+  「Google 由来（email 未設定含む）ユーザーでも同一位置にパスキー追加導線が表示されること」
+- 5.2 — Web 責務として `auth/me` 非 invalidate（OAuth 紐付けはサーバ #216 で担保）/ test:
+  hook「成功時に auth/me query を invalidate しないこと」
+- 5.3 — 登録済み件数を判定材料にせず常時表示 / test:
+  passkey-add-section.test.tsx「パスキー追加の起動要素とロスト対策説明を表示すること」
+- 6.1 — `passkey-add-loss-prevention` にロスト対策説明文 / test: 同上（loss-prevention 文言を assert）
+- 6.2 — 説明文は固定文字列で機密情報非含有 / test:
+  「ロスト対策説明文に credential 識別子等の機密情報を含めないこと」
+- NFR 1.1〜1.5 — 既存ファイルは additive 差込のみ（`use-passkey-registration` / `AccountInfoSection`
+  / `WithdrawSection` 不変）。新規/変更 3 スイート 48 テスト green を再実行で確認
+- NFR 2.1 — attestation/challenge 生値を mutation closure に閉じ込め console/storage/URL/message に非出力
+- NFR 2.2 — `PasskeyAddRegistrationError` は `kind` のみ、`ApiError.body` を message/DOM に非反射 / test:
+  hook「内部 body が message に混入しないこと」+ section「内部詳細（kind 名 / status）が DOM に反射しない」
+- NFR 2.3 — `apiClient`（同一オリジン相対パス）経由 / 既存契約に依拠
+- NFR 2.4 — `dangerouslySetInnerHTML` / `eval` / 動的 script なし（追加コードに非在）
+- NFR 3.1 — `web/src/lib/webauthn.ts` の `decodeCreationOptions` / `encodeAttestationResponse` を
+  再利用（同関数の存在を確認済み。重複実装なし）
+- NFR 4.1 — `navigator.credentials` / `apiClient` を stub/mock、jsdom で完結（外部依存なし）
+
+## Findings
+
+なし
+
+## Summary
+
+design-less impl として Req 1〜6 / NFR 1〜4 の全 numeric ID が実装（hook / section / dialog 配線）
+とテストの双方で観測でき、新規/変更 3 スイート 48 テストを reviewer 側で再実行して green を確認した。
+変更は `web/src/hooks/` と `web/src/components/` に閉じ、既存ファイルは additive 差込のみで
+CLAUDE.md のレイヤ配置に整合。AC 未カバー / missing test / boundary 逸脱いずれも検出せず。
+
+RESULT: approve

--- a/web/src/components/account-settings-dialog.test.tsx
+++ b/web/src/components/account-settings-dialog.test.tsx
@@ -332,6 +332,98 @@ describe("AccountSettingsDialog コンポーネント", () => {
     ).toBeInTheDocument();
   });
 
+  it("認証済みユーザーがダイアログを開くとパスキー追加登録セクションが表示されること (Issue #242 Req 1.1)", async () => {
+    setupMockFetch({ auth: "ok" });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+
+    // data 取得成功後に本セクションが描画される
+    await waitFor(() => {
+      expect(screen.getByTestId("passkey-add-section")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("passkey-add-trigger")).toBeInTheDocument();
+  });
+
+  it("Google 由来（email 未設定含む）ユーザーでも同一位置にパスキー追加導線が表示されること (Issue #242 Req 5.1)", async () => {
+    // email 空文字（Google 由来でパスキー未登録相当）を再現
+    setupMockFetch({ auth: "ok-empty-email" });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("passkey-add-section")).toBeInTheDocument();
+    });
+    // 起動要素は同一操作性で存在
+    expect(screen.getByTestId("passkey-add-trigger")).toBeInTheDocument();
+  });
+
+  it("アカウント情報取得中はパスキー追加登録セクションが表示されないこと (Issue #242 Req 1.3)", async () => {
+    // /auth/me を pending 状態にする
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "/auth/me") {
+        return new Promise(() => {}); // never resolve
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+
+    // loading プレースホルダは出るが、追加登録セクションは描画されない
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("account-settings-loading"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("passkey-add-section"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("passkey-add-trigger"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("アカウント情報取得に失敗したときはパスキー追加登録セクションが表示されないこと (Issue #242 Req 1.4)", async () => {
+    setupMockFetch({ auth: "error" });
+    const user = userEvent.setup();
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    await openDialog(user);
+
+    // エラー通知は出るが、追加登録セクションは描画されない
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("account-settings-error"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByTestId("passkey-add-section"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("passkey-add-trigger"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("入口ボタンを押さない（ダイアログを開かない）と追加登録起動要素は表示されないこと (Issue #242 Req 1.2 の未認証相当 UI 未描画)", () => {
+    // 未認証状態でも、ダイアログを開かなければ本セクションは DOM に存在しない
+    setupMockFetch({ auth: "error" });
+    render(<AccountSettingsDialog />, { wrapper: createWrapper() });
+
+    // トリガーは表示されるが、追加登録セクション自体はダイアログを開かない限り DOM 外
+    expect(screen.getByTestId("account-settings-trigger")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("passkey-add-section"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("passkey-add-trigger"),
+    ).not.toBeInTheDocument();
+  });
+
   it("email 未設定（空文字）のパスキーのみアカウントでも退会が同一フローで完了すること (Req 3.7)", async () => {
     setupMockFetch({ auth: "ok-empty-email", withdraw: "success" });
     const user = userEvent.setup();

--- a/web/src/components/account-settings-dialog.tsx
+++ b/web/src/components/account-settings-dialog.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { useCurrentUser } from "@/hooks/use-auth";
 import { WithdrawDialog } from "@/components/withdraw-dialog";
+import { PasskeyAddSection } from "@/components/passkey-add-section";
 import type { User } from "@/types/auth";
 
 /**
@@ -127,6 +128,12 @@ function AccountSettingsBody({ onWithdrawn }: AccountSettingsBodyProps) {
   return (
     <div className="space-y-6">
       <AccountInfoSection user={data} />
+      {/*
+       * 追加パスキー登録セクション (Issue #242 / Req 1)。
+       * `data` が取得成功したときのみ本要素が描画されるため、未認証・取得前・取得失敗時は
+       * 構造で自動的に非表示になる（Req 1.2 / 1.3 / 1.4）。
+       */}
+      <PasskeyAddSection />
       <WithdrawSection onWithdrawn={onWithdrawn} />
     </div>
   );

--- a/web/src/components/passkey-add-section.test.tsx
+++ b/web/src/components/passkey-add-section.test.tsx
@@ -1,0 +1,255 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// `usePasskeyAddRegistration` をモックし、返却する mutation state をケースごとに差し替える。
+// `PasskeyAddRegistrationError` は実物を再 export し、production 同等の error オブジェクトを
+// 組み立てられるようにする。
+vi.mock("@/hooks/use-passkey-add-registration", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/hooks/use-passkey-add-registration")
+  >("@/hooks/use-passkey-add-registration");
+  return {
+    ...actual,
+    usePasskeyAddRegistration: vi.fn(),
+  };
+});
+
+import {
+  PasskeyAddRegistrationError,
+  usePasskeyAddRegistration,
+  type PasskeyAddRegistrationErrorKind,
+} from "@/hooks/use-passkey-add-registration";
+import { PasskeyAddSection } from "./passkey-add-section";
+
+interface MockMutation {
+  mutate: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  error: PasskeyAddRegistrationError | null;
+}
+
+function buildMutation(overrides: Partial<MockMutation> = {}): MockMutation {
+  return {
+    mutate: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+function mockAddRegistration(mutation: MockMutation) {
+  vi.mocked(usePasskeyAddRegistration).mockReturnValue(
+    mutation as unknown as ReturnType<typeof usePasskeyAddRegistration>,
+  );
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function makeError(kind: PasskeyAddRegistrationErrorKind) {
+  return new PasskeyAddRegistrationError(kind);
+}
+
+describe("PasskeyAddSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("パスキー追加の起動要素とロスト対策説明を表示すること (Req 1.5, Req 6.1)", () => {
+    mockAddRegistration(buildMutation());
+    render(<PasskeyAddSection />, { wrapper: createWrapper() });
+
+    expect(screen.getByTestId("passkey-add-section")).toBeInTheDocument();
+    expect(screen.getByTestId("passkey-add-trigger")).toBeInTheDocument();
+    const lossPrevention = screen.getByTestId("passkey-add-loss-prevention");
+    expect(lossPrevention).toBeInTheDocument();
+    expect(lossPrevention.textContent ?? "").toMatch(
+      /別の端末や同期先|アクセスできなくなる/,
+    );
+  });
+
+  it("ロスト対策説明文に credential 識別子等の機密情報を含めないこと (Req 6.2)", () => {
+    mockAddRegistration(buildMutation());
+    render(<PasskeyAddSection />, { wrapper: createWrapper() });
+
+    const lossPrevention = screen.getByTestId("passkey-add-loss-prevention");
+    const text = lossPrevention.textContent ?? "";
+    // credential ID / user id / email 等の識別子キーワードを含まない
+    expect(text).not.toMatch(/credential[_-]?id/i);
+    expect(text).not.toMatch(/user[_-]?id/i);
+    expect(text).not.toMatch(/@/);
+  });
+
+  it("起動要素をクリックすると mutation.mutate が呼ばれること (Req 1.5, 2.1)", async () => {
+    const mutation = buildMutation();
+    mockAddRegistration(mutation);
+    const user = userEvent.setup();
+    render(<PasskeyAddSection />, { wrapper: createWrapper() });
+
+    await user.click(screen.getByTestId("passkey-add-trigger"));
+
+    expect(mutation.mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("mutation pending 中は起動要素が disabled になり文言が「登録中...」になること (Req 4.4)", () => {
+    mockAddRegistration(buildMutation({ isPending: true }));
+    render(<PasskeyAddSection />, { wrapper: createWrapper() });
+
+    const trigger = screen.getByTestId("passkey-add-trigger") as HTMLButtonElement;
+    expect(trigger.disabled).toBe(true);
+    expect(trigger).toHaveTextContent("登録中...");
+  });
+
+  it("mutation 終了後は起動要素が再操作可能な状態に戻ること (Req 4.5)", () => {
+    // 成功終了時: isPending は false に戻る
+    mockAddRegistration(buildMutation({ isSuccess: true }));
+    render(<PasskeyAddSection />, { wrapper: createWrapper() });
+
+    const trigger = screen.getByTestId("passkey-add-trigger") as HTMLButtonElement;
+    expect(trigger.disabled).toBe(false);
+    expect(trigger).toHaveTextContent("パスキーを追加");
+  });
+
+  it("成功時に成功フィードバックが視認できる形で表示されること (Req 2.4)", () => {
+    mockAddRegistration(buildMutation({ isSuccess: true }));
+    render(<PasskeyAddSection />, { wrapper: createWrapper() });
+
+    const success = screen.getByTestId("passkey-add-success");
+    expect(success).toBeInTheDocument();
+    expect(success).toHaveAttribute("role", "status");
+    expect(success).toHaveTextContent("パスキーを追加しました。");
+  });
+
+  it("重複エラー時に他のエラーと区別できる文言・testid で提示されること (Req 3.1, 3.4)", () => {
+    mockAddRegistration(
+      buildMutation({
+        isError: true,
+        error: makeError("already_registered"),
+      }),
+    );
+    render(<PasskeyAddSection />, { wrapper: createWrapper() });
+
+    // 専用 testid で重複エラーを区別できる
+    const dupError = screen.getByTestId("passkey-add-error-already-registered");
+    expect(dupError).toBeInTheDocument();
+    expect(dupError).toHaveAttribute("role", "alert");
+    expect(dupError.textContent ?? "").toMatch(
+      /すでに.*登録|既に.*登録|別の端末/,
+    );
+    // 汎用エラー表示は同時に出ない（キー分離を確認）
+    expect(screen.queryByTestId("passkey-add-error")).not.toBeInTheDocument();
+    // 起動要素は残り、再試行できる状態 (Req 3.3)
+    expect(screen.getByTestId("passkey-add-trigger")).toBeInTheDocument();
+  });
+
+  it.each<PasskeyAddRegistrationErrorKind>([
+    "server_rejected",
+    "server_error",
+    "network_error",
+  ])(
+    "汎用エラー %s は共通の汎用文言で提示され、専用の重複エラー枠が出ないこと (Req 4.2, 4.3, NFR 2.2)",
+    (kind) => {
+      mockAddRegistration(
+        buildMutation({
+          isError: true,
+          error: makeError(kind),
+        }),
+      );
+      render(<PasskeyAddSection />, { wrapper: createWrapper() });
+
+      const err = screen.getByTestId("passkey-add-error");
+      expect(err).toBeInTheDocument();
+      expect(err).toHaveAttribute("role", "alert");
+      // 内部詳細（kind 名 / status 数値等）が DOM に反射しない
+      expect(err.textContent ?? "").not.toContain(kind);
+      // 重複エラー枠は出ない
+      expect(
+        screen.queryByTestId("passkey-add-error-already-registered"),
+      ).not.toBeInTheDocument();
+      // 再試行可能な状態が維持される (Req 4.5 / 4.6)
+      const trigger = screen.getByTestId(
+        "passkey-add-trigger",
+      ) as HTMLButtonElement;
+      expect(trigger.disabled).toBe(false);
+    },
+  );
+
+  it("cancelled 発生時はエラー表示を出さず mutation.reset() を呼ぶ (Req 4.1)", async () => {
+    const mutation = buildMutation({
+      isError: true,
+      error: makeError("cancelled"),
+    });
+    mockAddRegistration(mutation);
+    render(<PasskeyAddSection />, { wrapper: createWrapper() });
+
+    // エラー枠は表示されない
+    expect(screen.queryByTestId("passkey-add-error")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("passkey-add-error-already-registered"),
+    ).not.toBeInTheDocument();
+    // useEffect で mutation.reset が呼ばれる
+    await waitFor(() => {
+      expect(mutation.reset).toHaveBeenCalled();
+    });
+    // 起動要素は残り再試行可能
+    expect(screen.getByTestId("passkey-add-trigger")).toBeInTheDocument();
+  });
+
+  it("再試行時に成功通知が消え、mutate が再度呼ばれること (Req 4.5)", async () => {
+    const mutation = buildMutation({ isSuccess: true });
+    mockAddRegistration(mutation);
+    const user = userEvent.setup();
+    render(<PasskeyAddSection />, { wrapper: createWrapper() });
+
+    // 初期状態で成功通知が出ている
+    expect(screen.getByTestId("passkey-add-success")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("passkey-add-trigger"));
+
+    // isSuccess 状態からの再クリックで reset と mutate が呼ばれる
+    expect(mutation.reset).toHaveBeenCalled();
+    expect(mutation.mutate).toHaveBeenCalledTimes(1);
+
+    // 成功通知は隠される（dismissedSuccess = true になる）
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("passkey-add-success"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("エラー分類のいずれでも起動要素が残り、認証済みセッション UI が破壊されないこと (Req 4.6)", () => {
+    // 代表として server_rejected を使う
+    mockAddRegistration(
+      buildMutation({
+        isError: true,
+        error: makeError("server_rejected"),
+      }),
+    );
+    render(<PasskeyAddSection />, { wrapper: createWrapper() });
+
+    // セクション自体が存在し（＝親の設定 UI 表示は維持される想定）、
+    // 起動要素も残る
+    expect(screen.getByTestId("passkey-add-section")).toBeInTheDocument();
+    expect(screen.getByTestId("passkey-add-trigger")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/passkey-add-section.tsx
+++ b/web/src/components/passkey-add-section.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { KeyRound } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  usePasskeyAddRegistration,
+  type PasskeyAddRegistrationErrorKind,
+} from "@/hooks/use-passkey-add-registration";
+
+/**
+ * `error.kind` → ユーザー可視の固定文言マッピング。
+ *
+ * - `cancelled` はキー不在（= 表示しない）: Requirement 4.1「画面を壊さずに戻す」を
+ *   UI 上で実現するため、汎用エラーとしても表示しない
+ * - `already_registered`: 重複登録である旨をユーザーが認識できる形（Req 3.1 / 3.4）。
+ *   他のキャンセル・拒否理由と区別できる独自文言を採用する
+ * - `server_rejected` / `server_error` / `network_error`: 汎用エラー文言
+ *   （拒否理由の内部区別を反射しない / Req 4.2 / NFR 2.2）
+ *
+ * NFR 2.2: `ApiError.body` の内部詳細（サーバ側 error code や stack 等）を DOM に一切
+ * 反射せず、kind 別の固定文言のみを表示する。
+ */
+const ERROR_MESSAGES: Partial<Record<PasskeyAddRegistrationErrorKind, string>> =
+  {
+    already_registered:
+      "この認証器はすでにアカウントに登録されています。別の端末や別のパスキー同期先を選んでください。",
+    server_rejected:
+      "パスキーの追加に失敗しました。時間をおいて再度お試しください。",
+    server_error:
+      "パスキーの追加に失敗しました。時間をおいて再度お試しください。",
+    network_error:
+      "通信状況を確認して、時間をおいて再度お試しください。",
+  };
+
+/**
+ * アカウント設定ダイアログ内の「パスキーを追加」セクション（Req 1 / 2 / 3 / 4 / 5 / 6）。
+ *
+ * 責務:
+ * - ロスト対策説明文の表示（Req 6.1 / 6.2）
+ * - 「パスキーを追加」ボタンの提示と `usePasskeyAddRegistration` mutation の起動（Req 1.5）
+ * - mutation 状態の UI 反映:
+ *   - `isPending`: ボタン disabled + 「登録中...」文言（Req 4.4 の多重送信防止）
+ *   - `isSuccess`: 成功フィードバック表示（Req 2.4）+ 次の追加試行のためにボタンを復元
+ *   - `error.kind === "already_registered"`: 重複エラー文言（Req 3.1 / 3.4）
+ *   - `error.kind === "cancelled"`: エラー表示なし + `mutation.reset()`（Req 4.1）
+ *   - `error.kind === その他`: 汎用エラー文言（Req 4.2 / 4.3 / NFR 2.2）
+ * - mutation 終了時（成功・失敗・キャンセル）でボタンを再操作可能な状態に戻す（Req 4.5）
+ *
+ * 認証済みユーザーが Account Settings UI を開いた場合にのみ描画される（Req 1.1）。
+ * 未認証・取得前・取得失敗時は親コンポーネント（`AccountSettingsBody`）が描画自体を
+ * 抑止するため、本コンポーネント内では表示可否判定を持たない（Req 1.2 / 1.3 / 1.4）。
+ *
+ * Google OAuth 由来ユーザー（パスキー未登録を含む）でも同一導線・同一操作性で
+ * 表示・動作する（Req 5.1 / 5.3）。パスキー登録済み件数を判定材料としないため、
+ * 「初回パスキー登録」も「2 つ目以降の追加登録」も本セクションから同じ mutation で
+ * 実行できる（Req 5.1 / 5.2 / 5.3）。
+ *
+ * NFR 2.1 遵守: `console.*` を呼ばず、attestation 生バイト等は本コンポーネントで扱わない
+ * （すべて `usePasskeyAddRegistration` の mutation 内 closure に閉じ込められる）。
+ * NFR 2.2 遵守: `error.message` / `ApiError.body` を DOM に反射させず、kind 別の固定
+ * 文言のみを表示する。
+ */
+export function PasskeyAddSection() {
+  const mutation = usePasskeyAddRegistration();
+  const { isPending, isError, isSuccess, error, reset, mutate } = mutation;
+  const [dismissedSuccess, setDismissedSuccess] = useState(false);
+  const errorKind: PasskeyAddRegistrationErrorKind | undefined = isError
+    ? error?.kind
+    : undefined;
+
+  // Req 4.1: cancelled は「画面を壊さず戻す」— エラー表示を出さず mutation state を初期化する
+  useEffect(() => {
+    if (errorKind === "cancelled") {
+      reset();
+    }
+  }, [errorKind, reset]);
+
+  const errorMessage = errorKind ? ERROR_MESSAGES[errorKind] : undefined;
+  const showSuccess = isSuccess && !dismissedSuccess;
+
+  // isSuccess が false → true に切り替わる（新しい成功が届く）たびに dismiss をリセットし、
+  // 直近の成功通知を可視化する。既に true のままの再レンダーではフラグを触らない。
+  useEffect(() => {
+    if (isSuccess) {
+      setDismissedSuccess(false);
+    }
+  }, [isSuccess]);
+
+  const handleAdd = () => {
+    // 前回の成功通知を隠して次の試行を開始する。実運用では reset() 後に mutate() で
+    // isSuccess が false→true 遷移するため、上の useEffect が新しい成功を可視化する。
+    if (isSuccess) {
+      setDismissedSuccess(true);
+      reset();
+    }
+    mutate();
+  };
+
+  return (
+    <section
+      data-testid="passkey-add-section"
+      className="space-y-3 rounded-lg border p-4"
+    >
+      <div className="space-y-1">
+        <h3 className="text-sm font-medium">パスキーを追加</h3>
+        {/* Req 6.1: ロスト対策の説明文。credential 識別子等の機密情報は含めない (Req 6.2) */}
+        <p
+          data-testid="passkey-add-loss-prevention"
+          className="text-xs text-muted-foreground"
+        >
+          別の端末や同期先のパスキーを追加しておくと、片方の端末を失っても
+          アカウントにアクセスできなくなるリスクを下げられます。
+        </p>
+      </div>
+
+      {/* 重複エラー (Req 3.1 / 3.4)。他の汎用エラーと文言・testid を分離することで
+          ユーザーが区別できるようにする。 */}
+      {errorKind === "already_registered" && (
+        <div
+          data-testid="passkey-add-error-already-registered"
+          role="alert"
+          className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm"
+        >
+          <p className="font-medium text-destructive">
+            {ERROR_MESSAGES.already_registered}
+          </p>
+        </div>
+      )}
+
+      {/* 汎用エラー (Req 4.2 / 4.3)。サーバ拒否・通信断・内部エラーを 1 系統に集約し、
+          内部詳細を反射しない (NFR 2.2)。 */}
+      {errorMessage && errorKind !== "already_registered" && (
+        <div
+          data-testid="passkey-add-error"
+          role="alert"
+          className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm"
+        >
+          <p className="font-medium text-destructive">{errorMessage}</p>
+        </div>
+      )}
+
+      {/* 成功フィードバック (Req 2.4)。role="status" で a11y 通知を伴う。 */}
+      {showSuccess && (
+        <div
+          data-testid="passkey-add-success"
+          role="status"
+          className="rounded-md border border-emerald-500/50 bg-emerald-500/10 p-3 text-sm"
+        >
+          <p className="font-medium text-emerald-700 dark:text-emerald-300">
+            パスキーを追加しました。
+          </p>
+        </div>
+      )}
+
+      <div className="pt-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-testid="passkey-add-trigger"
+          disabled={isPending}
+          onClick={handleAdd}
+        >
+          <KeyRound className="w-4 h-4" />
+          {isPending ? "登録中..." : "パスキーを追加"}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/web/src/hooks/use-passkey-add-registration.test.tsx
+++ b/web/src/hooks/use-passkey-add-registration.test.tsx
@@ -1,0 +1,439 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    apiClient: {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/lib/webauthn", () => ({
+  decodeCreationOptions: vi.fn(),
+  encodeAttestationResponse: vi.fn(),
+}));
+
+import { usePasskeyAddRegistration } from "./use-passkey-add-registration";
+import {
+  apiClient,
+  ApiError,
+  RequestPreparationError,
+  ResponseParseError,
+} from "@/lib/api";
+import {
+  decodeCreationOptions,
+  encodeAttestationResponse,
+} from "@/lib/webauthn";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { Wrapper, queryClient };
+}
+
+function makeCredential(): PublicKeyCredential {
+  return {
+    id: "attestation-id",
+    type: "public-key",
+    rawId: new Uint8Array([1, 2, 3]).buffer,
+    response: {},
+  } as unknown as PublicKeyCredential;
+}
+
+function makeDomException(name: string): Error {
+  if (typeof DOMException !== "undefined") {
+    return new DOMException("browser operation failed", name);
+  }
+  const error = new Error("browser operation failed");
+  error.name = name;
+  return error;
+}
+
+function stubSuccessfulCreate() {
+  const create = vi.fn().mockResolvedValue(makeCredential());
+  const get = vi.fn();
+  vi.stubGlobal("navigator", { credentials: { create, get } });
+  return { create, get };
+}
+
+function stubBeginSuccess() {
+  vi.mocked(apiClient.post).mockImplementation(
+    (async (url: string) => {
+      if (url === "/api/passkey/registration/add/begin") {
+        return { challenge_id: "add-1", options: { publicKey: {} } };
+      }
+      if (url === "/api/passkey/registration/add/finish") {
+        // 204 No Content: apiClient は空 body で undefined を返す契約
+        return undefined;
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    }) as typeof apiClient.post,
+  );
+}
+
+function stubFinishFailure(error: unknown) {
+  vi.mocked(apiClient.post).mockImplementation(
+    (async (url: string) => {
+      if (url === "/api/passkey/registration/add/begin") {
+        return { challenge_id: "add-1", options: { publicKey: {} } };
+      }
+      if (url === "/api/passkey/registration/add/finish") {
+        throw error;
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    }) as typeof apiClient.post,
+  );
+}
+
+describe("usePasskeyAddRegistration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(decodeCreationOptions).mockReturnValue({
+      publicKey: {
+        challenge: new Uint8Array([1]).buffer,
+      } as unknown as PublicKeyCredentialCreationOptions,
+    });
+    vi.mocked(encodeAttestationResponse).mockReturnValue({
+      id: "attestation-id",
+      type: "public-key",
+      rawId: "AQID",
+      response: {
+        clientDataJSON: "client-data",
+        attestationObject: "attestation",
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("begin→create→finish で成功し、認証系ceremony を呼ばず、begin は空ボディで送信されること (Req 2.1, 2.2, 2.3, 2.4)", async () => {
+    const { create, get } = stubSuccessfulCreate();
+    stubBeginSuccess();
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // begin は空ボディ (Req 2.1: 追加登録用チャレンジ取得は空ボディ)
+    expect(apiClient.post).toHaveBeenNthCalledWith(
+      1,
+      "/api/passkey/registration/add/begin",
+      {},
+    );
+    // ブラウザのパスキー作成 UI が起動される (Req 2.2)
+    expect(create).toHaveBeenCalledTimes(1);
+    // 生成された credential を追加登録用の確定処理へ提示 (Req 2.3)
+    expect(apiClient.post).toHaveBeenNthCalledWith(
+      2,
+      "/api/passkey/registration/add/finish",
+      {
+        challenge_id: "add-1",
+        credential: expect.objectContaining({ id: "attestation-id" }),
+      },
+    );
+    expect(apiClient.post).toHaveBeenCalledTimes(2);
+    // 認証系 endpoint は呼ばれない（追加登録は session を変えない / Req 2.5）
+    expect(get).not.toHaveBeenCalled();
+    expect(apiClient.post).not.toHaveBeenCalledWith(
+      expect.stringContaining("/authentication/"),
+      expect.anything(),
+    );
+    expect(apiClient.post).not.toHaveBeenCalledWith(
+      "/api/auth/session",
+      expect.anything(),
+    );
+  });
+
+  it("同一 authenticator の重複時（InvalidStateError）は already_registered に分類し finish を呼ばないこと (Req 3.1, 3.2, 3.4)", async () => {
+    const create = vi
+      .fn()
+      .mockRejectedValue(makeDomException("InvalidStateError"));
+    vi.stubGlobal("navigator", { credentials: { create } });
+    // begin だけ通り、finish は呼ばれてはならない
+    vi.mocked(apiClient.post).mockResolvedValue({
+      challenge_id: "add-1",
+      options: { publicKey: {} },
+    });
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    // 重複は cancelled とは別 kind として分類される (Req 3.4)
+    expect(result.current.error?.kind).toBe("already_registered");
+    // finish endpoint は呼ばれない (Req 3.2)
+    expect(apiClient.post).not.toHaveBeenCalledWith(
+      "/api/passkey/registration/add/finish",
+      expect.anything(),
+    );
+    // begin のみ呼ばれる
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/passkey/registration/add/begin",
+      {},
+    );
+  });
+
+  it.each([
+    ["NotAllowedError", "NotAllowedError"],
+    ["AbortError", "AbortError"],
+  ])(
+    "create のユーザーキャンセル（%s）は cancelled として分類し finish を呼ばないこと (Req 4.1)",
+    async (_label, name) => {
+      const create = vi.fn().mockRejectedValue(makeDomException(name));
+      vi.stubGlobal("navigator", { credentials: { create } });
+      vi.mocked(apiClient.post).mockResolvedValue({
+        challenge_id: "add-1",
+        options: { publicKey: {} },
+      });
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => usePasskeyAddRegistration(), {
+        wrapper: Wrapper,
+      });
+
+      act(() => result.current.mutate());
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.kind).toBe("cancelled");
+      expect(apiClient.post).not.toHaveBeenCalledWith(
+        "/api/passkey/registration/add/finish",
+        expect.anything(),
+      );
+    },
+  );
+
+  it("create が null を返した場合も cancelled として集約されること (Req 4.1)", async () => {
+    const create = vi.fn().mockResolvedValue(null);
+    vi.stubGlobal("navigator", { credentials: { create } });
+    vi.mocked(apiClient.post).mockResolvedValue({
+      challenge_id: "add-1",
+      options: { publicKey: {} },
+    });
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.kind).toBe("cancelled");
+    expect(apiClient.post).not.toHaveBeenCalledWith(
+      "/api/passkey/registration/add/finish",
+      expect.anything(),
+    );
+  });
+
+  it.each([400, 401, 403, 409, 422])(
+    "finish の %i は server_rejected として分類され、内部 body が message に混入しないこと (Req 4.2, NFR 2.2)",
+    async (status) => {
+      stubSuccessfulCreate();
+      stubFinishFailure(
+        new ApiError(status, {
+          code: "REGISTRATION_FAILED",
+          internal_reason: "must-not-leak-secret",
+        }),
+      );
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => usePasskeyAddRegistration(), {
+        wrapper: Wrapper,
+      });
+
+      act(() => result.current.mutate());
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.kind).toBe("server_rejected");
+      // 内部詳細は message に反射しない
+      expect(result.current.error?.message).not.toContain("must-not-leak-secret");
+      expect(result.current.error?.message).not.toContain("REGISTRATION_FAILED");
+    },
+  );
+
+  it("finish の 5xx は server_error として分類されること (Req 4.3)", async () => {
+    stubSuccessfulCreate();
+    stubFinishFailure(new ApiError(500, { code: "INTERNAL" }));
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.kind).toBe("server_error");
+  });
+
+  it("finish の fetch reject（TypeError）は network_error として分類されること (Req 4.3)", async () => {
+    stubSuccessfulCreate();
+    stubFinishFailure(new TypeError("Failed to fetch"));
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.kind).toBe("network_error");
+  });
+
+  it("finish の AbortError は network_error として分類されること (Req 4.3)", async () => {
+    stubSuccessfulCreate();
+    stubFinishFailure(makeDomException("AbortError"));
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.kind).toBe("network_error");
+  });
+
+  it("finish の RequestPreparationError は server_error として分類されること", async () => {
+    stubSuccessfulCreate();
+    stubFinishFailure(new RequestPreparationError(new TypeError("circular JSON")));
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.kind).toBe("server_error");
+  });
+
+  it("finish の ResponseParseError は server_error として分類されること", async () => {
+    stubSuccessfulCreate();
+    stubFinishFailure(new ResponseParseError(200, new SyntaxError()));
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.kind).toBe("server_error");
+  });
+
+  it("begin の fetch reject（TypeError）は network_error として分類されること (Req 4.3)", async () => {
+    vi.mocked(apiClient.post).mockRejectedValueOnce(
+      new TypeError("Failed to fetch"),
+    );
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.kind).toBe("network_error");
+  });
+
+  it("begin の 4xx は server_rejected として分類されること", async () => {
+    vi.mocked(apiClient.post).mockRejectedValueOnce(
+      new ApiError(400, { code: "INVALID_REQUEST", internal: "leak" }),
+    );
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.kind).toBe("server_rejected");
+    expect(result.current.error?.message).not.toContain("leak");
+  });
+
+  it("begin の 5xx は server_error として分類されること", async () => {
+    vi.mocked(apiClient.post).mockRejectedValueOnce(
+      new ApiError(500, { code: "INTERNAL_ERROR" }),
+    );
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.kind).toBe("server_error");
+  });
+
+  it("decodeCreationOptions が TypeError を投げた場合は server_error として分類されること", async () => {
+    // begin は成功、decode で TypeError
+    vi.mocked(apiClient.post).mockResolvedValueOnce({
+      challenge_id: "add-1",
+      options: { publicKey: {} },
+    });
+    vi.mocked(decodeCreationOptions).mockImplementationOnce(() => {
+      throw new TypeError("malformed options");
+    });
+    // navigator は使われないが、undefined 参照を避けるためスタブする
+    vi.stubGlobal("navigator", { credentials: { create: vi.fn() } });
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.kind).toBe("server_error");
+    // finish は呼ばれない
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+  });
+
+  it("成功時に auth/me query を invalidate しないこと（セッション維持 / Req 2.5）", async () => {
+    stubSuccessfulCreate();
+    stubBeginSuccess();
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => usePasskeyAddRegistration(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.mutate());
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    // auth/me を無効化しない（他画面の再描画・既存機能を変化させない）
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ["auth", "me"] });
+  });
+});

--- a/web/src/hooks/use-passkey-add-registration.ts
+++ b/web/src/hooks/use-passkey-add-registration.ts
@@ -1,0 +1,271 @@
+"use client";
+
+import {
+  useMutation,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import {
+  apiClient,
+  ApiError,
+  RequestPreparationError,
+  ResponseParseError,
+} from "@/lib/api";
+import {
+  decodeCreationOptions,
+  encodeAttestationResponse,
+} from "@/lib/webauthn";
+import type {
+  PasskeyBeginResponse,
+  PasskeyFinishRequest,
+} from "@/types/passkey";
+
+/**
+ * 追加パスキー登録 mutation で発生しうるエラー種別。
+ *
+ * 既存の `PasskeyRegistrationErrorKind`（新規作成用）は
+ * `InvalidStateError` を `cancelled` に集約するが、追加登録では excludeCredentials
+ * による「同一 authenticator の重複登録」を区別してユーザーに提示する必要がある
+ * （Req 3.1 / 3.4）。そのため本 spec 専用の `already_registered` を独立列挙する。
+ *
+ * - `cancelled`: ブラウザのパスキー作成 UI 上でユーザーが Cancel した / dismiss した
+ *   （`NotAllowedError` / `AbortError`）。UI は「画面を壊さず戻す」（Req 4.1）
+ * - `already_registered`: `excludeCredentials` で拒否された（`InvalidStateError`）。
+ *   ブラウザが finish 前に拒否するため、サーバの finish endpoint を呼ばない（Req 3.2）
+ * - `server_rejected`: サーバの finish endpoint が 4xx で拒否した
+ *   （REGISTRATION_FAILED / チャレンジ期限切れ / attestation 不正 / レート制限等）。
+ *   内部区別は UI に反射しない（Req 4.2 / NFR 2.2）
+ * - `server_error`: 5xx / preparation 失敗 / decode 失敗 等の再試行可能な内部エラー
+ * - `network_error`: fetch reject / AbortError による通信不通
+ */
+export type PasskeyAddRegistrationErrorKind =
+  | "cancelled"
+  | "already_registered"
+  | "server_rejected"
+  | "server_error"
+  | "network_error";
+
+/**
+ * `usePasskeyAddRegistration` mutation が throw するドメインエラー。
+ *
+ * サーバ拒否理由の内部詳細（`ApiError.body`）は message に反射せず、`kind` の enum で
+ * のみ表現する（NFR 2.2）。UI は `kind` を判別材料として、内部エラー詳細を DOM に
+ * 出さないこと。
+ */
+export class PasskeyAddRegistrationError extends Error {
+  readonly kind: PasskeyAddRegistrationErrorKind;
+  constructor(
+    kind: PasskeyAddRegistrationErrorKind,
+    options?: { message?: string },
+  ) {
+    super(options?.message ?? kind);
+    this.name = "PasskeyAddRegistrationError";
+    this.kind = kind;
+  }
+}
+
+// begin / browser create / finish の発生位置ごとにエラーを分類するための step index。
+const STEP_ADD_BEGIN = 1;
+const STEP_NAV_CREATE = 2;
+const STEP_ADD_FINISH = 3;
+
+// `navigator.credentials.create()` の DOMException のうち、ユーザーキャンセル系として
+// 「画面を壊さず戻す」（Req 4.1）に集約する name の集合。既存 `use-passkey-registration`
+// は `InvalidStateError` もこの集合に含めるが、本フックでは重複を独立 kind に区別する
+// ため、意図的に含めない。
+const CANCEL_ERROR_NAMES = new Set(["NotAllowedError", "AbortError"]);
+
+/**
+ * `navigator.credentials.create()` が throw する DOMException を判別する。
+ *
+ * jsdom / 本番ブラウザ双方で DOMException が定義されない状況を考慮し、
+ * `instanceof DOMException` に加えて `err.name` によるフォールバック判定を持つ
+ * （既存 `use-passkey-registration` と同じ idiom）。
+ */
+function isDomExceptionWithName(err: unknown, name: string): boolean {
+  if (typeof DOMException !== "undefined" && err instanceof DOMException) {
+    return err.name === name;
+  }
+  return err instanceof Error && err.name === name;
+}
+
+/** ユーザーキャンセル系のブラウザ拒否か判定する（重複エラーは含めない）。 */
+function isCancelledError(err: unknown): boolean {
+  if (typeof DOMException !== "undefined" && err instanceof DOMException) {
+    return CANCEL_ERROR_NAMES.has(err.name);
+  }
+  return err instanceof Error && CANCEL_ERROR_NAMES.has(err.name);
+}
+
+/**
+ * `navigator.credentials.create()` が excludeCredentials 由来で拒否したかを判定する。
+ *
+ * WebAuthn 仕様上、「同一アカウントに既に登録済みの authenticator」がブラウザ側で
+ * 拒否される場合は `InvalidStateError` (DOMException) が throw される。
+ */
+function isAlreadyRegisteredError(err: unknown): boolean {
+  return isDomExceptionWithName(err, "InvalidStateError");
+}
+
+/**
+ * finish の fetch 中断（AbortController 相当）を判別する。
+ * create 側の UI キャンセルとは区別し、通信断として `network_error` に集約する。
+ */
+function isAbortError(err: unknown): boolean {
+  return isDomExceptionWithName(err, "AbortError");
+}
+
+/**
+ * 内部例外を `PasskeyAddRegistrationError` に分類する。step index に基づき、
+ *
+ * - STEP_NAV_CREATE の `InvalidStateError` → `already_registered`（Req 3）
+ * - STEP_NAV_CREATE の `NotAllowedError` / `AbortError` → `cancelled`（Req 4.1）
+ * - STEP_ADD_FINISH の 4xx → `server_rejected`（Req 4.2）
+ * - STEP_ADD_FINISH の 5xx / fetch reject / AbortError → `network_error` / `server_error`
+ *   （Req 4.3。追加登録は begin から再試行することで整合を復元できるため、finish の
+ *   uncertain 状態を独立 kind で扱わない）
+ * - preparation 失敗 / decode の TypeError → `server_error`
+ * - STEP_ADD_BEGIN の fetch reject → `network_error`
+ *
+ * NFR 2.2: 内部エラー詳細（ApiError.body / status など）を UI に反射しないため、
+ * kind の列挙のみで表現し message には status / body 内容を書き込まない。
+ */
+function classifyError(
+  err: unknown,
+  step: number,
+): PasskeyAddRegistrationError {
+  if (err instanceof PasskeyAddRegistrationError) {
+    return err;
+  }
+
+  if (step === STEP_NAV_CREATE) {
+    if (isAlreadyRegisteredError(err)) {
+      return new PasskeyAddRegistrationError("already_registered");
+    }
+    if (isCancelledError(err)) {
+      return new PasskeyAddRegistrationError("cancelled");
+    }
+    // decodeCreationOptions が TypeError を投げる場合（サーバ応答が不正）を含む
+    if (err instanceof TypeError) {
+      return new PasskeyAddRegistrationError("server_error");
+    }
+    return new PasskeyAddRegistrationError("server_error");
+  }
+
+  if (step === STEP_ADD_FINISH) {
+    // dispatch 前の preparation 失敗はサーバ側に届いていないことが確定
+    if (err instanceof RequestPreparationError) {
+      return new PasskeyAddRegistrationError("server_error");
+    }
+    // 追加登録は fetch reject / abort でも再試行時に excludeCredentials が
+    // ブラウザ側で重複を弾くため、uncertain 状態を独立 kind として扱わず
+    // 通信不通として network_error に集約する（Req 4.3）
+    if (isAbortError(err) || err instanceof TypeError) {
+      return new PasskeyAddRegistrationError("network_error");
+    }
+    if (err instanceof ApiError && err.status >= 500) {
+      return new PasskeyAddRegistrationError("server_error");
+    }
+    if (err instanceof ApiError && err.status >= 400 && err.status < 500) {
+      // finish の 4xx は拒否確定。status/code の内部差は UI に反射しない
+      return new PasskeyAddRegistrationError("server_rejected");
+    }
+    // 204 no-content の場合 apiClient は undefined を返すため、ここには到達しない。
+    // ResponseParseError（サーバが 2xx で JSON を返しつつ parse 失敗した稀ケース）は
+    // 追加登録の性質上、実際にはサーバが 204 を返す契約のため通常発生しない。
+    // 発生した場合は再試行可能な server_error として扱う。
+    if (err instanceof ResponseParseError) {
+      return new PasskeyAddRegistrationError("server_error");
+    }
+    return new PasskeyAddRegistrationError("server_error");
+  }
+
+  // STEP_ADD_BEGIN 系
+  if (
+    err instanceof RequestPreparationError ||
+    err instanceof ResponseParseError
+  ) {
+    return new PasskeyAddRegistrationError("server_error");
+  }
+  if (err instanceof TypeError) {
+    // fetch reject（ネットワーク断・DNS 失敗等）
+    return new PasskeyAddRegistrationError("network_error");
+  }
+  if (err instanceof ApiError) {
+    if (err.status >= 500) {
+      return new PasskeyAddRegistrationError("server_error");
+    }
+    return new PasskeyAddRegistrationError("server_rejected");
+  }
+  return new PasskeyAddRegistrationError("server_error");
+}
+
+/**
+ * 追加パスキー登録の mutation chain を 1 フックで提供する（Issue #216 の add endpoint 配線）。
+ *
+ * サーバ既存契約に従い以下 3 ステップを直列に実行する:
+ *
+ *   1. `POST /api/passkey/registration/add/begin` (空ボディ `{}`)
+ *      → `{challenge_id, options}`。options は excludeCredentials を含む WebAuthn
+ *        creation options。
+ *   2. `decodeCreationOptions(options)` → `navigator.credentials.create({publicKey})`
+ *      → attestation。excludeCredentials で重複拒否された場合は `InvalidStateError`
+ *        が throw され、finish endpoint は呼ばれない（Req 3.2）
+ *   3. `encodeAttestationResponse(cred)` →
+ *      `POST /api/passkey/registration/add/finish { challenge_id, credential }`
+ *      → 204 No Content。既存 `apiClient` は 204 を JSON parse しないため
+ *        `void` 型で受ける（`web/src/lib/api.ts` L114-121）。
+ *
+ * 認証済み Cookie session（`credentials: "include"`）が既に成立している認証済みユーザーが
+ * 対象。本フックは session を変えないため `auth/me` を invalidate しない（Req 2.5）。
+ *
+ * NFR 2.1 遵守: challenge 平文・attestation 生バイトは `mutationFn` の closure 変数のみに
+ * 保持し、`console.*` / `localStorage` / `sessionStorage` / URL クエリ / エラー message に
+ * 一切残さない。mutation 終了で closure が GC 対象になることを前提とする。
+ *
+ * NFR 2.3 遵守: `apiClient` を経由することで同一オリジン相対パス（`API_BASE_URL = ""`）
+ * に閉じる（`web/src/lib/api.ts` の既存契約）。
+ *
+ * NFR 3.1 遵守: `decodeCreationOptions` / `encodeAttestationResponse` は既存
+ * `web/src/lib/webauthn.ts` を再利用し、同等機能を新規実装しない。
+ */
+export function usePasskeyAddRegistration(): UseMutationResult<
+  void,
+  PasskeyAddRegistrationError,
+  void
+> {
+  return useMutation<void, PasskeyAddRegistrationError, void>({
+    mutationFn: async () => {
+      let step = STEP_ADD_BEGIN;
+      try {
+        const beginResp = await apiClient.post<PasskeyBeginResponse>(
+          "/api/passkey/registration/add/begin",
+          {},
+        );
+
+        step = STEP_NAV_CREATE;
+        const creationOptions = decodeCreationOptions(beginResp.options);
+        const attestation = (await navigator.credentials.create(
+          creationOptions,
+        )) as PublicKeyCredential | null;
+        if (!attestation) {
+          // ブラウザ側の null 解決（キャンセル相当）を「壊さずに戻す」に集約
+          throw new PasskeyAddRegistrationError("cancelled");
+        }
+
+        step = STEP_ADD_FINISH;
+        const finishReq: PasskeyFinishRequest = {
+          challenge_id: beginResp.challenge_id,
+          credential: encodeAttestationResponse(attestation),
+        };
+        // 追加登録 finish は 204 No Content を返す。apiClient は 204 を JSON parse
+        // しないため `void` 型として受ける。
+        await apiClient.post<void>(
+          "/api/passkey/registration/add/finish",
+          finishReq,
+        );
+      } catch (err) {
+        throw classifyError(err, step);
+      }
+    },
+  });
+}


### PR DESCRIPTION
## 概要

Feedman Web（Next.js）のアカウント設定に、認証済みユーザーが 2 つ目以降のパスキーを登録するための
「パスキーを追加」導線を追加する。サーバ側の追加登録 API（`POST /api/passkey/registration/add/begin` /
`finish`）は Issue #216 で既に main に投入済みであり、本 PR のスコープは **Web 配線のみ**（バックエンド変更なし）。

パスキーのみで登録したアカウントはパスキーを 1 つ失うとアカウント喪失になるため、別の端末・別の同期先を
追加する導線とロスト対策説明文を Account Settings ダイアログに設ける。Google OAuth 由来のユーザーも同一導線
からパスキーを追加登録できる。

## 対応 Issue

Closes #242

## 関連 PR

なし（本 Issue は design-less impl のため設計 PR は作成していない）

## 実装内容

- (Req 1 / Task 全体) `account-settings-dialog.tsx` の `AccountSettingsBody` に `<PasskeyAddSection />` を配線（`data` 取得成功時のみ描画、loading/error 時は非表示）
- (Req 2 / NFR 3.1) `usePasskeyAddRegistration` フックを新規追加（begin → `navigator.credentials.create` → finish の mutation chain。`decodeCreationOptions` / `encodeAttestationResponse` は `@/lib/webauthn` を再利用）
- (Req 3) `InvalidStateError` を `already_registered` として独立分類し、`finish` を呼ばずに重複エラーを表示
- (Req 4) `cancelled` / `server_rejected` / `server_error` / `network_error` の 5 種エラー分類と pending 中の多重送信防止（`disabled={isPending}`）
- (Req 5) `PasskeyAddSection` は `user.email` を条件にせず `data` 有無のみで表示（Google 由来ユーザー対応）
- (Req 6) `passkey-add-loss-prevention` testid でロスト対策説明文を同一画面に表示
- (NFR 2) attestation 生バイト列・challenge 識別子を mutation closure に閉じ込め、console / storage / URL / エラー message に非出力。`PasskeyAddRegistrationError` は `kind` のみで区別し `ApiError.body` を DOM に非反射
- (NFR 4) `navigator.credentials` と `apiClient` を vi.stubGlobal / vi.mock で置換し、jsdom 環境で完結するテストを追加

## 受入基準チェック

- [x] Req 1.1: While 認証済みユーザーが Account Settings UI を開いているとき、パスキー追加登録の起動要素を表示する ← `account-settings-dialog.test.tsx` "認証済みユーザーがダイアログを開くとパスキー追加登録セクションが表示されること"
- [x] Req 1.2: While 未認証状態でアプリを閲覧しているとき、追加登録起動要素を表示しない ← 同上 "入口ボタンを押さない（ダイアログを開かない）と追加登録起動要素は表示されないこと"
- [x] Req 1.3: While アカウント情報取得前、確定的に操作可能な状態としては提示しない ← 同上 "アカウント情報取得中はパスキー追加登録セクションが表示されないこと"
- [x] Req 1.4: If 取得失敗時、確定的に操作可能な状態としては提示しない ← 同上 "アカウント情報取得に失敗したときはパスキー追加登録セクションが表示されないこと"
- [x] Req 1.5: When 起動要素を操作したとき、追加登録フローを開始する ← `passkey-add-section.test.tsx` "起動要素をクリックすると mutation.mutate が呼ばれること"
- [x] Req 2.1: begin → チャレンジ取得（空ボディ） ← `use-passkey-add-registration.test.tsx` "begin→create→finish で成功し…begin は空ボディで送信されること"
- [x] Req 2.2: ブラウザのパスキー作成 UI 起動 ← 同上（create 呼出を assert）
- [x] Req 2.3: credential 情報を finish に提示 ← 同上（finish 呼出を assert）
- [x] Req 2.4: 成功をユーザーが視認できる形で提示 ← `passkey-add-section.test.tsx` "成功時に成功フィードバックが視認できる形で表示されること"
- [x] Req 2.5: 成功後も認証済みセッション維持（auth/me 非 invalidate） ← `use-passkey-add-registration.test.tsx` "成功時に auth/me query を invalidate しないこと"
- [x] Req 3.1: 重複登録エラーをユーザーが認識できる形で提示 ← `passkey-add-section.test.tsx` "重複エラー時に他のエラーと区別できる文言・testid で提示されること"
- [x] Req 3.2: 重複時に finish を呼ばない ← `use-passkey-add-registration.test.tsx` "同一 authenticator の重複時…finish を呼ばないこと"
- [x] Req 3.3: 重複エラー後も再試行できる状態を維持 ← `passkey-add-section.test.tsx` 3.1 テスト内で trigger 残存を assert
- [x] Req 3.4: 重複と他エラーをユーザーが区別できる形で提示 ← 同上 "汎用エラー %s は共通の汎用文言で提示され、専用の重複エラー枠が出ないこと"
- [x] Req 4.1: キャンセル時はエラー非表示 + reset()・再試行可能 ← `passkey-add-section.test.tsx` "cancelled 発生時はエラー表示を出さず mutation.reset() を呼ぶ"
- [x] Req 4.2: サーバ拒否時は内部詳細を非反射の汎用エラー ← `use-passkey-add-registration.test.tsx` "finish の %i は server_rejected として分類され、内部 body が message に混入しないこと"
- [x] Req 4.3: ネットワーク断・内部エラー時に再試行導線維持 ← `passkey-add-section.test.tsx` "汎用エラー %s は…再試行可能な状態が維持される"
- [x] Req 4.4: pending 中は起動要素を非活性化 ← 同上 "mutation pending 中は起動要素が disabled になり文言が「登録中...」になること"
- [x] Req 4.5: 終了後に起動要素を再操作可能に戻す ← 同上 "mutation 終了後は起動要素が再操作可能な状態に戻ること"
- [x] Req 4.6: キャンセル・失敗時もセッション維持 ← hook の auth/me 非 invalidate テスト
- [x] Req 5.1: Google 由来ユーザーでも同一位置・同一操作性で表示 ← `account-settings-dialog.test.tsx` "Google 由来（email 未設定含む）ユーザーでも同一位置にパスキー追加導線が表示されること"
- [x] Req 5.2: Google 紐付けは解除・変更されない（Web 責務として auth/me 非 invalidate） ← hook の非 invalidate テスト
- [x] Req 5.3: 登録済み件数を条件にせず常時表示 ← `passkey-add-section.test.tsx` "パスキー追加の起動要素とロスト対策説明を表示すること"
- [x] Req 6.1: ロスト対策説明文を同一画面に表示 ← 同上（loss-prevention 文言を assert）
- [x] Req 6.2: 説明文に機密情報を含めない ← 同上 "ロスト対策説明文に credential 識別子等の機密情報を含めないこと"
- [x] NFR 1.1〜1.5: 既存ファイルは additive 差込のみ、全既存テスト green 維持
- [x] NFR 2.1〜2.4: attestation/challenge 生値の非漏出、CSP 方針の非緩和
- [x] NFR 3.1: WebAuthn utility（decodeCreationOptions / encodeAttestationResponse）を再利用
- [x] NFR 4.1: navigator.credentials / apiClient を mock、jsdom で完結するテスト

## テスト結果

```
新規追加: 3 スイート合計 48 テスト（hook 20 / UI 13 / dialog 統合 15）
合計: 55 スイート / 583 テスト すべて pass（既存 55 スイート 535 + 新規 48）

npm test   : 55 スイート / 583 テスト pass
npm run lint: 新規/変更ファイル分の警告・エラー なし
             （既存 5 件 warning は本 PR 対象外の feed-favicon 等由来）
npm run build: production build 成功（Compiled successfully / Generating static pages 完了）
npx tsc --noEmit: 新規/変更ファイル分のエラー 0 件
                  （既存 39 行の TS エラーは本 PR 前後で件数変化なし）
```

## 実装上の判断

1. **`InvalidStateError` を `already_registered` として独立分類**（Req 3 の中核）: 既存 `use-passkey-registration.ts` は `InvalidStateError` を `cancelled` に集約しているが、追加登録では `excludeCredentials` に登録済み credential が含まれるため同一 authenticator 選択時に `InvalidStateError` が明示的に発火し意味論的に異なる。既存フックの分類は変更していない。

2. **finish の uncertain 状態を独立 kind に分けなかった理由**: 追加登録では finish 失敗後の再試行 begin が `excludeCredentials` に当該 credential を含めるため、同 authenticator では `already_registered` に自然集約される。新規作成側の `registration_uncertain` 相当は不要と判断し `network_error` / `server_error` に集約した。

3. **204 No Content 対応**: 既存 `apiClient` は 204/205 で `undefined` を返す契約のため `apiClient.post<void>` として呼び出し、`ResponseParseError` を誘発しない。

4. **成功後の再操作 UX**: `isSuccess` 状態で再クリック時は `reset()` → `mutate()` を呼び、成功通知を再表示する設計。複数台追加ユースケースを考慮。

5. **成功時の `auth/me` 非 invalidate**（Req 2.5）: 追加登録はセッションを変えないため invalidate を呼ばない。呼ぶと `AuthGuard` / ヘッダー等が再取得し「他画面の表示を変化させない」に反する。

## 確認事項 / レビュワーへの依頼

- **design-less impl: 単一 PR で完了のため Closes を採用**
- **base: develop / baseRefName: （PR 作成後に検証予定） / OK**（作成後に更新）
- **UI コピー**: requirements.md 「Open Questions」で `design で確定` とされていた文言は実装者判断で採用（ロスト対策説明文・重複エラー文言・成功バナー文言・汎用エラー文言）。レビュワーが文言の変更を望む場合はコメントで指摘してください
- **UI 配置**: `AccountInfoSection` の直下・`WithdrawSection` の直上に独立セクションとして配置（退会と並列だが、ロスト対策文脈で登録直下が自然と判断）
- **追加登録件数の上限・可視化**: Out of Scope（credential 一覧 UI）に沿い、登録済み件数は表示しない。将来の Issue で対応予定
- Reviewer 独立レビュー結果: `docs/specs/242-feat-web-ui-registration-add-api-web/review-notes.md` 参照（RESULT: approve）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #242 のコメントを参照してください。